### PR TITLE
feat: unified test.sh entry point with suite selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,11 +197,9 @@ Images are published to `ghcr.io/martinkalema/convex-horizontal-scaling` — no 
 ```sh
 cd self-hosted/docker
 
-# Raft failover tests (10 tests — election, failover, rejoin)
-./test-raft-failover.sh
-
-# Write scaling tests (77 tests — Jepsen workloads, 2PC, chaos)
-./test-write-scaling.sh
+./test.sh              # All tests (87 tests — scaling + failover)
+./test.sh scaling      # Write scaling only (77 tests)
+./test.sh failover     # Raft failover only (10 tests)
 ```
 
 ### Deploy Functions

--- a/self-hosted/docker/test-raft-failover.sh
+++ b/self-hosted/docker/test-raft-failover.sh
@@ -49,7 +49,7 @@ echo -e "${BOLD}Preflight checks${NC}"
 for name in docker-node-p0a-1 docker-node-p0b-1 docker-node-p0c-1; do
     if ! docker inspect "$name" > /dev/null 2>&1; then
         echo -e "${RED}Container $name not running. Start:${NC}"
-        echo "  docker compose -f docker-compose.raft.yml up"
+        echo "  docker compose --profile cluster up"
         exit 1
     fi
 done

--- a/self-hosted/docker/test-write-scaling.sh
+++ b/self-hosted/docker/test-write-scaling.sh
@@ -316,6 +316,14 @@ export const readTwoKeys = query({
     return { a: a?.text ?? null, b: b?.text ?? null };
   },
 });
+
+// Simple message count (used by failover tests).
+export const count = query({
+  handler: async (ctx) => {
+    const msgs = await ctx.db.query("messages").collect();
+    return msgs.length;
+  },
+});
 TSEOF
 
 echo "  Deploying functions..."

--- a/self-hosted/docker/test.sh
+++ b/self-hosted/docker/test.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+#
+# Convex Cluster Integration Tests
+#
+# One test script, two suites — same pattern as CockroachDB roachtest.
+# Raft consensus tests run last (they kill nodes).
+#
+# Usage:
+#   ./test.sh              # Run all tests (scaling + failover)
+#   ./test.sh scaling      # Write scaling only (77 tests)
+#   ./test.sh failover     # Raft failover only (10 tests)
+#
+# Prerequisites:
+#   docker compose --profile cluster up
+
+set -euo pipefail
+
+SUITE="${1:-all}"
+
+case "$SUITE" in
+    all|scaling|failover) ;;
+    *)
+        echo "Usage: $0 [all|scaling|failover]"
+        echo "  all       Run all tests (default)"
+        echo "  scaling   Write scaling tests only (77 tests)"
+        echo "  failover  Raft failover tests only (10 tests)"
+        exit 1
+        ;;
+esac
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+echo ""
+echo "============================================================"
+echo "  Convex Cluster Integration Tests"
+echo "  Suite: $SUITE"
+echo "============================================================"
+echo ""
+
+TOTAL_PASSED=0
+TOTAL_FAILED=0
+
+if [ "$SUITE" = "all" ] || [ "$SUITE" = "scaling" ]; then
+    echo "── Running Write Scaling Suite ──────────────────────────────"
+    echo ""
+    if bash "$SCRIPT_DIR/test-write-scaling.sh"; then
+        echo ""
+        echo "  Write scaling suite: PASSED"
+    else
+        TOTAL_FAILED=$((TOTAL_FAILED + 1))
+        echo ""
+        echo "  Write scaling suite: FAILED"
+    fi
+    echo ""
+fi
+
+if [ "$SUITE" = "all" ] || [ "$SUITE" = "failover" ]; then
+    echo "── Running Raft Failover Suite ─────────────────────────────"
+    echo ""
+    if bash "$SCRIPT_DIR/test-raft-failover.sh"; then
+        echo ""
+        echo "  Raft failover suite: PASSED"
+    else
+        TOTAL_FAILED=$((TOTAL_FAILED + 1))
+        echo ""
+        echo "  Raft failover suite: FAILED"
+    fi
+    echo ""
+fi
+
+echo "============================================================"
+if [ "$TOTAL_FAILED" -eq 0 ]; then
+    echo "  ALL SUITES PASSED"
+else
+    echo "  $TOTAL_FAILED SUITE(S) FAILED"
+fi
+echo "============================================================"
+echo ""
+
+exit "$TOTAL_FAILED"


### PR DESCRIPTION
## Summary
- Create `test.sh` as unified entry point (CockroachDB roachtest pattern)
- Supports `./test.sh`, `./test.sh scaling`, `./test.sh failover`
- Scaling runs first, failover last (kills nodes)
- Add `count` query to deploy for failover test compatibility
- Fix stale compose file reference in failover test

## Test plan
- [ ] `./test.sh failover` passes (10 tests)
- [ ] `./test.sh scaling` passes (77 tests)
- [ ] `./test.sh` runs both suites