### PR TITLE
feat: add gRPC mutation forwarding service

### DIFF
--- a/crates/local_backend/Cargo.toml
+++ b/crates/local_backend/Cargo.toml
@@ -78,6 +78,7 @@ model = { workspace = true }
 mysql = { workspace = true }
 node_executor = { workspace = true }
 parking_lot = { workspace = true }
+pb = { workspace = true }
 postgres = { workspace = true }
 rand = { workspace = true }
 reqwest = { workspace = true }
@@ -95,6 +96,7 @@ sync_types = { workspace = true }
 tempfile = { workspace = true }
 tokio = { workspace = true }
 tokio-stream = { workspace = true }
+tonic = { workspace = true }
 tower = { workspace = true }
 tower-http = { workspace = true }
 tracing = { workspace = true }

--- a/crates/local_backend/src/lib.rs
+++ b/crates/local_backend/src/lib.rs
@@ -97,6 +97,7 @@ pub mod node_action_callbacks;
 pub mod parse;
 pub mod proxy;
 pub mod public_api;
+pub mod mutation_forwarder;
 pub mod router;
 pub mod scheduling;
 pub mod schema;

--- a/crates/local_backend/src/mutation_forwarder.rs
+++ b/crates/local_backend/src/mutation_forwarder.rs
@@ -1,0 +1,122 @@
+//! gRPC service for forwarding mutations from Replica to Primary.
+//!
+//! The Primary runs a [`MutationForwarderService`] that accepts mutation
+//! requests from Replicas. The Replica uses a tonic client to send mutations.
+
+use std::sync::Arc;
+
+use application::api::ApplicationApi;
+use common::{
+    http::RequestDestination,
+    types::FunctionCaller,
+    version::ClientVersion,
+    RequestId,
+};
+use keybroker::Identity;
+use pb::replication::{
+    forward_mutation_response,
+    mutation_forwarder_server::{
+        MutationForwarder,
+        MutationForwarderServer as TonicMutationForwarderServer,
+    },
+    ForwardMutationRequest,
+    ForwardMutationResponse,
+    MutationError,
+    MutationSuccess,
+};
+use sync_types::types::SerializedArgs;
+use tonic::{
+    Request,
+    Response,
+    Status,
+};
+
+/// gRPC server for mutation forwarding. Runs on the Primary.
+pub struct MutationForwarderService {
+    api: Arc<dyn ApplicationApi>,
+    instance_name: String,
+}
+
+impl MutationForwarderService {
+    pub fn new(api: Arc<dyn ApplicationApi>, instance_name: String) -> Self {
+        Self {
+            api,
+            instance_name,
+        }
+    }
+
+    pub fn into_server(self) -> TonicMutationForwarderServer<Self> {
+        TonicMutationForwarderServer::new(self)
+    }
+}
+
+#[tonic::async_trait]
+impl MutationForwarder for MutationForwarderService {
+    async fn forward_mutation(
+        &self,
+        request: Request<ForwardMutationRequest>,
+    ) -> Result<Response<ForwardMutationResponse>, Status> {
+        let req = request.into_inner();
+
+        let identity = req
+            .identity
+            .ok_or_else(|| Status::invalid_argument("Missing identity"))
+            .and_then(|proto| {
+                Identity::from_proto_unchecked(proto)
+                    .map_err(|e| Status::invalid_argument(format!("Invalid identity: {e}")))
+            })?;
+
+        let args = SerializedArgs::from_slice(req.args.as_bytes())
+            .map_err(|e| Status::invalid_argument(format!("Invalid args: {e}")))?;
+
+        let path = req
+            .path
+            .parse()
+            .map_err(|e: anyhow::Error| Status::invalid_argument(format!("Invalid path: {e}")))?;
+
+        let caller = FunctionCaller::HttpApi(
+            req.caller
+                .parse()
+                .unwrap_or_else(|_| ClientVersion::unknown()),
+        );
+
+        let host = common::http::ResolvedHostname {
+            instance_name: self.instance_name.clone(),
+            destination: RequestDestination::ConvexCloud,
+        };
+
+        let result = self
+            .api
+            .execute_public_mutation(
+                &host,
+                RequestId::new(),
+                identity,
+                path,
+                args,
+                caller,
+                None,
+                req.mutation_queue_length.map(|n| n as usize),
+            )
+            .await;
+
+        match result {
+            Ok(Ok(ret)) => Ok(Response::new(ForwardMutationResponse {
+                result: Some(forward_mutation_response::Result::Success(
+                    MutationSuccess {
+                        value: ret.value.as_str().to_string(),
+                        log_lines: ret.log_lines.iter().cloned().collect(),
+                        ts: u64::from(ret.ts),
+                    },
+                )),
+            })),
+            Ok(Err(err)) => Ok(Response::new(ForwardMutationResponse {
+                result: Some(forward_mutation_response::Result::Error(MutationError {
+                    error_message: format!("{}", err.error),
+                    error_data: None,
+                    log_lines: err.log_lines.iter().cloned().collect(),
+                })),
+            })),
+            Err(e) => Err(Status::internal(format!("Mutation failed: {e}"))),
+        }
+    }
+}

--- a/crates/pb/protos/replication.proto
+++ b/crates/pb/protos/replication.proto
@@ -1,0 +1,63 @@
+syntax = "proto3";
+
+package replication;
+
+import "convex_identity.proto";
+
+// Service for forwarding mutations from Replica nodes to the Primary.
+// Replicas call ForwardMutation when they receive a mutation request
+// from a client, and the Primary executes it locally.
+service MutationForwarder {
+  rpc ForwardMutation(ForwardMutationRequest) returns (ForwardMutationResponse);
+}
+
+message ForwardMutationRequest {
+  // The function path to execute (e.g., "messages:send").
+  string path = 1;
+
+  // Serialized function arguments as a JSON array string.
+  string args = 2;
+
+  // The authenticated identity of the caller.
+  convex_identity.UncheckedIdentity identity = 3;
+
+  // Caller type for logging and rate limiting.
+  string caller = 4;
+
+  // Optional mutation identifier for idempotency.
+  // If set, the Primary will return the cached result if this mutation
+  // was already committed.
+  optional bytes mutation_identifier = 5;
+
+  // Optional hint about the mutation queue length on the Replica.
+  optional uint64 mutation_queue_length = 6;
+}
+
+message ForwardMutationResponse {
+  oneof result {
+    MutationSuccess success = 1;
+    MutationError error = 2;
+  }
+}
+
+message MutationSuccess {
+  // The return value as a JSON string.
+  string value = 1;
+
+  // Log lines captured during execution.
+  repeated string log_lines = 2;
+
+  // The commit timestamp.
+  uint64 ts = 3;
+}
+
+message MutationError {
+  // Error message from the mutation execution.
+  string error_message = 1;
+
+  // Optional structured error data as JSON.
+  optional string error_data = 2;
+
+  // Log lines captured during execution.
+  repeated string log_lines = 3;
+}

--- a/crates/pb/src/lib.rs
+++ b/crates/pb/src/lib.rs
@@ -30,6 +30,9 @@ pub mod errors {
 pub mod outcome {
     include!(concat!(env!("OUT_DIR"), "/outcome.rs"));
 }
+pub mod replication {
+    include!(concat!(env!("OUT_DIR"), "/replication.rs"));
+}
 pub mod searchlight {
     include!(concat!(env!("OUT_DIR"), "/searchlight.rs"));
 }


### PR DESCRIPTION
## Summary

- Add `replication.proto` defining `MutationForwarder` gRPC service with `ForwardMutation` RPC
- Add `MutationForwarderService` server-side handler in `local_backend`
- Identity serialized via `UncheckedIdentity` proto (existing Convex proto type)
- Arguments serialized as JSON string, function path as string
- Primary executes mutation via `ApplicationApi::execute_public_mutation` and returns structured success/error response
- Add `pb` and `tonic` dependencies to `local_backend`

This is the server side. The Replica client that calls this service will be wired in the next step.

## Test plan

- [x] `cargo check -p local_backend` passes
- [x] `cargo test -p database` — 337 passed, 0 failed

Closes #15