### PR TITLE
refactor: dynamic database creation for any number of nodes

### DIFF
--- a/self-hosted/docker/docker-compose.partitioned.yml
+++ b/self-hosted/docker/docker-compose.partitioned.yml
@@ -16,11 +16,12 @@ services:
     environment:
       POSTGRES_PASSWORD: postgres
       POSTGRES_DB: convex_self_hosted
+      CONVEX_INSTANCES: convex-node-a,convex-node-b
     ports:
       - "5433:5432"
     volumes:
       - pgdata:/var/lib/postgresql/data
-      - ./init-partitioned-db.sql:/docker-entrypoint-initdb.d/init-db.sql
+      - ./init-databases.sh:/docker-entrypoint-initdb.d/init-databases.sh
     healthcheck:
       test: pg_isready -U postgres
       interval: 5s

--- a/self-hosted/docker/docker-compose.replicated.yml
+++ b/self-hosted/docker/docker-compose.replicated.yml
@@ -19,11 +19,12 @@ services:
     environment:
       POSTGRES_PASSWORD: postgres
       POSTGRES_DB: convex_self_hosted
+      CONVEX_INSTANCES: convex-primary,convex-replica,convex-replica2
     ports:
       - "5433:5432"
     volumes:
       - pgdata:/var/lib/postgresql/data
-      - ./init-db.sql:/docker-entrypoint-initdb.d/init-db.sql
+      - ./init-databases.sh:/docker-entrypoint-initdb.d/init-databases.sh
     healthcheck:
       test: pg_isready -U postgres
       interval: 5s

--- a/self-hosted/docker/init-databases.sh
+++ b/self-hosted/docker/init-databases.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+set -e
+
+# Dynamically create PostgreSQL databases for all Convex nodes.
+# Reads CONVEX_INSTANCES env var: comma-separated list of instance names.
+# Each instance name is converted to a database name by replacing - with _.
+#
+# Example:
+#   CONVEX_INSTANCES=convex-primary,convex-replica,convex-replica2
+#   Creates: convex_primary, convex_replica, convex_replica2
+#
+#   CONVEX_INSTANCES=convex-node-a,convex-node-b,convex-node-c,convex-node-d
+#   Creates: convex_node_a, convex_node_b, convex_node_c, convex_node_d
+
+if [ -z "$CONVEX_INSTANCES" ]; then
+    echo "CONVEX_INSTANCES not set, skipping dynamic database creation"
+    exit 0
+fi
+
+IFS=',' read -ra INSTANCES <<< "$CONVEX_INSTANCES"
+for instance in "${INSTANCES[@]}"; do
+    instance=$(echo "$instance" | xargs) # trim whitespace
+    db_name=$(echo "$instance" | tr '-' '_')
+    echo "Creating database: $db_name (for instance: $instance)"
+    psql -v ON_ERROR_STOP=0 --username "$POSTGRES_USER" <<-EOSQL
+        CREATE DATABASE "$db_name";
+EOSQL
+done
+
+echo "Created ${#INSTANCES[@]} databases"

--- a/self-hosted/docker/init-db.sql
+++ b/self-hosted/docker/init-db.sql
@@ -1,3 +1,0 @@
-CREATE DATABASE convex_primary;
-CREATE DATABASE convex_replica;
-CREATE DATABASE convex_replica2;

--- a/self-hosted/docker/init-partitioned-db.sql
+++ b/self-hosted/docker/init-partitioned-db.sql
@@ -1,2 +1,0 @@
-CREATE DATABASE convex_node_a;
-CREATE DATABASE convex_node_b;


### PR DESCRIPTION
## Summary

Replace hardcoded SQL init files with a dynamic shell script that creates databases based on `CONVEX_INSTANCES` environment variable.

### Before
- `init-db.sql`: hardcoded `convex_primary`, `convex_replica`, `convex_replica2`
- `init-partitioned-db.sql`: hardcoded `convex_node_a`, `convex_node_b`
- Adding a node required editing SQL files

### After
- `init-databases.sh`: reads `CONVEX_INSTANCES` env var, creates databases dynamically
- Adding a node: just add the instance name to the comma-separated list
- Works for any number of nodes

### Example
```yaml
CONVEX_INSTANCES: convex-node-a,convex-node-b,convex-node-c,convex-node-d
# Creates: convex_node_a, convex_node_b, convex_node_c, convex_node_d
```