### PR TITLE
feat: enable delta replication on partitioned writer nodes

### DIFF
--- a/crates/local_backend/src/lib.rs
+++ b/crates/local_backend/src/lib.rs
@@ -335,10 +335,13 @@ pub async fn make_app(
         runtime.spawn_background("beacon_worker", beacon_future);
     }
 
-    // Start the ReplicaDeltaConsumer on Replica to tail NATS and apply deltas.
+    // Start the ReplicaDeltaConsumer to tail NATS and apply deltas from other nodes.
+    // Runs on:
+    //   - Replicas (REPLICATION_MODE=replica): consumes Primary's deltas
+    //   - Partitioned writers (PARTITION_ID set): consumes other partitions' deltas
     // Creates a fresh NATS connection dedicated to the consumer.
-    // Uses spawn_background so the task outlives make_app scope.
-    if config.replication_mode == "replica" {
+    let needs_delta_consumer = config.replication_mode == "replica" || config.partition_id.is_some();
+    if needs_delta_consumer {
         if let Some(nats_url) = &config.nats_url {
             let nats_url = nats_url.clone();
             let committer = database.committer_client();


### PR DESCRIPTION
## Summary

Start `ReplicaDeltaConsumer` on partitioned writer nodes so every node consumes all other nodes' deltas via NATS. This enables cross-partition reads — Node A sees Node B's data and vice versa.

### Before
- Delta consumer only started when `REPLICATION_MODE=replica`
- Partitioned nodes (`REPLICATION_MODE=primary` + `PARTITION_ID`) only saw their own data

### After  
- Delta consumer starts when `REPLICATION_MODE=replica` OR `PARTITION_ID` is set
- Every partitioned node writes to its tables AND reads from all partitions

## Test plan
- [x] `cargo test -p database` — 341 passed
- [x] `cargo check -p local_backend` — compiles