### PR TITLE
fix: remove stray code fence breaking README markdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,6 @@ ALL 77 TESTS PASSED — 3,823 messages | 3,069 tasks | 1,390 sustained writes/no
 ```
 
 Every test pattern comes from a real bug found by Jepsen in a production database.
-```
 
 ## Architecture
 


### PR DESCRIPTION
## Summary
- Remove stray closing ``` that was rendering the Raft architecture diagram as plain text instead of inside a code block

## Test plan
- [x] Verified README renders correctly in markdown preview