### PR TITLE
feat: make DistributedLog configurable in Database::load

### DIFF
--- a/crates/application/src/test_helpers.rs
+++ b/crates/application/src/test_helpers.rs
@@ -218,6 +218,7 @@ impl<RT: Runtime> ApplicationTestExt<RT> for Application<RT> {
             // Essentially unlimited rate limit for testing
             Arc::new(new_unlimited_rate_limiter(rt.clone())),
             deleted_tablet_sender,
+            Arc::new(database::commit_delta::NoopDistributedLog),
         )
         .await?;
         initialize_application_system_tables(&database).await?;

--- a/crates/database/src/database.rs
+++ b/crates/database/src/database.rs
@@ -976,6 +976,7 @@ impl<RT: Runtime> Database<RT> {
         shared_index_cache: Option<SharedIndexCache>,
         retention_rate_limiter: Arc<RateLimiter<RT>>,
         deleted_tablet_sender: mpsc::Sender<TabletId>,
+        distributed_log: Arc<dyn crate::commit_delta::DistributedLog>,
     ) -> anyhow::Result<Self> {
         let _load_database_timer = metrics::load_database_timer();
 
@@ -1043,7 +1044,7 @@ impl<RT: Runtime> Database<RT> {
             retention_manager.clone(),
             shutdown,
             virtual_system_mapping.clone(),
-            Arc::new(crate::commit_delta::NoopDistributedLog),
+            distributed_log,
         );
         let table_mapping_snapshot_cache =
             AsyncLru::new(runtime.clone(), 20, 2, "table_mapping_snapshot");

--- a/crates/database/src/test_helpers/db_fixtures.rs
+++ b/crates/database/src/test_helpers/db_fixtures.rs
@@ -97,6 +97,7 @@ impl<RT: Runtime> DbFixtures<RT> {
             None,
             Arc::new(new_unlimited_rate_limiter(rt.clone())),
             deleted_tablet_sender,
+            Arc::new(crate::commit_delta::NoopDistributedLog),
         )
         .await?;
         db.set_search_storage(search_storage.clone());

--- a/crates/local_backend/src/lib.rs
+++ b/crates/local_backend/src/lib.rs
@@ -169,6 +169,7 @@ pub async fn make_app(
             Quota::per_second(*DOCUMENT_RETENTION_RATE_LIMIT),
         )),
         deleted_tablet_sender,
+        Arc::new(database::commit_delta::NoopDistributedLog),
     )
     .await?;
     initialize_application_system_tables(&database).await?;


### PR DESCRIPTION
## Summary

- Add `distributed_log: Arc<dyn DistributedLog>` parameter to `Database::load`
- Update all 3 callers to pass `NoopDistributedLog` (zero behavior change)
- Enables future callers to inject real distributed log implementations for replication

## Test plan

- [x] `cargo build -p database` passes
- [x] `cargo check -p application -p local_backend` passes

Closes #5