### PR TITLE
feat: unified Docker Compose with profiles for all deployment modes

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,32 +176,24 @@ One Primary handles writes, multiple Replicas serve reads. Replicas remap Tablet
 
 ## Quick Start
 
-One Docker Compose file, four deployment modes via profiles (same pattern as CockroachDB, etcd, and YugabyteDB Docker quickstarts).
-
-### Build
-
-```sh
-docker build -f self-hosted/docker-build/Dockerfile.backend \
-  -t convex-backend-replicated .
-```
+One Docker Compose file, three deployment modes via profiles. Raft consensus is always on — same as CockroachDB, etcd, and YugabyteDB (single-node is a Raft group of 1).
 
 ### Run
 
 ```sh
 cd self-hosted/docker
 
-# Single node (vanilla Convex)
+# 1 Raft node (dev/test)
 docker compose --profile single up
 
-# Primary + 2 read replicas
+# 3 Raft nodes, 1 partition (read scaling + HA)
 docker compose --profile replicated up
 
-# 2 partitioned writer nodes
+# 2 partitions × 3 Raft nodes (write scaling + HA)
 docker compose --profile partitioned up
-
-# 3-node Raft consensus (automatic failover)
-docker compose --profile ha up
 ```
+
+Images are published to `ghcr.io/martinkalema/convex-horizontal-scaling` — no local build needed.
 
 ### Test
 
@@ -218,7 +210,7 @@ cd self-hosted/docker
 ### Deploy Functions
 
 ```sh
-docker compose --profile ha exec ha-node-a ./generate_admin_key.sh
+docker compose --profile replicated exec node-1a ./generate_admin_key.sh
 npx convex deploy --url http://127.0.0.1:3210 --admin-key <KEY>
 ```
 

--- a/README.md
+++ b/README.md
@@ -176,6 +176,8 @@ One Primary handles writes, multiple Replicas serve reads. Replicas remap Tablet
 
 ## Quick Start
 
+One Docker Compose file, four deployment modes via profiles (same pattern as CockroachDB, etcd, and YugabyteDB Docker quickstarts).
+
 ### Build
 
 ```sh
@@ -183,29 +185,22 @@ docker build -f self-hosted/docker-build/Dockerfile.backend \
   -t convex-backend-replicated .
 ```
 
-### Run Raft Consensus (3-Node Automatic Failover)
+### Run
 
 ```sh
 cd self-hosted/docker
-docker compose -f docker-compose.raft.yml up
-```
 
-Three Raft nodes: Node A (port 3210, id=1), Node B (port 3220, id=2), Node C (port 3230, id=3). Leader elected automatically. Kill any node — writes resume on the new leader within ~1 second.
+# Single node (vanilla Convex)
+docker compose --profile single up
 
-### Run Partitioned Multi-Writer
+# Primary + 2 read replicas
+docker compose --profile replicated up
 
-```sh
-cd self-hosted/docker
-docker compose -f docker-compose.partitioned.yml up
-```
+# 2 partitioned writer nodes
+docker compose --profile partitioned up
 
-Two writer nodes: Node A (port 3210, partition 0) and Node B (port 3220, partition 1).
-
-### Run Primary-Replica
-
-```sh
-cd self-hosted/docker
-docker compose -f docker-compose.replicated.yml up
+# 3-node Raft consensus (automatic failover)
+docker compose --profile ha up
 ```
 
 ### Test
@@ -223,7 +218,7 @@ cd self-hosted/docker
 ### Deploy Functions
 
 ```sh
-docker compose -f docker-compose.partitioned.yml exec node-a ./generate_admin_key.sh
+docker compose --profile ha exec ha-node-a ./generate_admin_key.sh
 npx convex deploy --url http://127.0.0.1:3210 --admin-key <KEY>
 ```
 

--- a/README.md
+++ b/README.md
@@ -176,21 +176,18 @@ One Primary handles writes, multiple Replicas serve reads. Replicas remap Tablet
 
 ## Quick Start
 
-One Docker Compose file, three deployment modes via profiles. Raft consensus is always on — same as CockroachDB, etcd, and YugabyteDB (single-node is a Raft group of 1).
+One Docker Compose file, two profiles — same as CockroachDB, etcd, and YugabyteDB. Raft consensus is always on (single-node is a Raft group of 1).
 
 ### Run
 
 ```sh
 cd self-hosted/docker
 
-# 1 Raft node (dev/test)
+# 1 node (dev/test)
 docker compose --profile single up
 
-# 3 Raft nodes, 1 partition (read scaling + HA)
-docker compose --profile replicated up
-
-# 2 partitions × 3 Raft nodes (write scaling + HA)
-docker compose --profile partitioned up
+# 6 nodes — 2 partitions × 3 Raft nodes (read + write scaling + HA)
+docker compose --profile cluster up
 ```
 
 Images are published to `ghcr.io/martinkalema/convex-horizontal-scaling` — no local build needed.
@@ -210,7 +207,7 @@ cd self-hosted/docker
 ### Deploy Functions
 
 ```sh
-docker compose --profile replicated exec node-1a ./generate_admin_key.sh
+docker compose --profile cluster exec node-p0a ./generate_admin_key.sh
 npx convex deploy --url http://127.0.0.1:3210 --admin-key <KEY>
 ```
 

--- a/self-hosted/docker/docker-compose.yml
+++ b/self-hosted/docker/docker-compose.yml
@@ -1,17 +1,15 @@
 # Unified Docker Compose for Convex horizontal scaling.
 #
-# One file, three deployment modes via Docker Compose profiles.
-# Raft consensus is always on (same as CockroachDB, etcd, YugabyteDB).
-# Single-node is a Raft group of 1. Multi-node is a Raft group of 3.
+# Two deployment modes — same pattern as CockroachDB, etcd, and YugabyteDB.
+# Raft consensus is always on. Single-node is a Raft group of 1.
 #
 # Usage:
-#   docker compose --profile single up        # 1 Raft node (dev/test)
-#   docker compose --profile replicated up    # 3 Raft nodes, 1 partition (read scaling + HA)
-#   docker compose --profile partitioned up   # 2 partitions × 3 Raft nodes (write scaling + HA)
+#   docker compose --profile single up    # 1 node (dev/test)
+#   docker compose --profile cluster up   # 6 nodes (read + write scaling + HA)
 #
 # Profiles are mutually exclusive — run one at a time.
-# Node counts follow the giants' Docker quickstart pattern:
-# fixed 3-node Raft groups for dev. Use Kubernetes for variable counts.
+# Cluster mode: 2 partitions × 3 Raft nodes. Each partition has its own
+# leader with automatic failover. All nodes serve reads via NATS replication.
 
 # ── YAML Anchors (shared config, DRY) ─────────────────────────────
 
@@ -39,13 +37,11 @@ x-node-env-common: &node-env-common
 services:
   postgres:
     image: postgres:17
-    profiles: [single, replicated, partitioned]
+    profiles: [single, cluster]
     environment:
       POSTGRES_PASSWORD: postgres
       POSTGRES_DB: convex_self_hosted
-      # Superset: creates all databases regardless of profile.
-      # Unused databases cost nothing (~few KB metadata).
-      CONVEX_INSTANCES: convex-node-0,convex-node-1a,convex-node-1b,convex-node-1c,convex-node-2a,convex-node-2b,convex-node-2c,convex-node-3a,convex-node-3b,convex-node-3c
+      CONVEX_INSTANCES: convex-node-0,convex-node-p0a,convex-node-p0b,convex-node-p0c,convex-node-p1a,convex-node-p1b,convex-node-p1c
     ports:
       - "5433:5432"
     volumes:
@@ -58,7 +54,7 @@ services:
 
   nats:
     image: nats:alpine
-    profiles: [single, replicated, partitioned]
+    profiles: [single, cluster]
     command: ["--jetstream", "--store_dir", "/data", "--http_port", "8222"]
     ports:
       - "4222:4222"
@@ -97,245 +93,174 @@ services:
       nats:
         condition: service_healthy
 
-  # ── Replicated (3 Raft nodes, 1 partition — read scaling + HA) ─
+  # ── Cluster (2 partitions × 3 Raft nodes) ─────────────────────
+  #
+  # Partition 0: messages, users (Raft group: p0a, p0b, p0c)
+  # Partition 1: projects, tasks (Raft group: p1a, p1b, p1c)
+  #
+  # Each partition elects its own leader. All 6 nodes serve reads.
+  # Kill any node — its Raft group elects a new leader in ~1 second.
 
-  node-1a:
+  # ── Partition 0 (messages, users) ──────────────────────────────
+
+  node-p0a:
     <<: *backend-common
-    profiles: [replicated]
+    profiles: [cluster]
     ports:
       - "3210:3210"
       - "3211:3211"
       - "50051:50051"
     volumes:
-      - node-1a-data:/convex/data
+      - node-p0a-data:/convex/data
       - shared-storage:/convex/data/storage
     environment:
       <<: *node-env-common
-      INSTANCE_NAME: convex-node-1a
-      CONVEX_CLOUD_ORIGIN: http://127.0.0.1:3210
-      CONVEX_SITE_ORIGIN: http://127.0.0.1:3211
-      PARTITION_ID: "0"
-      NUM_PARTITIONS: "1"
-      RAFT_NODE_ID: "1"
-      RAFT_PEERS: 1=http://node-1a:50051,2=http://node-1b:50051,3=http://node-1c:50051
-    depends_on:
-      postgres:
-        condition: service_healthy
-      nats:
-        condition: service_healthy
-
-  node-1b:
-    <<: *backend-common
-    profiles: [replicated]
-    ports:
-      - "3220:3210"
-      - "3221:3211"
-      - "50052:50051"
-    volumes:
-      - node-1b-data:/convex/data
-      - shared-storage:/convex/data/storage
-    environment:
-      <<: *node-env-common
-      INSTANCE_NAME: convex-node-1b
-      CONVEX_CLOUD_ORIGIN: http://127.0.0.1:3220
-      CONVEX_SITE_ORIGIN: http://127.0.0.1:3221
-      PARTITION_ID: "0"
-      NUM_PARTITIONS: "1"
-      RAFT_NODE_ID: "2"
-      RAFT_PEERS: 1=http://node-1a:50051,2=http://node-1b:50051,3=http://node-1c:50051
-      REPLICA_STORAGE_PATH: /convex/data/storage
-    depends_on:
-      node-1a:
-        condition: service_healthy
-      nats:
-        condition: service_healthy
-
-  node-1c:
-    <<: *backend-common
-    profiles: [replicated]
-    ports:
-      - "3230:3210"
-      - "3231:3211"
-      - "50053:50051"
-    volumes:
-      - node-1c-data:/convex/data
-      - shared-storage:/convex/data/storage
-    environment:
-      <<: *node-env-common
-      INSTANCE_NAME: convex-node-1c
-      CONVEX_CLOUD_ORIGIN: http://127.0.0.1:3230
-      CONVEX_SITE_ORIGIN: http://127.0.0.1:3231
-      PARTITION_ID: "0"
-      NUM_PARTITIONS: "1"
-      RAFT_NODE_ID: "3"
-      RAFT_PEERS: 1=http://node-1a:50051,2=http://node-1b:50051,3=http://node-1c:50051
-      REPLICA_STORAGE_PATH: /convex/data/storage
-    depends_on:
-      node-1b:
-        condition: service_healthy
-      nats:
-        condition: service_healthy
-
-  # ── Partitioned (2 partitions × 3 Raft nodes — write scaling + HA)
-
-  # Partition 0: messages, users (3-node Raft group)
-  node-2a:
-    <<: *backend-common
-    profiles: [partitioned]
-    ports:
-      - "3210:3210"
-      - "3211:3211"
-      - "50051:50051"
-    volumes:
-      - node-2a-data:/convex/data
-      - shared-storage:/convex/data/storage
-    environment:
-      <<: *node-env-common
-      INSTANCE_NAME: convex-node-2a
+      INSTANCE_NAME: convex-node-p0a
       CONVEX_CLOUD_ORIGIN: http://127.0.0.1:3210
       CONVEX_SITE_ORIGIN: http://127.0.0.1:3211
       PARTITION_ID: "0"
       PARTITION_MAP: messages=0,users=0,projects=1,tasks=1
       NUM_PARTITIONS: "2"
       RAFT_NODE_ID: "1"
-      RAFT_PEERS: 1=http://node-2a:50051,2=http://node-2b:50051,3=http://node-2c:50051
+      RAFT_PEERS: 1=http://node-p0a:50051,2=http://node-p0b:50051,3=http://node-p0c:50051
     depends_on:
       postgres:
         condition: service_healthy
       nats:
         condition: service_healthy
 
-  node-2b:
+  node-p0b:
     <<: *backend-common
-    profiles: [partitioned]
+    profiles: [cluster]
     ports:
       - "3220:3210"
       - "3221:3211"
       - "50052:50051"
     volumes:
-      - node-2b-data:/convex/data
+      - node-p0b-data:/convex/data
       - shared-storage:/convex/data/storage
     environment:
       <<: *node-env-common
-      INSTANCE_NAME: convex-node-2b
+      INSTANCE_NAME: convex-node-p0b
       CONVEX_CLOUD_ORIGIN: http://127.0.0.1:3220
       CONVEX_SITE_ORIGIN: http://127.0.0.1:3221
       PARTITION_ID: "0"
       PARTITION_MAP: messages=0,users=0,projects=1,tasks=1
       NUM_PARTITIONS: "2"
       RAFT_NODE_ID: "2"
-      RAFT_PEERS: 1=http://node-2a:50051,2=http://node-2b:50051,3=http://node-2c:50051
+      RAFT_PEERS: 1=http://node-p0a:50051,2=http://node-p0b:50051,3=http://node-p0c:50051
       REPLICA_STORAGE_PATH: /convex/data/storage
     depends_on:
-      node-2a:
+      node-p0a:
         condition: service_healthy
       nats:
         condition: service_healthy
 
-  node-2c:
+  node-p0c:
     <<: *backend-common
-    profiles: [partitioned]
+    profiles: [cluster]
     ports:
       - "3230:3210"
       - "3231:3211"
       - "50053:50051"
     volumes:
-      - node-2c-data:/convex/data
+      - node-p0c-data:/convex/data
       - shared-storage:/convex/data/storage
     environment:
       <<: *node-env-common
-      INSTANCE_NAME: convex-node-2c
+      INSTANCE_NAME: convex-node-p0c
       CONVEX_CLOUD_ORIGIN: http://127.0.0.1:3230
       CONVEX_SITE_ORIGIN: http://127.0.0.1:3231
       PARTITION_ID: "0"
       PARTITION_MAP: messages=0,users=0,projects=1,tasks=1
       NUM_PARTITIONS: "2"
       RAFT_NODE_ID: "3"
-      RAFT_PEERS: 1=http://node-2a:50051,2=http://node-2b:50051,3=http://node-2c:50051
+      RAFT_PEERS: 1=http://node-p0a:50051,2=http://node-p0b:50051,3=http://node-p0c:50051
       REPLICA_STORAGE_PATH: /convex/data/storage
     depends_on:
-      node-2b:
+      node-p0b:
         condition: service_healthy
       nats:
         condition: service_healthy
 
-  # Partition 1: projects, tasks (3-node Raft group)
-  node-3a:
+  # ── Partition 1 (projects, tasks) ──────────────────────────────
+
+  node-p1a:
     <<: *backend-common
-    profiles: [partitioned]
+    profiles: [cluster]
     ports:
       - "3310:3210"
       - "3311:3211"
       - "50061:50051"
     volumes:
-      - node-3a-data:/convex/data
+      - node-p1a-data:/convex/data
       - shared-storage:/convex/data/storage
     environment:
       <<: *node-env-common
-      INSTANCE_NAME: convex-node-3a
+      INSTANCE_NAME: convex-node-p1a
       CONVEX_CLOUD_ORIGIN: http://127.0.0.1:3310
       CONVEX_SITE_ORIGIN: http://127.0.0.1:3311
       PARTITION_ID: "1"
       PARTITION_MAP: messages=0,users=0,projects=1,tasks=1
       NUM_PARTITIONS: "2"
       RAFT_NODE_ID: "1"
-      RAFT_PEERS: 1=http://node-3a:50051,2=http://node-3b:50051,3=http://node-3c:50051
+      RAFT_PEERS: 1=http://node-p1a:50051,2=http://node-p1b:50051,3=http://node-p1c:50051
     depends_on:
-      node-2c:
+      node-p0c:
         condition: service_healthy
       nats:
         condition: service_healthy
 
-  node-3b:
+  node-p1b:
     <<: *backend-common
-    profiles: [partitioned]
+    profiles: [cluster]
     ports:
       - "3320:3210"
       - "3321:3211"
       - "50062:50051"
     volumes:
-      - node-3b-data:/convex/data
+      - node-p1b-data:/convex/data
       - shared-storage:/convex/data/storage
     environment:
       <<: *node-env-common
-      INSTANCE_NAME: convex-node-3b
+      INSTANCE_NAME: convex-node-p1b
       CONVEX_CLOUD_ORIGIN: http://127.0.0.1:3320
       CONVEX_SITE_ORIGIN: http://127.0.0.1:3321
       PARTITION_ID: "1"
       PARTITION_MAP: messages=0,users=0,projects=1,tasks=1
       NUM_PARTITIONS: "2"
       RAFT_NODE_ID: "2"
-      RAFT_PEERS: 1=http://node-3a:50051,2=http://node-3b:50051,3=http://node-3c:50051
+      RAFT_PEERS: 1=http://node-p1a:50051,2=http://node-p1b:50051,3=http://node-p1c:50051
       REPLICA_STORAGE_PATH: /convex/data/storage
     depends_on:
-      node-3a:
+      node-p1a:
         condition: service_healthy
       nats:
         condition: service_healthy
 
-  node-3c:
+  node-p1c:
     <<: *backend-common
-    profiles: [partitioned]
+    profiles: [cluster]
     ports:
       - "3330:3210"
       - "3331:3211"
       - "50063:50051"
     volumes:
-      - node-3c-data:/convex/data
+      - node-p1c-data:/convex/data
       - shared-storage:/convex/data/storage
     environment:
       <<: *node-env-common
-      INSTANCE_NAME: convex-node-3c
+      INSTANCE_NAME: convex-node-p1c
       CONVEX_CLOUD_ORIGIN: http://127.0.0.1:3330
       CONVEX_SITE_ORIGIN: http://127.0.0.1:3331
       PARTITION_ID: "1"
       PARTITION_MAP: messages=0,users=0,projects=1,tasks=1
       NUM_PARTITIONS: "2"
       RAFT_NODE_ID: "3"
-      RAFT_PEERS: 1=http://node-3a:50051,2=http://node-3b:50051,3=http://node-3c:50051
+      RAFT_PEERS: 1=http://node-p1a:50051,2=http://node-p1b:50051,3=http://node-p1c:50051
       REPLICA_STORAGE_PATH: /convex/data/storage
     depends_on:
-      node-3b:
+      node-p1b:
         condition: service_healthy
       nats:
         condition: service_healthy
@@ -344,7 +269,7 @@ services:
 
   dashboard:
     image: ghcr.io/get-convex/convex-dashboard:latest
-    profiles: [single, replicated, partitioned]
+    profiles: [single, cluster]
     stop_grace_period: 10s
     stop_signal: SIGINT
     restart: unless-stopped
@@ -356,22 +281,13 @@ services:
 # ── Volumes ──────────────────────────────────────────────────────
 
 volumes:
-  # Infrastructure
   pgdata:
   natsdata:
-  # Single mode (1 Raft node)
   node-0-data:
-  # Replicated mode (3 Raft nodes, 1 partition)
-  node-1a-data:
-  node-1b-data:
-  node-1c-data:
-  # Partitioned mode — partition 0 (3 Raft nodes)
-  node-2a-data:
-  node-2b-data:
-  node-2c-data:
-  # Partitioned mode — partition 1 (3 Raft nodes)
-  node-3a-data:
-  node-3b-data:
-  node-3c-data:
-  # Shared across multi-node modes
+  node-p0a-data:
+  node-p0b-data:
+  node-p0c-data:
+  node-p1a-data:
+  node-p1b-data:
+  node-p1c-data:
   shared-storage:

--- a/self-hosted/docker/docker-compose.yml
+++ b/self-hosted/docker/docker-compose.yml
@@ -74,7 +74,7 @@ services:
   # ── Single-Node Mode ───────────────────────────────────────────
 
   backend:
-    image: ghcr.io/get-convex/convex-backend:latest
+    image: ghcr.io/martinkalema/convex-horizontal-scaling:backend-latest
     profiles: [single]
     stop_grace_period: 10s
     stop_signal: SIGINT

--- a/self-hosted/docker/docker-compose.yml
+++ b/self-hosted/docker/docker-compose.yml
@@ -1,17 +1,17 @@
 # Unified Docker Compose for Convex horizontal scaling.
 #
-# One file, four deployment modes via Docker Compose profiles
-# (same pattern as CockroachDB, etcd, and YugabyteDB quickstarts).
+# One file, three deployment modes via Docker Compose profiles.
+# Raft consensus is always on (same as CockroachDB, etcd, YugabyteDB).
+# Single-node is a Raft group of 1. Multi-node is a Raft group of 3.
 #
 # Usage:
-#   docker compose --profile single up        # Vanilla single-node
-#   docker compose --profile replicated up    # Primary + 2 read replicas
-#   docker compose --profile partitioned up   # 2 partitioned writer nodes
-#   docker compose --profile ha up            # 3-node Raft consensus group
+#   docker compose --profile single up        # 1 Raft node (dev/test)
+#   docker compose --profile replicated up    # 3 Raft nodes, 1 partition (read scaling + HA)
+#   docker compose --profile partitioned up   # 2 partitions × 3 Raft nodes (write scaling + HA)
 #
 # Profiles are mutually exclusive — run one at a time.
 # Node counts follow the giants' Docker quickstart pattern:
-# fixed 3-node clusters for dev. Use Kubernetes for variable counts.
+# fixed 3-node Raft groups for dev. Use Kubernetes for variable counts.
 
 # ── YAML Anchors (shared config, DRY) ─────────────────────────────
 
@@ -39,13 +39,13 @@ x-node-env-common: &node-env-common
 services:
   postgres:
     image: postgres:17
-    profiles: [replicated, partitioned, ha]
+    profiles: [single, replicated, partitioned]
     environment:
       POSTGRES_PASSWORD: postgres
       POSTGRES_DB: convex_self_hosted
       # Superset: creates all databases regardless of profile.
       # Unused databases cost nothing (~few KB metadata).
-      CONVEX_INSTANCES: convex-primary,convex-replica,convex-replica2,convex-node-a,convex-node-b,convex-node-c
+      CONVEX_INSTANCES: convex-node-0,convex-node-1a,convex-node-1b,convex-node-1c,convex-node-2a,convex-node-2b,convex-node-2c,convex-node-3a,convex-node-3b,convex-node-3c
     ports:
       - "5433:5432"
     volumes:
@@ -58,7 +58,7 @@ services:
 
   nats:
     image: nats:alpine
-    profiles: [replicated, partitioned, ha]
+    profiles: [single, replicated, partitioned]
     command: ["--jetstream", "--store_dir", "/data", "--http_port", "8222"]
     ports:
       - "4222:4222"
@@ -71,256 +71,271 @@ services:
       start_period: 5s
       retries: 3
 
-  # ── Single-Node Mode ───────────────────────────────────────────
+  # ── Single Node (Raft group of 1) ─────────────────────────────
 
-  backend:
-    image: ghcr.io/martinkalema/convex-horizontal-scaling:backend-latest
+  node-0:
+    <<: *backend-common
     profiles: [single]
-    stop_grace_period: 10s
-    stop_signal: SIGINT
-    ports:
-      - "${PORT:-3210}:3210"
-      - "${SITE_PROXY_PORT:-3211}:3211"
-    volumes:
-      - data:/convex/data
-    environment:
-      - ACTIONS_USER_TIMEOUT_SECS
-      - APPLICATION_MAX_CONCURRENT_MUTATIONS=${APPLICATION_MAX_CONCURRENT_MUTATIONS:-16}
-      - APPLICATION_MAX_CONCURRENT_NODE_ACTIONS=${APPLICATION_MAX_CONCURRENT_NODE_ACTIONS:-16}
-      - APPLICATION_MAX_CONCURRENT_QUERIES=${APPLICATION_MAX_CONCURRENT_QUERIES:-16}
-      - APPLICATION_MAX_CONCURRENT_V8_ACTIONS=${APPLICATION_MAX_CONCURRENT_V8_ACTIONS:-16}
-      - AWS_ACCESS_KEY_ID
-      - AWS_REGION
-      - AWS_S3_DISABLE_CHECKSUMS
-      - AWS_S3_DISABLE_SSE
-      - AWS_S3_FORCE_PATH_STYLE
-      - AWS_SECRET_ACCESS_KEY
-      - AWS_SESSION_TOKEN
-      - CONVEX_CLOUD_ORIGIN=${CONVEX_CLOUD_ORIGIN:-http://127.0.0.1:${PORT:-3210}}
-      - CONVEX_RELEASE_VERSION_DEV
-      - CONVEX_SITE_ORIGIN=${CONVEX_SITE_ORIGIN:-http://127.0.0.1:${SITE_PROXY_PORT:-3211}}
-      - DATABASE_URL
-      - DISABLE_BEACON
-      - DISABLE_METRICS_ENDPOINT=${DISABLE_METRICS_ENDPOINT:-true}
-      - DOCUMENT_RETENTION_DELAY=${DOCUMENT_RETENTION_DELAY:-172800}
-      - DO_NOT_REQUIRE_SSL
-      - HTTP_SERVER_TIMEOUT_SECONDS
-      - INSTANCE_NAME
-      - INSTANCE_SECRET
-      - MYSQL_URL
-      - POSTGRES_URL
-      - REDACT_LOGS_TO_CLIENT
-      - RUST_BACKTRACE
-      - RUST_LOG=${RUST_LOG:-info}
-      - S3_ENDPOINT_URL
-      - S3_STORAGE_EXPORTS_BUCKET
-      - S3_STORAGE_FILES_BUCKET
-      - S3_STORAGE_MODULES_BUCKET
-      - S3_STORAGE_SEARCH_BUCKET
-      - S3_STORAGE_SNAPSHOT_IMPORTS_BUCKET
-    healthcheck:
-      test: curl -f http://localhost:3210/version
-      interval: 5s
-      start_period: 10s
-
-  # ── Replicated Mode (Primary + 2 Read Replicas) ───────────────
-
-  primary:
-    <<: *backend-common
-    profiles: [replicated]
     ports:
       - "3210:3210"
       - "3211:3211"
       - "50051:50051"
     volumes:
-      - primary-data:/convex/data
-      - shared-storage:/convex/data/storage
+      - node-0-data:/convex/data
     environment:
       <<: *node-env-common
-      INSTANCE_NAME: convex-primary
-      CONVEX_CLOUD_ORIGIN: http://127.0.0.1:3210
-      CONVEX_SITE_ORIGIN: http://127.0.0.1:3211
-    depends_on:
-      postgres:
-        condition: service_healthy
-      nats:
-        condition: service_healthy
-
-  replica:
-    <<: *backend-common
-    profiles: [replicated]
-    ports:
-      - "3220:3210"
-      - "3221:3211"
-    volumes:
-      - replica-data:/convex/data
-      - shared-storage:/convex/data/storage
-    environment:
-      <<: *node-env-common
-      INSTANCE_NAME: convex-replica
-      REPLICATION_MODE: replica
-      CONVEX_CLOUD_ORIGIN: http://127.0.0.1:3220
-      CONVEX_SITE_ORIGIN: http://127.0.0.1:3221
-      PRIMARY_GRPC_URL: http://primary:50051
-      REPLICA_STORAGE_PATH: /convex/data/storage
-    depends_on:
-      primary:
-        condition: service_healthy
-      nats:
-        condition: service_healthy
-
-  replica2:
-    <<: *backend-common
-    profiles: [replicated]
-    ports:
-      - "3230:3210"
-      - "3231:3211"
-    volumes:
-      - replica2-data:/convex/data
-      - shared-storage:/convex/data/storage
-    environment:
-      <<: *node-env-common
-      INSTANCE_NAME: convex-replica2
-      REPLICATION_MODE: replica
-      CONVEX_CLOUD_ORIGIN: http://127.0.0.1:3230
-      CONVEX_SITE_ORIGIN: http://127.0.0.1:3231
-      PRIMARY_GRPC_URL: http://primary:50051
-      REPLICA_STORAGE_PATH: /convex/data/storage
-    depends_on:
-      primary:
-        condition: service_healthy
-      nats:
-        condition: service_healthy
-
-  # ── Partitioned Mode (2 Writer Nodes) ──────────────────────────
-
-  part-node-a:
-    <<: *backend-common
-    profiles: [partitioned]
-    ports:
-      - "3210:3210"
-      - "3211:3211"
-      - "50051:50051"
-    volumes:
-      - part-node-a-data:/convex/data
-      - shared-storage:/convex/data/storage
-    environment:
-      <<: *node-env-common
-      INSTANCE_NAME: convex-node-a
+      INSTANCE_NAME: convex-node-0
       CONVEX_CLOUD_ORIGIN: http://127.0.0.1:3210
       CONVEX_SITE_ORIGIN: http://127.0.0.1:3211
       PARTITION_ID: "0"
-      PARTITION_MAP: messages=0,users=0,projects=1,tasks=1
-      NUM_PARTITIONS: "2"
-    depends_on:
-      postgres:
-        condition: service_healthy
-      nats:
-        condition: service_healthy
-
-  part-node-b:
-    <<: *backend-common
-    profiles: [partitioned]
-    ports:
-      - "3220:3210"
-      - "3221:3211"
-      - "50052:50051"
-    volumes:
-      - part-node-b-data:/convex/data
-      - shared-storage:/convex/data/storage
-    environment:
-      <<: *node-env-common
-      INSTANCE_NAME: convex-node-b
-      CONVEX_CLOUD_ORIGIN: http://127.0.0.1:3220
-      CONVEX_SITE_ORIGIN: http://127.0.0.1:3221
-      PARTITION_ID: "1"
-      PARTITION_MAP: messages=0,users=0,projects=1,tasks=1
-      NUM_PARTITIONS: "2"
-      REPLICA_STORAGE_PATH: /convex/data/storage
-    depends_on:
-      part-node-a:
-        condition: service_healthy
-      nats:
-        condition: service_healthy
-
-  # ── HA Mode (3-Node Raft Consensus) ────────────────────────────
-
-  ha-node-a:
-    <<: *backend-common
-    profiles: [ha]
-    ports:
-      - "3210:3210"
-      - "3211:3211"
-      - "50051:50051"
-    volumes:
-      - ha-node-a-data:/convex/data
-      - shared-storage:/convex/data/storage
-    environment:
-      <<: *node-env-common
-      INSTANCE_NAME: convex-node-a
-      CONVEX_CLOUD_ORIGIN: http://127.0.0.1:3210
-      CONVEX_SITE_ORIGIN: http://127.0.0.1:3211
-      PARTITION_ID: "0"
-      PARTITION_MAP: messages=0,users=0,projects=1,tasks=1
       NUM_PARTITIONS: "1"
       RAFT_NODE_ID: "1"
-      RAFT_PEERS: 1=http://ha-node-a:50051,2=http://ha-node-b:50051,3=http://ha-node-c:50051
+      RAFT_PEERS: 1=http://node-0:50051
     depends_on:
       postgres:
         condition: service_healthy
       nats:
         condition: service_healthy
 
-  ha-node-b:
+  # ── Replicated (3 Raft nodes, 1 partition — read scaling + HA) ─
+
+  node-1a:
     <<: *backend-common
-    profiles: [ha]
+    profiles: [replicated]
+    ports:
+      - "3210:3210"
+      - "3211:3211"
+      - "50051:50051"
+    volumes:
+      - node-1a-data:/convex/data
+      - shared-storage:/convex/data/storage
+    environment:
+      <<: *node-env-common
+      INSTANCE_NAME: convex-node-1a
+      CONVEX_CLOUD_ORIGIN: http://127.0.0.1:3210
+      CONVEX_SITE_ORIGIN: http://127.0.0.1:3211
+      PARTITION_ID: "0"
+      NUM_PARTITIONS: "1"
+      RAFT_NODE_ID: "1"
+      RAFT_PEERS: 1=http://node-1a:50051,2=http://node-1b:50051,3=http://node-1c:50051
+    depends_on:
+      postgres:
+        condition: service_healthy
+      nats:
+        condition: service_healthy
+
+  node-1b:
+    <<: *backend-common
+    profiles: [replicated]
     ports:
       - "3220:3210"
       - "3221:3211"
       - "50052:50051"
     volumes:
-      - ha-node-b-data:/convex/data
+      - node-1b-data:/convex/data
       - shared-storage:/convex/data/storage
     environment:
       <<: *node-env-common
-      INSTANCE_NAME: convex-node-b
+      INSTANCE_NAME: convex-node-1b
       CONVEX_CLOUD_ORIGIN: http://127.0.0.1:3220
       CONVEX_SITE_ORIGIN: http://127.0.0.1:3221
       PARTITION_ID: "0"
-      PARTITION_MAP: messages=0,users=0,projects=1,tasks=1
       NUM_PARTITIONS: "1"
       RAFT_NODE_ID: "2"
-      RAFT_PEERS: 1=http://ha-node-a:50051,2=http://ha-node-b:50051,3=http://ha-node-c:50051
+      RAFT_PEERS: 1=http://node-1a:50051,2=http://node-1b:50051,3=http://node-1c:50051
       REPLICA_STORAGE_PATH: /convex/data/storage
     depends_on:
-      ha-node-a:
+      node-1a:
         condition: service_healthy
       nats:
         condition: service_healthy
 
-  ha-node-c:
+  node-1c:
     <<: *backend-common
-    profiles: [ha]
+    profiles: [replicated]
     ports:
       - "3230:3210"
       - "3231:3211"
       - "50053:50051"
     volumes:
-      - ha-node-c-data:/convex/data
+      - node-1c-data:/convex/data
       - shared-storage:/convex/data/storage
     environment:
       <<: *node-env-common
-      INSTANCE_NAME: convex-node-c
+      INSTANCE_NAME: convex-node-1c
+      CONVEX_CLOUD_ORIGIN: http://127.0.0.1:3230
+      CONVEX_SITE_ORIGIN: http://127.0.0.1:3231
+      PARTITION_ID: "0"
+      NUM_PARTITIONS: "1"
+      RAFT_NODE_ID: "3"
+      RAFT_PEERS: 1=http://node-1a:50051,2=http://node-1b:50051,3=http://node-1c:50051
+      REPLICA_STORAGE_PATH: /convex/data/storage
+    depends_on:
+      node-1b:
+        condition: service_healthy
+      nats:
+        condition: service_healthy
+
+  # ── Partitioned (2 partitions × 3 Raft nodes — write scaling + HA)
+
+  # Partition 0: messages, users (3-node Raft group)
+  node-2a:
+    <<: *backend-common
+    profiles: [partitioned]
+    ports:
+      - "3210:3210"
+      - "3211:3211"
+      - "50051:50051"
+    volumes:
+      - node-2a-data:/convex/data
+      - shared-storage:/convex/data/storage
+    environment:
+      <<: *node-env-common
+      INSTANCE_NAME: convex-node-2a
+      CONVEX_CLOUD_ORIGIN: http://127.0.0.1:3210
+      CONVEX_SITE_ORIGIN: http://127.0.0.1:3211
+      PARTITION_ID: "0"
+      PARTITION_MAP: messages=0,users=0,projects=1,tasks=1
+      NUM_PARTITIONS: "2"
+      RAFT_NODE_ID: "1"
+      RAFT_PEERS: 1=http://node-2a:50051,2=http://node-2b:50051,3=http://node-2c:50051
+    depends_on:
+      postgres:
+        condition: service_healthy
+      nats:
+        condition: service_healthy
+
+  node-2b:
+    <<: *backend-common
+    profiles: [partitioned]
+    ports:
+      - "3220:3210"
+      - "3221:3211"
+      - "50052:50051"
+    volumes:
+      - node-2b-data:/convex/data
+      - shared-storage:/convex/data/storage
+    environment:
+      <<: *node-env-common
+      INSTANCE_NAME: convex-node-2b
+      CONVEX_CLOUD_ORIGIN: http://127.0.0.1:3220
+      CONVEX_SITE_ORIGIN: http://127.0.0.1:3221
+      PARTITION_ID: "0"
+      PARTITION_MAP: messages=0,users=0,projects=1,tasks=1
+      NUM_PARTITIONS: "2"
+      RAFT_NODE_ID: "2"
+      RAFT_PEERS: 1=http://node-2a:50051,2=http://node-2b:50051,3=http://node-2c:50051
+      REPLICA_STORAGE_PATH: /convex/data/storage
+    depends_on:
+      node-2a:
+        condition: service_healthy
+      nats:
+        condition: service_healthy
+
+  node-2c:
+    <<: *backend-common
+    profiles: [partitioned]
+    ports:
+      - "3230:3210"
+      - "3231:3211"
+      - "50053:50051"
+    volumes:
+      - node-2c-data:/convex/data
+      - shared-storage:/convex/data/storage
+    environment:
+      <<: *node-env-common
+      INSTANCE_NAME: convex-node-2c
       CONVEX_CLOUD_ORIGIN: http://127.0.0.1:3230
       CONVEX_SITE_ORIGIN: http://127.0.0.1:3231
       PARTITION_ID: "0"
       PARTITION_MAP: messages=0,users=0,projects=1,tasks=1
-      NUM_PARTITIONS: "1"
+      NUM_PARTITIONS: "2"
       RAFT_NODE_ID: "3"
-      RAFT_PEERS: 1=http://ha-node-a:50051,2=http://ha-node-b:50051,3=http://ha-node-c:50051
+      RAFT_PEERS: 1=http://node-2a:50051,2=http://node-2b:50051,3=http://node-2c:50051
       REPLICA_STORAGE_PATH: /convex/data/storage
     depends_on:
-      ha-node-b:
+      node-2b:
+        condition: service_healthy
+      nats:
+        condition: service_healthy
+
+  # Partition 1: projects, tasks (3-node Raft group)
+  node-3a:
+    <<: *backend-common
+    profiles: [partitioned]
+    ports:
+      - "3310:3210"
+      - "3311:3211"
+      - "50061:50051"
+    volumes:
+      - node-3a-data:/convex/data
+      - shared-storage:/convex/data/storage
+    environment:
+      <<: *node-env-common
+      INSTANCE_NAME: convex-node-3a
+      CONVEX_CLOUD_ORIGIN: http://127.0.0.1:3310
+      CONVEX_SITE_ORIGIN: http://127.0.0.1:3311
+      PARTITION_ID: "1"
+      PARTITION_MAP: messages=0,users=0,projects=1,tasks=1
+      NUM_PARTITIONS: "2"
+      RAFT_NODE_ID: "1"
+      RAFT_PEERS: 1=http://node-3a:50051,2=http://node-3b:50051,3=http://node-3c:50051
+    depends_on:
+      node-2c:
+        condition: service_healthy
+      nats:
+        condition: service_healthy
+
+  node-3b:
+    <<: *backend-common
+    profiles: [partitioned]
+    ports:
+      - "3320:3210"
+      - "3321:3211"
+      - "50062:50051"
+    volumes:
+      - node-3b-data:/convex/data
+      - shared-storage:/convex/data/storage
+    environment:
+      <<: *node-env-common
+      INSTANCE_NAME: convex-node-3b
+      CONVEX_CLOUD_ORIGIN: http://127.0.0.1:3320
+      CONVEX_SITE_ORIGIN: http://127.0.0.1:3321
+      PARTITION_ID: "1"
+      PARTITION_MAP: messages=0,users=0,projects=1,tasks=1
+      NUM_PARTITIONS: "2"
+      RAFT_NODE_ID: "2"
+      RAFT_PEERS: 1=http://node-3a:50051,2=http://node-3b:50051,3=http://node-3c:50051
+      REPLICA_STORAGE_PATH: /convex/data/storage
+    depends_on:
+      node-3a:
+        condition: service_healthy
+      nats:
+        condition: service_healthy
+
+  node-3c:
+    <<: *backend-common
+    profiles: [partitioned]
+    ports:
+      - "3330:3210"
+      - "3331:3211"
+      - "50063:50051"
+    volumes:
+      - node-3c-data:/convex/data
+      - shared-storage:/convex/data/storage
+    environment:
+      <<: *node-env-common
+      INSTANCE_NAME: convex-node-3c
+      CONVEX_CLOUD_ORIGIN: http://127.0.0.1:3330
+      CONVEX_SITE_ORIGIN: http://127.0.0.1:3331
+      PARTITION_ID: "1"
+      PARTITION_MAP: messages=0,users=0,projects=1,tasks=1
+      NUM_PARTITIONS: "2"
+      RAFT_NODE_ID: "3"
+      RAFT_PEERS: 1=http://node-3a:50051,2=http://node-3b:50051,3=http://node-3c:50051
+      REPLICA_STORAGE_PATH: /convex/data/storage
+    depends_on:
+      node-3b:
         condition: service_healthy
       nats:
         condition: service_healthy
@@ -329,7 +344,7 @@ services:
 
   dashboard:
     image: ghcr.io/get-convex/convex-dashboard:latest
-    profiles: [single, replicated, partitioned, ha]
+    profiles: [single, replicated, partitioned]
     stop_grace_period: 10s
     stop_signal: SIGINT
     restart: unless-stopped
@@ -344,18 +359,19 @@ volumes:
   # Infrastructure
   pgdata:
   natsdata:
-  # Single mode
-  data:
-  # Replicated mode
-  primary-data:
-  replica-data:
-  replica2-data:
-  # Partitioned mode
-  part-node-a-data:
-  part-node-b-data:
-  # HA mode
-  ha-node-a-data:
-  ha-node-b-data:
-  ha-node-c-data:
+  # Single mode (1 Raft node)
+  node-0-data:
+  # Replicated mode (3 Raft nodes, 1 partition)
+  node-1a-data:
+  node-1b-data:
+  node-1c-data:
+  # Partitioned mode — partition 0 (3 Raft nodes)
+  node-2a-data:
+  node-2b-data:
+  node-2c-data:
+  # Partitioned mode — partition 1 (3 Raft nodes)
+  node-3a-data:
+  node-3b-data:
+  node-3c-data:
   # Shared across multi-node modes
   shared-storage:

--- a/self-hosted/docker/docker-compose.yml
+++ b/self-hosted/docker/docker-compose.yml
@@ -1,7 +1,81 @@
+# Unified Docker Compose for Convex horizontal scaling.
+#
+# One file, four deployment modes via Docker Compose profiles
+# (same pattern as CockroachDB, etcd, and YugabyteDB quickstarts).
+#
+# Usage:
+#   docker compose --profile single up        # Vanilla single-node
+#   docker compose --profile replicated up    # Primary + 2 read replicas
+#   docker compose --profile partitioned up   # 2 partitioned writer nodes
+#   docker compose --profile ha up            # 3-node Raft consensus group
+#
+# Profiles are mutually exclusive — run one at a time.
+# Node counts follow the giants' Docker quickstart pattern:
+# fixed 3-node clusters for dev. Use Kubernetes for variable counts.
+
+# ── YAML Anchors (shared config, DRY) ─────────────────────────────
+
+x-backend-common: &backend-common
+  image: ghcr.io/martinkalema/convex-horizontal-scaling:backend-latest
+  stop_grace_period: 10s
+  stop_signal: SIGINT
+  healthcheck:
+    test: curl -f http://localhost:3210/version
+    interval: 5s
+    start_period: 10s
+
+x-node-env-common: &node-env-common
+  POSTGRES_URL: postgresql://postgres:postgres@postgres:5432
+  DO_NOT_REQUIRE_SSL: "1"
+  RUST_LOG: info
+  DISABLE_BEACON: "true"
+  NATS_URL: nats://nats:4222
+  GRPC_PORT: "50051"
+  CHECKPOINT_STORAGE_PATH: /convex/data/checkpoints
+  REPLICATION_MODE: primary
+
+# ── Infrastructure ─────────────────────────────────────────────────
+
 services:
+  postgres:
+    image: postgres:17
+    profiles: [replicated, partitioned, ha]
+    environment:
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: convex_self_hosted
+      # Superset: creates all databases regardless of profile.
+      # Unused databases cost nothing (~few KB metadata).
+      CONVEX_INSTANCES: convex-primary,convex-replica,convex-replica2,convex-node-a,convex-node-b,convex-node-c
+    ports:
+      - "5433:5432"
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+      - ./init-databases.sh:/docker-entrypoint-initdb.d/init-databases.sh
+    healthcheck:
+      test: pg_isready -U postgres
+      interval: 5s
+      start_period: 10s
+
+  nats:
+    image: nats:alpine
+    profiles: [replicated, partitioned, ha]
+    command: ["--jetstream", "--store_dir", "/data", "--http_port", "8222"]
+    ports:
+      - "4222:4222"
+      - "8222:8222"
+    volumes:
+      - natsdata:/data
+    healthcheck:
+      test: ["CMD", "wget", "-qO-", "http://localhost:8222/healthz"]
+      interval: 5s
+      start_period: 5s
+      retries: 3
+
+  # ── Single-Node Mode ───────────────────────────────────────────
+
   backend:
-    # Change this to :${REV} if you want to pin to a specific version
     image: ghcr.io/get-convex/convex-backend:latest
+    profiles: [single]
     stop_grace_period: 10s
     stop_signal: SIGINT
     ports:
@@ -27,8 +101,8 @@ services:
       - CONVEX_SITE_ORIGIN=${CONVEX_SITE_ORIGIN:-http://127.0.0.1:${SITE_PROXY_PORT:-3211}}
       - DATABASE_URL
       - DISABLE_BEACON
-      - DISABLE_METRICS_ENDPOINT=${DISABLE_METRICS_ENDPOINT:-true} # Enable if you want prometheus compatible /metrics endpoint
-      - DOCUMENT_RETENTION_DELAY=${DOCUMENT_RETENTION_DELAY:-172800} # Lower default document retention to 2 days
+      - DISABLE_METRICS_ENDPOINT=${DISABLE_METRICS_ENDPOINT:-true}
+      - DOCUMENT_RETENTION_DELAY=${DOCUMENT_RETENTION_DELAY:-172800}
       - DO_NOT_REQUIRE_SSL
       - HTTP_SERVER_TIMEOUT_SECONDS
       - INSTANCE_NAME
@@ -44,25 +118,244 @@ services:
       - S3_STORAGE_MODULES_BUCKET
       - S3_STORAGE_SEARCH_BUCKET
       - S3_STORAGE_SNAPSHOT_IMPORTS_BUCKET
-
     healthcheck:
       test: curl -f http://localhost:3210/version
       interval: 5s
       start_period: 10s
 
-  dashboard:
-    # Change this to :${REV} if you want to pin to a specific version
-    image: ghcr.io/get-convex/convex-dashboard:latest
-    stop_grace_period: 10s
-    stop_signal: SIGINT
+  # ── Replicated Mode (Primary + 2 Read Replicas) ───────────────
+
+  primary:
+    <<: *backend-common
+    profiles: [replicated]
     ports:
-      - "${DASHBOARD_PORT:-6791}:6791"
+      - "3210:3210"
+      - "3211:3211"
+      - "50051:50051"
+    volumes:
+      - primary-data:/convex/data
+      - shared-storage:/convex/data/storage
     environment:
-      - NEXT_PUBLIC_DEPLOYMENT_URL=${NEXT_PUBLIC_DEPLOYMENT_URL:-http://127.0.0.1:${PORT:-3210}}
-      - NEXT_PUBLIC_LOAD_MONACO_INTERNALLY
+      <<: *node-env-common
+      INSTANCE_NAME: convex-primary
+      CONVEX_CLOUD_ORIGIN: http://127.0.0.1:3210
+      CONVEX_SITE_ORIGIN: http://127.0.0.1:3211
     depends_on:
-      backend:
+      postgres:
+        condition: service_healthy
+      nats:
         condition: service_healthy
 
+  replica:
+    <<: *backend-common
+    profiles: [replicated]
+    ports:
+      - "3220:3210"
+      - "3221:3211"
+    volumes:
+      - replica-data:/convex/data
+      - shared-storage:/convex/data/storage
+    environment:
+      <<: *node-env-common
+      INSTANCE_NAME: convex-replica
+      REPLICATION_MODE: replica
+      CONVEX_CLOUD_ORIGIN: http://127.0.0.1:3220
+      CONVEX_SITE_ORIGIN: http://127.0.0.1:3221
+      PRIMARY_GRPC_URL: http://primary:50051
+      REPLICA_STORAGE_PATH: /convex/data/storage
+    depends_on:
+      primary:
+        condition: service_healthy
+      nats:
+        condition: service_healthy
+
+  replica2:
+    <<: *backend-common
+    profiles: [replicated]
+    ports:
+      - "3230:3210"
+      - "3231:3211"
+    volumes:
+      - replica2-data:/convex/data
+      - shared-storage:/convex/data/storage
+    environment:
+      <<: *node-env-common
+      INSTANCE_NAME: convex-replica2
+      REPLICATION_MODE: replica
+      CONVEX_CLOUD_ORIGIN: http://127.0.0.1:3230
+      CONVEX_SITE_ORIGIN: http://127.0.0.1:3231
+      PRIMARY_GRPC_URL: http://primary:50051
+      REPLICA_STORAGE_PATH: /convex/data/storage
+    depends_on:
+      primary:
+        condition: service_healthy
+      nats:
+        condition: service_healthy
+
+  # ── Partitioned Mode (2 Writer Nodes) ──────────────────────────
+
+  part-node-a:
+    <<: *backend-common
+    profiles: [partitioned]
+    ports:
+      - "3210:3210"
+      - "3211:3211"
+      - "50051:50051"
+    volumes:
+      - part-node-a-data:/convex/data
+      - shared-storage:/convex/data/storage
+    environment:
+      <<: *node-env-common
+      INSTANCE_NAME: convex-node-a
+      CONVEX_CLOUD_ORIGIN: http://127.0.0.1:3210
+      CONVEX_SITE_ORIGIN: http://127.0.0.1:3211
+      PARTITION_ID: "0"
+      PARTITION_MAP: messages=0,users=0,projects=1,tasks=1
+      NUM_PARTITIONS: "2"
+    depends_on:
+      postgres:
+        condition: service_healthy
+      nats:
+        condition: service_healthy
+
+  part-node-b:
+    <<: *backend-common
+    profiles: [partitioned]
+    ports:
+      - "3220:3210"
+      - "3221:3211"
+      - "50052:50051"
+    volumes:
+      - part-node-b-data:/convex/data
+      - shared-storage:/convex/data/storage
+    environment:
+      <<: *node-env-common
+      INSTANCE_NAME: convex-node-b
+      CONVEX_CLOUD_ORIGIN: http://127.0.0.1:3220
+      CONVEX_SITE_ORIGIN: http://127.0.0.1:3221
+      PARTITION_ID: "1"
+      PARTITION_MAP: messages=0,users=0,projects=1,tasks=1
+      NUM_PARTITIONS: "2"
+      REPLICA_STORAGE_PATH: /convex/data/storage
+    depends_on:
+      part-node-a:
+        condition: service_healthy
+      nats:
+        condition: service_healthy
+
+  # ── HA Mode (3-Node Raft Consensus) ────────────────────────────
+
+  ha-node-a:
+    <<: *backend-common
+    profiles: [ha]
+    ports:
+      - "3210:3210"
+      - "3211:3211"
+      - "50051:50051"
+    volumes:
+      - ha-node-a-data:/convex/data
+      - shared-storage:/convex/data/storage
+    environment:
+      <<: *node-env-common
+      INSTANCE_NAME: convex-node-a
+      CONVEX_CLOUD_ORIGIN: http://127.0.0.1:3210
+      CONVEX_SITE_ORIGIN: http://127.0.0.1:3211
+      PARTITION_ID: "0"
+      PARTITION_MAP: messages=0,users=0,projects=1,tasks=1
+      NUM_PARTITIONS: "1"
+      RAFT_NODE_ID: "1"
+      RAFT_PEERS: 1=http://ha-node-a:50051,2=http://ha-node-b:50051,3=http://ha-node-c:50051
+    depends_on:
+      postgres:
+        condition: service_healthy
+      nats:
+        condition: service_healthy
+
+  ha-node-b:
+    <<: *backend-common
+    profiles: [ha]
+    ports:
+      - "3220:3210"
+      - "3221:3211"
+      - "50052:50051"
+    volumes:
+      - ha-node-b-data:/convex/data
+      - shared-storage:/convex/data/storage
+    environment:
+      <<: *node-env-common
+      INSTANCE_NAME: convex-node-b
+      CONVEX_CLOUD_ORIGIN: http://127.0.0.1:3220
+      CONVEX_SITE_ORIGIN: http://127.0.0.1:3221
+      PARTITION_ID: "0"
+      PARTITION_MAP: messages=0,users=0,projects=1,tasks=1
+      NUM_PARTITIONS: "1"
+      RAFT_NODE_ID: "2"
+      RAFT_PEERS: 1=http://ha-node-a:50051,2=http://ha-node-b:50051,3=http://ha-node-c:50051
+      REPLICA_STORAGE_PATH: /convex/data/storage
+    depends_on:
+      ha-node-a:
+        condition: service_healthy
+      nats:
+        condition: service_healthy
+
+  ha-node-c:
+    <<: *backend-common
+    profiles: [ha]
+    ports:
+      - "3230:3210"
+      - "3231:3211"
+      - "50053:50051"
+    volumes:
+      - ha-node-c-data:/convex/data
+      - shared-storage:/convex/data/storage
+    environment:
+      <<: *node-env-common
+      INSTANCE_NAME: convex-node-c
+      CONVEX_CLOUD_ORIGIN: http://127.0.0.1:3230
+      CONVEX_SITE_ORIGIN: http://127.0.0.1:3231
+      PARTITION_ID: "0"
+      PARTITION_MAP: messages=0,users=0,projects=1,tasks=1
+      NUM_PARTITIONS: "1"
+      RAFT_NODE_ID: "3"
+      RAFT_PEERS: 1=http://ha-node-a:50051,2=http://ha-node-b:50051,3=http://ha-node-c:50051
+      REPLICA_STORAGE_PATH: /convex/data/storage
+    depends_on:
+      ha-node-b:
+        condition: service_healthy
+      nats:
+        condition: service_healthy
+
+  # ── Dashboard ──────────────────────────────────────────────────
+
+  dashboard:
+    image: ghcr.io/get-convex/convex-dashboard:latest
+    profiles: [single, replicated, partitioned, ha]
+    stop_grace_period: 10s
+    stop_signal: SIGINT
+    restart: unless-stopped
+    ports:
+      - "6791:6791"
+    environment:
+      - NEXT_PUBLIC_DEPLOYMENT_URL=http://127.0.0.1:3210
+
+# ── Volumes ──────────────────────────────────────────────────────
+
 volumes:
+  # Infrastructure
+  pgdata:
+  natsdata:
+  # Single mode
   data:
+  # Replicated mode
+  primary-data:
+  replica-data:
+  replica2-data:
+  # Partitioned mode
+  part-node-a-data:
+  part-node-b-data:
+  # HA mode
+  ha-node-a-data:
+  ha-node-b-data:
+  ha-node-c-data:
+  # Shared across multi-node modes
+  shared-storage:

--- a/self-hosted/docker/test-raft-failover.sh
+++ b/self-hosted/docker/test-raft-failover.sh
@@ -11,7 +11,7 @@
 #   - YugabyteDB Jepsen nightly resilience benchmarks
 #
 # Prerequisites:
-#   docker compose -f docker-compose.raft.yml up
+#   docker compose --profile ha up
 #
 # Usage:
 #   cd self-hosted/docker && ./test-raft-failover.sh
@@ -46,7 +46,7 @@ fail() {
 echo ""
 echo -e "${BOLD}Preflight checks${NC}"
 
-for name in docker-node-a-1 docker-node-b-1 docker-node-c-1; do
+for name in docker-ha-node-a-1 docker-ha-node-b-1 docker-ha-node-c-1; do
     if ! docker inspect "$name" > /dev/null 2>&1; then
         echo -e "${RED}Container $name not running. Start:${NC}"
         echo "  docker compose -f docker-compose.raft.yml up"
@@ -56,9 +56,9 @@ done
 echo "  All 3 Raft nodes running."
 
 # Generate admin keys for all nodes.
-KEY_A=$(docker exec docker-node-a-1 ./generate_admin_key.sh 2>&1 | tail -1)
-KEY_B=$(docker exec docker-node-b-1 ./generate_admin_key.sh 2>&1 | tail -1)
-KEY_C=$(docker exec docker-node-c-1 ./generate_admin_key.sh 2>&1 | tail -1)
+KEY_A=$(docker exec docker-ha-node-a-1 ./generate_admin_key.sh 2>&1 | tail -1)
+KEY_B=$(docker exec docker-ha-node-b-1 ./generate_admin_key.sh 2>&1 | tail -1)
+KEY_C=$(docker exec docker-ha-node-c-1 ./generate_admin_key.sh 2>&1 | tail -1)
 echo "  Admin keys generated."
 
 # Deploy functions to Node A (leader deploys, followers replicate).
@@ -166,7 +166,7 @@ echo -e "${BOLD}Test 4: Kill Leader, Verify Failover${NC}"
 PRE_KILL=$CA
 
 echo "  Killing Node A (likely leader)..."
-docker kill docker-node-a-1 > /dev/null 2>&1
+docker kill docker-ha-node-a-1 > /dev/null 2>&1
 
 sleep 5
 
@@ -200,7 +200,7 @@ echo -e "${BOLD}Test 5: Restart Killed Node, Verify Rejoin${NC}"
 # ============================================================
 
 echo "  Restarting Node A..."
-docker start docker-node-a-1 > /dev/null 2>&1
+docker start docker-ha-node-a-1 > /dev/null 2>&1
 
 echo "  Waiting for recovery..."
 for attempt in $(seq 1 30); do
@@ -208,7 +208,7 @@ for attempt in $(seq 1 30); do
     sleep 1
 done
 
-KEY_A=$(docker exec docker-node-a-1 ./generate_admin_key.sh 2>&1 | tail -1)
+KEY_A=$(docker exec docker-ha-node-a-1 ./generate_admin_key.sh 2>&1 | tail -1)
 (cd "$DEPLOY_DIR" && npx convex deploy --admin-key "$KEY_A" --url "$NODE_A_URL" > /dev/null 2>&1)
 
 sleep 4

--- a/self-hosted/docker/test-raft-failover.sh
+++ b/self-hosted/docker/test-raft-failover.sh
@@ -11,7 +11,7 @@
 #   - YugabyteDB Jepsen nightly resilience benchmarks
 #
 # Prerequisites:
-#   docker compose --profile replicated up
+#   docker compose --profile cluster up
 #
 # Usage:
 #   cd self-hosted/docker && ./test-raft-failover.sh
@@ -46,7 +46,7 @@ fail() {
 echo ""
 echo -e "${BOLD}Preflight checks${NC}"
 
-for name in docker-node-1a-1 docker-node-1b-1 docker-node-1c-1; do
+for name in docker-node-p0a-1 docker-node-p0b-1 docker-node-p0c-1; do
     if ! docker inspect "$name" > /dev/null 2>&1; then
         echo -e "${RED}Container $name not running. Start:${NC}"
         echo "  docker compose -f docker-compose.raft.yml up"
@@ -56,9 +56,9 @@ done
 echo "  All 3 Raft nodes running."
 
 # Generate admin keys for all nodes.
-KEY_A=$(docker exec docker-node-1a-1 ./generate_admin_key.sh 2>&1 | tail -1)
-KEY_B=$(docker exec docker-node-1b-1 ./generate_admin_key.sh 2>&1 | tail -1)
-KEY_C=$(docker exec docker-node-1c-1 ./generate_admin_key.sh 2>&1 | tail -1)
+KEY_A=$(docker exec docker-node-p0a-1 ./generate_admin_key.sh 2>&1 | tail -1)
+KEY_B=$(docker exec docker-node-p0b-1 ./generate_admin_key.sh 2>&1 | tail -1)
+KEY_C=$(docker exec docker-node-p0c-1 ./generate_admin_key.sh 2>&1 | tail -1)
 echo "  Admin keys generated."
 
 # Deploy functions to Node A (leader deploys, followers replicate).
@@ -166,7 +166,7 @@ echo -e "${BOLD}Test 4: Kill Leader, Verify Failover${NC}"
 PRE_KILL=$CA
 
 echo "  Killing Node A (likely leader)..."
-docker kill docker-node-1a-1 > /dev/null 2>&1
+docker kill docker-node-p0a-1 > /dev/null 2>&1
 
 sleep 5
 
@@ -200,7 +200,7 @@ echo -e "${BOLD}Test 5: Restart Killed Node, Verify Rejoin${NC}"
 # ============================================================
 
 echo "  Restarting Node A..."
-docker start docker-node-1a-1 > /dev/null 2>&1
+docker start docker-node-p0a-1 > /dev/null 2>&1
 
 echo "  Waiting for recovery..."
 for attempt in $(seq 1 30); do
@@ -208,7 +208,7 @@ for attempt in $(seq 1 30); do
     sleep 1
 done
 
-KEY_A=$(docker exec docker-node-1a-1 ./generate_admin_key.sh 2>&1 | tail -1)
+KEY_A=$(docker exec docker-node-p0a-1 ./generate_admin_key.sh 2>&1 | tail -1)
 (cd "$DEPLOY_DIR" && npx convex deploy --admin-key "$KEY_A" --url "$NODE_A_URL" > /dev/null 2>&1)
 
 sleep 4

--- a/self-hosted/docker/test-raft-failover.sh
+++ b/self-hosted/docker/test-raft-failover.sh
@@ -11,7 +11,7 @@
 #   - YugabyteDB Jepsen nightly resilience benchmarks
 #
 # Prerequisites:
-#   docker compose --profile ha up
+#   docker compose --profile replicated up
 #
 # Usage:
 #   cd self-hosted/docker && ./test-raft-failover.sh
@@ -46,7 +46,7 @@ fail() {
 echo ""
 echo -e "${BOLD}Preflight checks${NC}"
 
-for name in docker-ha-node-a-1 docker-ha-node-b-1 docker-ha-node-c-1; do
+for name in docker-node-1a-1 docker-node-1b-1 docker-node-1c-1; do
     if ! docker inspect "$name" > /dev/null 2>&1; then
         echo -e "${RED}Container $name not running. Start:${NC}"
         echo "  docker compose -f docker-compose.raft.yml up"
@@ -56,9 +56,9 @@ done
 echo "  All 3 Raft nodes running."
 
 # Generate admin keys for all nodes.
-KEY_A=$(docker exec docker-ha-node-a-1 ./generate_admin_key.sh 2>&1 | tail -1)
-KEY_B=$(docker exec docker-ha-node-b-1 ./generate_admin_key.sh 2>&1 | tail -1)
-KEY_C=$(docker exec docker-ha-node-c-1 ./generate_admin_key.sh 2>&1 | tail -1)
+KEY_A=$(docker exec docker-node-1a-1 ./generate_admin_key.sh 2>&1 | tail -1)
+KEY_B=$(docker exec docker-node-1b-1 ./generate_admin_key.sh 2>&1 | tail -1)
+KEY_C=$(docker exec docker-node-1c-1 ./generate_admin_key.sh 2>&1 | tail -1)
 echo "  Admin keys generated."
 
 # Deploy functions to Node A (leader deploys, followers replicate).
@@ -166,7 +166,7 @@ echo -e "${BOLD}Test 4: Kill Leader, Verify Failover${NC}"
 PRE_KILL=$CA
 
 echo "  Killing Node A (likely leader)..."
-docker kill docker-ha-node-a-1 > /dev/null 2>&1
+docker kill docker-node-1a-1 > /dev/null 2>&1
 
 sleep 5
 
@@ -200,7 +200,7 @@ echo -e "${BOLD}Test 5: Restart Killed Node, Verify Rejoin${NC}"
 # ============================================================
 
 echo "  Restarting Node A..."
-docker start docker-ha-node-a-1 > /dev/null 2>&1
+docker start docker-node-1a-1 > /dev/null 2>&1
 
 echo "  Waiting for recovery..."
 for attempt in $(seq 1 30); do
@@ -208,7 +208,7 @@ for attempt in $(seq 1 30); do
     sleep 1
 done
 
-KEY_A=$(docker exec docker-ha-node-a-1 ./generate_admin_key.sh 2>&1 | tail -1)
+KEY_A=$(docker exec docker-node-1a-1 ./generate_admin_key.sh 2>&1 | tail -1)
 (cd "$DEPLOY_DIR" && npx convex deploy --admin-key "$KEY_A" --url "$NODE_A_URL" > /dev/null 2>&1)
 
 sleep 4

--- a/self-hosted/docker/test-write-scaling.sh
+++ b/self-hosted/docker/test-write-scaling.sh
@@ -44,7 +44,7 @@
 #  37. Ultimate Final Invariant Check
 #
 # Prerequisites:
-#   docker compose -f docker-compose.partitioned.yml up
+#   docker compose --profile partitioned up
 #
 # Usage:
 #   cd self-hosted/docker && ./test-write-scaling.sh
@@ -79,17 +79,17 @@ fail() {
 echo ""
 echo -e "${BOLD}Preflight checks${NC}"
 
-for name in docker-node-a-1 docker-node-b-1; do
+for name in docker-part-node-a-1 docker-part-node-b-1; do
     if ! docker inspect "$name" > /dev/null 2>&1; then
         echo -e "${RED}Container $name not running. Start the deployment first:${NC}"
-        echo "  docker compose -f docker-compose.partitioned.yml up"
+        echo "  docker compose --profile partitioned up"
         exit 1
     fi
 done
 echo "  Containers running."
 
-NODE_A_KEY=$(docker exec docker-node-a-1 ./generate_admin_key.sh 2>&1 | tail -1)
-NODE_B_KEY=$(docker exec docker-node-b-1 ./generate_admin_key.sh 2>&1 | tail -1)
+NODE_A_KEY=$(docker exec docker-part-node-a-1 ./generate_admin_key.sh 2>&1 | tail -1)
+NODE_B_KEY=$(docker exec docker-part-node-b-1 ./generate_admin_key.sh 2>&1 | tail -1)
 echo "  Admin keys generated."
 
 # --- Deploy test functions ---
@@ -599,7 +599,7 @@ PRE_M=$(jval messages "$PRE")
 
 # Restart Node B
 echo "  Restarting Node B..."
-docker restart docker-node-b-1 > /dev/null 2>&1
+docker restart docker-part-node-b-1 > /dev/null 2>&1
 
 # Write to Node A while Node B is restarting
 mutate "$NODE_A_URL" "$NODE_A_KEY" "messages:send" \
@@ -615,7 +615,7 @@ for attempt in $(seq 1 30); do
 done
 
 # Re-generate Node B key (may have changed on restart)
-NODE_B_KEY=$(docker exec docker-node-b-1 ./generate_admin_key.sh 2>&1 | tail -1)
+NODE_B_KEY=$(docker exec docker-part-node-b-1 ./generate_admin_key.sh 2>&1 | tail -1)
 
 # Re-deploy functions to Node B (modules are in-memory)
 echo "  Re-deploying functions to Node B..."
@@ -818,7 +818,7 @@ PRE_DOUBLE=$(query_api "$NODE_A_URL" "$NODE_A_KEY" "messages:dashboard")
 PRE_DOUBLE_M=$(jval messages "$PRE_DOUBLE")
 
 echo "  First restart of Node B..."
-docker restart docker-node-b-1 > /dev/null 2>&1
+docker restart docker-part-node-b-1 > /dev/null 2>&1
 
 # Write during first restart.
 mutate "$NODE_A_URL" "$NODE_A_KEY" "messages:send" \
@@ -831,7 +831,7 @@ for attempt in $(seq 1 30); do
 done
 
 echo "  Second restart of Node B..."
-docker restart docker-node-b-1 > /dev/null 2>&1
+docker restart docker-part-node-b-1 > /dev/null 2>&1
 
 # Write during second restart.
 mutate "$NODE_A_URL" "$NODE_A_KEY" "messages:send" \
@@ -843,7 +843,7 @@ for attempt in $(seq 1 30); do
     sleep 1
 done
 
-NODE_B_KEY=$(docker exec docker-node-b-1 ./generate_admin_key.sh 2>&1 | tail -1)
+NODE_B_KEY=$(docker exec docker-part-node-b-1 ./generate_admin_key.sh 2>&1 | tail -1)
 (cd "$DEPLOY_DIR" && npx convex deploy --admin-key "$NODE_B_KEY" --url "$NODE_B_URL" > /dev/null 2>&1)
 
 sleep 4
@@ -1103,16 +1103,16 @@ PRE_KILL=$(query_api "$NODE_A_URL" "$NODE_A_KEY" "messages:dashboard")
 PRE_KILL_M=$(jval messages "$PRE_KILL")
 
 echo "  Killing Node A..."
-docker stop docker-node-a-1 > /dev/null 2>&1
+docker stop docker-part-node-a-1 > /dev/null 2>&1
 sleep 2
 
 echo "  Killing Node B..."
-docker stop docker-node-b-1 > /dev/null 2>&1
+docker stop docker-part-node-b-1 > /dev/null 2>&1
 sleep 2
 
 echo "  Restarting both nodes..."
-docker start docker-node-a-1 > /dev/null 2>&1
-docker start docker-node-b-1 > /dev/null 2>&1
+docker start docker-part-node-a-1 > /dev/null 2>&1
+docker start docker-part-node-b-1 > /dev/null 2>&1
 
 echo "  Waiting for recovery..."
 for attempt in $(seq 1 60); do
@@ -1122,8 +1122,8 @@ for attempt in $(seq 1 60); do
     sleep 1
 done
 
-NODE_A_KEY=$(docker exec docker-node-a-1 ./generate_admin_key.sh 2>&1 | tail -1)
-NODE_B_KEY=$(docker exec docker-node-b-1 ./generate_admin_key.sh 2>&1 | tail -1)
+NODE_A_KEY=$(docker exec docker-part-node-a-1 ./generate_admin_key.sh 2>&1 | tail -1)
+NODE_B_KEY=$(docker exec docker-part-node-b-1 ./generate_admin_key.sh 2>&1 | tail -1)
 (cd "$DEPLOY_DIR" && npx convex deploy --admin-key "$NODE_A_KEY" --url "$NODE_A_URL" > /dev/null 2>&1)
 (cd "$DEPLOY_DIR" && npx convex deploy --admin-key "$NODE_B_KEY" --url "$NODE_B_URL" > /dev/null 2>&1)
 
@@ -1545,14 +1545,14 @@ echo -e "${BOLD}Test 34: Clock Monotonicity After Restart (TSO)${NC}"
 PRE_RESTART_A=$(query_api "$NODE_A_URL" "$NODE_A_KEY" "messages:dashboard")
 PRE_RESTART_AM=$(jval messages "$PRE_RESTART_A")
 
-docker restart docker-node-a-1 > /dev/null 2>&1
+docker restart docker-part-node-a-1 > /dev/null 2>&1
 echo "  Waiting for Node A recovery..."
 for attempt in $(seq 1 30); do
     curl -sf "$NODE_A_URL/version" > /dev/null 2>&1 && break
     sleep 1
 done
 
-NODE_A_KEY=$(docker exec docker-node-a-1 ./generate_admin_key.sh 2>&1 | tail -1)
+NODE_A_KEY=$(docker exec docker-part-node-a-1 ./generate_admin_key.sh 2>&1 | tail -1)
 (cd "$DEPLOY_DIR" && npx convex deploy --admin-key "$NODE_A_KEY" --url "$NODE_A_URL" > /dev/null 2>&1)
 
 # Write after restart — TSO must give a valid timestamp.

--- a/self-hosted/docker/test-write-scaling.sh
+++ b/self-hosted/docker/test-write-scaling.sh
@@ -79,7 +79,7 @@ fail() {
 echo ""
 echo -e "${BOLD}Preflight checks${NC}"
 
-for name in docker-part-node-a-1 docker-part-node-b-1; do
+for name in docker-node-2a-1 docker-node-2b-1; do
     if ! docker inspect "$name" > /dev/null 2>&1; then
         echo -e "${RED}Container $name not running. Start the deployment first:${NC}"
         echo "  docker compose --profile partitioned up"
@@ -88,8 +88,8 @@ for name in docker-part-node-a-1 docker-part-node-b-1; do
 done
 echo "  Containers running."
 
-NODE_A_KEY=$(docker exec docker-part-node-a-1 ./generate_admin_key.sh 2>&1 | tail -1)
-NODE_B_KEY=$(docker exec docker-part-node-b-1 ./generate_admin_key.sh 2>&1 | tail -1)
+NODE_A_KEY=$(docker exec docker-node-2a-1 ./generate_admin_key.sh 2>&1 | tail -1)
+NODE_B_KEY=$(docker exec docker-node-2b-1 ./generate_admin_key.sh 2>&1 | tail -1)
 echo "  Admin keys generated."
 
 # --- Deploy test functions ---
@@ -599,7 +599,7 @@ PRE_M=$(jval messages "$PRE")
 
 # Restart Node B
 echo "  Restarting Node B..."
-docker restart docker-part-node-b-1 > /dev/null 2>&1
+docker restart docker-node-2b-1 > /dev/null 2>&1
 
 # Write to Node A while Node B is restarting
 mutate "$NODE_A_URL" "$NODE_A_KEY" "messages:send" \
@@ -615,7 +615,7 @@ for attempt in $(seq 1 30); do
 done
 
 # Re-generate Node B key (may have changed on restart)
-NODE_B_KEY=$(docker exec docker-part-node-b-1 ./generate_admin_key.sh 2>&1 | tail -1)
+NODE_B_KEY=$(docker exec docker-node-2b-1 ./generate_admin_key.sh 2>&1 | tail -1)
 
 # Re-deploy functions to Node B (modules are in-memory)
 echo "  Re-deploying functions to Node B..."
@@ -818,7 +818,7 @@ PRE_DOUBLE=$(query_api "$NODE_A_URL" "$NODE_A_KEY" "messages:dashboard")
 PRE_DOUBLE_M=$(jval messages "$PRE_DOUBLE")
 
 echo "  First restart of Node B..."
-docker restart docker-part-node-b-1 > /dev/null 2>&1
+docker restart docker-node-2b-1 > /dev/null 2>&1
 
 # Write during first restart.
 mutate "$NODE_A_URL" "$NODE_A_KEY" "messages:send" \
@@ -831,7 +831,7 @@ for attempt in $(seq 1 30); do
 done
 
 echo "  Second restart of Node B..."
-docker restart docker-part-node-b-1 > /dev/null 2>&1
+docker restart docker-node-2b-1 > /dev/null 2>&1
 
 # Write during second restart.
 mutate "$NODE_A_URL" "$NODE_A_KEY" "messages:send" \
@@ -843,7 +843,7 @@ for attempt in $(seq 1 30); do
     sleep 1
 done
 
-NODE_B_KEY=$(docker exec docker-part-node-b-1 ./generate_admin_key.sh 2>&1 | tail -1)
+NODE_B_KEY=$(docker exec docker-node-2b-1 ./generate_admin_key.sh 2>&1 | tail -1)
 (cd "$DEPLOY_DIR" && npx convex deploy --admin-key "$NODE_B_KEY" --url "$NODE_B_URL" > /dev/null 2>&1)
 
 sleep 4
@@ -1103,16 +1103,16 @@ PRE_KILL=$(query_api "$NODE_A_URL" "$NODE_A_KEY" "messages:dashboard")
 PRE_KILL_M=$(jval messages "$PRE_KILL")
 
 echo "  Killing Node A..."
-docker stop docker-part-node-a-1 > /dev/null 2>&1
+docker stop docker-node-2a-1 > /dev/null 2>&1
 sleep 2
 
 echo "  Killing Node B..."
-docker stop docker-part-node-b-1 > /dev/null 2>&1
+docker stop docker-node-2b-1 > /dev/null 2>&1
 sleep 2
 
 echo "  Restarting both nodes..."
-docker start docker-part-node-a-1 > /dev/null 2>&1
-docker start docker-part-node-b-1 > /dev/null 2>&1
+docker start docker-node-2a-1 > /dev/null 2>&1
+docker start docker-node-2b-1 > /dev/null 2>&1
 
 echo "  Waiting for recovery..."
 for attempt in $(seq 1 60); do
@@ -1122,8 +1122,8 @@ for attempt in $(seq 1 60); do
     sleep 1
 done
 
-NODE_A_KEY=$(docker exec docker-part-node-a-1 ./generate_admin_key.sh 2>&1 | tail -1)
-NODE_B_KEY=$(docker exec docker-part-node-b-1 ./generate_admin_key.sh 2>&1 | tail -1)
+NODE_A_KEY=$(docker exec docker-node-2a-1 ./generate_admin_key.sh 2>&1 | tail -1)
+NODE_B_KEY=$(docker exec docker-node-2b-1 ./generate_admin_key.sh 2>&1 | tail -1)
 (cd "$DEPLOY_DIR" && npx convex deploy --admin-key "$NODE_A_KEY" --url "$NODE_A_URL" > /dev/null 2>&1)
 (cd "$DEPLOY_DIR" && npx convex deploy --admin-key "$NODE_B_KEY" --url "$NODE_B_URL" > /dev/null 2>&1)
 
@@ -1545,14 +1545,14 @@ echo -e "${BOLD}Test 34: Clock Monotonicity After Restart (TSO)${NC}"
 PRE_RESTART_A=$(query_api "$NODE_A_URL" "$NODE_A_KEY" "messages:dashboard")
 PRE_RESTART_AM=$(jval messages "$PRE_RESTART_A")
 
-docker restart docker-part-node-a-1 > /dev/null 2>&1
+docker restart docker-node-2a-1 > /dev/null 2>&1
 echo "  Waiting for Node A recovery..."
 for attempt in $(seq 1 30); do
     curl -sf "$NODE_A_URL/version" > /dev/null 2>&1 && break
     sleep 1
 done
 
-NODE_A_KEY=$(docker exec docker-part-node-a-1 ./generate_admin_key.sh 2>&1 | tail -1)
+NODE_A_KEY=$(docker exec docker-node-2a-1 ./generate_admin_key.sh 2>&1 | tail -1)
 (cd "$DEPLOY_DIR" && npx convex deploy --admin-key "$NODE_A_KEY" --url "$NODE_A_URL" > /dev/null 2>&1)
 
 # Write after restart — TSO must give a valid timestamp.

--- a/self-hosted/docker/test-write-scaling.sh
+++ b/self-hosted/docker/test-write-scaling.sh
@@ -44,7 +44,7 @@
 #  37. Ultimate Final Invariant Check
 #
 # Prerequisites:
-#   docker compose --profile partitioned up
+#   docker compose --profile cluster up
 #
 # Usage:
 #   cd self-hosted/docker && ./test-write-scaling.sh
@@ -79,17 +79,17 @@ fail() {
 echo ""
 echo -e "${BOLD}Preflight checks${NC}"
 
-for name in docker-node-2a-1 docker-node-2b-1; do
+for name in docker-node-p0a-1 docker-node-p1a-1; do
     if ! docker inspect "$name" > /dev/null 2>&1; then
         echo -e "${RED}Container $name not running. Start the deployment first:${NC}"
-        echo "  docker compose --profile partitioned up"
+        echo "  docker compose --profile cluster up"
         exit 1
     fi
 done
 echo "  Containers running."
 
-NODE_A_KEY=$(docker exec docker-node-2a-1 ./generate_admin_key.sh 2>&1 | tail -1)
-NODE_B_KEY=$(docker exec docker-node-2b-1 ./generate_admin_key.sh 2>&1 | tail -1)
+NODE_A_KEY=$(docker exec docker-node-p0a-1 ./generate_admin_key.sh 2>&1 | tail -1)
+NODE_B_KEY=$(docker exec docker-node-p1a-1 ./generate_admin_key.sh 2>&1 | tail -1)
 echo "  Admin keys generated."
 
 # --- Deploy test functions ---
@@ -599,7 +599,7 @@ PRE_M=$(jval messages "$PRE")
 
 # Restart Node B
 echo "  Restarting Node B..."
-docker restart docker-node-2b-1 > /dev/null 2>&1
+docker restart docker-node-p1a-1 > /dev/null 2>&1
 
 # Write to Node A while Node B is restarting
 mutate "$NODE_A_URL" "$NODE_A_KEY" "messages:send" \
@@ -615,7 +615,7 @@ for attempt in $(seq 1 30); do
 done
 
 # Re-generate Node B key (may have changed on restart)
-NODE_B_KEY=$(docker exec docker-node-2b-1 ./generate_admin_key.sh 2>&1 | tail -1)
+NODE_B_KEY=$(docker exec docker-node-p1a-1 ./generate_admin_key.sh 2>&1 | tail -1)
 
 # Re-deploy functions to Node B (modules are in-memory)
 echo "  Re-deploying functions to Node B..."
@@ -818,7 +818,7 @@ PRE_DOUBLE=$(query_api "$NODE_A_URL" "$NODE_A_KEY" "messages:dashboard")
 PRE_DOUBLE_M=$(jval messages "$PRE_DOUBLE")
 
 echo "  First restart of Node B..."
-docker restart docker-node-2b-1 > /dev/null 2>&1
+docker restart docker-node-p1a-1 > /dev/null 2>&1
 
 # Write during first restart.
 mutate "$NODE_A_URL" "$NODE_A_KEY" "messages:send" \
@@ -831,7 +831,7 @@ for attempt in $(seq 1 30); do
 done
 
 echo "  Second restart of Node B..."
-docker restart docker-node-2b-1 > /dev/null 2>&1
+docker restart docker-node-p1a-1 > /dev/null 2>&1
 
 # Write during second restart.
 mutate "$NODE_A_URL" "$NODE_A_KEY" "messages:send" \
@@ -843,7 +843,7 @@ for attempt in $(seq 1 30); do
     sleep 1
 done
 
-NODE_B_KEY=$(docker exec docker-node-2b-1 ./generate_admin_key.sh 2>&1 | tail -1)
+NODE_B_KEY=$(docker exec docker-node-p1a-1 ./generate_admin_key.sh 2>&1 | tail -1)
 (cd "$DEPLOY_DIR" && npx convex deploy --admin-key "$NODE_B_KEY" --url "$NODE_B_URL" > /dev/null 2>&1)
 
 sleep 4
@@ -1103,16 +1103,16 @@ PRE_KILL=$(query_api "$NODE_A_URL" "$NODE_A_KEY" "messages:dashboard")
 PRE_KILL_M=$(jval messages "$PRE_KILL")
 
 echo "  Killing Node A..."
-docker stop docker-node-2a-1 > /dev/null 2>&1
+docker stop docker-node-p0a-1 > /dev/null 2>&1
 sleep 2
 
 echo "  Killing Node B..."
-docker stop docker-node-2b-1 > /dev/null 2>&1
+docker stop docker-node-p1a-1 > /dev/null 2>&1
 sleep 2
 
 echo "  Restarting both nodes..."
-docker start docker-node-2a-1 > /dev/null 2>&1
-docker start docker-node-2b-1 > /dev/null 2>&1
+docker start docker-node-p0a-1 > /dev/null 2>&1
+docker start docker-node-p1a-1 > /dev/null 2>&1
 
 echo "  Waiting for recovery..."
 for attempt in $(seq 1 60); do
@@ -1122,8 +1122,8 @@ for attempt in $(seq 1 60); do
     sleep 1
 done
 
-NODE_A_KEY=$(docker exec docker-node-2a-1 ./generate_admin_key.sh 2>&1 | tail -1)
-NODE_B_KEY=$(docker exec docker-node-2b-1 ./generate_admin_key.sh 2>&1 | tail -1)
+NODE_A_KEY=$(docker exec docker-node-p0a-1 ./generate_admin_key.sh 2>&1 | tail -1)
+NODE_B_KEY=$(docker exec docker-node-p1a-1 ./generate_admin_key.sh 2>&1 | tail -1)
 (cd "$DEPLOY_DIR" && npx convex deploy --admin-key "$NODE_A_KEY" --url "$NODE_A_URL" > /dev/null 2>&1)
 (cd "$DEPLOY_DIR" && npx convex deploy --admin-key "$NODE_B_KEY" --url "$NODE_B_URL" > /dev/null 2>&1)
 
@@ -1545,14 +1545,14 @@ echo -e "${BOLD}Test 34: Clock Monotonicity After Restart (TSO)${NC}"
 PRE_RESTART_A=$(query_api "$NODE_A_URL" "$NODE_A_KEY" "messages:dashboard")
 PRE_RESTART_AM=$(jval messages "$PRE_RESTART_A")
 
-docker restart docker-node-2a-1 > /dev/null 2>&1
+docker restart docker-node-p0a-1 > /dev/null 2>&1
 echo "  Waiting for Node A recovery..."
 for attempt in $(seq 1 30); do
     curl -sf "$NODE_A_URL/version" > /dev/null 2>&1 && break
     sleep 1
 done
 
-NODE_A_KEY=$(docker exec docker-node-2a-1 ./generate_admin_key.sh 2>&1 | tail -1)
+NODE_A_KEY=$(docker exec docker-node-p0a-1 ./generate_admin_key.sh 2>&1 | tail -1)
 (cd "$DEPLOY_DIR" && npx convex deploy --admin-key "$NODE_A_KEY" --url "$NODE_A_URL" > /dev/null 2>&1)
 
 # Write after restart — TSO must give a valid timestamp.


### PR DESCRIPTION
## Summary
- Consolidate 3 separate compose files into one `docker-compose.yml` using Docker Compose profiles (CockroachDB/etcd/YugabyteDB quickstart pattern)
- Publish backend image to `ghcr.io/martinkalema/convex-horizontal-scaling:backend-latest`
- Update test scripts with new container names (`ha-node-a`, `part-node-a`)

## Usage
```sh
docker compose --profile single up        # vanilla single-node
docker compose --profile replicated up    # primary + 2 read replicas
docker compose --profile partitioned up   # 2 partitioned writers
docker compose --profile ha up            # 3-node Raft consensus
```

## Test plan
- [ ] `docker compose --profile ha up` starts 3 Raft nodes, leader elected
- [ ] `docker compose --profile partitioned up` starts 2 writer nodes
- [ ] `docker compose --profile replicated up` starts primary + 2 replicas
- [ ] `docker compose --profile single up` starts vanilla single node
- [ ] `./test-raft-failover.sh` passes with new container names
- [ ] `./test-write-scaling.sh` passes with new container names