### PR TITLE
feat: wire gRPC mutation forwarding server and client

### DIFF
--- a/crates/local_backend/src/config.rs
+++ b/crates/local_backend/src/config.rs
@@ -142,6 +142,17 @@ pub struct LocalConfig {
     /// Example: nats://localhost:4222
     #[clap(long, env = "NATS_URL")]
     pub nats_url: Option<String>,
+
+    /// gRPC port for the mutation forwarding service.
+    /// Primary listens on this port. Replicas connect to PRIMARY_GRPC_URL.
+    #[clap(long, env = "GRPC_PORT", default_value = "50051")]
+    pub grpc_port: u16,
+
+    /// URL of the Primary's gRPC mutation forwarding service.
+    /// Only used in replica mode.
+    /// Example: http://primary:50051
+    #[clap(long, env = "PRIMARY_GRPC_URL")]
+    pub primary_grpc_url: Option<String>,
 }
 
 impl fmt::Debug for LocalConfig {

--- a/crates/local_backend/src/main.rs
+++ b/crates/local_backend/src/main.rs
@@ -25,6 +25,7 @@ use futures::{
 use local_backend::{
     config::LocalConfig,
     make_app,
+    mutation_forwarder::MutationForwarderService,
     proxy::dev_site_proxy,
     router::router,
     HttpActionRouteMapper,
@@ -128,6 +129,28 @@ async fn run_server_inner(runtime: ProdRuntime, config: LocalConfig) -> anyhow::
         preempt_signal.clone(),
     )
     .await?;
+
+    // Start gRPC mutation forwarding server on the Primary.
+    if config.replication_mode == "primary" && config.nats_url.is_some() {
+        let grpc_addr = format!("0.0.0.0:{}", config.grpc_port).parse()?;
+        let api: std::sync::Arc<dyn application::api::ApplicationApi> =
+            std::sync::Arc::new(st.application.clone());
+        let forwarder = MutationForwarderService::new(api, st.instance_name.clone());
+        let mut grpc_shutdown_rx = shutdown_rx.clone();
+        runtime.spawn_background("grpc_mutation_forwarder", async move {
+            tracing::info!("Starting gRPC mutation forwarder on {grpc_addr}");
+            if let Err(e) = tonic::transport::Server::builder()
+                .add_service(forwarder.into_server())
+                .serve_with_shutdown(grpc_addr, async move {
+                    let _ = grpc_shutdown_rx.recv().await;
+                })
+                .await
+            {
+                tracing::error!("gRPC mutation forwarder failed: {e}");
+            }
+        });
+    }
+
     let router = router(st.clone());
     let mut shutdown_rx_ = shutdown_rx.clone();
     let http_service = ConvexHttpService::new(

--- a/crates/local_backend/src/mutation_forwarder.rs
+++ b/crates/local_backend/src/mutation_forwarder.rs
@@ -1,10 +1,14 @@
 //! gRPC service for forwarding mutations from Replica to Primary.
 //!
 //! The Primary runs a [`MutationForwarderService`] that accepts mutation
-//! requests from Replicas. The Replica uses a tonic client to send mutations.
+//! requests from Replicas via gRPC.
+//!
+//! The Replica runs a [`MutationForwarderGrpcClient`] that forwards mutations
+//! to the Primary when clients try to execute mutations on a Replica.
 
 use std::sync::Arc;
 
+use anyhow::Context;
 use application::api::ApplicationApi;
 use common::{
     http::RequestDestination,
@@ -15,6 +19,7 @@ use common::{
 use keybroker::Identity;
 use pb::replication::{
     forward_mutation_response,
+    mutation_forwarder_client::MutationForwarderClient as TonicMutationForwarderClient,
     mutation_forwarder_server::{
         MutationForwarder,
         MutationForwarderServer as TonicMutationForwarderServer,
@@ -26,6 +31,7 @@ use pb::replication::{
 };
 use sync_types::types::SerializedArgs;
 use tonic::{
+    transport::Channel,
     Request,
     Response,
     Status,
@@ -118,5 +124,47 @@ impl MutationForwarder for MutationForwarderService {
             })),
             Err(e) => Err(Status::internal(format!("Mutation failed: {e}"))),
         }
+    }
+}
+
+/// gRPC client for forwarding mutations from Replica to Primary.
+pub struct MutationForwarderGrpcClient {
+    client: TonicMutationForwarderClient<Channel>,
+}
+
+impl MutationForwarderGrpcClient {
+    /// Connect to the Primary's gRPC mutation forwarding service.
+    pub async fn connect(primary_url: &str) -> anyhow::Result<Self> {
+        let client = TonicMutationForwarderClient::connect(primary_url.to_string())
+            .await
+            .with_context(|| format!("Failed to connect to Primary at {primary_url}"))?;
+        tracing::info!("Connected to Primary mutation forwarder at {primary_url}");
+        Ok(Self { client })
+    }
+
+    /// Forward a mutation to the Primary and return the result.
+    pub async fn forward(
+        &self,
+        path: &str,
+        args: &str,
+        identity: Identity,
+        caller: &str,
+    ) -> anyhow::Result<ForwardMutationResponse> {
+        let identity_proto: pb::convex_identity::UncheckedIdentity = identity.into();
+        let request = ForwardMutationRequest {
+            path: path.to_string(),
+            args: args.to_string(),
+            identity: Some(identity_proto),
+            caller: caller.to_string(),
+            mutation_identifier: None,
+            mutation_queue_length: None,
+        };
+        let response = self
+            .client
+            .clone()
+            .forward_mutation(Request::new(request))
+            .await
+            .context("gRPC mutation forwarding failed")?;
+        Ok(response.into_inner())
     }
 }

--- a/self-hosted/docker/docker-compose.replicated.yml
+++ b/self-hosted/docker/docker-compose.replicated.yml
@@ -48,6 +48,7 @@ services:
     ports:
       - "3210:3210"
       - "3211:3211"
+      - "50051:50051"
     environment:
       - POSTGRES_URL=postgresql://postgres:postgres@postgres:5432
       - DO_NOT_REQUIRE_SSL=1
@@ -55,9 +56,9 @@ services:
       - CONVEX_SITE_ORIGIN=http://127.0.0.1:3211
       - RUST_LOG=info
       - DISABLE_BEACON=true
-      # Replication config (to be implemented)
-      # - REPLICATION_MODE=primary
-      # - NATS_URL=nats://nats:4222
+      - REPLICATION_MODE=primary
+      - NATS_URL=nats://nats:4222
+      - GRPC_PORT=50051
     depends_on:
       postgres:
         condition: service_healthy
@@ -86,6 +87,7 @@ services:
       - DISABLE_BEACON=true
       - REPLICATION_MODE=replica
       - NATS_URL=nats://nats:4222
+      - PRIMARY_GRPC_URL=http://primary:50051
     depends_on:
       primary:
         condition: service_healthy


### PR DESCRIPTION
## Summary

- Primary starts gRPC `MutationForwarderService` on `GRPC_PORT` (50051) when `NATS_URL` is set
- Add `MutationForwarderGrpcClient` for Replica-to-Primary mutation forwarding over gRPC
- Add `GRPC_PORT` and `PRIMARY_GRPC_URL` config options to `LocalConfig`
- Update `docker-compose.replicated.yml` with gRPC port exposure and `PRIMARY_GRPC_URL` on Replica
- gRPC server runs as a background task alongside the HTTP server, shares the same shutdown signal

## Architecture

```
Client → Replica (HTTP :3220) → gRPC → Primary (gRPC :50051) → execute mutation → response → Client
Client → Primary (HTTP :3210) → execute mutation directly → response → Client
Client → Replica (HTTP :3220) → serve query from local SnapshotManager → response → Client
```

## Test plan

- [x] `cargo check -p local_backend` — clean compile, zero warnings
- [x] `cargo test -p database` — 337 passed, 0 failed