### PR TITLE
feat: add Raft leadership guard to Committer

### DIFF
--- a/crates/application/src/test_helpers.rs
+++ b/crates/application/src/test_helpers.rs
@@ -222,6 +222,7 @@ impl<RT: Runtime> ApplicationTestExt<RT> for Application<RT> {
             false,
             None,
             None,
+            None,
         )
         .await?;
         initialize_application_system_tables(&database).await?;

--- a/crates/database/src/committer.rs
+++ b/crates/database/src/committer.rs
@@ -250,6 +250,11 @@ pub struct Committer<RT: Runtime> {
     // metadata needed to finalize the commit. (Vitess redo log pattern)
     prepared_transactions:
         std::collections::HashMap<crate::two_phase::TwoPhaseTransactionId, PreparedTransaction>,
+
+    // Raft partition state for leadership checking.
+    // When set, the Committer rejects writes if this node is not the Raft leader.
+    // None means no Raft (existing behavior — always accept writes).
+    raft_state: Option<crate::raft_partition::RaftPartitionState>,
 }
 
 impl<RT: Runtime> Committer<RT> {
@@ -264,6 +269,7 @@ impl<RT: Runtime> Committer<RT> {
         distributed_log: Arc<dyn DistributedLog>,
         partition_map: Option<crate::partition::PartitionMap>,
         timestamp_oracle: Option<Arc<dyn crate::timestamp_oracle::TimestampOracle>>,
+        raft_state: Option<crate::raft_partition::RaftPartitionState>,
     ) -> CommitterClient {
         let persistence_reader = persistence.reader();
         let conflict_checker = PendingWrites::new();
@@ -285,6 +291,7 @@ impl<RT: Runtime> Committer<RT> {
             partition_map,
             timestamp_oracle,
             prepared_transactions: std::collections::HashMap::new(),
+            raft_state,
         };
         let handle = runtime.spawn("committer", async move {
             if let Err(err) = committer.go(rx).await {
@@ -801,6 +808,22 @@ impl<RT: Runtime> Committer<RT> {
         transaction: FinalTransaction,
         write_source: WriteSource,
     ) -> anyhow::Result<ValidatedCommit> {
+        // Raft leadership check: if Raft is configured and this node is
+        // not the leader, reject writes. Clients should forward to the
+        // current leader. This is TiKV's pattern — only the Raft leader
+        // runs the Apply Worker.
+        if let Some(ref raft) = self.raft_state {
+            if !raft.is_leader() {
+                let leader = raft.leader_id();
+                anyhow::bail!(
+                    "Not the Raft leader for partition {}. Current leader: node {}. Forward this \
+                     mutation to the leader.",
+                    raft.partition_id(),
+                    leader,
+                );
+            }
+        }
+
         // Partition ownership check: if partitioning is enabled, verify
         // that all writes to USER tables target tables owned by this node.
         // System tables (starting with _) are exempt — every node writes

--- a/crates/database/src/database.rs
+++ b/crates/database/src/database.rs
@@ -980,6 +980,7 @@ impl<RT: Runtime> Database<RT> {
         replica_mode: bool,
         partition_map: Option<crate::partition::PartitionMap>,
         timestamp_oracle: Option<Arc<dyn crate::timestamp_oracle::TimestampOracle>>,
+        raft_state: Option<crate::raft_partition::RaftPartitionState>,
     ) -> anyhow::Result<Self> {
         let _load_database_timer = metrics::load_database_timer();
 
@@ -1075,6 +1076,7 @@ impl<RT: Runtime> Database<RT> {
             committer_distributed_log,
             partition_map,
             timestamp_oracle,
+            raft_state,
         );
         let table_mapping_snapshot_cache =
             AsyncLru::new(runtime.clone(), 20, 2, "table_mapping_snapshot");

--- a/crates/database/src/test_helpers/db_fixtures.rs
+++ b/crates/database/src/test_helpers/db_fixtures.rs
@@ -101,6 +101,7 @@ impl<RT: Runtime> DbFixtures<RT> {
             false,
             None,
             None,
+            None,
         )
         .await?;
         db.set_search_storage(search_storage.clone());

--- a/crates/database/src/tests/replication_tests.rs
+++ b/crates/database/src/tests/replication_tests.rs
@@ -43,6 +43,7 @@ async fn test_primary_commit_publishes_delta(rt: TestRuntime) -> anyhow::Result<
         false,
         None,
         None,
+        None,
     )
     .await?;
     primary.set_search_storage(Arc::new(LocalDirStorage::new(rt.clone())?));

--- a/crates/database/src/tests/write_scaling_tests.rs
+++ b/crates/database/src/tests/write_scaling_tests.rs
@@ -52,6 +52,7 @@ async fn create_node(
         false,
         partition_map,
         None,
+        None,
     )
     .await?;
     db.set_search_storage(Arc::new(LocalDirStorage::new(rt.clone())?));

--- a/crates/local_backend/src/lib.rs
+++ b/crates/local_backend/src/lib.rs
@@ -225,6 +225,7 @@ pub async fn make_app(
             )
         }),
         timestamp_oracle,
+        None, // raft_state: set after Raft node starts, not during Database::load
     )
     .await?;
     initialize_application_system_tables(&database).await?;


### PR DESCRIPTION
## Summary

Add Raft leadership guard to the Committer's validate_commit(). When Raft is configured, writes are rejected with a redirect error if this node is not the Raft leader for its partition. TiKV's pattern: only the leader runs the Apply Worker.

## Changes

- `committer.rs`: Add `raft_state` field, leadership check at top of `validate_commit()`
- `database.rs`: Add `raft_state` parameter to `Database::load()`
- All callers updated to pass `None` (tests, fixtures, local_backend)

## Test plan

- [x] `cargo test -p database` — 362 tests pass
- [x] `cargo build -p local_backend` — compiles clean

Partial progress on #53