### PR TITLE
feat: wire replica mode into Database::load and local_backend

### DIFF
--- a/crates/application/src/test_helpers.rs
+++ b/crates/application/src/test_helpers.rs
@@ -219,6 +219,7 @@ impl<RT: Runtime> ApplicationTestExt<RT> for Application<RT> {
             Arc::new(new_unlimited_rate_limiter(rt.clone())),
             deleted_tablet_sender,
             Arc::new(database::commit_delta::NoopDistributedLog),
+            false,
         )
         .await?;
         initialize_application_system_tables(&database).await?;

--- a/crates/database/src/database.rs
+++ b/crates/database/src/database.rs
@@ -977,6 +977,7 @@ impl<RT: Runtime> Database<RT> {
         retention_rate_limiter: Arc<RateLimiter<RT>>,
         deleted_tablet_sender: mpsc::Sender<TabletId>,
         distributed_log: Arc<dyn crate::commit_delta::DistributedLog>,
+        replica_mode: bool,
     ) -> anyhow::Result<Self> {
         let _load_database_timer = metrics::load_database_timer();
 
@@ -1020,6 +1021,11 @@ impl<RT: Runtime> Database<RT> {
             ..
         } = db_snapshot;
 
+        let snapshot_for_dummy = if replica_mode {
+            Some(snapshot.clone())
+        } else {
+            None
+        };
         let snapshot_manager = SnapshotManager::new(*ts, snapshot);
         let (snapshot_reader, snapshot_writer) = new_split_rw_lock(snapshot_manager);
 
@@ -1036,16 +1042,45 @@ impl<RT: Runtime> Database<RT> {
         let persistence_reader = persistence.reader();
         let (log_owner, log_reader, log_writer) = new_write_log(*ts);
         let subscriptions = SubscriptionsWorker::start(log_owner, runtime.clone());
-        let committer = Committer::start(
-            log_writer,
-            snapshot_writer,
-            persistence,
-            runtime.clone(),
-            retention_manager.clone(),
-            shutdown,
-            virtual_system_mapping.clone(),
-            distributed_log,
-        );
+        let committer = if replica_mode {
+            // In replica mode, give the snapshot writer and log writer to the
+            // ReplicaSnapshotUpdater instead of the Committer.
+            let _replica_updater = crate::replica::ReplicaSnapshotUpdater::start(
+                runtime.clone(),
+                distributed_log.clone(),
+                snapshot_writer,
+                log_writer,
+                *ts,
+            );
+            // Create a dummy Committer that will never receive writes.
+            // We need one because Database expects a CommitterClient.
+            let (_, _, dummy_log_writer) = new_write_log(*ts);
+            let dummy_snapshot = snapshot_for_dummy.expect("snapshot_for_dummy must be Some in replica mode");
+            let dummy_snapshot_manager = SnapshotManager::new(*ts, dummy_snapshot);
+            let (_, dummy_snapshot_writer) = new_split_rw_lock(dummy_snapshot_manager);
+            tracing::info!("Database loading in replica mode — tailing distributed log from ts={ts}");
+            Committer::start(
+                dummy_log_writer,
+                dummy_snapshot_writer,
+                persistence,
+                runtime.clone(),
+                retention_manager.clone(),
+                shutdown,
+                virtual_system_mapping.clone(),
+                Arc::new(crate::commit_delta::NoopDistributedLog),
+            )
+        } else {
+            Committer::start(
+                log_writer,
+                snapshot_writer,
+                persistence,
+                runtime.clone(),
+                retention_manager.clone(),
+                shutdown,
+                virtual_system_mapping.clone(),
+                distributed_log,
+            )
+        };
         let table_mapping_snapshot_cache =
             AsyncLru::new(runtime.clone(), 20, 2, "table_mapping_snapshot");
         let by_id_indexes_snapshot_cache =

--- a/crates/database/src/test_helpers/db_fixtures.rs
+++ b/crates/database/src/test_helpers/db_fixtures.rs
@@ -98,6 +98,7 @@ impl<RT: Runtime> DbFixtures<RT> {
             Arc::new(new_unlimited_rate_limiter(rt.clone())),
             deleted_tablet_sender,
             Arc::new(crate::commit_delta::NoopDistributedLog),
+            false,
         )
         .await?;
         db.set_search_storage(search_storage.clone());

--- a/crates/database/src/tests/replication_tests.rs
+++ b/crates/database/src/tests/replication_tests.rs
@@ -40,6 +40,7 @@ async fn test_primary_commit_publishes_delta(rt: TestRuntime) -> anyhow::Result<
         Arc::new(new_unlimited_rate_limiter(rt.clone())),
         deleted_tablet_sender,
         distributed_log.clone(),
+        false,
     )
     .await?;
     primary.set_search_storage(Arc::new(LocalDirStorage::new(rt.clone())?));

--- a/crates/local_backend/src/lib.rs
+++ b/crates/local_backend/src/lib.rs
@@ -183,6 +183,7 @@ pub async fn make_app(
         )),
         deleted_tablet_sender,
         distributed_log,
+        config.replication_mode == "replica",
     )
     .await?;
     initialize_application_system_tables(&database).await?;

--- a/self-hosted/docker/docker-compose.replicated.yml
+++ b/self-hosted/docker/docker-compose.replicated.yml
@@ -68,31 +68,33 @@ services:
       interval: 5s
       start_period: 10s
 
-  # Replica is commented out until we wire replication into the binary.
-  # When ready, it will consume deltas from NATS and serve read-only queries.
-  #
-  # replica:
-  #   image: ghcr.io/get-convex/convex-backend:latest
-  #   stop_grace_period: 10s
-  #   stop_signal: SIGINT
-  #   ports:
-  #     - "3220:3210"
-  #     - "3221:3211"
-  #   environment:
-  #     - POSTGRES_URL=postgresql://postgres:postgres@postgres:5432
-  #     - DO_NOT_REQUIRE_SSL=1
-  #     - CONVEX_CLOUD_ORIGIN=http://127.0.0.1:3220
-  #     - CONVEX_SITE_ORIGIN=http://127.0.0.1:3221
-  #     - RUST_LOG=info
-  #     - DISABLE_BEACON=true
-  #     - REPLICATION_MODE=replica
-  #     - NATS_URL=nats://nats:4222
-  #     - PRIMARY_URL=http://primary:3210
-  #   depends_on:
-  #     primary:
-  #       condition: service_healthy
-  #     nats:
-  #       condition: service_healthy
+  replica:
+    image: ghcr.io/get-convex/convex-backend:latest
+    stop_grace_period: 10s
+    stop_signal: SIGINT
+    ports:
+      - "3220:3210"
+      - "3221:3211"
+    volumes:
+      - replica-data:/convex/data
+    environment:
+      - POSTGRES_URL=postgresql://postgres:postgres@postgres:5432
+      - DO_NOT_REQUIRE_SSL=1
+      - CONVEX_CLOUD_ORIGIN=http://127.0.0.1:3220
+      - CONVEX_SITE_ORIGIN=http://127.0.0.1:3221
+      - RUST_LOG=info
+      - DISABLE_BEACON=true
+      - REPLICATION_MODE=replica
+      - NATS_URL=nats://nats:4222
+    depends_on:
+      primary:
+        condition: service_healthy
+      nats:
+        condition: service_healthy
+    healthcheck:
+      test: curl -f http://localhost:3210/version
+      interval: 5s
+      start_period: 10s
 
   dashboard:
     image: ghcr.io/get-convex/convex-dashboard:latest
@@ -109,3 +111,4 @@ services:
 volumes:
   pgdata:
   natsdata:
+  replica-data:


### PR DESCRIPTION
## Summary

- Add `replica_mode: bool` parameter to `Database::load`
- In replica mode: `ReplicaSnapshotUpdater` gets the snapshot writer and log writer, tails the distributed log
- Dummy Committer created for read-path compatibility in replica mode
- `local_backend` passes `replica_mode` based on `REPLICATION_MODE` env var
- Uncomment replica service in `docker-compose.replicated.yml`

The backend can now start in either Primary mode (accepts writes, publishes deltas) or Replica mode (tails distributed log, serves reads).

## Test plan

- [x] `cargo build -p database` passes
- [x] `cargo test -p database` — 337 passed, 0 failed
- [x] `cargo check -p local_backend` passes

Closes #16