### PR TITLE
test: expand to 56 assertions across 23 categories

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,17 +7,31 @@ The first horizontal scaling implementation for the [Convex open-source backend]
 Two independent Convex nodes, each owning a partition of tables, writing in parallel, replicating to each other in real-time via NATS JetStream. A global Timestamp Oracle (TiDB PD pattern) ensures ordering. Two-phase commit handles cross-partition writes.
 
 ```
-ALL 25 TESTS PASSED
+ALL 56 TESTS PASSED — 2,365 messages | 1,814 tasks | 1,440 sustained writes/node
 
  1. Cross-partition data verification     (Vitess VDiff)         — PASS
  2. Bank invariant — single table         (CockroachDB Jepsen)   — PASS
  3. Bank invariant — multi-table          (TiDB bank-multitable) — PASS
  4. Partition enforcement (5 subtests)    (Vitess Single mode)   — PASS
- 5. Concurrent write scaling              (CockroachDB KV)       — PASS 175 writes/sec
+ 5. Concurrent write scaling              (CockroachDB KV)       — PASS 171 writes/sec
  6. Monotonic reads                       (TiDB monotonic)       — PASS
  7. Node restart recovery                 (TiDB kill -9)         — PASS
  8. Idempotent re-run                     (CockroachDB workload) — PASS
  9. Two-phase commit cross-partition      (Vitess 2PC)           — PASS
+10. Rapid-fire writes 50/node             (Jepsen stress)        — PASS
+11. Write-then-immediate-read             (stale read detection) — PASS
+12. Double node restart                   (CockroachDB nemesis)  — PASS
+13. Post-chaos invariant check            (workload check)       — PASS
+14. Sequential ordering                   (Jepsen sequential)    — PASS
+15. Set completeness (100 elements)       (Jepsen set)           — PASS
+16. Concurrent counter                    (Jepsen counter)       — PASS
+17. Write-then-cross-node-read            (cross-node stale)     — PASS
+18. Interleaved cross-partition reads     (read skew detection)  — PASS
+19. Large batch write (50 docs)           (atomicity)            — PASS
+20. Full cluster restart                  (CockroachDB nemesis)  — PASS
+21. Sustained writes 30 seconds           (endurance)            — PASS
+22. Duplicate insert idempotency          (correctness)          — PASS
+23. Final exhaustive invariant check      (workload check)       — PASS
 ```
 
 ## Architecture
@@ -98,7 +112,7 @@ cd self-hosted/docker
 ./test-write-scaling.sh
 ```
 
-Runs all 25 integration tests (9 categories) against the live partitioned deployment.
+Runs all 56 integration tests (23 categories) against the live partitioned deployment.
 
 ### Deploy Functions
 
@@ -159,23 +173,69 @@ npx convex deploy --url http://127.0.0.1:3210 --admin-key <KEY>
 cargo test -p database   # 346 tests
 ```
 
-### Integration Tests (25 assertions across 9 categories)
+### Integration Tests (56 assertions across 23 categories)
 
 ```sh
 cd self-hosted/docker && ./test-write-scaling.sh
 ```
 
-| # | Test | Source | What it proves |
+**Correctness (Jepsen patterns):**
+
+| # | Test | Source | What it catches |
 | --- | --- | --- | --- |
-| 1 | Cross-partition data verification | Vitess VDiff | Both nodes see all data from both partitions |
-| 2 | Bank invariant — single table | CockroachDB Jepsen bank | Numeric totals preserved across replication |
-| 3 | Bank invariant — multi-table | TiDB bank-multitable | Cross-table invariants hold across partitions |
-| 4 | Partition enforcement | Vitess Single mode | Wrong-partition writes rejected, no phantom data |
-| 5 | Concurrent write scaling | CockroachDB KV | Parallel writes with zero data loss |
-| 6 | Monotonic reads | TiDB monotonic | Values never go backward |
-| 7 | Node restart recovery | TiDB kill -9 / CockroachDB nemesis | Recovers after crash, sees writes from downtime |
-| 8 | Idempotent re-run | CockroachDB workload check | No corruption from repeated operations |
-| 9 | Two-phase commit | Vitess 2PC | Atomic writes to tables on different partitions |
+| 1 | Cross-partition data verification | Vitess VDiff | Replication fails to propagate data |
+| 2 | Bank invariant — single table | CockroachDB Jepsen bank | Numeric totals violated by replication |
+| 3 | Bank invariant — multi-table | TiDB bank-multitable | Cross-table invariants broken |
+| 14 | Sequential ordering | Jepsen sequential | Writes visible out of order |
+| 15 | Set completeness (100 elements) | Jepsen set | Lost inserts |
+| 16 | Concurrent counter | Jepsen counter / YugabyteDB | Phantom counts or lost increments |
+| 22 | Duplicate insert idempotency | Custom | Deduplication or corruption |
+
+**Partition enforcement:**
+
+| # | Test | Source | What it catches |
+| --- | --- | --- | --- |
+| 4 | Partition enforcement (5 subtests) | Vitess Single mode | Wrong-partition writes accepted |
+
+**Scaling and performance:**
+
+| # | Test | Source | What it catches |
+| --- | --- | --- | --- |
+| 5 | Concurrent write scaling | CockroachDB KV | Data loss under parallel writes |
+| 10 | Rapid-fire writes (50/node) | Jepsen stress | Crashes under burst load |
+| 21 | Sustained writes (30 seconds) | CockroachDB endurance | Replication lag, data loss under sustained load |
+
+**Consistency:**
+
+| # | Test | Source | What it catches |
+| --- | --- | --- | --- |
+| 6 | Monotonic reads | TiDB monotonic | Values going backward |
+| 11 | Write-then-immediate-read | TiDB Jepsen stale read | Stale read on same node |
+| 17 | Write-then-cross-node-read | TiDB Jepsen stale read | Cross-node stale read |
+| 18 | Interleaved cross-partition reads | Read skew detection | Inconsistent snapshots |
+
+**Two-phase commit and atomicity:**
+
+| # | Test | Source | What it catches |
+| --- | --- | --- | --- |
+| 9 | Cross-partition atomic write | Vitess 2PC | Partial commits |
+| 19 | Large batch write (50 docs) | Custom | Partial batch |
+
+**Chaos and recovery:**
+
+| # | Test | Source | What it catches |
+| --- | --- | --- | --- |
+| 7 | Single node restart | TiDB kill -9 | Data loss after restart |
+| 12 | Double node restart | CockroachDB nemesis | Corruption from rapid restarts |
+| 20 | Full cluster restart | CockroachDB nemesis | Data loss when all nodes down |
+
+**Invariant preservation:**
+
+| # | Test | Source | What it catches |
+| --- | --- | --- | --- |
+| 8 | Idempotent re-run | CockroachDB workload check | Corruption from repeated ops |
+| 13 | Post-chaos invariant check | CockroachDB workload check | Invariants broken by stress |
+| 23 | Final exhaustive invariant check | CockroachDB workload check | Any violation after all 22 tests |
 
 ## Documentation
 

--- a/docs/write-scaling-tests.md
+++ b/docs/write-scaling-tests.md
@@ -1,158 +1,206 @@
-# Write Scaling Tests: Verifying Partitioned Multi-Writer Architecture
+# Write Scaling Tests: 56 Assertions Across 23 Categories
 
-Based on how CockroachDB, TiDB, and Vitess test their distributed read/write scaling.
+Based on how CockroachDB, TiDB, YugabyteDB, Google Spanner, and Vitess test their distributed read/write scaling.
 
-## Test Matrix
+## Test Results
 
-All three systems test across the same core categories. We implement the ones applicable to our architecture.
+```
+ALL 56 TESTS PASSED
 
-| # | Test | Source | CockroachDB | TiDB | Vitess | Ours |
-|---|------|--------|-------------|------|--------|------|
-| 1 | Cross-partition data verification | Vitess VDiff | - | - | VDiff row-by-row | test 1 |
-| 2 | Bank invariant (single table) | Jepsen bank | bank workload | bank test | - | test 2 |
-| 3 | Bank invariant (multi-table) | TiDB bank-multitable | - | bank-multitable | - | test 3 |
-| 4 | Partition enforcement | Vitess Single mode | - | - | reject cross-shard | test 4 |
-| 5 | Concurrent write scaling | CockroachDB KV | KV 95 benchmark | sysbench | - | test 5 |
-| 6 | Monotonic reads | TiDB monotonic | sequential check | monotonic register | - | test 6 |
-| 7 | Node restart recovery | CockroachDB nemesis | node crash test | kill -9 + verify | - | test 7 |
-| 8 | Idempotent re-run | CockroachDB workload check | workload check | - | - | test 8 |
+2,365 messages | 1,814 tasks | 16 users | 8 projects
+1,440 sustained writes/node in 30 seconds
+Full cluster restart recovery
+Zero data loss
+```
 
-## Test Descriptions
+## Test Categories
+
+### Correctness (Jepsen Patterns)
+
+| # | Test | Source | Assertions | What it catches |
+| --- | --- | --- | --- | --- |
+| 1 | Cross-partition data verification | Vitess VDiff | 2 | Both nodes see all data from both partitions |
+| 2 | Bank invariant — single table | CockroachDB Jepsen bank | 3 | Numeric totals violated by replication |
+| 3 | Bank invariant — multi-table | TiDB bank-multitable | 3 | Cross-table invariants broken across partitions |
+| 14 | Sequential ordering | Jepsen sequential | 1 | Writes by one client visible out of order |
+| 15 | Set completeness | Jepsen set | 2 | Lost inserts — element written but never visible |
+| 16 | Concurrent counter | Jepsen counter / YugabyteDB | 3 | Phantom counts or lost increments |
+| 22 | Duplicate insert idempotency | Custom | 1 | Insert deduplication or corruption |
+
+### Partition Enforcement (Vitess Single Mode)
+
+| # | Test | Source | Assertions | What it catches |
+| --- | --- | --- | --- | --- |
+| 4 | Partition enforcement | Vitess Single mode | 5 | Wrong-partition writes accepted, phantom data |
+
+### Scaling and Performance (CockroachDB KV)
+
+| # | Test | Source | Assertions | What it catches |
+| --- | --- | --- | --- | --- |
+| 5 | Concurrent write scaling | CockroachDB KV 95 | 3 | Data loss under parallel writes |
+| 10 | Rapid-fire writes (50/node) | Jepsen stress | 5 | Crashes or lost writes under burst load |
+| 21 | Sustained writes (30 seconds) | CockroachDB endurance | 5 | Replication lag, data loss, node crashes under sustained load |
+
+### Consistency (TiDB / CockroachDB Patterns)
+
+| # | Test | Source | Assertions | What it catches |
+| --- | --- | --- | --- | --- |
+| 6 | Monotonic reads | TiDB monotonic | 1 | Values going backward (stale reads) |
+| 11 | Write-then-immediate-read | TiDB Jepsen stale read | 1 | Read returns stale data on same node |
+| 17 | Write-then-cross-node-read | TiDB Jepsen stale read | 1 | Cross-node stale read after write |
+| 18 | Interleaved cross-partition reads | Read skew detection | 1 | Nodes return inconsistent snapshots |
+
+### Two-Phase Commit (Vitess 2PC)
+
+| # | Test | Source | Assertions | What it catches |
+| --- | --- | --- | --- | --- |
+| 9 | Cross-partition atomic write | Vitess 2PC | 4 | Partial commits, non-atomic cross-partition writes |
+
+### Atomicity
+
+| # | Test | Source | Assertions | What it catches |
+| --- | --- | --- | --- | --- |
+| 19 | Large batch write (50 docs) | Custom | 2 | Partial batch — some docs written, others lost |
+
+### Chaos and Recovery (TiDB kill-9 / CockroachDB Nemesis)
+
+| # | Test | Source | Assertions | What it catches |
+| --- | --- | --- | --- | --- |
+| 7 | Single node restart | TiDB kill-9 | 2 | Data loss or inability to write after restart |
+| 12 | Double node restart | CockroachDB nemesis | 1 | Corruption from rapid consecutive restarts |
+| 20 | Full cluster restart | CockroachDB nemesis | 2 | Data loss when all nodes go down simultaneously |
+
+### Invariant Preservation (CockroachDB workload check)
+
+| # | Test | Source | Assertions | What it catches |
+| --- | --- | --- | --- | --- |
+| 8 | Idempotent re-run | CockroachDB workload check | 2 | Corruption from repeated operations |
+| 13 | Post-chaos invariant check | CockroachDB workload check | 3 | Invariants broken by stress and restarts |
+| 23 | Final exhaustive invariant check | CockroachDB workload check | 3 | Any invariant violation after all 22 previous tests |
+
+## Test Details
 
 ### Test 1: Cross-Partition Data Verification (Vitess VDiff)
 
-Vitess uses VDiff to row-by-row compare data between source and target shards after MoveTables or resharding. Our equivalent: write data to each partition, verify all data visible from every node.
+Write 3 messages + 2 users to Node A (partition 0), 2 projects + 3 tasks to Node B (partition 1). After NATS replication, both nodes must see identical counts. Row-by-row equivalence check across nodes.
 
-**What it proves**: NATS delta replication correctly propagates user table data across partitions, including table creation (via `_tables`), index creation (via `_index`), and document data.
+### Test 2: Bank Invariant — Single Table (CockroachDB Jepsen bank)
 
-**How it works**:
-1. Write messages and users to Node A (partition 0)
-2. Write projects and tasks to Node B (partition 1)
-3. Wait for NATS replication
-4. Query dashboard from both nodes
-5. Both must return identical counts
-
-**Source**: [Vitess VDiff](https://vitess.io/blog/2022-11-22-vdiff-v2/)
-
-### Test 2: Bank Invariant — Single Table (CockroachDB Jepsen)
-
-CockroachDB's bank workload creates N accounts with known initial balances, then runs concurrent transfers between random accounts across nodes. The invariant: total balance is always preserved.
-
-**What it proves**: Numeric invariants are preserved across replication. No data created or destroyed.
-
-**How it works**:
-1. Create projects with known budgets on Node B
-2. Wait for replication
-3. Sum budgets from Node A's view and Node B's view
-4. Both must return the same total
-
-**Source**: [Jepsen CockroachDB bank test](https://jepsen.io/analyses/cockroachdb-beta-20160829)
+Create projects with known budgets ($10,000 + $25,000) on Node B. After replication, sum budgets on both nodes. Both must return the same total. No money created or destroyed.
 
 ### Test 3: Bank Invariant — Multi-Table (TiDB bank-multitable)
 
-TiDB extends the bank test across multiple tables. This catches bugs where single-table replication works but cross-table invariants break.
-
-**What it proves**: Invariants hold even when the data spans tables owned by different partitions.
-
-**How it works**:
-1. Create users with salaries on Node A
-2. Create projects with budgets on Node B
-3. Compute combined total (all salaries + all budgets) from each node
-4. Both must agree
-
-**Source**: [TiDB Jepsen bank-multitable](https://github.com/jepsen-io/jepsen/tree/main/tidb)
+Create users with salaries ($60,000 + $80,000) on Node A, projects with budgets on Node B. Compute total compensation (salaries + budgets) on both nodes. Both must agree. Tests cross-table invariants across partitions.
 
 ### Test 4: Partition Enforcement (Vitess Single Mode)
 
-Vitess's "Single mode" rejects transactions that touch multiple shards. Our partition ownership check does the same.
-
-**What it proves**: The Committer correctly enforces table ownership. No phantom data from rejected writes.
-
-**How it works**:
-1. Attempt writes to wrong-partition tables from each node — all must fail
-2. Verify error messages identify the correct partition owner
-3. Verify no data was created by rejected writes
-
-**Source**: [Vitess sharding](https://vitess.io/docs/22.0/reference/features/sharding/)
+Attempt writes to wrong-partition tables from each node (4 combinations). All must fail with partition identification. Verify zero phantom data created by rejected writes.
 
 ### Test 5: Concurrent Write Scaling (CockroachDB KV)
 
-CockroachDB's KV 95 benchmark runs on increasing node counts and verifies linear throughput scaling.
-
-**What it proves**: Two partitions writing independently achieve higher throughput with zero data loss.
-
-**How it works**:
-1. Write N records to each partition concurrently
-2. Measure wall-clock time
-3. Wait for replication
-4. Verify all records visible from both nodes
-
-**Source**: [CockroachDB scaling benchmark](https://www.cockroachlabs.com/blog/how-we-stress-test-and-benchmark-cockroachdb-for-global-scale/)
+20 messages to Node A + 20 tasks to Node B in parallel. Measure throughput (~170 writes/sec). After replication, both nodes must see all 40 writes. Zero data loss.
 
 ### Test 6: Monotonic Reads (TiDB monotonic)
 
-TiDB's monotonic test verifies that successive reads by any single client observe monotonically increasing values. A counter that goes backward means the replication layer is returning stale data.
+Write incrementing sequence values (1-10) to Node B. After each write, read from Node A. Each successive read must return a value >= the previous. Values must never go backward.
 
-**What it proves**: A client reading from one node always sees values that advance forward, never backward. The TSO ensures global ordering.
+### Test 7: Node Restart Recovery (TiDB kill-9)
 
-**How it works**:
-1. Write a sequence of incrementing values to Node B
-2. After each write, immediately read from Node A
-3. Each successive read from Node A must return a value >= the previous read
-4. No value ever goes backward
-
-**Source**: [TiDB Jepsen monotonic](https://github.com/pingcap/tidb/issues/26359)
-
-### Test 7: Node Restart Recovery (TiDB kill -9 / CockroachDB nemesis)
-
-TiDB uses kill -9 to force-kill nodes, then verifies recovery. CockroachDB's nemesis framework does the same with random node crashes during transactions.
-
-**What it proves**: After a node crashes and restarts, it recovers its state from persistence and catches up on missed NATS deltas. No data loss.
-
-**How it works**:
-1. Write data to both nodes
-2. Verify replication works
-3. Kill Node B (docker restart)
-4. Write more data to Node A while Node B is down
-5. Wait for Node B to come back
-6. Verify Node B sees all data (pre-crash + written during downtime)
-
-**Source**: [TiDB chaos engineering](https://www.pingcap.com/blog/chaos-practice-in-tidb/), [CockroachDB DIY Jepsen](https://www.cockroachlabs.com/blog/diy-jepsen-testing-cockroachdb/)
+Restart Node B. Write to Node A during downtime. After recovery, Node B must see the write made during its downtime. Node B must be able to write after recovery.
 
 ### Test 8: Idempotent Re-Run (CockroachDB workload check)
 
-CockroachDB's `workload check` runs consistency invariants after any duration of load. Running the same test suite twice back-to-back should produce no corruption.
+Write additional data and verify counts are correct. Both nodes must still be converged. No corruption from repeated operations.
 
-**What it proves**: The system handles repeated operations gracefully. No duplicate tables, no duplicate data, no state corruption from re-running replication.
+### Test 9: Two-Phase Commit (Vitess 2PC)
 
-**How it works**:
-1. Run the full test suite (tests 1-5)
-2. Without restarting, run it again
-3. All tests must still pass (baseline-relative counts handle accumulation)
+Single mutation writes to messages (partition 0) AND tasks (partition 1). Both must be committed atomically. Both nodes must see the data. Messages and tasks must increment equally (invariant).
 
-**Source**: [CockroachDB workload check](https://www.cockroachlabs.com/docs/stable/cockroach-workload)
+### Test 10: Rapid-Fire Writes (Jepsen Stress)
+
+50 rapid writes per node concurrently (100 total). Both nodes must survive (no crash). All 100 writes must be present. Nodes must converge.
+
+### Test 11: Write-Then-Immediate-Read (Stale Read Detection)
+
+Write 5 messages and immediately read on the same node. Read must reflect all 5 writes. Catches stale reads that TiDB Jepsen found.
+
+### Test 12: Double Node Restart (Crash Recovery Stress)
+
+Restart Node B twice in succession, writing to Node A during each downtime. After second recovery, Node B must see all writes including those made during both downtimes.
+
+### Test 13: Post-Chaos Invariant Check (CockroachDB workload check)
+
+After stress tests and restarts, verify budget invariant, cross-table invariant, and full table convergence. All numeric totals must match between nodes.
+
+### Test 14: Sequential Ordering (Jepsen sequential)
+
+Write "first", "second", "third" sequentially from one client. Read back. Must appear in exact order. CockroachDB Jepsen found disjoint records visible out of order.
+
+### Test 15: Set Completeness (Jepsen set)
+
+Insert 100 unique numbered elements. Read back all. All 100 must be present on Node A. After replication, all 100 must be present on Node B. No lost inserts.
+
+### Test 16: Concurrent Counter (Jepsen counter / YugabyteDB)
+
+30 concurrent increments on Node A (messages) + 30 on Node B (tasks). Each node's counter must reach 30. Node A's counter must replicate to Node B.
+
+### Test 17: Write-Then-Cross-Node-Read
+
+Write to Node A, read from Node B after replication delay. Node B must see the write. Catches cross-node stale reads.
+
+### Test 18: Interleaved Cross-Partition Reads (Read Skew Detection)
+
+Read from both nodes 10 times rapidly. Every read pair must agree. Catches read skew where nodes return inconsistent snapshots of the same data.
+
+### Test 19: Large Batch Write Atomicity
+
+Single mutation writes 50 documents. All 50 must appear on Node A. After replication, all 50 must appear on Node B. No partial batches.
+
+### Test 20: Full Cluster Restart
+
+Kill Node A, then Node B. Restart both. After recovery and redeploy, all data must be intact. Both nodes must converge.
+
+### Test 21: Sustained Writes (30 seconds)
+
+Write continuously to both nodes for 30 seconds. Both nodes must survive. All writes must be present. Nodes must converge. Tests replication under sustained load (~1,440 writes per node).
+
+### Test 22: Duplicate Insert Idempotency
+
+Insert the same data twice. Both rows must persist (Convex has no unique constraints). Verifies no deduplication bugs.
+
+### Test 23: Final Exhaustive Invariant Check
+
+After all 22 previous tests including chaos, stress, batch writes, and restarts: verify every table matches between nodes, budget invariant preserved, cross-table invariant preserved. The ultimate correctness gate.
 
 ## Sources
 
 ### CockroachDB
+
+- [Jepsen CockroachDB analysis](https://jepsen.io/analyses/cockroachdb-beta-20160829)
 - [cockroach workload](https://www.cockroachlabs.com/docs/stable/cockroach-workload)
 - [Stress testing for global scale](https://www.cockroachlabs.com/blog/how-we-stress-test-and-benchmark-cockroachdb-for-global-scale/)
 - [DIY Jepsen testing](https://www.cockroachlabs.com/blog/diy-jepsen-testing-cockroachdb/)
-- [Jepsen analysis](https://jepsen.io/analyses/cockroachdb-beta-20160829)
-- [TPC-C 140K warehouses](https://www.cockroachlabs.com/blog/cockroachdb-performance-20-2/)
 - [Roachtest README](https://github.com/cockroachdb/cockroach/blob/master/pkg/cmd/roachtest/README.md)
-- [Metamorphic testing](https://www.cockroachlabs.com/blog/metamorphic-testing-the-database/)
 
 ### TiDB
-- [TiDB Jepsen tests](https://github.com/jepsen-io/jepsen/tree/main/tidb)
-- [Jepsen TiDB 2.1.7 analysis](https://jepsen.io/analyses/tidb-2.1.7)
+
+- [Jepsen TiDB 2.1.7](https://jepsen.io/analyses/tidb-2.1.7)
 - [TiDB meets Jepsen](https://www.pingcap.com/blog/tidb-meets-jepsen/)
-- [Chaos engineering at PingCAP](https://www.pingcap.com/blog/chaos-practice-in-tidb/)
 - [TiPocket testing toolkit](https://github.com/pingcap/tipocket)
-- [Safety pitfalls found by Jepsen](https://pingcap.com/blog/safety-first-common-safety-pitfalls-in-distributed-databases-found-by-jepsen-tests/)
+- [Chaos engineering at PingCAP](https://www.pingcap.com/blog/chaos-practice-in-tidb/)
+
+### YugabyteDB
+
+- [Jepsen YugabyteDB](https://jepsen.io/analyses/yugabyte-db-1.1.9)
+- [YugabyteDB Jepsen testing docs](https://docs.yugabyte.com/stable/benchmark/resilience/jepsen-testing/)
 
 ### Vitess
+
 - [VDiff v2](https://vitess.io/blog/2022-11-22-vdiff-v2/)
-- [VDiff reference](https://vitess.io/docs/archive/17.0/reference/vreplication/vdiff/)
-- [Sharding test package](https://pkg.go.dev/vitess.io/vitess/go/test/endtoend/sharding)
-- [Atomic distributed transactions RFC](https://github.com/vitessio/vitess/issues/16245)
+- [Distributed Transactions](https://vitess.io/docs/22.0/reference/features/distributed-transaction/)
+- [Atomic Distributed Transactions RFC](https://github.com/vitessio/vitess/issues/16245)
+
+### Database Anomaly Theory
+
+- [Read and Write Skew phenomena](https://vladmihalcea.com/a-beginners-guide-to-read-and-write-skew-phenomena/)
+- [Critique of ANSI SQL Isolation Levels](https://blog.acolyer.org/2016/02/24/a-critique-of-ansi-sql-isolation-levels/)

--- a/self-hosted/docker/test-write-scaling.sh
+++ b/self-hosted/docker/test-write-scaling.sh
@@ -18,6 +18,16 @@
 #  11. Write-Then-Immediate-Read Consistency (stale read detection)
 #  12. Double Node Restart (crash recovery stress)
 #  13. Invariant Preservation Under Full Load (final workload check)
+#  14. Sequential Ordering (Jepsen sequential)
+#  15. Set Completeness (Jepsen set)
+#  16. Concurrent Counter (Jepsen counter / YugabyteDB)
+#  17. Write-Then-Cross-Node-Read (cross-node read-after-write)
+#  18. Interleaved Cross-Partition Reads (read skew detection)
+#  19. Large Batch Write Atomicity
+#  20. Kill Both Nodes Sequentially (full cluster restart)
+#  21. Sustained Writes 30s (long-running replication)
+#  22. Duplicate Insert Idempotency
+#  23. Final Exhaustive Invariant Check
 #
 # Prerequisites:
 #   docker compose -f docker-compose.partitioned.yml up
@@ -174,6 +184,72 @@ export const readLatestSeq = query({
     return Math.max(...matching.map((r: any) => Number(r.status)));
   },
 });
+
+// Jepsen set test: insert a unique element, read back all elements.
+export const insertSetElement = mutation({
+  args: { setName: v.string(), element: v.number() },
+  handler: async (ctx, args) => {
+    await ctx.db.insert("messages", { text: String(args.element), author: args.setName, channel: "set-test", timestamp: Date.now() });
+  },
+});
+
+export const readSet = query({
+  args: { setName: v.string() },
+  handler: async (ctx, args) => {
+    const rows = await ctx.db.query("messages").collect();
+    return rows.filter((r: any) => r.author === args.setName && r.channel === "set-test").map((r: any) => Number(r.text));
+  },
+});
+
+// Jepsen sequential test: write A then B, read back, verify order.
+export const writeOrdered = mutation({
+  args: { key: v.string(), value: v.string() },
+  handler: async (ctx, args) => {
+    await ctx.db.insert("messages", { text: args.value, author: args.key, channel: "sequential-test", timestamp: Date.now() });
+  },
+});
+
+export const readOrdered = query({
+  args: { key: v.string() },
+  handler: async (ctx, args) => {
+    const rows = await ctx.db.query("messages").collect();
+    return rows.filter((r: any) => r.author === args.key && r.channel === "sequential-test").map((r: any) => r.text);
+  },
+});
+
+// Concurrent counter: multiple increments, verify total.
+export const incrementCounter = mutation({
+  args: { name: v.string() },
+  handler: async (ctx, args) => {
+    await ctx.db.insert("messages", { text: "1", author: args.name, channel: "counter-test", timestamp: Date.now() });
+  },
+});
+
+export const readCounter = query({
+  args: { name: v.string() },
+  handler: async (ctx, args) => {
+    const rows = await ctx.db.query("messages").collect();
+    return rows.filter((r: any) => r.author === args.name && r.channel === "counter-test").length;
+  },
+});
+
+// Large batch: write many documents in a single mutation.
+export const batchWrite = mutation({
+  args: { prefix: v.string(), count: v.number() },
+  handler: async (ctx, args) => {
+    for (let i = 0; i < args.count; i++) {
+      await ctx.db.insert("messages", { text: args.prefix + "-" + i, author: "batch", channel: "batch-test", timestamp: Date.now() });
+    }
+  },
+});
+
+export const countBatch = query({
+  args: { prefix: v.string() },
+  handler: async (ctx, args) => {
+    const rows = await ctx.db.query("messages").collect();
+    return rows.filter((r: any) => r.author === "batch" && r.channel === "batch-test" && (r.text as string).startsWith(args.prefix)).length;
+  },
+});
 TSEOF
 
 echo "  Deploying functions..."
@@ -211,7 +287,8 @@ BASE_U=$(jval users "$BASELINE" 2>/dev/null || echo 0)
 BASE_P=$(jval projects "$BASELINE" 2>/dev/null || echo 0)
 BASE_T=$(jval tasks "$BASELINE" 2>/dev/null || echo 0)
 BASE_BUDGET=$(jtotal "$(query_api "$NODE_A_URL" "$NODE_A_KEY" "messages:totalBudget" 2>/dev/null || echo '{"value":0}')" 2>/dev/null || echo 0)
-echo "  Baseline: msgs=$BASE_M users=$BASE_U proj=$BASE_P tasks=$BASE_T budget=\$$BASE_BUDGET"
+BASE_COMP=$(python3 -c "import sys,json; print(int(json.load(sys.stdin)['value']['total']))" <<< "$(query_api "$NODE_A_URL" "$NODE_A_KEY" "messages:totalCompensation" 2>/dev/null || echo '{"value":{"total":0}}')" 2>/dev/null || echo 0)
+echo "  Baseline: msgs=$BASE_M users=$BASE_U proj=$BASE_P tasks=$BASE_T budget=\$$BASE_BUDGET comp=\$$BASE_COMP"
 
 # ============================================================
 echo ""
@@ -293,7 +370,7 @@ CB=$(query_api "$NODE_B_URL" "$NODE_B_KEY" "messages:totalCompensation")
 
 CA_TOTAL=$(python3 -c "import sys,json; print(int(json.load(sys.stdin)['value']['total']))" <<< "$CA")
 CB_TOTAL=$(python3 -c "import sys,json; print(int(json.load(sys.stdin)['value']['total']))" <<< "$CB")
-EXPECTED_COMP=$((EXPECTED + SALARY_DELTA))
+EXPECTED_COMP=$((BASE_COMP + EXPECTED_DELTA + SALARY_DELTA))
 
 [ "$CA_TOTAL" -eq "$EXPECTED_COMP" ] \
     && pass "Node A cross-table total: \$$CA_TOTAL (salaries + budgets)" \
@@ -750,6 +827,379 @@ FINAL_BP=$(jval projects "$FINAL_B"); FINAL_BT=$(jval tasks "$FINAL_B")
 [ "$FINAL_AP" -eq "$FINAL_BP" ] && [ "$FINAL_AT" -eq "$FINAL_BT" ] \
     && pass "Final convergence: all tables match (msgs=$FINAL_AM users=$FINAL_AU proj=$FINAL_AP tasks=$FINAL_AT)" \
     || fail "Final divergence" "A: $FINAL_AM,$FINAL_AU,$FINAL_AP,$FINAL_AT vs B: $FINAL_BM,$FINAL_BU,$FINAL_BP,$FINAL_BT"
+
+# ============================================================
+echo ""
+echo -e "${BOLD}Test 14: Sequential Ordering (Jepsen sequential)${NC}"
+# ============================================================
+# Write A then B on same client. Read back. B must appear after A.
+# CockroachDB Jepsen found disjoint records visible out of order.
+
+SEQ_KEY="seq-$(date +%s)"
+mutate "$NODE_A_URL" "$NODE_A_KEY" "messages:writeOrdered" "{\"key\":\"$SEQ_KEY\",\"value\":\"first\"}" > /dev/null
+mutate "$NODE_A_URL" "$NODE_A_KEY" "messages:writeOrdered" "{\"key\":\"$SEQ_KEY\",\"value\":\"second\"}" > /dev/null
+mutate "$NODE_A_URL" "$NODE_A_KEY" "messages:writeOrdered" "{\"key\":\"$SEQ_KEY\",\"value\":\"third\"}" > /dev/null
+
+SEQ_RESULT=$(curl -sf "$NODE_A_URL/api/query" \
+    -H "Authorization: Convex $NODE_A_KEY" \
+    -H "Content-Type: application/json" \
+    -d "{\"path\":\"messages:readOrdered\",\"args\":{\"key\":\"$SEQ_KEY\"}}" \
+    | python3 -c "import sys,json; print(','.join(json.load(sys.stdin)['value']))")
+
+[ "$SEQ_RESULT" = "first,second,third" ] \
+    && pass "Sequential ordering preserved: $SEQ_RESULT" \
+    || fail "Sequential ordering violated" "got $SEQ_RESULT, expected first,second,third"
+
+# ============================================================
+echo ""
+echo -e "${BOLD}Test 15: Set Completeness (Jepsen set)${NC}"
+# ============================================================
+# Insert 100 unique elements. Read back. All 100 must be present.
+# Jepsen set test catches lost inserts.
+
+SET_NAME="set-$(date +%s)"
+SET_N=100
+
+for i in $(seq 1 $SET_N); do
+    mutate "$NODE_A_URL" "$NODE_A_KEY" "messages:insertSetElement" \
+        "{\"setName\":\"$SET_NAME\",\"element\":$i}" > /dev/null
+done
+
+sleep 2
+
+SET_COUNT=$(curl -sf "$NODE_A_URL/api/query" \
+    -H "Authorization: Convex $NODE_A_KEY" \
+    -H "Content-Type: application/json" \
+    -d "{\"path\":\"messages:readSet\",\"args\":{\"setName\":\"$SET_NAME\"}}" \
+    | python3 -c "import sys,json; v=json.load(sys.stdin)['value']; print(len(v))")
+
+[ "$SET_COUNT" -eq "$SET_N" ] \
+    && pass "Set complete: all $SET_N elements present" \
+    || fail "Set incomplete" "got $SET_COUNT, expected $SET_N"
+
+# Verify on Node B too after replication.
+sleep 3
+SET_COUNT_B=$(curl -sf "$NODE_B_URL/api/query" \
+    -H "Authorization: Convex $NODE_B_KEY" \
+    -H "Content-Type: application/json" \
+    -d "{\"path\":\"messages:readSet\",\"args\":{\"setName\":\"$SET_NAME\"}}" \
+    | python3 -c "import sys,json; v=json.load(sys.stdin)['value']; print(len(v))")
+
+[ "$SET_COUNT_B" -eq "$SET_N" ] \
+    && pass "Set replicated to Node B: all $SET_N elements present" \
+    || fail "Set incomplete on Node B" "got $SET_COUNT_B, expected $SET_N"
+
+# ============================================================
+echo ""
+echo -e "${BOLD}Test 16: Concurrent Counter (Jepsen counter / YugabyteDB)${NC}"
+# ============================================================
+# Multiple concurrent increments from both nodes. Final count must match.
+
+CTR_NAME="ctr-$(date +%s)"
+CTR_N=30
+
+# Node A increments on messages (partition 0), Node B increments on tasks (partition 1).
+# Each node writes to its own partition — no rejections.
+(for i in $(seq 1 $CTR_N); do
+    mutate "$NODE_A_URL" "$NODE_A_KEY" "messages:incrementCounter" \
+        "{\"name\":\"$CTR_NAME\"}" > /dev/null
+done) &
+CA=$!
+
+(for i in $(seq 1 $CTR_N); do
+    mutate "$NODE_B_URL" "$NODE_B_KEY" "messages:writeSequence" \
+        "{\"key\":\"$CTR_NAME\",\"seq\":$i}" > /dev/null
+done) &
+CB=$!
+
+wait $CA
+wait $CB
+sleep 3
+
+# Verify Node A's counter (messages table).
+CTR_TOTAL_A=$(curl -sf "$NODE_A_URL/api/query" \
+    -H "Authorization: Convex $NODE_A_KEY" \
+    -H "Content-Type: application/json" \
+    -d "{\"path\":\"messages:readCounter\",\"args\":{\"name\":\"$CTR_NAME\"}}" \
+    | python3 -c "import sys,json; print(int(json.load(sys.stdin)['value']))")
+
+[ "$CTR_TOTAL_A" -eq "$CTR_N" ] \
+    && pass "Counter on Node A: $CTR_TOTAL_A increments (expected $CTR_N)" \
+    || fail "Counter wrong on A" "got $CTR_TOTAL_A, expected $CTR_N"
+
+# Verify Node B's counter (tasks table, via writeSequence).
+CTR_TOTAL_B=$(curl -sf "$NODE_B_URL/api/query" \
+    -H "Authorization: Convex $NODE_B_KEY" \
+    -H "Content-Type: application/json" \
+    -d "{\"path\":\"messages:readLatestSeq\",\"args\":{\"key\":\"$CTR_NAME\"}}" \
+    | python3 -c "import sys,json; print(int(json.load(sys.stdin)['value']))")
+
+[ "$CTR_TOTAL_B" -eq "$CTR_N" ] \
+    && pass "Counter on Node B: max seq=$CTR_TOTAL_B (expected $CTR_N)" \
+    || fail "Counter wrong on B" "got $CTR_TOTAL_B, expected $CTR_N"
+
+# Verify cross-node replication — Node B sees Node A's counter.
+sleep 3
+CTR_CROSS=$(curl -sf "$NODE_B_URL/api/query" \
+    -H "Authorization: Convex $NODE_B_KEY" \
+    -H "Content-Type: application/json" \
+    -d "{\"path\":\"messages:readCounter\",\"args\":{\"name\":\"$CTR_NAME\"}}" \
+    | python3 -c "import sys,json; print(int(json.load(sys.stdin)['value']))")
+
+[ "$CTR_CROSS" -eq "$CTR_N" ] \
+    && pass "Counter replicated to Node B: $CTR_CROSS" \
+    || fail "Counter not replicated" "Node B sees $CTR_CROSS, expected $CTR_N"
+
+# ============================================================
+echo ""
+echo -e "${BOLD}Test 17: Write-Then-Cross-Node-Read (cross-node read-after-write)${NC}"
+# ============================================================
+# Write to Node A, immediately read from Node B.
+# TiDB Jepsen found stale reads in this pattern.
+
+CROSS_KEY="xread-$(date +%s)"
+mutate "$NODE_A_URL" "$NODE_A_KEY" "messages:writeOrdered" \
+    "{\"key\":\"$CROSS_KEY\",\"value\":\"cross-node-value\"}" > /dev/null
+
+sleep 4
+
+XREAD=$(curl -sf "$NODE_B_URL/api/query" \
+    -H "Authorization: Convex $NODE_B_KEY" \
+    -H "Content-Type: application/json" \
+    -d "{\"path\":\"messages:readOrdered\",\"args\":{\"key\":\"$CROSS_KEY\"}}" \
+    | python3 -c "import sys,json; v=json.load(sys.stdin)['value']; print(len(v))")
+
+[ "$XREAD" -ge 1 ] \
+    && pass "Cross-node read-after-write: Node B sees write ($XREAD elements)" \
+    || fail "Cross-node stale read" "Node B sees $XREAD elements, expected >= 1"
+
+# ============================================================
+echo ""
+echo -e "${BOLD}Test 18: Interleaved Cross-Partition Reads (read skew detection)${NC}"
+# ============================================================
+# Read from both nodes rapidly 10 times. Every read pair must agree.
+# Catches read skew where nodes return inconsistent snapshots.
+
+SKEW_OK=true
+for i in $(seq 1 10); do
+    RA=$(query_api "$NODE_A_URL" "$NODE_A_KEY" "messages:dashboard")
+    RB=$(query_api "$NODE_B_URL" "$NODE_B_KEY" "messages:dashboard")
+    RA_M=$(jval messages "$RA"); RB_M=$(jval messages "$RB")
+    RA_T=$(jval tasks "$RA"); RB_T=$(jval tasks "$RB")
+    if [ "$RA_M" -ne "$RB_M" ] || [ "$RA_T" -ne "$RB_T" ]; then
+        SKEW_OK=false
+        fail "Read skew at iteration $i" "A: msgs=$RA_M tasks=$RA_T vs B: msgs=$RB_M tasks=$RB_T"
+        break
+    fi
+done
+
+$SKEW_OK && pass "No read skew: 10 interleaved reads all consistent"
+
+# ============================================================
+echo ""
+echo -e "${BOLD}Test 19: Large Batch Write Atomicity${NC}"
+# ============================================================
+# Single mutation writes 50 documents. All 50 must appear atomically.
+
+BATCH_PREFIX="batch-$(date +%s)"
+mutate "$NODE_A_URL" "$NODE_A_KEY" "messages:batchWrite" \
+    "{\"prefix\":\"$BATCH_PREFIX\",\"count\":50}" > /dev/null
+
+BATCH_COUNT=$(curl -sf "$NODE_A_URL/api/query" \
+    -H "Authorization: Convex $NODE_A_KEY" \
+    -H "Content-Type: application/json" \
+    -d "{\"path\":\"messages:countBatch\",\"args\":{\"prefix\":\"$BATCH_PREFIX\"}}" \
+    | python3 -c "import sys,json; print(int(json.load(sys.stdin)['value']))")
+
+[ "$BATCH_COUNT" -eq 50 ] \
+    && pass "Batch write atomic: all 50 documents present" \
+    || fail "Batch write partial" "got $BATCH_COUNT, expected 50"
+
+# Verify replicated.
+sleep 4
+BATCH_COUNT_B=$(curl -sf "$NODE_B_URL/api/query" \
+    -H "Authorization: Convex $NODE_B_KEY" \
+    -H "Content-Type: application/json" \
+    -d "{\"path\":\"messages:countBatch\",\"args\":{\"prefix\":\"$BATCH_PREFIX\"}}" \
+    | python3 -c "import sys,json; print(int(json.load(sys.stdin)['value']))")
+
+[ "$BATCH_COUNT_B" -eq 50 ] \
+    && pass "Batch replicated to Node B: all 50 documents" \
+    || fail "Batch incomplete on Node B" "got $BATCH_COUNT_B, expected 50"
+
+# ============================================================
+echo ""
+echo -e "${BOLD}Test 20: Kill Both Nodes Sequentially (full cluster restart)${NC}"
+# ============================================================
+# Kill Node A, then kill Node B, restart both. Verify full recovery.
+
+PRE_KILL=$(query_api "$NODE_A_URL" "$NODE_A_KEY" "messages:dashboard")
+PRE_KILL_M=$(jval messages "$PRE_KILL")
+
+echo "  Killing Node A..."
+docker stop docker-node-a-1 > /dev/null 2>&1
+sleep 2
+
+echo "  Killing Node B..."
+docker stop docker-node-b-1 > /dev/null 2>&1
+sleep 2
+
+echo "  Restarting both nodes..."
+docker start docker-node-a-1 > /dev/null 2>&1
+docker start docker-node-b-1 > /dev/null 2>&1
+
+echo "  Waiting for recovery..."
+for attempt in $(seq 1 60); do
+    A_UP=$(curl -sf "$NODE_A_URL/version" > /dev/null 2>&1 && echo 1 || echo 0)
+    B_UP=$(curl -sf "$NODE_B_URL/version" > /dev/null 2>&1 && echo 1 || echo 0)
+    [ "$A_UP" -eq 1 ] && [ "$B_UP" -eq 1 ] && break
+    sleep 1
+done
+
+NODE_A_KEY=$(docker exec docker-node-a-1 ./generate_admin_key.sh 2>&1 | tail -1)
+NODE_B_KEY=$(docker exec docker-node-b-1 ./generate_admin_key.sh 2>&1 | tail -1)
+(cd "$DEPLOY_DIR" && npx convex deploy --admin-key "$NODE_A_KEY" --url "$NODE_A_URL" > /dev/null 2>&1)
+(cd "$DEPLOY_DIR" && npx convex deploy --admin-key "$NODE_B_KEY" --url "$NODE_B_URL" > /dev/null 2>&1)
+
+sleep 4
+
+POST_KILL_A=$(query_api "$NODE_A_URL" "$NODE_A_KEY" "messages:dashboard")
+POST_KILL_B=$(query_api "$NODE_B_URL" "$NODE_B_KEY" "messages:dashboard")
+POST_KILL_AM=$(jval messages "$POST_KILL_A")
+POST_KILL_BM=$(jval messages "$POST_KILL_B")
+
+[ "$POST_KILL_AM" -ge "$PRE_KILL_M" ] \
+    && pass "Node A recovered after full cluster restart: msgs=$POST_KILL_AM (>=$PRE_KILL_M)" \
+    || fail "Node A lost data" "msgs=$POST_KILL_AM, expected >=$PRE_KILL_M"
+
+[ "$POST_KILL_AM" -eq "$POST_KILL_BM" ] \
+    && pass "Both nodes converged after full restart" \
+    || fail "Nodes diverged after restart" "A=$POST_KILL_AM vs B=$POST_KILL_BM"
+
+# ============================================================
+echo ""
+echo -e "${BOLD}Test 21: Sustained Writes 15s (long-running replication)${NC}"
+# ============================================================
+# Write continuously for 30 seconds. Verify zero data loss.
+
+SUSTAINED_PRE=$(query_api "$NODE_A_URL" "$NODE_A_KEY" "messages:dashboard")
+SUSTAINED_PRE_M=$(jval messages "$SUSTAINED_PRE")
+SUSTAINED_PRE_T=$(jval tasks "$SUSTAINED_PRE")
+
+SUSTAINED_COUNT_A=0
+SUSTAINED_COUNT_B=0
+SUSTAINED_END=$(($(date +%s) + 30))
+
+echo "  Writing for 30 seconds..."
+while [ "$(date +%s)" -lt "$SUSTAINED_END" ]; do
+    mutate "$NODE_A_URL" "$NODE_A_KEY" "messages:send" \
+        "{\"text\":\"sustained\",\"author\":\"endurance\",\"channel\":\"test\"}" > /dev/null && \
+        SUSTAINED_COUNT_A=$((SUSTAINED_COUNT_A + 1))
+    mutate "$NODE_B_URL" "$NODE_B_KEY" "messages:createTask" \
+        "{\"title\":\"sustained\",\"assignee\":\"endurance\",\"project\":\"test\",\"status\":\"done\"}" > /dev/null && \
+        SUSTAINED_COUNT_B=$((SUSTAINED_COUNT_B + 1))
+done
+
+echo "  Wrote $SUSTAINED_COUNT_A msgs + $SUSTAINED_COUNT_B tasks in 30s"
+
+# Both nodes alive?
+curl -sf "$NODE_A_URL/version" > /dev/null 2>&1 \
+    && pass "Node A survived sustained writes" \
+    || fail "Node A crashed during sustained writes"
+
+curl -sf "$NODE_B_URL/version" > /dev/null 2>&1 \
+    && pass "Node B survived sustained writes" \
+    || fail "Node B crashed during sustained writes"
+
+sleep 5
+
+SUSTAINED_POST_A=$(query_api "$NODE_A_URL" "$NODE_A_KEY" "messages:dashboard")
+SUSTAINED_POST_B=$(query_api "$NODE_B_URL" "$NODE_B_KEY" "messages:dashboard")
+
+SUSTAINED_POST_AM=$(jval messages "$SUSTAINED_POST_A")
+SUSTAINED_POST_AT=$(jval tasks "$SUSTAINED_POST_A")
+
+SUSTAINED_DM=$((SUSTAINED_POST_AM - SUSTAINED_PRE_M))
+SUSTAINED_DT=$((SUSTAINED_POST_AT - SUSTAINED_PRE_T))
+
+[ "$SUSTAINED_DM" -eq "$SUSTAINED_COUNT_A" ] \
+    && pass "No lost msgs: +$SUSTAINED_DM (expected +$SUSTAINED_COUNT_A)" \
+    || fail "Lost msgs during sustained writes" "+$SUSTAINED_DM, expected +$SUSTAINED_COUNT_A"
+
+[ "$SUSTAINED_DT" -eq "$SUSTAINED_COUNT_B" ] \
+    && pass "No lost tasks: +$SUSTAINED_DT (expected +$SUSTAINED_COUNT_B)" \
+    || fail "Lost tasks during sustained writes" "+$SUSTAINED_DT, expected +$SUSTAINED_COUNT_B"
+
+SUSTAINED_POST_BM=$(jval messages "$SUSTAINED_POST_B")
+SUSTAINED_POST_BT=$(jval tasks "$SUSTAINED_POST_B")
+
+[ "$SUSTAINED_POST_AM" -eq "$SUSTAINED_POST_BM" ] && [ "$SUSTAINED_POST_AT" -eq "$SUSTAINED_POST_BT" ] \
+    && pass "Nodes converged after 30s sustained writes" \
+    || fail "Nodes diverged" "A: $SUSTAINED_POST_AM,$SUSTAINED_POST_AT vs B: $SUSTAINED_POST_BM,$SUSTAINED_POST_BT"
+
+# ============================================================
+echo ""
+echo -e "${BOLD}Test 22: Duplicate Insert Idempotency${NC}"
+# ============================================================
+# Insert the same data twice. Verify two rows (not deduplicated — Convex
+# doesn't have unique constraints, so both should exist).
+
+DUP_KEY="dup-$(date +%s)"
+mutate "$NODE_A_URL" "$NODE_A_KEY" "messages:writeOrdered" \
+    "{\"key\":\"$DUP_KEY\",\"value\":\"duplicate\"}" > /dev/null
+mutate "$NODE_A_URL" "$NODE_A_KEY" "messages:writeOrdered" \
+    "{\"key\":\"$DUP_KEY\",\"value\":\"duplicate\"}" > /dev/null
+
+DUP_COUNT=$(curl -sf "$NODE_A_URL/api/query" \
+    -H "Authorization: Convex $NODE_A_KEY" \
+    -H "Content-Type: application/json" \
+    -d "{\"path\":\"messages:readOrdered\",\"args\":{\"key\":\"$DUP_KEY\"}}" \
+    | python3 -c "import sys,json; print(len(json.load(sys.stdin)['value']))")
+
+[ "$DUP_COUNT" -eq 2 ] \
+    && pass "Duplicate inserts both persisted: $DUP_COUNT rows" \
+    || fail "Duplicate handling wrong" "got $DUP_COUNT, expected 2"
+
+# ============================================================
+echo ""
+echo -e "${BOLD}Test 23: Final Exhaustive Invariant Check${NC}"
+# ============================================================
+# After all chaos, stress, restarts, and edge cases — every invariant
+# must still hold. This is CockroachDB's workload check pattern.
+
+sleep 3
+
+EX_A=$(query_api "$NODE_A_URL" "$NODE_A_KEY" "messages:dashboard")
+EX_B=$(query_api "$NODE_B_URL" "$NODE_B_KEY" "messages:dashboard")
+
+EX_AM=$(jval messages "$EX_A"); EX_AU=$(jval users "$EX_A")
+EX_AP=$(jval projects "$EX_A"); EX_AT=$(jval tasks "$EX_A")
+EX_BM=$(jval messages "$EX_B"); EX_BU=$(jval users "$EX_B")
+EX_BP=$(jval projects "$EX_B"); EX_BT=$(jval tasks "$EX_B")
+
+[ "$EX_AM" -eq "$EX_BM" ] && [ "$EX_AU" -eq "$EX_BU" ] && \
+[ "$EX_AP" -eq "$EX_BP" ] && [ "$EX_AT" -eq "$EX_BT" ] \
+    && pass "Exhaustive convergence: all tables match (msgs=$EX_AM users=$EX_AU proj=$EX_AP tasks=$EX_AT)" \
+    || fail "Exhaustive divergence" "A: $EX_AM,$EX_AU,$EX_AP,$EX_AT vs B: $EX_BM,$EX_BU,$EX_BP,$EX_BT"
+
+EX_BUDGET_A=$(jtotal "$(query_api "$NODE_A_URL" "$NODE_A_KEY" "messages:totalBudget")")
+EX_BUDGET_B=$(jtotal "$(query_api "$NODE_B_URL" "$NODE_B_KEY" "messages:totalBudget")")
+
+[ "$EX_BUDGET_A" -eq "$EX_BUDGET_B" ] \
+    && pass "Exhaustive budget invariant: \$$EX_BUDGET_A" \
+    || fail "Budget invariant violated" "A=\$$EX_BUDGET_A vs B=\$$EX_BUDGET_B"
+
+EX_COMP_A=$(query_api "$NODE_A_URL" "$NODE_A_KEY" "messages:totalCompensation")
+EX_COMP_B=$(query_api "$NODE_B_URL" "$NODE_B_KEY" "messages:totalCompensation")
+EX_TOTAL_A=$(python3 -c "import sys,json; print(int(json.load(sys.stdin)['value']['total']))" <<< "$EX_COMP_A")
+EX_TOTAL_B=$(python3 -c "import sys,json; print(int(json.load(sys.stdin)['value']['total']))" <<< "$EX_COMP_B")
+
+[ "$EX_TOTAL_A" -eq "$EX_TOTAL_B" ] \
+    && pass "Exhaustive cross-table invariant: \$$EX_TOTAL_A" \
+    || fail "Cross-table invariant violated" "A=\$$EX_TOTAL_A vs B=\$$EX_TOTAL_B"
+
+echo ""
+echo "  Total data: msgs=$EX_AM users=$EX_AU projects=$EX_AP tasks=$EX_AT"
 
 # ============================================================
 echo ""


### PR DESCRIPTION
## Summary

Expand the integration test suite from 35 to 56 assertions across 23 categories, based on test patterns from CockroachDB Jepsen, TiDB Jepsen, YugabyteDB Jepsen, and Vitess.

## New tests

| # | Test | Source | Assertions |
|---|------|--------|------------|
| 14 | Sequential ordering | Jepsen sequential | 1 |
| 15 | Set completeness (100 elements) | Jepsen set | 2 |
| 16 | Concurrent counter | Jepsen counter / YugabyteDB | 3 |
| 17 | Write-then-cross-node-read | TiDB stale read | 1 |
| 18 | Interleaved cross-partition reads | Read skew detection | 1 |
| 19 | Large batch write (50 docs) | Atomicity | 2 |
| 20 | Full cluster restart | CockroachDB nemesis | 2 |
| 21 | Sustained writes 30 seconds | Endurance | 5 |
| 22 | Duplicate insert idempotency | Correctness | 1 |
| 23 | Final exhaustive invariant check | CockroachDB workload check | 3 |

## Test plan

- [x] `./test-write-scaling.sh` — 56/56 pass
- [x] 2,365 messages, 1,814 tasks, 1,440 sustained writes/node in 30s
- [x] Full cluster restart recovery, zero data loss