### PR TITLE
style: apply cargo fmt formatting

### DIFF
--- a/crates/database/src/checkpoint.rs
+++ b/crates/database/src/checkpoint.rs
@@ -8,7 +8,8 @@
 //! Postgres.
 //!
 //! After bootstrap, the Replica tails NATS from the checkpoint timestamp for
-//! live delta replication. The Replica never connects to the Primary's database.
+//! live delta replication. The Replica never connects to the Primary's
+//! database.
 
 use std::{
     collections::BTreeMap,

--- a/crates/database/src/commit_delta.rs
+++ b/crates/database/src/commit_delta.rs
@@ -111,8 +111,10 @@ pub mod testing {
     use futures::stream::BoxStream;
     use parking_lot::Mutex;
     use tokio::sync::broadcast;
-    use tokio_stream::wrappers::BroadcastStream;
-    use tokio_stream::StreamExt;
+    use tokio_stream::{
+        wrappers::BroadcastStream,
+        StreamExt,
+    };
 
     use super::{
         CommitDelta,
@@ -162,8 +164,8 @@ pub mod testing {
                 .collect();
 
             let receiver = self.sender.subscribe();
-            let broadcast_stream = BroadcastStream::new(receiver)
-                .filter_map(move |result| match result {
+            let broadcast_stream =
+                BroadcastStream::new(receiver).filter_map(move |result| match result {
                     Ok(delta) if delta.ts > from_ts => Some(Ok(delta)),
                     Ok(_) => None,
                     Err(e) => Some(Err(anyhow::anyhow!("broadcast lag: {e}"))),

--- a/crates/database/src/partition.rs
+++ b/crates/database/src/partition.rs
@@ -68,11 +68,7 @@ impl PartitionMap {
     ///
     /// Tables not listed default to partition 0.
     /// System tables (starting with `_`) are always partition 0 regardless.
-    pub fn from_config(
-        config: &str,
-        local_partition: PartitionId,
-        num_partitions: u32,
-    ) -> Self {
+    pub fn from_config(config: &str, local_partition: PartitionId, num_partitions: u32) -> Self {
         let mut assignments = BTreeMap::new();
         if !config.is_empty() {
             for pair in config.split(',') {
@@ -176,11 +172,8 @@ mod tests {
 
     #[test]
     fn test_multi_partition() {
-        let map = PartitionMap::from_config(
-            "messages=1,users=1,projects=2,tasks=2",
-            PartitionId(1),
-            3,
-        );
+        let map =
+            PartitionMap::from_config("messages=1,users=1,projects=2,tasks=2", PartitionId(1), 3);
 
         // Assigned tables.
         assert_eq!(

--- a/crates/database/src/replica.rs
+++ b/crates/database/src/replica.rs
@@ -20,7 +20,8 @@ use crate::{
 };
 
 /// Consumes [`CommitDelta`]s from a [`DistributedLog`] and feeds them
-/// through the Committer's apply loop via `CommitterClient::apply_replica_delta`.
+/// through the Committer's apply loop via
+/// `CommitterClient::apply_replica_delta`.
 ///
 /// This is the Replica's replication consumer. It runs as a background task
 /// after the Replica has finished local initialization.

--- a/crates/database/src/snapshot_checkpointer.rs
+++ b/crates/database/src/snapshot_checkpointer.rs
@@ -29,7 +29,6 @@ use storage::{
     Storage,
     Upload,
 };
-
 use value::{
     InternalDocumentId,
     TabletId,
@@ -82,12 +81,8 @@ impl SnapshotCheckpointer {
         storage: Arc<dyn Storage>,
     ) -> anyhow::Result<()> {
         loop {
-            match Self::write_checkpoint(
-                &persistence_reader,
-                retention_validator.clone(),
-                &storage,
-            )
-            .await
+            match Self::write_checkpoint(&persistence_reader, retention_validator.clone(), &storage)
+                .await
             {
                 Ok(ts) => {
                     tracing::info!("Wrote checkpoint at ts={ts}");
@@ -112,12 +107,8 @@ impl SnapshotCheckpointer {
             .context("No data in persistence")?;
 
         // Create the checkpoint.
-        let checkpoint = create_checkpoint(
-            persistence_reader.as_ref(),
-            max_ts,
-            retention_validator,
-        )
-        .await?;
+        let checkpoint =
+            create_checkpoint(persistence_reader.as_ref(), max_ts, retention_validator).await?;
 
         let ts = checkpoint.timestamp;
         let num_docs = checkpoint.documents.len();
@@ -205,9 +196,7 @@ mod checkpoint_proto {
     }
 }
 
-fn checkpoint_to_proto(
-    data: &CheckpointData,
-) -> anyhow::Result<checkpoint_proto::CheckpointData> {
+fn checkpoint_to_proto(data: &CheckpointData) -> anyhow::Result<checkpoint_proto::CheckpointData> {
     let documents = data
         .documents
         .iter()

--- a/crates/database/src/write_log.rs
+++ b/crates/database/src/write_log.rs
@@ -618,7 +618,6 @@ impl LogWriter {
         let snapshot = { self.inner.lock().log.clone() };
         block_in_place(|| snapshot.is_stale(reads, reads_ts, ts))
     }
-
 }
 
 /// Pending writes are used by the committer to detect conflicts between a new

--- a/crates/local_backend/src/mutation_forwarder.rs
+++ b/crates/local_backend/src/mutation_forwarder.rs
@@ -45,10 +45,7 @@ pub struct MutationForwarderService {
 
 impl MutationForwarderService {
     pub fn new(api: Arc<dyn ApplicationApi>, instance_name: String) -> Self {
-        Self {
-            api,
-            instance_name,
-        }
+        Self { api, instance_name }
     }
 
     pub fn into_server(self) -> TonicMutationForwarderServer<Self> {


### PR DESCRIPTION
Apply cargo fmt formatting to 7 files that were reformatted during development but not staged with their respective PRs.