### PR TITLE
fix: filter system table updates from cross-node replication

### DIFF
--- a/crates/database/src/committer.rs
+++ b/crates/database/src/committer.rs
@@ -1039,6 +1039,29 @@ impl<RT: Runtime> Committer<RT> {
             delta.tablet_id_to_table_name.len(),
         );
 
+        // Filter out system table updates. Each node manages its own system
+        // tables independently — only user table data should be replicated.
+        let tablet_map = delta.tablet_id_to_table_name.clone();
+        let original_count = delta.document_updates.len();
+        let mut delta = delta;
+        delta.document_updates.retain(|update| {
+            let tablet_id = update.id.tablet_id;
+            match tablet_map.get(&tablet_id) {
+                Some(name) if name.is_system() => false,
+                _ => true,
+            }
+        });
+        if delta.document_updates.len() < original_count {
+            tracing::debug!(
+                "Filtered {} system table updates from delta",
+                original_count - delta.document_updates.len(),
+            );
+        }
+        if delta.document_updates.is_empty() {
+            tracing::debug!("Delta at ts={} has no user table updates, skipping", u64::from(commit_ts));
+            return Ok(commit_ts);
+        }
+
         // Helper: build remap from current snapshot state.
         let build_remap = |snapshot: &Snapshot, tablet_map: &BTreeMap<value::TabletId, value::TableName>| -> BTreeMap<value::TabletId, value::TabletId> {
             let mapping = snapshot.table_registry.table_mapping();


### PR DESCRIPTION
## Problem

When Node B boots and initializes system tables, it publishes those as deltas. Node A receives them and tries to apply — but Node A already has its own system tables. Result: "Tried to create duplicate table _external_deps_packages".

## Fix

Filter out system table updates in `apply_replica_delta`. Each node manages its own system tables independently. Only user table document updates (`messages`, `users`, `projects`, `tasks`) are replicated across nodes.

## Test plan

- [x] `cargo test -p database` — 341 passed