### PR TITLE
feat: add CommitClient trait for local/remote commit abstraction

### DIFF
--- a/crates/database/src/commit_client.rs
+++ b/crates/database/src/commit_client.rs
@@ -1,0 +1,109 @@
+//! Trait abstraction over how transactions are committed.
+//!
+//! On a Primary node, [`LocalCommitClient`] sends transactions to the
+//! in-process [`Committer`] via an mpsc channel (the existing behavior).
+//!
+//! On a Replica node, a future `RemoteCommitClient` will forward transactions
+//! to the Primary over gRPC.
+
+use std::{
+    collections::BTreeSet,
+    sync::Arc,
+};
+
+use async_trait::async_trait;
+use common::{
+    persistence::PersistenceReader,
+    runtime::Runtime,
+    types::Timestamp,
+};
+use futures::future::BoxFuture;
+use value::TableName;
+
+use crate::{
+    committer::CommitterClient,
+    write_log::WriteSource,
+    Transaction,
+};
+
+/// Trait for committing transactions. Abstracts over local (in-process) and
+/// remote (over-the-network) commit paths.
+#[async_trait]
+pub trait CommitClient: Send + Sync + 'static {
+    /// Commit a transaction, returning the assigned commit timestamp.
+    fn commit<RT: Runtime>(
+        &self,
+        transaction: Transaction<RT>,
+        write_source: WriteSource,
+    ) -> BoxFuture<'_, anyhow::Result<Timestamp>>;
+
+    /// Load indexes into memory for the given tables.
+    async fn load_indexes_into_memory(&self, tables: BTreeSet<TableName>) -> anyhow::Result<()>;
+
+    /// Get a reader for the persistence layer.
+    fn persistence_reader(&self) -> Arc<dyn PersistenceReader>;
+}
+
+/// Local commit client that delegates to the in-process [`CommitterClient`].
+/// This is the default for Primary nodes and single-node deployments.
+pub struct LocalCommitClient {
+    inner: CommitterClient,
+}
+
+impl LocalCommitClient {
+    pub fn new(inner: CommitterClient) -> Self {
+        Self { inner }
+    }
+
+    /// Access the underlying [`CommitterClient`] for operations that are
+    /// specific to the Primary (bootstrap, etc.).
+    pub fn committer(&self) -> &CommitterClient {
+        &self.inner
+    }
+}
+
+#[async_trait]
+impl CommitClient for LocalCommitClient {
+    fn commit<RT: Runtime>(
+        &self,
+        transaction: Transaction<RT>,
+        write_source: WriteSource,
+    ) -> BoxFuture<'_, anyhow::Result<Timestamp>> {
+        self.inner.commit(transaction, write_source)
+    }
+
+    async fn load_indexes_into_memory(&self, tables: BTreeSet<TableName>) -> anyhow::Result<()> {
+        self.inner.load_indexes_into_memory(tables).await
+    }
+
+    fn persistence_reader(&self) -> Arc<dyn PersistenceReader> {
+        self.inner.persistence_reader()
+    }
+}
+
+/// A read-only commit client for Replica nodes. Rejects all mutations locally
+/// — in a full implementation, this would forward to the Primary via gRPC.
+pub struct ReadOnlyCommitClient;
+
+#[async_trait]
+impl CommitClient for ReadOnlyCommitClient {
+    fn commit<RT: Runtime>(
+        &self,
+        _transaction: Transaction<RT>,
+        _write_source: WriteSource,
+    ) -> BoxFuture<'_, anyhow::Result<Timestamp>> {
+        Box::pin(async {
+            anyhow::bail!(
+                "Cannot commit on a Replica node. Mutations must be forwarded to the Primary."
+            )
+        })
+    }
+
+    async fn load_indexes_into_memory(&self, _tables: BTreeSet<TableName>) -> anyhow::Result<()> {
+        anyhow::bail!("Cannot load indexes on a Replica node.")
+    }
+
+    fn persistence_reader(&self) -> Arc<dyn PersistenceReader> {
+        panic!("ReadOnlyCommitClient does not have a persistence reader")
+    }
+}

--- a/crates/database/src/committer.rs
+++ b/crates/database/src/committer.rs
@@ -1252,6 +1252,10 @@ impl CommitterClient {
         rx.await.map_err(|_| metrics::shutdown_error())?
     }
 
+    pub fn persistence_reader(&self) -> Arc<dyn PersistenceReader> {
+        self.persistence_reader.clone()
+    }
+
     pub fn commit<RT: Runtime>(
         &self,
         transaction: Transaction<RT>,

--- a/crates/database/src/lib.rs
+++ b/crates/database/src/lib.rs
@@ -11,6 +11,7 @@
 #![feature(once_cell_try)]
 
 mod bootstrap_model;
+pub mod commit_client;
 pub mod commit_delta;
 mod committer;
 mod database;


### PR DESCRIPTION
## Summary

- Add `CommitClient` trait abstracting over how transactions are committed
- Add `LocalCommitClient` wrapping existing `CommitterClient` (Primary/single-node)
- Add `ReadOnlyCommitClient` that rejects mutations (Replica nodes)
- Add `persistence_reader()` accessor to `CommitterClient`

## Test plan

- [x] `cargo build -p database` passes
- [x] `cargo test -p database` — 336 passed, 0 failed

Closes #9