### PR TITLE
feat: add replication mode to local_backend binary

### DIFF
--- a/crates/local_backend/src/config.rs
+++ b/crates/local_backend/src/config.rs
@@ -130,6 +130,18 @@ pub struct LocalConfig {
     /// of log integrations (eg axiom/datadog).
     #[clap(long)]
     pub local_log_sink: Option<String>,
+
+    /// Replication mode: "primary" (default) or "replica".
+    /// Primary nodes accept writes and publish deltas to NATS.
+    /// Replica nodes consume deltas from NATS and serve read-only queries.
+    #[clap(long, env = "REPLICATION_MODE", default_value = "primary")]
+    pub replication_mode: String,
+
+    /// NATS URL for distributed log replication.
+    /// Required when replication_mode is set.
+    /// Example: nats://localhost:4222
+    #[clap(long, env = "NATS_URL")]
+    pub nats_url: Option<String>,
 }
 
 impl fmt::Debug for LocalConfig {

--- a/crates/local_backend/src/lib.rs
+++ b/crates/local_backend/src/lib.rs
@@ -157,6 +157,19 @@ pub async fn make_app(
     let segment_metadata_fetcher: Arc<dyn SegmentTermMetadataFetcher> = in_process_searcher;
     let (deleted_tablet_sender, deleted_tablet_receiver) = tokio::sync::mpsc::channel(100);
     let usage_event_logger = Arc::new(NoOpUsageEventLogger);
+    // Set up distributed log based on replication mode.
+    let distributed_log: Arc<dyn database::commit_delta::DistributedLog> =
+        if let Some(nats_url) = &config.nats_url {
+            let nats_config = database::nats_distributed_log::NatsConfig {
+                url: nats_url.clone(),
+            };
+            Arc::new(
+                database::nats_distributed_log::NatsDistributedLog::connect(nats_config).await?,
+            )
+        } else {
+            Arc::new(database::commit_delta::NoopDistributedLog)
+        };
+
     let database = Database::load(
         persistence.clone(),
         runtime.clone(),
@@ -169,7 +182,7 @@ pub async fn make_app(
             Quota::per_second(*DOCUMENT_RETENTION_RATE_LIMIT),
         )),
         deleted_tablet_sender,
-        Arc::new(database::commit_delta::NoopDistributedLog),
+        distributed_log,
     )
     .await?;
     initialize_application_system_tables(&database).await?;


### PR DESCRIPTION
## Summary

- Add `REPLICATION_MODE` env var (`primary`/`replica`) to `LocalConfig`
- Add `NATS_URL` env var for distributed log connection
- When `NATS_URL` is set, wire `NatsDistributedLog` into `Database::load`
- Without `NATS_URL`, fall back to `NoopDistributedLog` (existing behavior)

The backend can now publish commit deltas to NATS when running as a Primary.

## Test plan

- [x] `cargo check -p local_backend` passes
- [x] `cargo test -p database` — 337 passed, 0 failed

Closes #14