### PR TITLE
feat: multi-writer Docker deployment with partitioned tables

### DIFF
--- a/crates/application/src/test_helpers.rs
+++ b/crates/application/src/test_helpers.rs
@@ -220,6 +220,7 @@ impl<RT: Runtime> ApplicationTestExt<RT> for Application<RT> {
             deleted_tablet_sender,
             Arc::new(database::commit_delta::NoopDistributedLog),
             false,
+            None,
         )
         .await?;
         initialize_application_system_tables(&database).await?;

--- a/crates/database/src/database.rs
+++ b/crates/database/src/database.rs
@@ -978,6 +978,7 @@ impl<RT: Runtime> Database<RT> {
         deleted_tablet_sender: mpsc::Sender<TabletId>,
         distributed_log: Arc<dyn crate::commit_delta::DistributedLog>,
         replica_mode: bool,
+        partition_map: Option<crate::partition::PartitionMap>,
     ) -> anyhow::Result<Self> {
         let _load_database_timer = metrics::load_database_timer();
 
@@ -1067,7 +1068,7 @@ impl<RT: Runtime> Database<RT> {
             shutdown,
             virtual_system_mapping.clone(),
             committer_distributed_log,
-            None, // partition_map: None = single-partition mode
+            partition_map,
         );
         let table_mapping_snapshot_cache =
             AsyncLru::new(runtime.clone(), 20, 2, "table_mapping_snapshot");

--- a/crates/database/src/test_helpers/db_fixtures.rs
+++ b/crates/database/src/test_helpers/db_fixtures.rs
@@ -99,6 +99,7 @@ impl<RT: Runtime> DbFixtures<RT> {
             deleted_tablet_sender,
             Arc::new(crate::commit_delta::NoopDistributedLog),
             false,
+            None,
         )
         .await?;
         db.set_search_storage(search_storage.clone());

--- a/crates/database/src/tests/replication_tests.rs
+++ b/crates/database/src/tests/replication_tests.rs
@@ -41,6 +41,7 @@ async fn test_primary_commit_publishes_delta(rt: TestRuntime) -> anyhow::Result<
         deleted_tablet_sender,
         distributed_log.clone(),
         false,
+        None,
     )
     .await?;
     primary.set_search_storage(Arc::new(LocalDirStorage::new(rt.clone())?));

--- a/crates/local_backend/src/config.rs
+++ b/crates/local_backend/src/config.rs
@@ -154,6 +154,23 @@ pub struct LocalConfig {
     #[clap(long, env = "PRIMARY_GRPC_URL")]
     pub primary_grpc_url: Option<String>,
 
+    /// Partition ID for this node. Each node owns a partition.
+    /// Used with PARTITION_MAP to enable partitioned write scaling.
+    /// Example: 0, 1, 2
+    #[clap(long, env = "PARTITION_ID")]
+    pub partition_id: Option<u32>,
+
+    /// Partition map: table-to-partition assignment.
+    /// Format: "messages=1,users=1,projects=2,tasks=2"
+    /// Tables not listed default to partition 0.
+    /// System tables always on partition 0.
+    #[clap(long, env = "PARTITION_MAP")]
+    pub partition_map: Option<String>,
+
+    /// Total number of partitions in the cluster.
+    #[clap(long, env = "NUM_PARTITIONS")]
+    pub num_partitions: Option<u32>,
+
     /// Storage directory for the Replica to read shared files (modules, etc.).
     /// Should point to a path shared with the Primary's storage.
     /// Required in replica mode.

--- a/crates/local_backend/src/lib.rs
+++ b/crates/local_backend/src/lib.rs
@@ -169,7 +169,7 @@ pub async fn make_app(
             let nats_config = database::nats_distributed_log::NatsConfig {
                 url: nats_url.clone(),
                 consumer_name: Some(config.name()),
-                partition_id: None, // TODO: set from partition config
+                partition_id: config.partition_id,
             };
             Arc::new(
                 database::nats_distributed_log::NatsDistributedLog::connect(nats_config).await?,
@@ -192,6 +192,15 @@ pub async fn make_app(
         deleted_tablet_sender,
         distributed_log.clone(),
         config.replication_mode == "replica",
+        config.partition_id.map(|id| {
+            let partition_map_str = config.partition_map.as_deref().unwrap_or("");
+            let num_partitions = config.num_partitions.unwrap_or(1);
+            database::partition::PartitionMap::from_config(
+                partition_map_str,
+                database::partition::PartitionId(id),
+                num_partitions,
+            )
+        }),
     )
     .await?;
     initialize_application_system_tables(&database).await?;

--- a/self-hosted/docker/docker-compose.partitioned.yml
+++ b/self-hosted/docker/docker-compose.partitioned.yml
@@ -1,0 +1,135 @@
+# Partitioned multi-writer deployment for horizontal write scaling.
+#
+# Two writer nodes, each owning a partition of tables:
+#   - Node A (partition 0): owns system tables + messages, users
+#   - Node B (partition 1): owns projects, tasks
+#
+# Both nodes consume all deltas from NATS for full read view.
+# Writes to non-owned tables are rejected with a routing error.
+#
+# Usage:
+#   docker compose -f docker-compose.partitioned.yml up
+
+services:
+  postgres:
+    image: postgres:17
+    environment:
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: convex_self_hosted
+    ports:
+      - "5433:5432"
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+      - ./init-partitioned-db.sql:/docker-entrypoint-initdb.d/init-db.sql
+    healthcheck:
+      test: pg_isready -U postgres
+      interval: 5s
+      start_period: 10s
+
+  nats:
+    image: nats:alpine
+    command: ["--jetstream", "--store_dir", "/data", "--http_port", "8222"]
+    ports:
+      - "4222:4222"
+      - "8222:8222"
+    volumes:
+      - natsdata:/data
+    healthcheck:
+      test: ["CMD", "wget", "-qO-", "http://localhost:8222/healthz"]
+      interval: 5s
+      start_period: 5s
+      retries: 3
+
+  node-a:
+    image: convex-backend-replicated:latest
+    stop_grace_period: 10s
+    stop_signal: SIGINT
+    ports:
+      - "3210:3210"
+      - "3211:3211"
+      - "50051:50051"
+    volumes:
+      - node-a-data:/convex/data
+      - shared-storage:/convex/data/storage
+    environment:
+      - POSTGRES_URL=postgresql://postgres:postgres@postgres:5432
+      - DO_NOT_REQUIRE_SSL=1
+      - CONVEX_CLOUD_ORIGIN=http://127.0.0.1:3210
+      - CONVEX_SITE_ORIGIN=http://127.0.0.1:3211
+      - RUST_LOG=info
+      - DISABLE_BEACON=true
+      - INSTANCE_NAME=convex-node-a
+      - REPLICATION_MODE=primary
+      - NATS_URL=nats://nats:4222
+      - GRPC_PORT=50051
+      - CHECKPOINT_STORAGE_PATH=/convex/data/checkpoints
+      # Partition config: Node A owns partition 0 (system tables + messages, users)
+      - PARTITION_ID=0
+      - PARTITION_MAP=messages=0,users=0,projects=1,tasks=1
+      - NUM_PARTITIONS=2
+    depends_on:
+      postgres:
+        condition: service_healthy
+      nats:
+        condition: service_healthy
+    healthcheck:
+      test: curl -f http://localhost:3210/version
+      interval: 5s
+      start_period: 10s
+
+  node-b:
+    image: convex-backend-replicated:latest
+    stop_grace_period: 10s
+    stop_signal: SIGINT
+    ports:
+      - "3220:3210"
+      - "3221:3211"
+      - "50052:50051"
+    volumes:
+      - node-b-data:/convex/data
+      - shared-storage:/convex/data/storage
+    environment:
+      - POSTGRES_URL=postgresql://postgres:postgres@postgres:5432
+      - DO_NOT_REQUIRE_SSL=1
+      - CONVEX_CLOUD_ORIGIN=http://127.0.0.1:3220
+      - CONVEX_SITE_ORIGIN=http://127.0.0.1:3221
+      - RUST_LOG=info
+      - DISABLE_BEACON=true
+      - INSTANCE_NAME=convex-node-b
+      - REPLICATION_MODE=primary
+      - NATS_URL=nats://nats:4222
+      - GRPC_PORT=50051
+      - CHECKPOINT_STORAGE_PATH=/convex/data/checkpoints
+      - REPLICA_STORAGE_PATH=/convex/data/storage
+      # Partition config: Node B owns partition 1 (projects, tasks)
+      - PARTITION_ID=1
+      - PARTITION_MAP=messages=0,users=0,projects=1,tasks=1
+      - NUM_PARTITIONS=2
+    depends_on:
+      node-a:
+        condition: service_healthy
+      nats:
+        condition: service_healthy
+    healthcheck:
+      test: curl -f http://localhost:3210/version
+      interval: 5s
+      start_period: 10s
+
+  dashboard:
+    image: ghcr.io/get-convex/convex-dashboard:latest
+    stop_grace_period: 10s
+    stop_signal: SIGINT
+    ports:
+      - "6791:6791"
+    environment:
+      - NEXT_PUBLIC_DEPLOYMENT_URL=http://127.0.0.1:3210
+    depends_on:
+      node-a:
+        condition: service_healthy
+
+volumes:
+  pgdata:
+  natsdata:
+  node-a-data:
+  node-b-data:
+  shared-storage:

--- a/self-hosted/docker/init-partitioned-db.sql
+++ b/self-hosted/docker/init-partitioned-db.sql
@@ -1,0 +1,2 @@
+CREATE DATABASE convex_node_a;
+CREATE DATABASE convex_node_b;


### PR DESCRIPTION
## Summary

Complete write scaling infrastructure: two writer nodes, each owning a partition of tables, with full read view on both nodes via NATS delta replication.

### Docker deployment

- `docker-compose.partitioned.yml` with Node A (partition 0) and Node B (partition 1)
- Node A owns: system tables, `messages`, `users`
- Node B owns: `projects`, `tasks`
- Both consume all NATS deltas for cross-partition reads

### Code changes

- Add `PARTITION_ID`, `PARTITION_MAP`, `NUM_PARTITIONS` env vars to `LocalConfig`
- Wire partition map from config into `Database::load` → `Committer`
- Set `partition_id` on `NatsConfig` for per-partition NATS subjects
- Update all `Database::load` callers with `None` partition map for backward compat

### How it works

1. Node A receives mutation for `messages:send` → owns `messages` → commits locally
2. Node B receives mutation for `projects:create` → owns `projects` → commits locally
3. Both publish deltas to their partition subject (`convex.commits.0`, `convex.commits.1`)
4. Both consume ALL subjects → full read view on both nodes
5. If Node A receives mutation for `projects:create` → rejects with "owned by partition-1"

## Test plan

- [x] `cargo test -p database` — 341 passed
- [x] `cargo check -p local_backend` — compiles

Closes #28