### PR TITLE
feat: wire global TSO and fix cross-partition delta replication

### DIFF
--- a/crates/application/src/test_helpers.rs
+++ b/crates/application/src/test_helpers.rs
@@ -221,6 +221,7 @@ impl<RT: Runtime> ApplicationTestExt<RT> for Application<RT> {
             Arc::new(database::commit_delta::NoopDistributedLog),
             false,
             None,
+            None,
         )
         .await?;
         initialize_application_system_tables(&database).await?;

--- a/crates/database/src/committer.rs
+++ b/crates/database/src/committer.rs
@@ -212,6 +212,12 @@ pub struct Committer<RT: Runtime> {
     // Partition map for write routing. Determines which tables this node owns.
     // None means single-partition mode (owns everything).
     partition_map: Option<crate::partition::PartitionMap>,
+
+    // Global timestamp oracle for multi-node deployments (TiDB PD pattern).
+    // When set, next_commit_ts() draws from the TSO instead of the local clock,
+    // ensuring globally unique timestamps across all nodes.
+    // None means single-node mode (local clock, existing behavior).
+    timestamp_oracle: Option<Arc<dyn crate::timestamp_oracle::TimestampOracle>>,
 }
 
 impl<RT: Runtime> Committer<RT> {
@@ -225,6 +231,7 @@ impl<RT: Runtime> Committer<RT> {
         virtual_system_mapping: VirtualSystemMapping,
         distributed_log: Arc<dyn DistributedLog>,
         partition_map: Option<crate::partition::PartitionMap>,
+        timestamp_oracle: Option<Arc<dyn crate::timestamp_oracle::TimestampOracle>>,
     ) -> CommitterClient {
         let persistence_reader = persistence.reader();
         let conflict_checker = PendingWrites::new();
@@ -243,6 +250,7 @@ impl<RT: Runtime> Committer<RT> {
             user_documents_size_gauge: user_documents_size_subgauge(),
             distributed_log,
             partition_map,
+            timestamp_oracle,
         };
         let handle = runtime.spawn("committer", async move {
             if let Err(err) = committer.go(rx).await {
@@ -322,7 +330,9 @@ impl<RT: Runtime> Committer<RT> {
                             let publish_commit_span = committer_span.as_ref().map(|root| Span::enter_with_parents("publish_commit", [root, &parent_span])).unwrap_or_else(|| parent_span);
                             let _guard = publish_commit_span.set_local_parent();
                             let commit_ts = pending_write.must_commit_ts();
-                            self.publish_commit(pending_write, write_bytes, document_writes, index_writes);
+                            self.publish_commit(
+                                pending_write, write_bytes, document_writes, index_writes,
+                            );
                             let _ = result.send(Ok(commit_ts));
 
                             // When we next get free cycles and there is no ongoing bump,
@@ -728,8 +738,8 @@ impl<RT: Runtime> Committer<RT> {
                     if !partition_map.is_local(&table_name) {
                         let partition = partition_map.partition_for_table(&table_name);
                         anyhow::bail!(
-                            "Write to table '{}' rejected: owned by {}, not this node ({}). \
-                             Route this mutation to the correct partition owner.",
+                            "Write to table '{}' rejected: owned by {}, not this node ({}). Route \
+                             this mutation to the correct partition owner.",
                             table_name,
                             partition,
                             partition_map.local_partition(),
@@ -754,18 +764,23 @@ impl<RT: Runtime> Committer<RT> {
             let begin_ts = *transaction.begin_timestamp;
             if latest_replicated_ts < begin_ts {
                 // Check if any reads are from remote partitions.
-                let has_remote_reads = transaction.reads.read_set().iter_indexed().any(|(index_name, _)| {
-                    let tablet_id = index_name.table();
-                    if let Ok(name) = transaction.table_mapping.tablet_name(*tablet_id) {
-                        !partition_map.is_local(&name)
-                    } else {
-                        false
-                    }
-                });
+                let has_remote_reads =
+                    transaction
+                        .reads
+                        .read_set()
+                        .iter_indexed()
+                        .any(|(index_name, _)| {
+                            let tablet_id = index_name.table();
+                            if let Ok(name) = transaction.table_mapping.tablet_name(*tablet_id) {
+                                !partition_map.is_local(&name)
+                            } else {
+                                false
+                            }
+                        });
                 if has_remote_reads {
                     tracing::warn!(
-                        "Cross-partition OCC: local replica behind (latest={}, begin={}). \
-                         Remote reads may miss conflicts. Proceeding with best-effort validation.",
+                        "Cross-partition OCC: local replica behind (latest={}, begin={}). Remote \
+                         reads may miss conflicts. Proceeding with best-effort validation.",
                         latest_replicated_ts,
                         begin_ts,
                     );
@@ -1031,16 +1046,27 @@ impl<RT: Runtime> Committer<RT> {
         };
         use value::ResolvedDocumentId;
 
-        let commit_ts = delta.ts;
+        // Use next_commit_ts() instead of the remote delta's timestamp.
+        // Even with a shared TSO, the receiving node may have already advanced
+        // past the remote timestamp (e.g., during init or from its own commits).
+        // The write log requires strictly increasing timestamps, so we must
+        // assign a locally-valid timestamp — same as how CockroachDB's apply
+        // loop assigns a local HLC timestamp when applying Raft proposals.
+        let remote_ts = delta.ts;
+        let commit_ts = self.next_commit_ts()?;
         tracing::info!(
-            "Applying replica delta: ts={}, {} document updates, {} tablet mappings",
+            "Applying replica delta: remote_ts={}, local_ts={}, {} document updates, {} tablet \
+             mappings",
+            u64::from(remote_ts),
             u64::from(commit_ts),
             delta.document_updates.len(),
             delta.tablet_id_to_table_name.len(),
         );
 
         // Helper: build remap from current snapshot state.
-        let build_remap = |snapshot: &Snapshot, tablet_map: &BTreeMap<value::TabletId, value::TableName>| -> BTreeMap<value::TabletId, value::TabletId> {
+        let build_remap = |snapshot: &Snapshot,
+                           tablet_map: &BTreeMap<value::TabletId, value::TableName>|
+         -> BTreeMap<value::TabletId, value::TabletId> {
             let mapping = snapshot.table_registry.table_mapping();
             let mut remap = BTreeMap::new();
             for (primary_id, name) in tablet_map {
@@ -1055,19 +1081,80 @@ impl<RT: Runtime> Committer<RT> {
             remap
         };
 
-        // Separate _tables updates from other updates.
-        // _tables updates create new tables and must be applied first.
+        // Classify each update as user-relevant or node-local.
+        //
+        // Like CockroachDB's separation of system descriptors (global) from
+        // node-local operational state: metadata that describes user tables
+        // must replicate globally, but each node's operational state is local.
+        //
+        // Categories:
+        //   1. _tables entries for user tables → Phase 1 (table creation)
+        //   2. _index entries for user tables → Phase 2 (index creation)
+        //   3. User table document data → Phase 2 (data replication)
+        //   4. Everything else (node-local system data) → SKIP
+        //
+        // The key insight: we classify by what the data DESCRIBES, not by
+        // which system table it's stored in. An _index entry creating
+        // "projects.by_id" is user table metadata even though _index is a
+        // system table.
+        use common::bootstrap_model::index::INDEX_TABLE;
+
         let tables_table_name: &value::TableName = &TABLES_TABLE;
+        let index_table_name: &value::TableName = &INDEX_TABLE;
         let mut tables_updates = Vec::new();
         let mut other_updates = Vec::new();
+        let mut skipped_system = 0usize;
+
         for update in &delta.document_updates {
             let primary_tablet = update.id.tablet_id;
             let table_name = delta.tablet_id_to_table_name.get(&primary_tablet);
+
             if table_name.map(|n| n == tables_table_name).unwrap_or(false) {
+                // _tables entry: kept for Phase 1 (user table creation).
+                // System table entries will be skipped in Phase 1 by the
+                // table_exists check.
                 tables_updates.push(update);
-            } else {
+            } else if table_name.map(|n| n == index_table_name).unwrap_or(false) {
+                // _index entry: check if it describes a user table index.
+                // Parse the table_id field from the document and check if
+                // it maps to a user table in the delta's tablet mapping.
+                let is_user_index = update.new_document.as_ref().map_or(false, |doc| {
+                    doc.value()
+                        .0
+                        .get(&"table_id".parse::<common::types::FieldName>().unwrap())
+                        .and_then(|v| {
+                            if let value::ConvexValue::String(s) = v {
+                                let tid: Result<value::TabletId, _> = s.parse();
+                                tid.ok()
+                            } else {
+                                None
+                            }
+                        })
+                        .map_or(false, |tid| {
+                            delta
+                                .tablet_id_to_table_name
+                                .get(&tid)
+                                .map_or(false, |name| !name.is_system())
+                        })
+                });
+                if is_user_index {
+                    other_updates.push(update);
+                } else {
+                    skipped_system += 1;
+                }
+            } else if table_name.map(|n| !n.is_system()).unwrap_or(false) {
+                // User table data: replicate.
                 other_updates.push(update);
+            } else {
+                // Node-local system data: skip.
+                skipped_system += 1;
             }
+        }
+        if skipped_system > 0 {
+            tracing::debug!(
+                "Filtered {} node-local system updates from delta",
+                skipped_system,
+            );
         }
 
         let mut snapshot = self.snapshot_manager.read().latest_snapshot();
@@ -1075,20 +1162,116 @@ impl<RT: Runtime> Committer<RT> {
         let mut all_index_updates = Vec::new();
 
         // Phase 1: Apply _tables updates (creates new tables).
+        //
+        // Each node assigns table numbers independently (like CockroachDB's
+        // non-transactional descriptor ID allocator or TiDB's PD global ID).
+        // When replicating a _tables entry from another node, the remote
+        // table number may collide with a different local table. We reassign
+        // the table number to a locally-unique value, preserving only the
+        // table name and TabletId (derived from developer_id) for remapping.
         if !tables_updates.is_empty() {
+            use common::document::CreationTime;
+            use value::{
+                ConvexObject,
+                TableNamespace,
+                TableNumber,
+            };
+
             let remap = build_remap(&snapshot, &delta.tablet_id_to_table_name);
+            let mapping = snapshot.table_registry.table_mapping();
+
+            // Find the next available user table number by scanning local tables.
+            // User table numbers start above NUM_RESERVED_SYSTEM_TABLE_NUMBERS (10000).
+            let max_local_number: u32 = mapping
+                .iter()
+                .map(|(_, _, num, _)| u32::from(num))
+                .max()
+                .unwrap_or(10000);
+            let mut next_number = max_local_number + 1;
+
             for update in &tables_updates {
                 let primary_tablet = update.id.tablet_id;
                 let local_tablet = match remap.get(&primary_tablet) {
                     Some(t) => *t,
                     None => continue,
                 };
-                let remapped = DocumentUpdate {
-                    id: ResolvedDocumentId { tablet_id: local_tablet, developer_id: update.id.developer_id },
-                    old_document: update.old_document.as_ref().map(|d| d.to_remapped(local_tablet)),
-                    new_document: update.new_document.as_ref().map(|d| d.to_remapped(local_tablet)),
+
+                // Parse the TableMetadata to check if the table already exists
+                // locally and to reassign the table number if needed.
+                let new_doc = match &update.new_document {
+                    Some(d) => d,
+                    None => {
+                        // Deletion — remap and apply directly.
+                        let remapped = DocumentUpdate {
+                            id: ResolvedDocumentId {
+                                tablet_id: local_tablet,
+                                developer_id: update.id.developer_id,
+                            },
+                            old_document: update
+                                .old_document
+                                .as_ref()
+                                .map(|d| d.to_remapped(local_tablet)),
+                            new_document: None,
+                        };
+                        let (idx_updates, ..) = snapshot.update(&remapped, commit_ts)?;
+                        all_index_updates.extend(idx_updates);
+                        all_remapped_updates.push(remapped);
+                        continue;
+                    },
                 };
-                let (idx_updates, _, _) = snapshot.update(&remapped, commit_ts)?;
+
+                let metadata: TableMetadata = new_doc.value().0.clone().try_into()?;
+
+                // If the table already exists locally by name, skip this update.
+                // Each node may have independently created the same table.
+                if snapshot
+                    .table_registry
+                    .table_exists(metadata.namespace, &metadata.name)
+                {
+                    tracing::debug!(
+                        "Skipping _tables update for '{}': already exists locally",
+                        metadata.name,
+                    );
+                    continue;
+                }
+
+                // Reassign the table number to avoid collisions with local tables.
+                // This is the same pattern as CockroachDB's descriptor ID allocator:
+                // each node picks the next available number locally.
+                let local_number = TableNumber::try_from(next_number)?;
+                next_number += 1;
+                let local_metadata = TableMetadata::new_with_state(
+                    metadata.namespace,
+                    metadata.name.clone(),
+                    local_number,
+                    metadata.state,
+                );
+                let local_value: ConvexObject = local_metadata.try_into()?;
+
+                tracing::info!(
+                    "Creating replicated table '{}' with local number {} (remote was {})",
+                    metadata.name,
+                    u32::from(local_number),
+                    u32::from(metadata.number),
+                );
+
+                // Build a new ResolvedDocument with the remapped tablet ID and
+                // the locally-assigned table number.
+                let remapped_id = ResolvedDocumentId {
+                    tablet_id: local_tablet,
+                    developer_id: update.id.developer_id,
+                };
+                let remapped_doc =
+                    ResolvedDocument::new(remapped_id, new_doc.creation_time(), local_value)?;
+                let remapped = DocumentUpdate {
+                    id: remapped_id,
+                    old_document: update
+                        .old_document
+                        .as_ref()
+                        .map(|d| d.to_remapped(local_tablet)),
+                    new_document: Some(remapped_doc),
+                };
+                let (idx_updates, ..) = snapshot.update(&remapped, commit_ts)?;
                 all_index_updates.extend(idx_updates);
                 all_remapped_updates.push(remapped);
             }
@@ -1112,11 +1295,20 @@ impl<RT: Runtime> Committer<RT> {
                 },
             };
             let remapped = DocumentUpdate {
-                id: ResolvedDocumentId { tablet_id: local_tablet, developer_id: update.id.developer_id },
-                old_document: update.old_document.as_ref().map(|d| d.to_remapped(local_tablet)),
-                new_document: update.new_document.as_ref().map(|d| d.to_remapped(local_tablet)),
+                id: ResolvedDocumentId {
+                    tablet_id: local_tablet,
+                    developer_id: update.id.developer_id,
+                },
+                old_document: update
+                    .old_document
+                    .as_ref()
+                    .map(|d| d.to_remapped(local_tablet)),
+                new_document: update
+                    .new_document
+                    .as_ref()
+                    .map(|d| d.to_remapped(local_tablet)),
             };
-            let (idx_updates, _, _) = snapshot.update(&remapped, commit_ts)?;
+            let (idx_updates, ..) = snapshot.update(&remapped, commit_ts)?;
             all_index_updates.extend(idx_updates);
             all_remapped_updates.push(remapped);
         }
@@ -1127,10 +1319,7 @@ impl<RT: Runtime> Committer<RT> {
             .iter()
             .map(|update| DocumentLogEntry {
                 ts: commit_ts,
-                id: value::InternalDocumentId::new(
-                    update.id.tablet_id,
-                    update.id.internal_id(),
-                ),
+                id: value::InternalDocumentId::new(update.id.tablet_id, update.id.internal_id()),
                 value: update.new_document.clone(),
                 prev_ts: None,
             })
@@ -1435,6 +1624,29 @@ impl<RT: Runtime> Committer<RT> {
 
     fn next_commit_ts(&mut self) -> anyhow::Result<Timestamp> {
         let _timer = next_commit_ts_seconds();
+
+        // When a global TSO is configured (TiDB PD pattern), draw timestamps
+        // from it instead of the local clock. This ensures globally unique,
+        // monotonically increasing timestamps across all nodes in the cluster.
+        // The BatchTimestampOracle's fast path is a local mutex increment
+        // (zero network calls), so block_in_place is safe here.
+        if let Some(ref tso) = self.timestamp_oracle {
+            let tso = tso.clone();
+            let ts = block_in_place(|| {
+                let rt = tokio::runtime::Handle::current();
+                rt.block_on(tso.next_ts())
+            })?;
+            // Still enforce local monotonicity against snapshot and last_assigned.
+            let latest_ts = self.snapshot_manager.read().latest_ts();
+            let max = cmp::max(
+                ts,
+                cmp::max(latest_ts.succ()?, self.last_assigned_ts.succ()?),
+            );
+            self.last_assigned_ts = max;
+            return Ok(max);
+        }
+
+        // Single-node mode: existing behavior (local clock + monotonic counter).
         let latest_ts = self.snapshot_manager.read().latest_ts();
         let max = cmp::max(
             latest_ts.succ()?,

--- a/crates/database/src/database.rs
+++ b/crates/database/src/database.rs
@@ -979,6 +979,7 @@ impl<RT: Runtime> Database<RT> {
         distributed_log: Arc<dyn crate::commit_delta::DistributedLog>,
         replica_mode: bool,
         partition_map: Option<crate::partition::PartitionMap>,
+        timestamp_oracle: Option<Arc<dyn crate::timestamp_oracle::TimestampOracle>>,
     ) -> anyhow::Result<Self> {
         let _load_database_timer = metrics::load_database_timer();
 
@@ -1054,8 +1055,12 @@ impl<RT: Runtime> Database<RT> {
         // In replica mode, we use NoopDistributedLog for the Committer since
         // the Replica should not re-publish deltas it receives.
         let committer_distributed_log = if replica_mode {
-            tracing::info!("Database loading in replica mode — Committer will handle local initialization, then tail distributed log from ts={ts}");
-            Arc::new(crate::commit_delta::NoopDistributedLog) as Arc<dyn crate::commit_delta::DistributedLog>
+            tracing::info!(
+                "Database loading in replica mode — Committer will handle local initialization, \
+                 then tail distributed log from ts={ts}"
+            );
+            Arc::new(crate::commit_delta::NoopDistributedLog)
+                as Arc<dyn crate::commit_delta::DistributedLog>
         } else {
             distributed_log.clone()
         };
@@ -1069,6 +1074,7 @@ impl<RT: Runtime> Database<RT> {
             virtual_system_mapping.clone(),
             committer_distributed_log,
             partition_map,
+            timestamp_oracle,
         );
         let table_mapping_snapshot_cache =
             AsyncLru::new(runtime.clone(), 20, 2, "table_mapping_snapshot");
@@ -1159,8 +1165,9 @@ impl<RT: Runtime> Database<RT> {
     /// See PersistenceReader.load_documents_from_table for performance caveats!
     ///
     /// rate_limiter must be based on rows per second.
-    /// Get a clone of the CommitterClient for sending messages to the Committer.
-    /// Used by the ReplicaDeltaConsumer to feed deltas through the apply loop.
+    /// Get a clone of the CommitterClient for sending messages to the
+    /// Committer. Used by the ReplicaDeltaConsumer to feed deltas through
+    /// the apply loop.
     pub fn committer_client(&self) -> CommitterClient {
         self.committer.clone()
     }

--- a/crates/database/src/nats_distributed_log.rs
+++ b/crates/database/src/nats_distributed_log.rs
@@ -39,8 +39,9 @@ use crate::{
 
 const STREAM_NAME: &str = "CONVEX_COMMITS";
 /// Base subject for commit deltas. In single-partition mode, publishes to
-/// "convex.commits". In partitioned mode, publishes to "convex.commits.{partition_id}".
-/// The stream subscribes to "convex.commits.>" to capture all partitions.
+/// "convex.commits". In partitioned mode, publishes to
+/// "convex.commits.{partition_id}". The stream subscribes to "convex.commits.>"
+/// to capture all partitions.
 const SUBJECT_BASE: &str = "convex.commits";
 
 /// Configuration for connecting to NATS.
@@ -86,10 +87,7 @@ impl NatsDistributedLog {
         let stream = jetstream
             .get_or_create_stream(jetstream::stream::Config {
                 name: STREAM_NAME.to_string(),
-                subjects: vec![
-                    format!("{SUBJECT_BASE}"),
-                    format!("{SUBJECT_BASE}.>"),
-                ],
+                subjects: vec![format!("{SUBJECT_BASE}"), format!("{SUBJECT_BASE}.>")],
                 retention: jetstream::stream::RetentionPolicy::Limits,
                 max_age: std::time::Duration::from_secs(86400),
                 storage: jetstream::stream::StorageType::File,
@@ -101,13 +99,16 @@ impl NatsDistributedLog {
         // Verify the stream is accessible.
         let mut stream = stream;
         let info = stream.info().await.context("Failed to get stream info")?;
-        let consumer_name = config.consumer_name.unwrap_or_else(|| "convex-node".to_string());
+        let consumer_name = config
+            .consumer_name
+            .unwrap_or_else(|| "convex-node".to_string());
         let publish_subject = match config.partition_id {
             Some(id) => format!("{SUBJECT_BASE}.{id}"),
             None => SUBJECT_BASE.to_string(),
         };
         tracing::info!(
-            "Connected to NATS JetStream at {}. Stream '{}': {} messages, {} bytes. Consumer: {}, Publish subject: {}",
+            "Connected to NATS JetStream at {}. Stream '{}': {} messages, {} bytes. Consumer: {}, \
+             Publish subject: {}",
             config.url,
             STREAM_NAME,
             info.state.messages,
@@ -116,7 +117,12 @@ impl NatsDistributedLog {
             publish_subject,
         );
 
-        Ok(Self { jetstream, stream, consumer_name, publish_subject })
+        Ok(Self {
+            jetstream,
+            stream,
+            consumer_name,
+            publish_subject,
+        })
     }
 }
 
@@ -152,7 +158,7 @@ impl DeltaEnvelope {
         let tablet_mapping = delta
             .tablet_id_to_table_name
             .iter()
-            .map(|(id, name)| (hex::encode(id.0.0), name.to_string()))
+            .map(|(id, name)| (hex::encode(id.0 .0), name.to_string()))
             .collect();
 
         Ok(Self {
@@ -211,8 +217,7 @@ impl DistributedLog for NatsDistributedLog {
         let num_updates = delta.document_updates.len();
 
         let envelope = DeltaEnvelope::from_delta(&delta, &self.consumer_name)?;
-        let payload =
-            serde_json::to_vec(&envelope).context("Failed to serialize CommitDelta")?;
+        let payload = serde_json::to_vec(&envelope).context("Failed to serialize CommitDelta")?;
         let payload_size = payload.len();
 
         // Publish and wait for acknowledgment from NATS server.
@@ -276,44 +281,42 @@ impl DistributedLog for NatsDistributedLog {
         let stream = messages.filter_map(move |msg_result| {
             let node_name = self_node_name.clone();
             async move {
-            match msg_result {
-                Ok(msg) => {
-                    if let Err(e) = msg.ack().await {
-                        tracing::warn!("Failed to ack NATS message: {e:?}");
-                    }
-                    let envelope: DeltaEnvelope = match serde_json::from_slice(&msg.payload) {
-                        Ok(e) => e,
-                        Err(e) => {
-                            tracing::error!("Failed to deserialize delta from NATS: {e}");
-                            return Some(Err(anyhow::anyhow!(
-                                "Failed to deserialize delta: {e}"
-                            )));
-                        },
-                    };
-                    if envelope.ts <= from_ts_u64 {
-                        return None;
-                    }
-                    // Skip deltas published by this node to avoid double-applying.
-                    if !envelope.source_node.is_empty() && envelope.source_node == node_name {
+                match msg_result {
+                    Ok(msg) => {
+                        if let Err(e) = msg.ack().await {
+                            tracing::warn!("Failed to ack NATS message: {e:?}");
+                        }
+                        let envelope: DeltaEnvelope = match serde_json::from_slice(&msg.payload) {
+                            Ok(e) => e,
+                            Err(e) => {
+                                tracing::error!("Failed to deserialize delta from NATS: {e}");
+                                return Some(Err(anyhow::anyhow!(
+                                    "Failed to deserialize delta: {e}"
+                                )));
+                            },
+                        };
+                        if envelope.ts <= from_ts_u64 {
+                            return None;
+                        }
+                        // Skip deltas published by this node to avoid double-applying.
+                        if !envelope.source_node.is_empty() && envelope.source_node == node_name {
+                            tracing::debug!("Skipping self-published delta at ts={}", envelope.ts,);
+                            return None;
+                        }
                         tracing::debug!(
-                            "Skipping self-published delta at ts={}",
+                            "Received commit delta from NATS: ts={}, source={}",
                             envelope.ts,
+                            envelope.source_node,
                         );
-                        return None;
-                    }
-                    tracing::debug!(
-                        "Received commit delta from NATS: ts={}, source={}",
-                        envelope.ts,
-                        envelope.source_node,
-                    );
-                    Some(envelope.to_delta())
-                },
-                Err(e) => {
-                    tracing::error!("NATS message error: {e}");
-                    Some(Err(anyhow::anyhow!("NATS message error: {e}")))
-                },
+                        Some(envelope.to_delta())
+                    },
+                    Err(e) => {
+                        tracing::error!("NATS message error: {e}");
+                        Some(Err(anyhow::anyhow!("NATS message error: {e}")))
+                    },
+                }
             }
-        }});
+        });
 
         Ok(Box::pin(stream))
     }

--- a/crates/database/src/test_helpers/db_fixtures.rs
+++ b/crates/database/src/test_helpers/db_fixtures.rs
@@ -100,6 +100,7 @@ impl<RT: Runtime> DbFixtures<RT> {
             Arc::new(crate::commit_delta::NoopDistributedLog),
             false,
             None,
+            None,
         )
         .await?;
         db.set_search_storage(search_storage.clone());

--- a/crates/database/src/tests/mod.rs
+++ b/crates/database/src/tests/mod.rs
@@ -137,6 +137,7 @@ mod search_index_backfill_tests;
 mod streaming_export_tests;
 mod usage_tracking;
 mod vector_tests;
+mod write_scaling_tests;
 
 mod apply_function_runner_tx;
 pub mod text_test_utils;

--- a/crates/database/src/tests/replication_tests.rs
+++ b/crates/database/src/tests/replication_tests.rs
@@ -42,6 +42,7 @@ async fn test_primary_commit_publishes_delta(rt: TestRuntime) -> anyhow::Result<
         distributed_log.clone(),
         false,
         None,
+        None,
     )
     .await?;
     primary.set_search_storage(Arc::new(LocalDirStorage::new(rt.clone())?));
@@ -67,11 +68,9 @@ async fn test_primary_commit_publishes_delta(rt: TestRuntime) -> anyhow::Result<
     );
 
     // Find a delta that contains our document update (new_document is Some).
-    let has_doc_update = deltas.iter().any(|d| {
-        d.document_updates
-            .iter()
-            .any(|u| u.new_document.is_some())
-    });
+    let has_doc_update = deltas
+        .iter()
+        .any(|d| d.document_updates.iter().any(|u| u.new_document.is_some()));
     assert!(has_doc_update, "Expected a delta with a document insert");
 
     Ok(())

--- a/crates/database/src/tests/write_scaling_tests.rs
+++ b/crates/database/src/tests/write_scaling_tests.rs
@@ -1,0 +1,124 @@
+//! Write Scaling Unit Tests
+//!
+//! Tests partition ownership enforcement (Vitess Single mode pattern).
+//! Cross-partition replication tests run against the live Docker deployment
+//! via self-hosted/docker/test-write-scaling.sh (CockroachDB roachtest
+//! pattern).
+
+use std::sync::Arc;
+
+use common::{
+    assert_obj,
+    runtime::{
+        new_unlimited_rate_limiter,
+        testing::TestRuntime,
+    },
+    shutdown::ShutdownSignal,
+    testing::TestPersistence,
+};
+use keybroker::Identity;
+use search::searcher::SearcherStub;
+use storage::LocalDirStorage;
+use value::TableName;
+
+use crate::{
+    commit_delta::testing::InMemoryDistributedLog,
+    partition::{
+        PartitionId,
+        PartitionMap,
+    },
+    Database,
+    TestFacingModel,
+};
+
+async fn create_node(
+    rt: &TestRuntime,
+    distributed_log: Arc<InMemoryDistributedLog>,
+    partition_map: Option<PartitionMap>,
+) -> anyhow::Result<Database<TestRuntime>> {
+    let tp = Arc::new(TestPersistence::new());
+    let searcher: Arc<dyn search::Searcher> = Arc::new(SearcherStub {});
+    let (deleted_tablet_sender, _) = tokio::sync::mpsc::channel(100);
+    let db = Database::load(
+        tp,
+        rt.clone(),
+        searcher,
+        ShutdownSignal::panic(),
+        Default::default(),
+        None,
+        Arc::new(new_unlimited_rate_limiter(rt.clone())),
+        deleted_tablet_sender,
+        distributed_log,
+        false,
+        partition_map,
+        None,
+    )
+    .await?;
+    db.set_search_storage(Arc::new(LocalDirStorage::new(rt.clone())?));
+    let handle = db.start_search_and_vector_bootstrap();
+    handle.join().await?;
+    Ok(db)
+}
+
+async fn insert_doc(
+    db: &Database<TestRuntime>,
+    table: &str,
+    fields: common::value::ConvexObject,
+) -> anyhow::Result<common::types::Timestamp> {
+    let table_name: TableName = table.parse()?;
+    let mut tx = db.begin(Identity::system()).await?;
+    TestFacingModel::new(&mut tx)
+        .insert(&table_name, fields)
+        .await?;
+    db.commit(tx).await
+}
+
+/// Vitess Single mode pattern: writes to non-owned tables must be rejected
+/// with a clear error identifying the correct partition owner.
+#[convex_macro::test_runtime]
+async fn test_partition_enforcement(rt: TestRuntime) -> anyhow::Result<()> {
+    let log = Arc::new(InMemoryDistributedLog::new());
+
+    let node_a = create_node(
+        &rt,
+        log.clone(),
+        Some(PartitionMap::from_config(
+            "messages=0,projects=1",
+            PartitionId(0),
+            2,
+        )),
+    )
+    .await?;
+    let node_b = create_node(
+        &rt,
+        log.clone(),
+        Some(PartitionMap::from_config(
+            "messages=0,projects=1",
+            PartitionId(1),
+            2,
+        )),
+    )
+    .await?;
+
+    // Node A writing to projects (owned by partition 1) — must fail.
+    let result_a = insert_doc(&node_a, "projects", assert_obj!("name" => "wrong")).await;
+    assert!(result_a.is_err(), "Node A should reject write to projects");
+    assert!(
+        result_a.unwrap_err().to_string().contains("partition-1"),
+        "Error should mention the owning partition"
+    );
+
+    // Node B writing to messages (owned by partition 0) — must fail.
+    let result_b = insert_doc(&node_b, "messages", assert_obj!("text" => "wrong")).await;
+    assert!(result_b.is_err(), "Node B should reject write to messages");
+    assert!(
+        result_b.unwrap_err().to_string().contains("partition-0"),
+        "Error should mention the owning partition"
+    );
+
+    // Correct-partition writes succeed.
+    insert_doc(&node_a, "messages", assert_obj!("text" => "correct")).await?;
+    insert_doc(&node_b, "projects", assert_obj!("name" => "correct")).await?;
+
+    Ok(())
+}

--- a/crates/database/src/timestamp_oracle.rs
+++ b/crates/database/src/timestamp_oracle.rs
@@ -18,8 +18,8 @@
 //!
 //! - [`LocalTimestampOracle`]: Wraps the existing Committer logic for
 //!   single-node deployments. No behavior change.
-//! - [`BatchTimestampOracle`]: Reserves batches from NATS KV for
-//!   multi-node deployments.
+//! - [`BatchTimestampOracle`]: Reserves batches from NATS KV for multi-node
+//!   deployments.
 
 use std::sync::Arc;
 
@@ -133,10 +133,7 @@ const DEFAULT_BATCH_SIZE: u64 = 1000;
 
 impl BatchTimestampOracle {
     /// Connect to NATS and initialize the KV bucket for timestamp allocation.
-    pub async fn connect(
-        nats_url: &str,
-        batch_size: Option<u64>,
-    ) -> anyhow::Result<Self> {
+    pub async fn connect(nats_url: &str, batch_size: Option<u64>) -> anyhow::Result<Self> {
         // Reuse the crypto provider if already installed.
         let _ = rustls::crypto::ring::default_provider().install_default();
 
@@ -163,7 +160,10 @@ impl BatchTimestampOracle {
             .as_nanos() as u64;
 
         // Try to create the key. If it already exists, that's fine.
-        match kv.create(TSO_COUNTER_KEY, initial_ts.to_be_bytes().to_vec().into()).await {
+        match kv
+            .create(TSO_COUNTER_KEY, initial_ts.to_be_bytes().to_vec().into())
+            .await
+        {
             Ok(_) => tracing::info!("TSO: Initialized counter at {initial_ts}"),
             Err(_) => tracing::info!("TSO: Counter already exists"),
         }
@@ -204,8 +204,11 @@ impl BatchTimestampOracle {
                 .context("TSO: Counter key not found")?;
 
             let current_value = u64::from_be_bytes(
-                entry.value.as_ref().try_into()
-                    .context("TSO: Invalid counter value")?
+                entry
+                    .value
+                    .as_ref()
+                    .try_into()
+                    .context("TSO: Invalid counter value")?,
             );
 
             let new_lower = current_value;
@@ -214,7 +217,10 @@ impl BatchTimestampOracle {
 
             // Atomic compare-and-swap: only succeeds if no other node
             // modified the counter since we read it.
-            match kv.update(TSO_COUNTER_KEY, new_value.into(), entry.revision).await {
+            match kv
+                .update(TSO_COUNTER_KEY, new_value.into(), entry.revision)
+                .await
+            {
                 Ok(_) => {
                     tracing::info!(
                         "TSO: Reserved batch [{new_lower}, {new_upper}) on attempt {attempt}"
@@ -267,8 +273,11 @@ impl TimestampOracle for BatchTimestampOracle {
         match kv.entry(TSO_MAX_COMMITTED_KEY).await? {
             Some(entry) => {
                 let ts = u64::from_be_bytes(
-                    entry.value.as_ref().try_into()
-                        .context("TSO: Invalid max_committed value")?
+                    entry
+                        .value
+                        .as_ref()
+                        .try_into()
+                        .context("TSO: Invalid max_committed value")?,
                 );
                 Timestamp::try_from(ts)
             },

--- a/crates/local_backend/src/lib.rs
+++ b/crates/local_backend/src/lib.rs
@@ -14,6 +14,11 @@ use ::authentication::{
     access_token_auth::NullAccessTokenAuth,
     application_auth::ApplicationAuth,
 };
+use ::storage::{
+    LocalDirStorage,
+    Storage,
+    StorageUseCase,
+};
 use application::{
     self,
     api::ApplicationApi,
@@ -58,11 +63,6 @@ use function_runner::{
     FunctionRunner,
 };
 use governor::Quota;
-use ::storage::{
-    LocalDirStorage,
-    Storage,
-    StorageUseCase,
-};
 use http_client::CachedHttpClient;
 use indexing::index_cache::SharedIndexCache;
 use model::{
@@ -98,11 +98,11 @@ pub mod environment_variables;
 pub mod http_actions;
 pub mod log_sinks;
 pub mod logs;
+pub mod mutation_forwarder;
 pub mod node_action_callbacks;
 pub mod parse;
 pub mod proxy;
 pub mod public_api;
-pub mod mutation_forwarder;
 pub mod router;
 pub mod scheduling;
 pub mod schema;
@@ -164,19 +164,37 @@ pub async fn make_app(
     let (deleted_tablet_sender, deleted_tablet_receiver) = tokio::sync::mpsc::channel(100);
     let usage_event_logger = Arc::new(NoOpUsageEventLogger);
     // Set up distributed log based on replication mode.
-    let distributed_log: Arc<dyn database::commit_delta::DistributedLog> =
-        if let Some(nats_url) = &config.nats_url {
-            let nats_config = database::nats_distributed_log::NatsConfig {
-                url: nats_url.clone(),
-                consumer_name: Some(config.name()),
-                partition_id: config.partition_id,
-            };
-            Arc::new(
-                database::nats_distributed_log::NatsDistributedLog::connect(nats_config).await?,
-            )
-        } else {
-            Arc::new(database::commit_delta::NoopDistributedLog)
+    let distributed_log: Arc<dyn database::commit_delta::DistributedLog> = if let Some(nats_url) =
+        &config.nats_url
+    {
+        let nats_config = database::nats_distributed_log::NatsConfig {
+            url: nats_url.clone(),
+            consumer_name: Some(config.name()),
+            partition_id: config.partition_id,
         };
+        Arc::new(database::nats_distributed_log::NatsDistributedLog::connect(nats_config).await?)
+    } else {
+        Arc::new(database::commit_delta::NoopDistributedLog)
+    };
+
+    // Set up the global Timestamp Oracle (TSO) for multi-node deployments.
+    // Like TiDB's PD, this ensures globally unique timestamps across nodes.
+    // In single-node mode, None falls back to the local clock.
+    let timestamp_oracle: Option<Arc<dyn database::timestamp_oracle::TimestampOracle>> = if config
+        .partition_id
+        .is_some()
+    {
+        if let Some(nats_url) = &config.nats_url {
+            let tso =
+                database::timestamp_oracle::BatchTimestampOracle::connect(nats_url, None).await?;
+            tracing::info!("Using BatchTimestampOracle (TiDB PD pattern) for global timestamps");
+            Some(Arc::new(tso))
+        } else {
+            None
+        }
+    } else {
+        None
+    };
 
     let database = Database::load(
         persistence.clone(),
@@ -201,12 +219,15 @@ pub async fn make_app(
                 num_partitions,
             )
         }),
+        timestamp_oracle,
     )
     .await?;
     initialize_application_system_tables(&database).await?;
     let application_storage = if config.replication_mode == "replica" {
         // Replica uses local storage — doesn't write storage config to DB.
-        let replica_path = config.replica_storage_path.as_ref()
+        let replica_path = config
+            .replica_storage_path
+            .as_ref()
             .ok_or_else(|| anyhow::anyhow!("REPLICA_STORAGE_PATH is required in replica mode"))?;
         let (storage, search_storage) =
             application::ApplicationStorage::new_local(runtime.clone(), replica_path)?;
@@ -233,15 +254,14 @@ pub async fn make_app(
 
     // Start the SnapshotCheckpointer on the Primary when NATS is configured.
     if config.replication_mode == "primary" && config.nats_url.is_some() {
-        let checkpoint_path = config.checkpoint_storage_path.as_ref()
-            .ok_or_else(|| anyhow::anyhow!("CHECKPOINT_STORAGE_PATH is required in primary mode with NATS_URL"))?;
-        let checkpoint_storage: Arc<dyn Storage> = Arc::new(
-            LocalDirStorage::for_use_case(
-                runtime.clone(),
-                checkpoint_path,
-                StorageUseCase::Checkpoints,
-            )?,
-        );
+        let checkpoint_path = config.checkpoint_storage_path.as_ref().ok_or_else(|| {
+            anyhow::anyhow!("CHECKPOINT_STORAGE_PATH is required in primary mode with NATS_URL")
+        })?;
+        let checkpoint_storage: Arc<dyn Storage> = Arc::new(LocalDirStorage::for_use_case(
+            runtime.clone(),
+            checkpoint_path,
+            StorageUseCase::Checkpoints,
+        )?);
         let _checkpointer = database::snapshot_checkpointer::SnapshotCheckpointer::start(
             runtime.clone(),
             persistence.reader(),
@@ -335,29 +355,50 @@ pub async fn make_app(
         runtime.spawn_background("beacon_worker", beacon_future);
     }
 
-    // Start the ReplicaDeltaConsumer to tail NATS and apply deltas from other nodes.
-    // Runs on:
+    // Start the ReplicaDeltaConsumer to tail NATS and apply deltas from other
+    // nodes. Runs on:
     //   - Replicas (REPLICATION_MODE=replica): consumes Primary's deltas
     //   - Partitioned writers (PARTITION_ID set): consumes other partitions' deltas
     // Creates a fresh NATS connection dedicated to the consumer.
-    let needs_delta_consumer = config.replication_mode == "replica" || config.partition_id.is_some();
+    let needs_delta_consumer =
+        config.replication_mode == "replica" || config.partition_id.is_some();
     if needs_delta_consumer {
         if let Some(nats_url) = &config.nats_url {
             let nats_url = nats_url.clone();
             let committer = database.committer_client();
-            let from_ts = *database.now_ts_for_reads();
+            // In partitioned mode, start consuming from the beginning of the
+            // stream. Each node has its own database with independent timestamps,
+            // so we can't use the local database timestamp as a lower bound.
+            // The self-delta skip (source_node filter) prevents double-applying.
+            // In replica mode, use the local timestamp since the replica loaded
+            // from the same persistence as the primary.
+            let from_ts = if config.partition_id.is_some() {
+                common::types::Timestamp::MIN
+            } else {
+                *database.now_ts_for_reads()
+            };
             let consumer_name = config.name();
             runtime.spawn_background("replica_delta_consumer_setup", async move {
-                let consumer_nats = match database::nats_distributed_log::NatsDistributedLog::connect(
-                    database::nats_distributed_log::NatsConfig { url: nats_url, consumer_name: Some(consumer_name), partition_id: None },
-                ).await {
-                    Ok(n) => Arc::new(n),
-                    Err(e) => {
-                        tracing::error!("Failed to connect NATS for ReplicaDeltaConsumer: {e:#}");
-                        return;
-                    },
-                };
-                let consumer_nats_dyn: Arc<dyn database::commit_delta::DistributedLog> = consumer_nats;
+                let consumer_nats =
+                    match database::nats_distributed_log::NatsDistributedLog::connect(
+                        database::nats_distributed_log::NatsConfig {
+                            url: nats_url,
+                            consumer_name: Some(consumer_name),
+                            partition_id: None,
+                        },
+                    )
+                    .await
+                    {
+                        Ok(n) => Arc::new(n),
+                        Err(e) => {
+                            tracing::error!(
+                                "Failed to connect NATS for ReplicaDeltaConsumer: {e:#}"
+                            );
+                            return;
+                        },
+                    };
+                let consumer_nats_dyn: Arc<dyn database::commit_delta::DistributedLog> =
+                    consumer_nats;
                 tracing::info!("ReplicaDeltaConsumer subscribing to NATS...");
                 match consumer_nats_dyn.subscribe(from_ts.into()).await {
                     Ok(mut stream) => {
@@ -368,8 +409,15 @@ pub async fn make_app(
                                     let ts = delta.ts;
                                     let n = delta.document_updates.len();
                                     match committer.apply_replica_delta(delta).await {
-                                        Ok(_) => tracing::info!("Applied replica delta: ts={}, {} updates", u64::from(ts), n),
-                                        Err(e) => tracing::error!("Failed to apply delta at ts={}: {e:#}", u64::from(ts)),
+                                        Ok(_) => tracing::info!(
+                                            "Applied replica delta: ts={}, {} updates",
+                                            u64::from(ts),
+                                            n
+                                        ),
+                                        Err(e) => tracing::error!(
+                                            "Failed to apply delta at ts={}: {e:#}",
+                                            u64::from(ts)
+                                        ),
                                     }
                                 },
                                 Err(e) => tracing::error!("Error reading NATS delta: {e:#}"),

--- a/docs/write-scaling-tests.md
+++ b/docs/write-scaling-tests.md
@@ -1,0 +1,158 @@
+# Write Scaling Tests: Verifying Partitioned Multi-Writer Architecture
+
+Based on how CockroachDB, TiDB, and Vitess test their distributed read/write scaling.
+
+## Test Matrix
+
+All three systems test across the same core categories. We implement the ones applicable to our architecture.
+
+| # | Test | Source | CockroachDB | TiDB | Vitess | Ours |
+|---|------|--------|-------------|------|--------|------|
+| 1 | Cross-partition data verification | Vitess VDiff | - | - | VDiff row-by-row | test 1 |
+| 2 | Bank invariant (single table) | Jepsen bank | bank workload | bank test | - | test 2 |
+| 3 | Bank invariant (multi-table) | TiDB bank-multitable | - | bank-multitable | - | test 3 |
+| 4 | Partition enforcement | Vitess Single mode | - | - | reject cross-shard | test 4 |
+| 5 | Concurrent write scaling | CockroachDB KV | KV 95 benchmark | sysbench | - | test 5 |
+| 6 | Monotonic reads | TiDB monotonic | sequential check | monotonic register | - | test 6 |
+| 7 | Node restart recovery | CockroachDB nemesis | node crash test | kill -9 + verify | - | test 7 |
+| 8 | Idempotent re-run | CockroachDB workload check | workload check | - | - | test 8 |
+
+## Test Descriptions
+
+### Test 1: Cross-Partition Data Verification (Vitess VDiff)
+
+Vitess uses VDiff to row-by-row compare data between source and target shards after MoveTables or resharding. Our equivalent: write data to each partition, verify all data visible from every node.
+
+**What it proves**: NATS delta replication correctly propagates user table data across partitions, including table creation (via `_tables`), index creation (via `_index`), and document data.
+
+**How it works**:
+1. Write messages and users to Node A (partition 0)
+2. Write projects and tasks to Node B (partition 1)
+3. Wait for NATS replication
+4. Query dashboard from both nodes
+5. Both must return identical counts
+
+**Source**: [Vitess VDiff](https://vitess.io/blog/2022-11-22-vdiff-v2/)
+
+### Test 2: Bank Invariant — Single Table (CockroachDB Jepsen)
+
+CockroachDB's bank workload creates N accounts with known initial balances, then runs concurrent transfers between random accounts across nodes. The invariant: total balance is always preserved.
+
+**What it proves**: Numeric invariants are preserved across replication. No data created or destroyed.
+
+**How it works**:
+1. Create projects with known budgets on Node B
+2. Wait for replication
+3. Sum budgets from Node A's view and Node B's view
+4. Both must return the same total
+
+**Source**: [Jepsen CockroachDB bank test](https://jepsen.io/analyses/cockroachdb-beta-20160829)
+
+### Test 3: Bank Invariant — Multi-Table (TiDB bank-multitable)
+
+TiDB extends the bank test across multiple tables. This catches bugs where single-table replication works but cross-table invariants break.
+
+**What it proves**: Invariants hold even when the data spans tables owned by different partitions.
+
+**How it works**:
+1. Create users with salaries on Node A
+2. Create projects with budgets on Node B
+3. Compute combined total (all salaries + all budgets) from each node
+4. Both must agree
+
+**Source**: [TiDB Jepsen bank-multitable](https://github.com/jepsen-io/jepsen/tree/main/tidb)
+
+### Test 4: Partition Enforcement (Vitess Single Mode)
+
+Vitess's "Single mode" rejects transactions that touch multiple shards. Our partition ownership check does the same.
+
+**What it proves**: The Committer correctly enforces table ownership. No phantom data from rejected writes.
+
+**How it works**:
+1. Attempt writes to wrong-partition tables from each node — all must fail
+2. Verify error messages identify the correct partition owner
+3. Verify no data was created by rejected writes
+
+**Source**: [Vitess sharding](https://vitess.io/docs/22.0/reference/features/sharding/)
+
+### Test 5: Concurrent Write Scaling (CockroachDB KV)
+
+CockroachDB's KV 95 benchmark runs on increasing node counts and verifies linear throughput scaling.
+
+**What it proves**: Two partitions writing independently achieve higher throughput with zero data loss.
+
+**How it works**:
+1. Write N records to each partition concurrently
+2. Measure wall-clock time
+3. Wait for replication
+4. Verify all records visible from both nodes
+
+**Source**: [CockroachDB scaling benchmark](https://www.cockroachlabs.com/blog/how-we-stress-test-and-benchmark-cockroachdb-for-global-scale/)
+
+### Test 6: Monotonic Reads (TiDB monotonic)
+
+TiDB's monotonic test verifies that successive reads by any single client observe monotonically increasing values. A counter that goes backward means the replication layer is returning stale data.
+
+**What it proves**: A client reading from one node always sees values that advance forward, never backward. The TSO ensures global ordering.
+
+**How it works**:
+1. Write a sequence of incrementing values to Node B
+2. After each write, immediately read from Node A
+3. Each successive read from Node A must return a value >= the previous read
+4. No value ever goes backward
+
+**Source**: [TiDB Jepsen monotonic](https://github.com/pingcap/tidb/issues/26359)
+
+### Test 7: Node Restart Recovery (TiDB kill -9 / CockroachDB nemesis)
+
+TiDB uses kill -9 to force-kill nodes, then verifies recovery. CockroachDB's nemesis framework does the same with random node crashes during transactions.
+
+**What it proves**: After a node crashes and restarts, it recovers its state from persistence and catches up on missed NATS deltas. No data loss.
+
+**How it works**:
+1. Write data to both nodes
+2. Verify replication works
+3. Kill Node B (docker restart)
+4. Write more data to Node A while Node B is down
+5. Wait for Node B to come back
+6. Verify Node B sees all data (pre-crash + written during downtime)
+
+**Source**: [TiDB chaos engineering](https://www.pingcap.com/blog/chaos-practice-in-tidb/), [CockroachDB DIY Jepsen](https://www.cockroachlabs.com/blog/diy-jepsen-testing-cockroachdb/)
+
+### Test 8: Idempotent Re-Run (CockroachDB workload check)
+
+CockroachDB's `workload check` runs consistency invariants after any duration of load. Running the same test suite twice back-to-back should produce no corruption.
+
+**What it proves**: The system handles repeated operations gracefully. No duplicate tables, no duplicate data, no state corruption from re-running replication.
+
+**How it works**:
+1. Run the full test suite (tests 1-5)
+2. Without restarting, run it again
+3. All tests must still pass (baseline-relative counts handle accumulation)
+
+**Source**: [CockroachDB workload check](https://www.cockroachlabs.com/docs/stable/cockroach-workload)
+
+## Sources
+
+### CockroachDB
+- [cockroach workload](https://www.cockroachlabs.com/docs/stable/cockroach-workload)
+- [Stress testing for global scale](https://www.cockroachlabs.com/blog/how-we-stress-test-and-benchmark-cockroachdb-for-global-scale/)
+- [DIY Jepsen testing](https://www.cockroachlabs.com/blog/diy-jepsen-testing-cockroachdb/)
+- [Jepsen analysis](https://jepsen.io/analyses/cockroachdb-beta-20160829)
+- [TPC-C 140K warehouses](https://www.cockroachlabs.com/blog/cockroachdb-performance-20-2/)
+- [Roachtest README](https://github.com/cockroachdb/cockroach/blob/master/pkg/cmd/roachtest/README.md)
+- [Metamorphic testing](https://www.cockroachlabs.com/blog/metamorphic-testing-the-database/)
+
+### TiDB
+- [TiDB Jepsen tests](https://github.com/jepsen-io/jepsen/tree/main/tidb)
+- [Jepsen TiDB 2.1.7 analysis](https://jepsen.io/analyses/tidb-2.1.7)
+- [TiDB meets Jepsen](https://www.pingcap.com/blog/tidb-meets-jepsen/)
+- [Chaos engineering at PingCAP](https://www.pingcap.com/blog/chaos-practice-in-tidb/)
+- [TiPocket testing toolkit](https://github.com/pingcap/tipocket)
+- [Safety pitfalls found by Jepsen](https://pingcap.com/blog/safety-first-common-safety-pitfalls-in-distributed-databases-found-by-jepsen-tests/)
+
+### Vitess
+- [VDiff v2](https://vitess.io/blog/2022-11-22-vdiff-v2/)
+- [VDiff reference](https://vitess.io/docs/archive/17.0/reference/vreplication/vdiff/)
+- [Sharding test package](https://pkg.go.dev/vitess.io/vitess/go/test/endtoend/sharding)
+- [Atomic distributed transactions RFC](https://github.com/vitessio/vitess/issues/16245)

--- a/self-hosted/docker/test-write-scaling.sh
+++ b/self-hosted/docker/test-write-scaling.sh
@@ -1,0 +1,528 @@
+#!/usr/bin/env bash
+#
+# Write Scaling Integration Tests (CockroachDB roachtest pattern)
+#
+# Runs against the live partitioned Docker deployment. Eight test categories
+# inspired by CockroachDB, TiDB, and Vitess:
+#
+#   1. Cross-Partition Data Verification (Vitess VDiff)
+#   2. Bank Invariant — Single Table (CockroachDB Jepsen bank)
+#   3. Bank Invariant — Multi-Table (TiDB bank-multitable)
+#   4. Partition Enforcement (Vitess Single mode)
+#   5. Concurrent Write Scaling (CockroachDB KV)
+#   6. Monotonic Reads (TiDB monotonic)
+#   7. Node Restart Recovery (TiDB kill -9 / CockroachDB nemesis)
+#   8. Idempotent Re-Run (CockroachDB workload check)
+#
+# Prerequisites:
+#   docker compose -f docker-compose.partitioned.yml up
+#
+# Usage:
+#   cd self-hosted/docker && ./test-write-scaling.sh
+
+set -euo pipefail
+
+NODE_A_URL="http://127.0.0.1:3210"
+NODE_B_URL="http://127.0.0.1:3220"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BOLD='\033[1m'
+NC='\033[0m'
+
+PASSED=0
+FAILED=0
+
+pass() {
+    PASSED=$((PASSED + 1))
+    echo -e "  ${GREEN}PASS${NC} $1"
+}
+
+fail() {
+    FAILED=$((FAILED + 1))
+    echo -e "  ${RED}FAIL${NC} $1"
+    [ -n "${2:-}" ] && echo -e "       $2"
+}
+
+# --- Preflight ---
+
+echo ""
+echo -e "${BOLD}Preflight checks${NC}"
+
+for name in docker-node-a-1 docker-node-b-1; do
+    if ! docker inspect "$name" > /dev/null 2>&1; then
+        echo -e "${RED}Container $name not running. Start the deployment first:${NC}"
+        echo "  docker compose -f docker-compose.partitioned.yml up"
+        exit 1
+    fi
+done
+echo "  Containers running."
+
+NODE_A_KEY=$(docker exec docker-node-a-1 ./generate_admin_key.sh 2>&1 | tail -1)
+NODE_B_KEY=$(docker exec docker-node-b-1 ./generate_admin_key.sh 2>&1 | tail -1)
+echo "  Admin keys generated."
+
+# --- Deploy test functions ---
+
+DEPLOY_DIR=$(mktemp -d)
+mkdir -p "$DEPLOY_DIR/convex"
+
+cat > "$DEPLOY_DIR/package.json" << 'EOF'
+{ "name": "write-scaling-test", "version": "1.0.0", "dependencies": { "convex": "^1" } }
+EOF
+
+cat > "$DEPLOY_DIR/convex/messages.ts" << 'TSEOF'
+import { mutation, query } from "./_generated/server";
+import { v } from "convex/values";
+
+export const send = mutation({
+  args: { text: v.string(), author: v.optional(v.string()), channel: v.optional(v.string()) },
+  handler: async (ctx, args) => {
+    await ctx.db.insert("messages", { text: args.text, author: args.author ?? "anon", channel: args.channel ?? "general", timestamp: Date.now() });
+  },
+});
+
+export const createUser = mutation({
+  args: { name: v.string(), role: v.string() },
+  handler: async (ctx, args) => {
+    return await ctx.db.insert("users", { ...args, createdAt: Date.now() });
+  },
+});
+
+export const createProject = mutation({
+  args: { name: v.string(), status: v.string(), budget: v.number() },
+  handler: async (ctx, args) => {
+    return await ctx.db.insert("projects", { ...args, createdAt: Date.now() });
+  },
+});
+
+export const createTask = mutation({
+  args: { title: v.string(), assignee: v.string(), project: v.string(), status: v.string() },
+  handler: async (ctx, args) => {
+    return await ctx.db.insert("tasks", { ...args, createdAt: Date.now() });
+  },
+});
+
+export const dashboard = query({
+  handler: async (ctx) => {
+    const messages = await ctx.db.query("messages").collect();
+    const users = await ctx.db.query("users").collect();
+    const projects = await ctx.db.query("projects").collect();
+    const tasks = await ctx.db.query("tasks").collect();
+    return {
+      messages: messages.length,
+      users: users.length,
+      projects: projects.length,
+      tasks: tasks.length,
+    };
+  },
+});
+
+export const totalBudget = query({
+  handler: async (ctx) => {
+    const projects = await ctx.db.query("projects").collect();
+    return projects.reduce((sum: number, p: any) => sum + (p.budget || 0), 0);
+  },
+});
+
+export const createUserWithSalary = mutation({
+  args: { name: v.string(), salary: v.number() },
+  handler: async (ctx, args) => {
+    return await ctx.db.insert("users", { name: args.name, salary: args.salary, createdAt: Date.now() });
+  },
+});
+
+export const totalCompensation = query({
+  handler: async (ctx) => {
+    const users = await ctx.db.query("users").collect();
+    const projects = await ctx.db.query("projects").collect();
+    const salaries = users.reduce((sum: number, u: any) => sum + (u.salary || 0), 0);
+    const budgets = projects.reduce((sum: number, p: any) => sum + (p.budget || 0), 0);
+    return { salaries, budgets, total: salaries + budgets };
+  },
+});
+
+export const writeSequence = mutation({
+  args: { key: v.string(), seq: v.number() },
+  handler: async (ctx, args) => {
+    await ctx.db.insert("tasks", { title: args.key, assignee: "monotonic", project: "test", status: String(args.seq), createdAt: Date.now() });
+  },
+});
+
+export const readLatestSeq = query({
+  args: { key: v.string() },
+  handler: async (ctx, args) => {
+    const rows = await ctx.db.query("tasks").collect();
+    const matching = rows.filter((r: any) => r.title === args.key && r.assignee === "monotonic");
+    if (matching.length === 0) return -1;
+    return Math.max(...matching.map((r: any) => Number(r.status)));
+  },
+});
+TSEOF
+
+echo "  Deploying functions..."
+(cd "$DEPLOY_DIR" && npm install --silent 2>/dev/null)
+(cd "$DEPLOY_DIR" && npx convex deploy --admin-key "$NODE_A_KEY" --url "$NODE_A_URL" > /dev/null 2>&1)
+(cd "$DEPLOY_DIR" && npx convex deploy --admin-key "$NODE_B_KEY" --url "$NODE_B_URL" > /dev/null 2>&1)
+echo "  Functions deployed to both nodes."
+
+# --- Helpers ---
+
+mutate() {
+    curl -sf "$1/api/mutation" \
+        -H "Authorization: Convex $2" \
+        -H "Content-Type: application/json" \
+        -d "{\"path\":\"$3\",\"args\":$4}"
+}
+
+query_api() {
+    curl -sf "$1/api/query" \
+        -H "Authorization: Convex $2" \
+        -H "Content-Type: application/json" \
+        -d "{\"path\":\"$3\",\"args\":{}}"
+}
+
+jval() { python3 -c "import sys,json; print(int(json.load(sys.stdin)['value']['$1']))" <<< "$2"; }
+jtotal() { python3 -c "import sys,json; print(int(json.load(sys.stdin)['value']))" <<< "$1"; }
+
+# --- Baseline: capture existing counts before tests ---
+
+echo ""
+echo -e "${BOLD}Capturing baseline counts...${NC}"
+BASELINE=$(query_api "$NODE_A_URL" "$NODE_A_KEY" "messages:dashboard" 2>/dev/null || echo '{"value":{"messages":0,"users":0,"projects":0,"tasks":0}}')
+BASE_M=$(jval messages "$BASELINE" 2>/dev/null || echo 0)
+BASE_U=$(jval users "$BASELINE" 2>/dev/null || echo 0)
+BASE_P=$(jval projects "$BASELINE" 2>/dev/null || echo 0)
+BASE_T=$(jval tasks "$BASELINE" 2>/dev/null || echo 0)
+BASE_BUDGET=$(jtotal "$(query_api "$NODE_A_URL" "$NODE_A_KEY" "messages:totalBudget" 2>/dev/null || echo '{"value":0}')" 2>/dev/null || echo 0)
+echo "  Baseline: msgs=$BASE_M users=$BASE_U proj=$BASE_P tasks=$BASE_T budget=\$$BASE_BUDGET"
+
+# ============================================================
+echo ""
+echo -e "${BOLD}Test 1: Cross-Partition Data Verification (Vitess VDiff)${NC}"
+# ============================================================
+
+mutate "$NODE_A_URL" "$NODE_A_KEY" "messages:send" '{"text":"msg-1","author":"alice","channel":"general"}' > /dev/null
+mutate "$NODE_A_URL" "$NODE_A_KEY" "messages:send" '{"text":"msg-2","author":"bob","channel":"eng"}' > /dev/null
+mutate "$NODE_A_URL" "$NODE_A_KEY" "messages:send" '{"text":"msg-3","author":"charlie","channel":"general"}' > /dev/null
+mutate "$NODE_A_URL" "$NODE_A_KEY" "messages:createUser" '{"name":"Alice","role":"engineer"}' > /dev/null
+mutate "$NODE_A_URL" "$NODE_A_KEY" "messages:createUser" '{"name":"Bob","role":"manager"}' > /dev/null
+
+mutate "$NODE_B_URL" "$NODE_B_KEY" "messages:createProject" '{"name":"Alpha","status":"active","budget":10000}' > /dev/null
+mutate "$NODE_B_URL" "$NODE_B_KEY" "messages:createProject" '{"name":"Beta","status":"planning","budget":25000}' > /dev/null
+mutate "$NODE_B_URL" "$NODE_B_KEY" "messages:createTask" '{"title":"Design","assignee":"Alice","project":"Alpha","status":"done"}' > /dev/null
+mutate "$NODE_B_URL" "$NODE_B_KEY" "messages:createTask" '{"title":"Build","assignee":"Bob","project":"Alpha","status":"active"}' > /dev/null
+mutate "$NODE_B_URL" "$NODE_B_KEY" "messages:createTask" '{"title":"Plan","assignee":"Charlie","project":"Beta","status":"todo"}' > /dev/null
+
+echo "  Waiting for NATS replication..."
+sleep 4
+
+DA=$(query_api "$NODE_A_URL" "$NODE_A_KEY" "messages:dashboard")
+DB=$(query_api "$NODE_B_URL" "$NODE_B_KEY" "messages:dashboard")
+
+AM=$(jval messages "$DA"); AU=$(jval users "$DA"); AP=$(jval projects "$DA"); AT=$(jval tasks "$DA")
+BM=$(jval messages "$DB"); BU=$(jval users "$DB"); BP=$(jval projects "$DB"); BT=$(jval tasks "$DB")
+
+# Check deltas from baseline
+DM=$((AM - BASE_M)); DU=$((AU - BASE_U)); DP=$((AP - BASE_P)); DT=$((AT - BASE_T))
+
+[ "$DM" -eq 3 ] && [ "$DU" -eq 2 ] && [ "$DP" -eq 2 ] && [ "$DT" -eq 3 ] \
+    && pass "Node A: +3 msgs, +2 users, +2 proj, +3 tasks (total: $AM,$AU,$AP,$AT)" \
+    || fail "Node A wrong delta" "delta: msgs=$DM users=$DU proj=$DP tasks=$DT, expected +3 +2 +2 +3"
+
+[ "$AM" -eq "$BM" ] && [ "$AU" -eq "$BU" ] && [ "$AP" -eq "$BP" ] && [ "$AT" -eq "$BT" ] \
+    && pass "VDiff equivalence: both nodes identical ($AM,$AU,$AP,$AT)" \
+    || fail "Nodes diverged" "A: $AM,$AU,$AP,$AT vs B: $BM,$BU,$BP,$BT"
+
+# ============================================================
+echo ""
+echo -e "${BOLD}Test 2: Bank Test / Invariant Preservation (CockroachDB Jepsen)${NC}"
+# ============================================================
+
+# New budgets: Alpha=10000, Beta=25000 → delta=35000
+EXPECTED_DELTA=35000
+EXPECTED=$((BASE_BUDGET + EXPECTED_DELTA))
+
+TA=$(jtotal "$(query_api "$NODE_A_URL" "$NODE_A_KEY" "messages:totalBudget")")
+TB=$(jtotal "$(query_api "$NODE_B_URL" "$NODE_B_KEY" "messages:totalBudget")")
+
+[ "$TA" -eq "$EXPECTED" ] \
+    && pass "Node A budget total preserved: \$$TA (base \$$BASE_BUDGET + \$$EXPECTED_DELTA)" \
+    || fail "Node A budget invariant violated" "got \$$TA, expected \$$EXPECTED"
+
+[ "$TB" -eq "$EXPECTED" ] \
+    && pass "Node B budget total preserved: \$$TB" \
+    || fail "Node B budget invariant violated" "got \$$TB, expected \$$EXPECTED"
+
+[ "$TA" -eq "$TB" ] \
+    && pass "Cross-node invariant: both agree on \$$TA" \
+    || fail "Cross-node invariant violated" "A=\$$TA vs B=\$$TB"
+
+# ============================================================
+echo ""
+echo -e "${BOLD}Test 3: Bank Invariant — Multi-Table (TiDB bank-multitable)${NC}"
+# ============================================================
+
+# Create users with salaries on Node A, projects with budgets already on Node B.
+mutate "$NODE_A_URL" "$NODE_A_KEY" "messages:createUserWithSalary" '{"name":"Eve","salary":60000}' > /dev/null
+mutate "$NODE_A_URL" "$NODE_A_KEY" "messages:createUserWithSalary" '{"name":"Frank","salary":80000}' > /dev/null
+
+SALARY_DELTA=140000  # 60000 + 80000
+
+echo "  Waiting for replication..."
+sleep 4
+
+CA=$(query_api "$NODE_A_URL" "$NODE_A_KEY" "messages:totalCompensation")
+CB=$(query_api "$NODE_B_URL" "$NODE_B_KEY" "messages:totalCompensation")
+
+CA_TOTAL=$(python3 -c "import sys,json; print(int(json.load(sys.stdin)['value']['total']))" <<< "$CA")
+CB_TOTAL=$(python3 -c "import sys,json; print(int(json.load(sys.stdin)['value']['total']))" <<< "$CB")
+EXPECTED_COMP=$((EXPECTED + SALARY_DELTA))
+
+[ "$CA_TOTAL" -eq "$EXPECTED_COMP" ] \
+    && pass "Node A cross-table total: \$$CA_TOTAL (salaries + budgets)" \
+    || fail "Node A cross-table invariant" "got \$$CA_TOTAL, expected \$$EXPECTED_COMP"
+
+[ "$CB_TOTAL" -eq "$EXPECTED_COMP" ] \
+    && pass "Node B cross-table total: \$$CB_TOTAL" \
+    || fail "Node B cross-table invariant" "got \$$CB_TOTAL, expected \$$EXPECTED_COMP"
+
+[ "$CA_TOTAL" -eq "$CB_TOTAL" ] \
+    && pass "Cross-node multi-table invariant: both agree on \$$CA_TOTAL" \
+    || fail "Cross-node multi-table invariant violated" "A=\$$CA_TOTAL vs B=\$$CB_TOTAL"
+
+# ============================================================
+echo ""
+echo -e "${BOLD}Test 4: Partition Enforcement (Vitess Single Mode)${NC}"
+# ============================================================
+
+# Node A → projects (partition 1): must fail
+R=$(curl -s "$NODE_A_URL/api/mutation" -H "Authorization: Convex $NODE_A_KEY" -H "Content-Type: application/json" \
+    -d '{"path":"messages:createProject","args":{"name":"X","status":"x","budget":0}}')
+echo "$R" | grep -q "InternalServerError" \
+    && pass "Node A rejected write to 'projects' (partition 1)" \
+    || fail "Node A should reject projects write" "$R"
+
+# Node B → messages (partition 0): must fail
+R=$(curl -s "$NODE_B_URL/api/mutation" -H "Authorization: Convex $NODE_B_KEY" -H "Content-Type: application/json" \
+    -d '{"path":"messages:send","args":{"text":"x","author":"x","channel":"x"}}')
+echo "$R" | grep -q "InternalServerError" \
+    && pass "Node B rejected write to 'messages' (partition 0)" \
+    || fail "Node B should reject messages write" "$R"
+
+# Node A → tasks (partition 1): must fail
+R=$(curl -s "$NODE_A_URL/api/mutation" -H "Authorization: Convex $NODE_A_KEY" -H "Content-Type: application/json" \
+    -d '{"path":"messages:createTask","args":{"title":"x","assignee":"x","project":"x","status":"x"}}')
+echo "$R" | grep -q "InternalServerError" \
+    && pass "Node A rejected write to 'tasks' (partition 1)" \
+    || fail "Node A should reject tasks write" "$R"
+
+# Node B → users (partition 0): must fail
+R=$(curl -s "$NODE_B_URL/api/mutation" -H "Authorization: Convex $NODE_B_KEY" -H "Content-Type: application/json" \
+    -d '{"path":"messages:createUser","args":{"name":"x","role":"x"}}')
+echo "$R" | grep -q "InternalServerError" \
+    && pass "Node B rejected write to 'users' (partition 0)" \
+    || fail "Node B should reject users write" "$R"
+
+# Verify no phantom data — counts should match post-test1 values
+sleep 1
+DC=$(query_api "$NODE_A_URL" "$NODE_A_KEY" "messages:dashboard")
+CP=$(jval projects "$DC"); CM=$(jval messages "$DC")
+[ "$CP" -eq "$AP" ] && [ "$CM" -eq "$AM" ] \
+    && pass "No phantom data from rejected writes (proj=$CP msgs=$CM unchanged)" \
+    || fail "Phantom data detected" "proj=$CP (expected $AP) msgs=$CM (expected $AM)"
+
+# ============================================================
+echo ""
+echo -e "${BOLD}Test 5: Concurrent Write Scaling (CockroachDB KV)${NC}"
+# ============================================================
+
+N=20
+
+START=$(python3 -c "import time; print(time.time())")
+
+# Node A: messages in background
+(for i in $(seq 1 $N); do
+    mutate "$NODE_A_URL" "$NODE_A_KEY" "messages:send" \
+        "{\"text\":\"concurrent-$i\",\"author\":\"load\",\"channel\":\"perf\"}" > /dev/null
+done) &
+PA=$!
+
+# Node B: tasks in background
+(for i in $(seq 1 $N); do
+    mutate "$NODE_B_URL" "$NODE_B_KEY" "messages:createTask" \
+        "{\"title\":\"concurrent-$i\",\"assignee\":\"load\",\"project\":\"perf\",\"status\":\"done\"}" > /dev/null
+done) &
+PB=$!
+
+wait $PA
+wait $PB
+
+END=$(python3 -c "import time; print(time.time())")
+DUR=$(python3 -c "print(f'{$END - $START:.2f}')")
+OPS=$((N * 2))
+TPS=$(python3 -c "print(f'{$OPS / ($END - $START):.1f}')")
+
+echo "  $OPS writes in ${DUR}s (${TPS} writes/sec)"
+echo "  Waiting for replication..."
+sleep 4
+
+FA=$(query_api "$NODE_A_URL" "$NODE_A_KEY" "messages:dashboard")
+FB=$(query_api "$NODE_B_URL" "$NODE_B_KEY" "messages:dashboard")
+
+# Expected: post-test1 counts + N concurrent writes each
+EM=$((AM + N))
+ET=$((AT + N))
+
+FAM=$(jval messages "$FA"); FAT=$(jval tasks "$FA")
+FBM=$(jval messages "$FB"); FBT=$(jval tasks "$FB")
+
+[ "$FAM" -eq "$EM" ] && [ "$FAT" -eq "$ET" ] \
+    && pass "Node A: all writes visible (msgs=$FAM tasks=$FAT)" \
+    || fail "Node A missing writes" "msgs=$FAM (expected $EM) tasks=$FAT (expected $ET)"
+
+[ "$FBM" -eq "$EM" ] && [ "$FBT" -eq "$ET" ] \
+    && pass "Node B: all writes visible (msgs=$FBM tasks=$FBT)" \
+    || fail "Node B missing writes" "msgs=$FBM (expected $EM) tasks=$FBT (expected $ET)"
+
+[ "$FAM" -eq "$FBM" ] && [ "$FAT" -eq "$FBT" ] \
+    && pass "Both nodes converged after concurrent writes" \
+    || fail "Nodes diverged" "A: msgs=$FAM tasks=$FAT vs B: msgs=$FBM tasks=$FBT"
+
+# ============================================================
+echo ""
+echo -e "${BOLD}Test 6: Monotonic Reads (TiDB monotonic)${NC}"
+# ============================================================
+
+# Write a sequence of incrementing values to Node B (tasks table).
+# After each write, read from Node A. Values must never go backward.
+MONO_KEY="mono-$(date +%s)"
+LAST_SEEN=-1
+MONO_OK=true
+
+for i in $(seq 1 10); do
+    mutate "$NODE_B_URL" "$NODE_B_KEY" "messages:writeSequence" \
+        "{\"key\":\"$MONO_KEY\",\"seq\":$i}" > /dev/null
+    sleep 0.5
+    VAL=$(curl -sf "$NODE_A_URL/api/query" \
+        -H "Authorization: Convex $NODE_A_KEY" \
+        -H "Content-Type: application/json" \
+        -d "{\"path\":\"messages:readLatestSeq\",\"args\":{\"key\":\"$MONO_KEY\"}}" \
+        | python3 -c "import sys,json; print(int(json.load(sys.stdin)['value']))" 2>/dev/null || echo "-1")
+    if [ "$VAL" -lt "$LAST_SEEN" ]; then
+        MONO_OK=false
+        fail "Monotonic violation at seq=$i" "read $VAL after previously reading $LAST_SEEN"
+        break
+    fi
+    LAST_SEEN=$VAL
+done
+
+if $MONO_OK; then
+    pass "Monotonic reads: values never went backward (last=$LAST_SEEN)"
+fi
+
+# Override readLatestSeq to pass key arg
+query_with_args() {
+    curl -sf "$1/api/query" \
+        -H "Authorization: Convex $2" \
+        -H "Content-Type: application/json" \
+        -d "{\"path\":\"$3\",\"args\":$4}"
+}
+
+# ============================================================
+echo ""
+echo -e "${BOLD}Test 7: Node Restart Recovery (TiDB kill -9 / CockroachDB nemesis)${NC}"
+# ============================================================
+
+# Capture pre-restart state
+PRE=$(query_api "$NODE_A_URL" "$NODE_A_KEY" "messages:dashboard")
+PRE_M=$(jval messages "$PRE")
+
+# Restart Node B
+echo "  Restarting Node B..."
+docker restart docker-node-b-1 > /dev/null 2>&1
+
+# Write to Node A while Node B is restarting
+mutate "$NODE_A_URL" "$NODE_A_KEY" "messages:send" \
+    '{"text":"during-restart","author":"recovery-test","channel":"test"}' > /dev/null
+
+# Wait for Node B to come back healthy
+echo "  Waiting for Node B to recover..."
+for attempt in $(seq 1 30); do
+    if curl -sf "http://127.0.0.1:3220/version" > /dev/null 2>&1; then
+        break
+    fi
+    sleep 1
+done
+
+# Re-generate Node B key (may have changed on restart)
+NODE_B_KEY=$(docker exec docker-node-b-1 ./generate_admin_key.sh 2>&1 | tail -1)
+
+# Re-deploy functions to Node B (modules are in-memory)
+echo "  Re-deploying functions to Node B..."
+(cd "$DEPLOY_DIR" && npx convex deploy --admin-key "$NODE_B_KEY" --url "$NODE_B_URL" > /dev/null 2>&1)
+
+sleep 4
+
+# Verify Node B sees the write made during restart
+POST_B=$(query_api "$NODE_B_URL" "$NODE_B_KEY" "messages:dashboard")
+POST_BM=$(jval messages "$POST_B")
+
+EXPECTED_POST_M=$((PRE_M + 1))
+[ "$POST_BM" -ge "$EXPECTED_POST_M" ] \
+    && pass "Node B recovered: sees msgs=$POST_BM (includes write during downtime)" \
+    || fail "Node B missing writes after restart" "msgs=$POST_BM, expected >= $EXPECTED_POST_M"
+
+# Verify Node B can still serve its own writes
+mutate "$NODE_B_URL" "$NODE_B_KEY" "messages:createTask" \
+    '{"title":"post-restart","assignee":"test","project":"recovery","status":"done"}' > /dev/null \
+    && pass "Node B can write after recovery" \
+    || fail "Node B cannot write after recovery"
+
+# ============================================================
+echo ""
+echo -e "${BOLD}Test 8: Idempotent Re-Run (CockroachDB workload check)${NC}"
+# ============================================================
+
+# Capture state, write more data, verify no corruption
+SNAP_A=$(query_api "$NODE_A_URL" "$NODE_A_KEY" "messages:dashboard")
+SNAP_AM=$(jval messages "$SNAP_A")
+
+mutate "$NODE_A_URL" "$NODE_A_KEY" "messages:send" \
+    '{"text":"idempotent-1","author":"check","channel":"test"}' > /dev/null
+mutate "$NODE_A_URL" "$NODE_A_KEY" "messages:send" \
+    '{"text":"idempotent-2","author":"check","channel":"test"}' > /dev/null
+
+sleep 3
+
+CHECK_A=$(query_api "$NODE_A_URL" "$NODE_A_KEY" "messages:dashboard")
+CHECK_B=$(query_api "$NODE_B_URL" "$NODE_B_KEY" "messages:dashboard")
+
+CHECK_AM=$(jval messages "$CHECK_A")
+CHECK_BM=$(jval messages "$CHECK_B")
+
+EXPECTED_IDEM=$((SNAP_AM + 2))
+
+[ "$CHECK_AM" -eq "$EXPECTED_IDEM" ] \
+    && pass "Node A: correct after additional writes (msgs=$CHECK_AM)" \
+    || fail "Node A count wrong" "msgs=$CHECK_AM, expected $EXPECTED_IDEM"
+
+[ "$CHECK_AM" -eq "$CHECK_BM" ] \
+    && pass "Both nodes still converged (msgs=$CHECK_AM)" \
+    || fail "Nodes diverged after re-run" "A=$CHECK_AM vs B=$CHECK_BM"
+
+# ============================================================
+echo ""
+echo "============================================================"
+TOTAL=$((PASSED + FAILED))
+if [ "$FAILED" -eq 0 ]; then
+    echo -e "${GREEN}ALL $TOTAL TESTS PASSED${NC}"
+else
+    echo -e "${RED}$FAILED/$TOTAL TESTS FAILED${NC}"
+fi
+echo "============================================================"
+echo ""
+
+rm -rf "$DEPLOY_DIR"
+exit "$FAILED"


### PR DESCRIPTION
## Summary

- Wire `BatchTimestampOracle` (TiDB PD pattern) into the Committer — both nodes draw globally unique timestamps from a shared NATS KV counter via atomic CAS batch allocation
- Fix cross-partition delta replication: classify updates by what they describe (user table metadata vs node-local system data), reassign table numbers locally (CockroachDB descriptor ID pattern), use `next_commit_ts()` for replica deltas
- Add 8-category integration test suite (21 assertions) inspired by CockroachDB roachtest, TiDB Jepsen, and Vitess VDiff — all 21 pass

## Test plan

- [x] `cargo test -p database` — 342 tests pass (including new partition enforcement test)
- [x] `./test-write-scaling.sh` — 21/21 pass against live Docker deployment:
  1. Cross-partition data verification (Vitess VDiff)
  2. Bank invariant single-table (CockroachDB Jepsen bank)
  3. Bank invariant multi-table (TiDB bank-multitable)
  4. Partition enforcement (Vitess Single mode)
  5. Concurrent write scaling (CockroachDB KV) — 176.5 writes/sec
  6. Monotonic reads (TiDB monotonic)
  7. Node restart recovery (TiDB kill-9 / CockroachDB nemesis)
  8. Idempotent re-run (CockroachDB workload check)