### PR TITLE
feat: persistent Raft log storage with TiKV raft-engine

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -195,6 +195,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
 dependencies = [
  "cfg-if",
+ "const-random",
  "getrandom 0.2.15",
  "once_cell",
  "serde",
@@ -397,7 +398,7 @@ dependencies = [
  "sourcemap",
  "storage",
  "storage_zip_reader",
- "strum",
+ "strum 0.27.1",
  "tempfile",
  "thiserror 2.0.17",
  "thousands",
@@ -1409,7 +1410,7 @@ dependencies = [
  "proptest-derive",
  "serde",
  "serde_json",
- "strum",
+ "strum 0.27.1",
  "tuple_struct",
  "utoipa",
 ]
@@ -1454,7 +1455,7 @@ dependencies = [
  "clang-sys",
  "itertools 0.13.0",
  "log 0.4.27",
- "prettyplease 0.2.9",
+ "prettyplease",
  "proc-macro2",
  "quote",
  "regex",
@@ -2128,11 +2129,11 @@ dependencies = [
  "pb",
  "pb_extras",
  "pin-project",
- "prometheus",
+ "prometheus 0.14.0",
  "proptest",
  "proptest-derive",
  "proptest-http",
- "prost-types 0.13.1",
+ "prost-types",
  "rand 0.9.0",
  "rand_chacha 0.9.0",
  "regex",
@@ -2145,7 +2146,7 @@ dependencies = [
  "sha2",
  "shape_inference",
  "sourcemap",
- "strum",
+ "strum 0.27.1",
  "thiserror 2.0.17",
  "tld",
  "tokio",
@@ -2222,6 +2223,26 @@ name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
+name = "const-random"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87e00182fe74b066627d63b85fd550ac2998d4b0bd86bfed477a0ae4c7c71359"
+dependencies = [
+ "const-random-macro",
+]
+
+[[package]]
+name = "const-random-macro"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9d839f2a20b0aee515dc581a6172f2321f96cab76c1a38a4c584a194955390e"
+dependencies = [
+ "getrandom 0.2.15",
+ "once_cell",
+ "tiny-keccak",
+]
 
 [[package]]
 name = "const_format"
@@ -2314,7 +2335,7 @@ dependencies = [
  "rand 0.9.0",
  "serde",
  "serde_json",
- "strum",
+ "strum 0.27.1",
  "uuid",
 ]
 
@@ -2474,6 +2495,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd66663db5a988098a89599d4857919b3acf7f61402e61365acfd3919857b9be"
 
 [[package]]
+name = "crossbeam"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1137cd7e7fc0fb5d3c5a8678be38ec56e819125d8d7907411fe24ccb943faca8"
+dependencies = [
+ "crossbeam-channel",
+ "crossbeam-deque",
+ "crossbeam-epoch",
+ "crossbeam-queue",
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-channel"
 version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2484,35 +2518,29 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-deque"
-version = "0.8.3"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce6fd6f855243022dcecf8702fef0c297d4338e226845fe067f6341ad9fa0cef"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
 dependencies = [
- "cfg-if",
  "crossbeam-epoch",
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.14"
+version = "0.9.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46bd5f3f85273295a9d14aedfb86f6aadbff6d8f5295c4a9edb08e819dcf5695"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
 dependencies = [
- "autocfg",
- "cfg-if",
  "crossbeam-utils",
- "memoffset",
- "scopeguard",
 ]
 
 [[package]]
 name = "crossbeam-queue"
-version = "0.3.8"
+version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1cfb3ea8a53f37c40dea2c7bedcbd88bdfae54f5e2175d6ecaff1c988353add"
+checksum = "0f58bbc28f91df819d0aa2a2c00cd19754769c2fad90579b3592b1c9ba7a3115"
 dependencies = [
- "cfg-if",
  "crossbeam-utils",
 ]
 
@@ -2853,12 +2881,13 @@ dependencies = [
  "parking_lot",
  "pb",
  "pretty_assertions",
- "prometheus",
+ "prometheus 0.14.0",
  "proptest",
  "proptest-derive",
- "prost 0.11.9",
- "prost 0.13.1",
+ "prost",
+ "protobuf 2.28.0",
  "raft",
+ "raft-engine",
  "raft-proto",
  "rand 0.9.0",
  "rand_chacha 0.9.0",
@@ -2997,8 +3026,8 @@ dependencies = [
  "proc-macro2",
  "quote",
  "stringcase",
- "strum",
- "strum_macros",
+ "strum 0.27.1",
+ "strum_macros 0.27.1",
  "syn 2.0.108",
  "thiserror 2.0.17",
 ]
@@ -3389,7 +3418,7 @@ dependencies = [
  "cmd_util",
  "http 1.3.1",
  "metrics",
- "prometheus",
+ "prometheus 0.14.0",
  "proptest",
  "proptest-derive",
  "sentry",
@@ -3652,8 +3681,8 @@ dependencies = [
  "maplit",
  "pb_build",
  "proptest",
- "prost 0.13.1",
- "prost-types 0.13.1",
+ "prost",
+ "prost-types",
  "tonic",
  "tonic-build",
  "url",
@@ -3683,8 +3712,8 @@ dependencies = [
  "pretty_assertions",
  "proptest",
  "proptest-derive",
- "prost 0.13.1",
- "prost-types 0.13.1",
+ "prost",
+ "prost-types",
  "reqwest",
  "serde",
  "serde_json",
@@ -3714,8 +3743,8 @@ dependencies = [
  "pretty_assertions",
  "proptest",
  "proptest-derive",
- "prost 0.13.1",
- "prost-types 0.13.1",
+ "prost",
+ "prost-types",
  "rand 0.9.0",
  "reqwest",
  "serde",
@@ -3893,7 +3922,7 @@ dependencies = [
  "model",
  "moka",
  "parking_lot",
- "prometheus",
+ "prometheus 0.14.0",
  "proptest",
  "proptest-derive",
  "rand 0.9.0",
@@ -4590,7 +4619,7 @@ dependencies = [
  "openidconnect",
  "reqwest",
  "reqwest-middleware",
- "strum",
+ "strum 0.27.1",
  "thiserror 2.0.17",
  "tokio",
 ]
@@ -5225,7 +5254,7 @@ dependencies = [
  "phf",
  "pkcs8 0.10.2",
  "pretty_assertions",
- "prometheus",
+ "prometheus 0.14.0",
  "proptest",
  "proptest-derive",
  "proptest-http",
@@ -5246,7 +5275,7 @@ dependencies = [
  "sourcemap",
  "spki 0.7.3",
  "storage",
- "strum",
+ "strum 0.27.1",
  "thiserror 2.0.17",
  "tokio",
  "tokio-stream",
@@ -5404,7 +5433,7 @@ dependencies = [
  "pretty_assertions",
  "proptest",
  "proptest-derive",
- "prost 0.13.1",
+ "prost",
  "rand 0.9.0",
  "rsa",
  "runtime",
@@ -5456,7 +5485,7 @@ version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 dependencies = [
- "spin",
+ "spin 0.9.8",
 ]
 
 [[package]]
@@ -5625,13 +5654,13 @@ dependencies = [
  "maplit",
  "metrics",
  "performance_stats",
- "prometheus",
+ "prometheus 0.14.0",
  "rand 0.9.0",
  "runtime",
  "sentry",
  "serde",
  "serde_json",
- "strum",
+ "strum 0.27.1",
  "tokio",
  "tokio-tungstenite",
  "tracing",
@@ -5890,6 +5919,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "lz4-sys"
+version = "1.11.1+lz4-1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bd8c0d6c6ed0cd30b3652886bb8711dc4bb01d637a68105a3d5158039b418e6"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
 name = "lz4_flex"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6000,9 +6039,9 @@ dependencies = [
 
 [[package]]
 name = "memoffset"
-version = "0.8.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d61c719bcfbcf5d62b3a09efa6088de8c54bc0bfcd3ea7ae39fcc186108b8de1"
+checksum = "5de893c32cde5f383baa4c04c5d6dbdd735cfd4a794b0debdb2bb1b421da5ff4"
 dependencies = [
  "autocfg",
 ]
@@ -6037,7 +6076,7 @@ dependencies = [
  "derive_more",
  "parking_lot",
  "paste",
- "prometheus",
+ "prometheus 0.14.0",
  "sentry",
  "tracing",
 ]
@@ -6227,7 +6266,7 @@ dependencies = [
  "serde_bytes",
  "serde_json",
  "storage",
- "strum",
+ "strum 0.27.1",
  "tempfile",
  "thiserror 2.0.17",
  "tokio",
@@ -6273,7 +6312,7 @@ dependencies = [
  "httparse",
  "memchr",
  "mime",
- "spin",
+ "spin 0.9.8",
  "version_check",
 ]
 
@@ -6321,7 +6360,7 @@ dependencies = [
  "lz4_flex 0.13.0",
  "metrics",
  "mysql_async",
- "prometheus",
+ "prometheus 0.14.0",
  "proptest",
  "rand 0.9.0",
  "runtime",
@@ -6442,6 +6481,19 @@ dependencies = [
 
 [[package]]
 name = "nix"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "598beaf3cc6fdd9a5dfb1630c2800c7acd31df7aaf0f565796fba2b53ca1af1b"
+dependencies = [
+ "bitflags 1.3.2",
+ "cfg-if",
+ "libc",
+ "memoffset",
+ "pin-utils",
+]
+
+[[package]]
+name = "nix"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
@@ -6465,6 +6517,15 @@ dependencies = [
  "log 0.4.27",
  "rand 0.8.5",
  "signatory",
+]
+
+[[package]]
+name = "no-std-compat"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b93853da6d84c2e3c7d730d6473e8817692dd89be387eb01b94d7f108ecb5b8c"
+dependencies = [
+ "spin 0.5.2",
 ]
 
 [[package]]
@@ -6774,6 +6835,9 @@ name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+dependencies = [
+ "portable-atomic",
+]
 
 [[package]]
 name = "oneshot"
@@ -7035,9 +7099,9 @@ dependencies = [
  "pb_build",
  "pb_extras",
  "proptest",
- "prost 0.13.1",
+ "prost",
  "prost-reflect",
- "prost-types 0.13.1",
+ "prost-types",
  "tonic",
  "value",
 ]
@@ -7047,7 +7111,7 @@ name = "pb_build"
 version = "0.1.0"
 dependencies = [
  "cfg-if",
- "prost 0.13.1",
+ "prost",
  "tonic-build",
 ]
 
@@ -7314,7 +7378,7 @@ dependencies = [
  "metrics",
  "parking_lot",
  "postgres-protocol",
- "prometheus",
+ "prometheus 0.14.0",
  "proptest",
  "rand 0.9.0",
  "rustls",
@@ -7386,7 +7450,7 @@ dependencies = [
  "flate2",
  "num",
  "paste",
- "prost 0.13.1",
+ "prost",
 ]
 
 [[package]]
@@ -7405,16 +7469,6 @@ dependencies = [
  "diff",
  "output_vt100",
  "yansi",
-]
-
-[[package]]
-name = "prettyplease"
-version = "0.1.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c8646e95016a7a6c4adea95bafa8a16baab64b583356217f2c85db4a39d9a86"
-dependencies = [
- "proc-macro2",
- "syn 1.0.109",
 ]
 
 [[package]]
@@ -7548,6 +7602,21 @@ dependencies = [
 
 [[package]]
 name = "prometheus"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d33c28a30771f7f96db69893f78b857f7450d7e0237e9c8fc6427a81bae7ed1"
+dependencies = [
+ "cfg-if",
+ "fnv",
+ "lazy_static 1.5.0",
+ "memchr",
+ "parking_lot",
+ "protobuf 2.28.0",
+ "thiserror 1.0.59",
+]
+
+[[package]]
+name = "prometheus"
 version = "0.14.0"
 source = "git+https://github.com/get-convex/rust-prometheus?rev=8794d2bbf2a5a9adc501067ee4440dde6b5e6e25#8794d2bbf2a5a9adc501067ee4440dde6b5e6e25"
 dependencies = [
@@ -7558,6 +7627,18 @@ dependencies = [
  "parking_lot",
  "protobuf 3.7.2",
  "thiserror 2.0.17",
+]
+
+[[package]]
+name = "prometheus-static-metric"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8f30cdb09c39930b8fa5e0f23cbb895ab3f766b187403a0ba0956fc1ef4f0e5"
+dependencies = [
+ "lazy_static 1.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -7602,44 +7683,12 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.11.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b82eaa1d779e9a4bc1c3217db8ffbeabaae1dca241bf70183242128d48681cd"
-dependencies = [
- "bytes",
- "prost-derive 0.11.9",
-]
-
-[[package]]
-name = "prost"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e13db3d3fde688c61e2446b4d843bc27a7e8af269a69440c0308021dc92333cc"
 dependencies = [
  "bytes",
- "prost-derive 0.13.1",
-]
-
-[[package]]
-name = "prost-build"
-version = "0.11.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "119533552c9a7ffacc21e099c24a0ac8bb19c2a2a3f363de84cd9b844feab270"
-dependencies = [
- "bytes",
- "heck 0.4.1",
- "itertools 0.10.5",
- "lazy_static 1.5.0",
- "log 0.4.27",
- "multimap",
- "petgraph",
- "prettyplease 0.1.25",
- "prost 0.11.9",
- "prost-types 0.11.9",
- "regex",
- "syn 1.0.109",
- "tempfile",
- "which 4.4.2",
+ "prost-derive",
 ]
 
 [[package]]
@@ -7655,25 +7704,12 @@ dependencies = [
  "multimap",
  "once_cell",
  "petgraph",
- "prettyplease 0.2.9",
- "prost 0.13.1",
- "prost-types 0.13.1",
+ "prettyplease",
+ "prost",
+ "prost-types",
  "regex",
  "syn 2.0.108",
  "tempfile",
-]
-
-[[package]]
-name = "prost-derive"
-version = "0.11.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5d2d8d10f3c6ded6da8b05b5fb3b8a5082514344d56c9f871412d29b4e075b4"
-dependencies = [
- "anyhow",
- "itertools 0.10.5",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
 ]
 
 [[package]]
@@ -7697,17 +7733,8 @@ checksum = "37587d5a8a1b3dc9863403d084fc2254b91ab75a702207098837950767e2260b"
 dependencies = [
  "logos",
  "miette 7.2.0",
- "prost 0.13.1",
- "prost-types 0.13.1",
-]
-
-[[package]]
-name = "prost-types"
-version = "0.11.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "213622a1460818959ac1181aaeb2dc9c7f63df720db7d788b3e24eacd1983e13"
-dependencies = [
- "prost 0.11.9",
+ "prost",
+ "prost-types",
 ]
 
 [[package]]
@@ -7716,7 +7743,7 @@ version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cee5168b05f49d4b0ca581206eb14a7b22fafd963efe729ac48eb03266e25cc2"
 dependencies = [
- "prost 0.13.1",
+ "prost",
 ]
 
 [[package]]
@@ -7724,6 +7751,9 @@ name = "protobuf"
 version = "2.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "106dd99e98437432fed6519dedecfade6a06a73bb7b2a1e019fdd2bee5778d94"
+dependencies = [
+ "bytes",
+]
 
 [[package]]
 name = "protobuf"
@@ -7743,10 +7773,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2df9942df2981178a930a72d442de47e2f0df18ad68e50a30f816f1848215ad0"
 dependencies = [
  "bitflags 1.3.2",
- "proc-macro2",
- "prost-build 0.11.9",
- "quote",
- "syn 1.0.109",
+ "protobuf 2.28.0",
+ "protobuf-codegen",
+ "regex",
+]
+
+[[package]]
+name = "protobuf-codegen"
+version = "2.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "033460afb75cf755fcfc16dfaed20b86468082a2ea24e05ac35ab4a099a017d6"
+dependencies = [
+ "protobuf 2.28.0",
 ]
 
 [[package]]
@@ -7829,6 +7867,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f12688b23a649902762d4c11d854d73c49c9b93138f2de16403ef9f571ad5bae"
 dependencies = [
+ "bytes",
  "fxhash",
  "getset",
  "protobuf 2.28.0",
@@ -7842,13 +7881,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "raft-engine"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1213c3a24e3fee8afcc74b2be08c4081adde96f092e0fc1c607abb3e16ae722e"
+dependencies = [
+ "byteorder",
+ "crc32fast",
+ "crossbeam 0.8.4",
+ "fail",
+ "fs2",
+ "hashbrown 0.14.5",
+ "hex",
+ "if_chain",
+ "lazy_static 1.5.0",
+ "libc",
+ "log 0.4.27",
+ "lz4-sys",
+ "nix 0.26.4",
+ "num-derive",
+ "num-traits",
+ "parking_lot",
+ "prometheus 0.13.4",
+ "prometheus-static-metric",
+ "protobuf 2.28.0",
+ "rayon",
+ "rhai",
+ "scopeguard",
+ "serde",
+ "serde_repr",
+ "strum 0.25.0",
+ "thiserror 1.0.59",
+]
+
+[[package]]
 name = "raft-proto"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb6884896294f553e8d5cfbdb55080b9f5f2f43394afff59c9f077e0f4b46d6b"
 dependencies = [
- "lazy_static 1.5.0",
- "prost 0.11.9",
+ "bytes",
  "protobuf 2.28.0",
  "protobuf-build",
 ]
@@ -8240,6 +8312,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57397d16646700483b67d2dd6511d79318f9d057fdbd21a4066aeac8b41d310a"
 dependencies = [
  "bytemuck",
+]
+
+[[package]]
+name = "rhai"
+version = "1.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f9ef5dabe4c0b43d8f1187dc6beb67b53fe607fff7e30c5eb7f71b814b8c2c1"
+dependencies = [
+ "ahash",
+ "bitflags 2.10.0",
+ "no-std-compat",
+ "num-traits",
+ "once_cell",
+ "rhai_codegen",
+ "smallvec",
+ "smartstring",
+ "thin-vec",
+ "web-time",
+]
+
+[[package]]
+name = "rhai_codegen"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4322a2a4e8cf30771dd9f27f7f37ca9ac8fe812dddd811096a98483080dabe6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.108",
 ]
 
 [[package]]
@@ -8648,7 +8749,7 @@ dependencies = [
  "once_cell",
  "parking_lot",
  "pb",
- "prometheus",
+ "prometheus 0.14.0",
  "proptest",
  "proptest-derive",
  "rand 0.9.0",
@@ -8658,7 +8759,7 @@ dependencies = [
  "serde",
  "serde_json",
  "storage",
- "strum",
+ "strum 0.27.1",
  "sucds",
  "tantivy",
  "tantivy-common",
@@ -9349,7 +9450,7 @@ version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ecd47c6b5a57ac35e3ede3a6279340dc746d57d900c245033552da01440d0efa"
 dependencies = [
- "crossbeam",
+ "crossbeam 0.2.12",
  "lazy_static 0.2.11",
  "slog",
 ]
@@ -9371,7 +9472,7 @@ version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f588bfcaae14a1b0c2b7a8c17685644702afaa0154eac9f4be3b81f2078a82c6"
 dependencies = [
- "crossbeam",
+ "crossbeam 0.2.12",
  "log 0.3.9",
  "slog",
  "slog-scope 3.0.0",
@@ -9422,6 +9523,17 @@ name = "smallvec"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8917285742e9f3e1683f0a9c4e6b57960b7314d0b08d30d1ecd426713ee2eee9"
+
+[[package]]
+name = "smartstring"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fb72c633efbaa2dd666986505016c32c3044395ceaf881518399d2f4127ee29"
+dependencies = [
+ "autocfg",
+ "static_assertions",
+ "version_check",
+]
 
 [[package]]
 name = "smol_str"
@@ -9507,6 +9619,12 @@ dependencies = [
  "tempfile",
  "validator",
 ]
+
+[[package]]
+name = "spin"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "spin"
@@ -9677,11 +9795,33 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "strum"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290d54ea6f91c969195bdbcd7442c8c2a2ba87da8bf60a7ee86a235d4bc1e125"
+dependencies = [
+ "strum_macros 0.25.3",
+]
+
+[[package]]
+name = "strum"
 version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f64def088c51c9510a8579e3c5d67c65349dcf755e5479ad3d010aa6454e2c32"
 dependencies = [
- "strum_macros",
+ "strum_macros 0.27.1",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.25.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23dc1fa9ac9c169a78ba62f0b841814b7abae11bdd047b9c58f893439e309ea0"
+dependencies = [
+ "heck 0.4.1",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 2.0.108",
 ]
 
 [[package]]
@@ -10107,6 +10247,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "thin-vec"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "144f754d318415ac792f9d69fc87abbbfc043ce2ef041c60f16ad828f638717d"
+
+[[package]]
 name = "thiserror"
 version = "1.0.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10261,6 +10407,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "tiny-keccak"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
+dependencies = [
+ "crunchy",
+]
+
+[[package]]
 name = "tinystr"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10388,7 +10543,7 @@ checksum = "f360c6fa7fd188e65904979ea07f1f44c57f0759ab18ecca88551c26acdf4cd6"
 dependencies = [
  "lazy_static 1.5.0",
  "parking_lot",
- "prometheus",
+ "prometheus 0.14.0",
  "tokio",
  "tokio-metrics",
 ]
@@ -10569,7 +10724,7 @@ dependencies = [
  "hyper-util",
  "percent-encoding",
  "pin-project",
- "prost 0.13.1",
+ "prost",
  "rustls-native-certs 0.8.1",
  "socket2 0.5.7",
  "tokio",
@@ -10587,10 +10742,10 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d85f0383fadd15609306383a90e85eaed44169f931a5d2be1b42c76ceff1825e"
 dependencies = [
- "prettyplease 0.2.9",
+ "prettyplease",
  "proc-macro2",
- "prost-build 0.13.1",
- "prost-types 0.13.1",
+ "prost-build",
+ "prost-types",
  "quote",
  "syn 2.0.108",
 ]
@@ -10601,7 +10756,7 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27b322337dbd837f3dec2c0d29074da49ec80b7ead45ec1c56d6805c43f370f5"
 dependencies = [
- "prost 0.13.1",
+ "prost",
  "tokio",
  "tokio-stream",
  "tonic",
@@ -11192,7 +11347,7 @@ dependencies = [
  "miniz_oxide 0.8.8",
  "paste",
  "temporal_capi",
- "which 6.0.3",
+ "which",
 ]
 
 [[package]]
@@ -11523,18 +11678,6 @@ checksum = "471d1c1645d361eb782a1650b1786a8fb58dd625e681a04c09f5ff7c8764a7b0"
 dependencies = [
  "hashbrown 0.14.5",
  "once_cell",
-]
-
-[[package]]
-name = "which"
-version = "4.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7"
-dependencies = [
- "either",
- "home",
- "once_cell",
- "rustix",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -196,8 +196,9 @@ serde = { version = "1", features = [ "derive" ] }
 serde_bytes = "0.11.14"
 serde_json = { version = "1", features = [ "float_roundtrip", "preserve_order", "raw_value", "unbounded_depth" ] }
 serde_with = "3.16.1"
-raft = { version = "0.7.0", default-features = false, features = [ "prost-codec", "default-logger" ] }
-raft-proto = { version = "0.7.0", default-features = false, features = [ "prost-codec" ] }
+raft = { version = "0.7.0", features = [ "protobuf-codec", "default-logger" ] }
+raft-engine = "0.4"
+raft-proto = { version = "0.7.0", features = [ "protobuf-codec" ] }
 sha1 = { version = "0.10.5", features = [ "oid" ] }
 slog = "2.7"
 slog-stdlog = "2.0"

--- a/crates/database/Cargo.toml
+++ b/crates/database/Cargo.toml
@@ -71,8 +71,9 @@ rand = { workspace = true }
 rand_chacha = { workspace = true }
 runtime = { workspace = true }
 rustls = { version = "0.23", features = ["ring"] }
-prost-011 = { package = "prost", version = "0.11" }
+protobuf = "2"
 raft = { workspace = true }
+raft-engine = { workspace = true }
 raft-proto = { workspace = true }
 search = { workspace = true }
 serde = { workspace = true }

--- a/crates/database/src/raft_node.rs
+++ b/crates/database/src/raft_node.rs
@@ -15,6 +15,7 @@
 
 use std::{
     collections::HashMap,
+    sync::Arc,
     time::{
         Duration,
         Instant,
@@ -123,14 +124,31 @@ pub struct RaftNode {
 }
 
 impl RaftNode {
-    /// Create a new Raft node.
+    /// Create a new Raft node with persistent storage.
+    ///
+    /// The `engine` is a shared raft-engine instance (one per node, all
+    /// partitions share it). On first boot, the storage is initialized
+    /// with the given peers. On restart, existing state is loaded from
+    /// raft-engine — this is what prevents the "to_commit X is out of
+    /// range [last_index 0]" panic that MemStorage caused.
     pub fn new(
         config: RaftNodeConfig,
+        engine: Arc<raft_engine::Engine>,
         mailbox: mpsc::UnboundedReceiver<RaftMessage>,
         peer_senders: HashMap<u64, mpsc::UnboundedSender<Message>>,
     ) -> anyhow::Result<Self> {
-        let storage =
-            ConvexRaftStorage::new(config.partition_id, config.node_id, config.peers.clone());
+        let storage = ConvexRaftStorage::new(
+            config.partition_id,
+            engine,
+            config.node_id,
+            config.peers.clone(),
+        )?;
+
+        // On restart, pick up where we left off (applied index from
+        // the persisted hard state's commit). This prevents raft-rs
+        // from re-applying already-committed entries.
+        let initial_state = storage.initial_state().map_err(|e| anyhow::anyhow!("{e}"))?;
+        let applied = initial_state.hard_state.get_commit();
 
         let raft_config = Config {
             id: config.node_id,
@@ -138,7 +156,7 @@ impl RaftNode {
             heartbeat_tick: config.heartbeat_tick,
             max_size_per_msg: 1024 * 1024,
             max_inflight_msgs: 256,
-            applied: 0,
+            applied,
             check_quorum: true,
             pre_vote: true,
             ..Default::default()
@@ -247,22 +265,21 @@ impl RaftNode {
                     }
                 }
 
-                // 2. Apply snapshot if present.
-                if *ready.snapshot() != Snapshot::default() {
-                    let snapshot = ready.snapshot().clone();
-                    if let Err(e) = self.storage.apply_snapshot(snapshot) {
-                        tracing::error!("Failed to apply snapshot: {e}");
-                    }
-                }
+                // 2. Snapshot transfer not yet implemented.
+                // Nodes that fall too far behind must re-bootstrap.
 
-                // 3. Persist log entries.
-                if let Err(e) = self.storage.append_entries(ready.entries()) {
-                    tracing::error!("Failed to append entries: {e}");
-                }
-
-                // 4. Persist hard state.
+                // 3+4. Persist log entries + hard state atomically.
+                // TiKV WriteBatch pattern: entries and hard state go in one
+                // atomic write to raft-engine for crash consistency.
                 if let Some(hs) = ready.hs() {
-                    self.storage.set_hardstate(hs.clone());
+                    if let Err(e) = self
+                        .storage
+                        .append_entries_and_hardstate(ready.entries(), hs)
+                    {
+                        tracing::error!("Failed to persist entries+hardstate: {e}");
+                    }
+                } else if let Err(e) = self.storage.append_entries(ready.entries()) {
+                    tracing::error!("Failed to persist entries: {e}");
                 }
 
                 // 5. Send persisted messages.
@@ -307,11 +324,13 @@ impl RaftNode {
                 // 7. Advance the Raft state.
                 let mut light_rd = self.raw_node.advance(ready);
 
-                // Update commit index.
+                // Update commit index in persisted hard state.
                 if let Some(commit) = light_rd.commit_index() {
-                    let mut hs = self.storage.hard_state();
-                    hs.commit = commit;
-                    self.storage.set_hardstate(hs);
+                    let mut hs = self.storage.hard_state().unwrap_or_default();
+                    hs.set_commit(commit);
+                    if let Err(e) = self.storage.set_hardstate(&hs) {
+                        tracing::error!("Failed to persist commit index: {e}");
+                    }
                 }
 
                 // Send any remaining messages.
@@ -389,7 +408,7 @@ impl RaftNode {
 
         self.storage.append_entries(ready.entries()).unwrap();
         if let Some(hs) = ready.hs() {
-            self.storage.set_hardstate(hs.clone());
+            self.storage.set_hardstate(hs).unwrap();
         }
         for entry in ready.take_committed_entries() {
             if !entry.data.is_empty() {
@@ -410,6 +429,14 @@ impl RaftNode {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::raft_storage::ConvexRaftStorage;
+
+    fn test_engine() -> Arc<raft_engine::Engine> {
+        let dir = tempfile::tempdir().unwrap();
+        // Leak the tempdir so it lives for the test duration.
+        let path = dir.into_path();
+        ConvexRaftStorage::open_engine(path.to_str().unwrap()).unwrap()
+    }
 
     #[tokio::test]
     async fn test_single_node_election() {
@@ -421,8 +448,9 @@ mod tests {
             heartbeat_tick: 3,
         };
 
+        let engine = test_engine();
         let (_tx, rx) = mpsc::unbounded_channel();
-        let mut node = RaftNode::new(config, rx, HashMap::new()).unwrap();
+        let mut node = RaftNode::new(config, engine, rx, HashMap::new()).unwrap();
 
         // Tick enough times to trigger election.
         for _ in 0..20 {
@@ -443,8 +471,9 @@ mod tests {
             heartbeat_tick: 3,
         };
 
+        let engine = test_engine();
         let (_tx, rx) = mpsc::unbounded_channel();
-        let mut node = RaftNode::new(config, rx, HashMap::new()).unwrap();
+        let mut node = RaftNode::new(config, engine, rx, HashMap::new()).unwrap();
 
         // Become leader first.
         for _ in 0..20 {
@@ -485,8 +514,9 @@ mod tests {
             heartbeat_tick: 3,
         };
 
+        let engine = test_engine();
         let (_tx, rx) = mpsc::unbounded_channel();
-        let mut node = RaftNode::new(config, rx, HashMap::new()).unwrap();
+        let mut node = RaftNode::new(config, engine, rx, HashMap::new()).unwrap();
 
         let became_leader = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
         let became_leader_clone = became_leader.clone();

--- a/crates/database/src/raft_partition.rs
+++ b/crates/database/src/raft_partition.rs
@@ -111,14 +111,15 @@ pub struct RaftPartitionManager {
 }
 
 impl RaftPartitionManager {
-    /// Create a new Raft partition manager.
+    /// Create a new Raft partition manager with persistent storage.
     pub fn new(
         config: RaftNodeConfig,
+        engine: Arc<raft_engine::Engine>,
         peer_senders: HashMap<u64, mpsc::UnboundedSender<Message>>,
     ) -> anyhow::Result<Self> {
         let (mailbox_tx, mailbox_rx) = mpsc::unbounded_channel();
 
-        let mut node = RaftNode::new(config.clone(), mailbox_rx, peer_senders)?;
+        let mut node = RaftNode::new(config.clone(), engine, mailbox_rx, peer_senders)?;
 
         let is_leader = Arc::new(AtomicBool::new(false));
         let leader_id = Arc::new(AtomicU64::new(0));
@@ -183,6 +184,13 @@ impl RaftPartitionManager {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::raft_storage::ConvexRaftStorage;
+
+    fn test_engine() -> Arc<raft_engine::Engine> {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.into_path();
+        ConvexRaftStorage::open_engine(path.to_str().unwrap()).unwrap()
+    }
 
     #[test]
     fn test_partition_state_defaults() {
@@ -193,7 +201,7 @@ mod tests {
             ..Default::default()
         };
 
-        let manager = RaftPartitionManager::new(config, HashMap::new()).unwrap();
+        let manager = RaftPartitionManager::new(config, test_engine(), HashMap::new()).unwrap();
         let state = manager.state();
 
         assert!(!state.is_leader());
@@ -211,7 +219,7 @@ mod tests {
             heartbeat_tick: 3,
         };
 
-        let mut manager = RaftPartitionManager::new(config, HashMap::new()).unwrap();
+        let mut manager = RaftPartitionManager::new(config, test_engine(), HashMap::new()).unwrap();
         let state = manager.state();
 
         assert!(!state.is_leader());
@@ -236,7 +244,7 @@ mod tests {
             ..Default::default()
         };
 
-        let manager = RaftPartitionManager::new(config, HashMap::new()).unwrap();
+        let manager = RaftPartitionManager::new(config, test_engine(), HashMap::new()).unwrap();
         let state = manager.state();
 
         // Should be able to send without error (node exists).

--- a/crates/database/src/raft_storage.rs
+++ b/crates/database/src/raft_storage.rs
@@ -1,117 +1,229 @@
-//! PostgreSQL-backed Raft log storage.
+//! Persistent Raft log storage backed by TiKV's raft-engine.
 //!
-//! Implements the `raft::Storage` trait using an in-memory write-ahead buffer
-//! backed by PostgreSQL for durability. This is the same pattern TiKV uses
-//! with RocksDB — an in-memory component for fast access and a persistent
-//! component for durability.
+//! raft-engine is a log-structured append-only storage engine purpose-built
+//! for Multi-Raft logs. TiKV switched from RocksDB to raft-engine as the
+//! default in v6.1 because:
+//!   - Write amplification ~1x (vs RocksDB's up to 30x)
+//!   - No LSM compaction stalls
+//!   - Designed for FIFO Raft log patterns (append, read, truncate)
 //!
-//! The Storage trait provides:
-//! - `initial_state()` — hard state and conf state at startup
-//! - `entries()` — log entries in a range
-//! - `term()` — term for a given index
-//! - `first_index()` / `last_index()` — log bounds
-//! - `snapshot()` — current snapshot
+//! We store per-partition:
+//!   - Log entries via `add_entries` (raft-engine tracks first/last index)
+//!   - HardState via `put_message` (term, vote, commit)
+//!   - ConfState via `put_message` (voter/learner membership)
 //!
-//! Reference: [TiKV Raft Storage](https://tikv.org/blog/implement-raft-in-rust/)
+//! Reference: [TiKV raft-engine](https://github.com/tikv/raft-engine)
+//! Reference: [PingCAP Blog](https://www.pingcap.com/blog/raft-engine-a-log-structured-embedded-storage-engine-for-multi-raft-logs-in-tikv/)
 
-use std::sync::{
-    Arc,
-    RwLock,
-};
+use std::sync::Arc;
 
+use anyhow::Context;
 use raft::{
     prelude::*,
-    storage::MemStorage,
     GetEntriesContext,
     RaftState,
     Result as RaftResult,
     Storage,
+    StorageError,
+};
+use raft_engine::{
+    Config as EngineConfig,
+    Engine,
+    LogBatch,
+    MessageExt,
 };
 
 use crate::partition::PartitionId;
 
-/// In-memory Raft log storage with PostgreSQL durability.
+/// Key for storing HardState in raft-engine's KV space.
+const HARD_STATE_KEY: &[u8] = b"hard_state";
+/// Key for storing ConfState in raft-engine's KV space.
+const CONF_STATE_KEY: &[u8] = b"conf_state";
+
+/// Bridge between raft-rs Entry type and raft-engine's MessageExt trait.
+/// Tells raft-engine how to extract the log index from an Entry.
+/// This is the same pattern TiKV uses in its PeerStorage.
+struct RaftMessageExt;
+
+impl MessageExt for RaftMessageExt {
+    type Entry = Entry;
+
+    fn index(entry: &Entry) -> u64 {
+        entry.get_index()
+    }
+}
+
+/// Persistent Raft log storage backed by raft-engine (TiKV pattern).
 ///
-/// Uses `raft::MemStorage` internally for fast access. Persistence to
-/// PostgreSQL happens asynchronously after entries are committed.
-/// On restart, the log is rebuilt from PostgreSQL.
-///
-/// This matches TiKV's pattern: MemStorage for the hot path,
-/// RocksDB (our PostgreSQL) for durability.
+/// Each node runs one raft-engine instance shared across all partitions.
+/// Partitions are isolated by `region_id` (= partition_id as u64).
 #[derive(Clone)]
 pub struct ConvexRaftStorage {
-    /// The partition this storage belongs to.
+    /// The partition this storage belongs to (used as raft-engine region_id).
     partition_id: PartitionId,
-    /// In-memory Raft log (raft-rs built-in).
-    inner: MemStorage,
+    /// Shared raft-engine instance.
+    engine: Arc<Engine>,
+    /// Cached ConfState for the Storage trait (raft-engine doesn't track this
+    /// separately from entries, so we cache it in memory and persist to KV).
+    conf_state: ConfState,
 }
 
 impl ConvexRaftStorage {
-    /// Create a new Raft storage for a partition.
-    pub fn new(partition_id: PartitionId, node_id: u64, peers: Vec<u64>) -> Self {
-        let storage = MemStorage::new_with_conf_state(ConfState::from((peers, vec![])));
-        Self {
-            partition_id,
-            inner: storage,
-        }
+    /// Open or create the raft-engine at the given path.
+    /// Called once per node at startup. Returns the engine to be shared
+    /// across all partition storages on this node.
+    pub fn open_engine(path: &str) -> anyhow::Result<Arc<Engine>> {
+        let cfg = EngineConfig {
+            dir: path.to_owned(),
+            // Minimal config following TiKV defaults for raft-engine.
+            // purge_threshold triggers GC when total log size exceeds this.
+            ..Default::default()
+        };
+        let engine =
+            Engine::open(cfg).context("Failed to open raft-engine for persistent Raft storage")?;
+        tracing::info!("Opened raft-engine at {path}");
+        Ok(Arc::new(engine))
     }
 
-    /// Create storage initialized from an existing snapshot.
-    /// Used when a node restarts and loads from PostgreSQL.
-    pub fn from_snapshot(partition_id: PartitionId, snapshot: Snapshot) -> RaftResult<Self> {
-        let storage = MemStorage::new();
-        storage.wl().apply_snapshot(snapshot)?;
+    /// Create storage for a partition using a shared engine.
+    /// On first boot: initializes with the given peers.
+    /// On restart: loads existing state from the engine.
+    pub fn new(
+        partition_id: PartitionId,
+        engine: Arc<Engine>,
+        node_id: u64,
+        peers: Vec<u64>,
+    ) -> anyhow::Result<Self> {
+        let region_id = partition_id.0 as u64;
+
+        // Check if this partition already has persisted state (restart case).
+        let existing_cs: Option<ConfState> = engine
+            .get_message(region_id, CONF_STATE_KEY)
+            .context("Failed to read ConfState from raft-engine")?;
+
+        let conf_state = if let Some(cs) = existing_cs {
+            tracing::info!(
+                "Raft storage: loaded existing state for partition {partition_id}, voters={:?}",
+                cs.get_voters(),
+            );
+            cs
+        } else {
+            // First boot: initialize with peers.
+            let cs = ConfState::from((peers.clone(), vec![]));
+            let mut batch = LogBatch::default();
+            batch
+                .put_message(region_id, CONF_STATE_KEY.to_vec(), &cs)
+                .context("Failed to persist initial ConfState")?;
+            engine
+                .write(&mut batch, true)
+                .context("Failed to write initial ConfState to raft-engine")?;
+            tracing::info!(
+                "Raft storage: initialized partition {partition_id} with peers {peers:?}",
+            );
+            cs
+        };
+
         Ok(Self {
             partition_id,
-            inner: storage,
+            engine,
+            conf_state,
         })
     }
 
-    /// Append entries to the in-memory log.
+    /// Region ID for raft-engine (partition_id as u64).
+    fn region_id(&self) -> u64 {
+        self.partition_id.0 as u64
+    }
+
+    /// Append entries to the persistent log.
     /// Called during Ready processing after entries are received.
-    pub fn append_entries(&self, entries: &[Entry]) -> RaftResult<()> {
-        self.inner.wl().append(entries)
+    pub fn append_entries(&self, entries: &[Entry]) -> anyhow::Result<()> {
+        if entries.is_empty() {
+            return Ok(());
+        }
+        let mut batch = LogBatch::default();
+        batch
+            .add_entries::<RaftMessageExt>(self.region_id(), entries)
+            .context("Failed to add entries to LogBatch")?;
+        self.engine
+            .write(&mut batch, true)
+            .context("Failed to write entries to raft-engine")?;
+        Ok(())
     }
 
-    /// Apply a snapshot to storage.
-    pub fn apply_snapshot(&self, snapshot: Snapshot) -> RaftResult<()> {
-        self.inner.wl().apply_snapshot(snapshot)
+    /// Persist hard state (term, vote, commit index).
+    /// Called during Ready processing alongside entry append.
+    pub fn set_hardstate(&self, hs: &HardState) -> anyhow::Result<()> {
+        let mut batch = LogBatch::default();
+        batch
+            .put_message(self.region_id(), HARD_STATE_KEY.to_vec(), hs)
+            .context("Failed to add HardState to LogBatch")?;
+        self.engine
+            .write(&mut batch, true)
+            .context("Failed to write HardState to raft-engine")?;
+        Ok(())
     }
 
-    /// Set the hard state (term, vote, commit index).
-    pub fn set_hardstate(&self, hs: HardState) {
-        self.inner.wl().set_hardstate(hs);
+    /// Persist hard state and entries atomically in one batch.
+    /// This is the TiKV WriteBatch pattern — entries + hard state go
+    /// in one atomic write to ensure crash consistency.
+    pub fn append_entries_and_hardstate(
+        &self,
+        entries: &[Entry],
+        hs: &HardState,
+    ) -> anyhow::Result<()> {
+        let mut batch = LogBatch::default();
+        if !entries.is_empty() {
+            batch
+                .add_entries::<RaftMessageExt>(self.region_id(), entries)
+                .context("Failed to add entries to LogBatch")?;
+        }
+        batch
+            .put_message(self.region_id(), HARD_STATE_KEY.to_vec(), hs)
+            .context("Failed to add HardState to LogBatch")?;
+        self.engine
+            .write(&mut batch, true)
+            .context("Failed to write entries+HardState to raft-engine")?;
+        Ok(())
     }
 
     /// Set the conf state (voter/learner membership).
-    pub fn set_conf_state(&self, cs: ConfState) {
-        self.inner.wl().set_conf_state(cs);
+    pub fn set_conf_state(&mut self, cs: ConfState) -> anyhow::Result<()> {
+        let mut batch = LogBatch::default();
+        batch
+            .put_message(self.region_id(), CONF_STATE_KEY.to_vec(), &cs)
+            .context("Failed to add ConfState to LogBatch")?;
+        self.engine
+            .write(&mut batch, true)
+            .context("Failed to write ConfState to raft-engine")?;
+        self.conf_state = cs;
+        Ok(())
     }
 
-    /// Get a clone of the current hard state.
-    pub fn hard_state(&self) -> HardState {
-        self.inner.rl().hard_state().clone()
-    }
-
-    /// Create and apply a snapshot at the given index.
-    pub fn create_snapshot(
-        &self,
-        index: u64,
-        term: u64,
-        conf_state: ConfState,
-        data: Vec<u8>,
-    ) -> RaftResult<()> {
-        let mut snapshot = Snapshot::default();
-        snapshot.mut_metadata().index = index;
-        snapshot.mut_metadata().term = term;
-        snapshot.mut_metadata().set_conf_state(conf_state);
-        snapshot.data = data.into();
-        self.inner.wl().apply_snapshot(snapshot)
+    /// Get the current hard state.
+    pub fn hard_state(&self) -> anyhow::Result<HardState> {
+        let hs: Option<HardState> = self
+            .engine
+            .get_message(self.region_id(), HARD_STATE_KEY)
+            .context("Failed to read HardState from raft-engine")?;
+        Ok(hs.unwrap_or_default())
     }
 
     /// Compact the log up to the given index.
-    pub fn compact(&self, index: u64) -> RaftResult<()> {
-        self.inner.wl().compact(index)
+    /// Removes entries before `index` to reclaim disk space.
+    pub fn compact(&self, index: u64) -> anyhow::Result<()> {
+        self.engine.compact_to(self.region_id(), index);
+        Ok(())
+    }
+
+    /// Purge expired files from the engine.
+    /// Should be called periodically (TiKV does every 10 seconds).
+    pub fn purge(&self) -> anyhow::Result<()> {
+        let _ = self
+            .engine
+            .purge_expired_files()
+            .context("Failed to purge raft-engine files")?;
+        Ok(())
     }
 
     /// Get the partition this storage belongs to.
@@ -120,9 +232,24 @@ impl ConvexRaftStorage {
     }
 }
 
+/// Implement raft-rs Storage trait backed by raft-engine.
+/// This is the equivalent of TiKV's PeerStorage.
 impl Storage for ConvexRaftStorage {
     fn initial_state(&self) -> RaftResult<RaftState> {
-        self.inner.initial_state()
+        let hs: HardState = self
+            .engine
+            .get_message(self.region_id(), HARD_STATE_KEY)
+            .map_err(|e| {
+                raft::Error::Store(StorageError::Other(Box::new(std::io::Error::other(
+                    e.to_string(),
+                ))))
+            })?
+            .unwrap_or_default();
+
+        Ok(RaftState {
+            hard_state: hs,
+            conf_state: self.conf_state.clone(),
+        })
     }
 
     fn entries(
@@ -130,25 +257,59 @@ impl Storage for ConvexRaftStorage {
         low: u64,
         high: u64,
         max_size: impl Into<Option<u64>>,
-        context: GetEntriesContext,
+        _context: GetEntriesContext,
     ) -> RaftResult<Vec<Entry>> {
-        self.inner.entries(low, high, max_size, context)
+        let max = max_size.into().map(|s| s as usize);
+        let mut entries = Vec::new();
+        self.engine
+            .fetch_entries_to::<RaftMessageExt>(self.region_id(), low, high, max, &mut entries)
+            .map_err(|e| {
+                raft::Error::Store(StorageError::Other(Box::new(std::io::Error::other(
+                    e.to_string(),
+                ))))
+            })?;
+        Ok(entries)
     }
 
     fn term(&self, idx: u64) -> RaftResult<u64> {
-        self.inner.term(idx)
+        let entry: Option<Entry> = self
+            .engine
+            .get_entry::<RaftMessageExt>(self.region_id(), idx)
+            .map_err(|e| {
+                raft::Error::Store(StorageError::Other(Box::new(std::io::Error::other(
+                    e.to_string(),
+                ))))
+            })?;
+        match entry {
+            Some(e) => Ok(e.get_term()),
+            None => {
+                // Check if this is the dummy entry at index 0.
+                if idx == 0 {
+                    return Ok(0);
+                }
+                Err(raft::Error::Store(StorageError::Compacted))
+            },
+        }
     }
 
     fn first_index(&self) -> RaftResult<u64> {
-        self.inner.first_index()
+        Ok(self
+            .engine
+            .first_index(self.region_id())
+            .unwrap_or(1))
     }
 
     fn last_index(&self) -> RaftResult<u64> {
-        self.inner.last_index()
+        Ok(self
+            .engine
+            .last_index(self.region_id())
+            .unwrap_or(0))
     }
 
-    fn snapshot(&self, request_index: u64, to: u64) -> RaftResult<Snapshot> {
-        self.inner.snapshot(request_index, to)
+    fn snapshot(&self, _request_index: u64, _to: u64) -> RaftResult<Snapshot> {
+        // Snapshot transfer not yet implemented.
+        // For now, nodes that fall too far behind must re-bootstrap.
+        Err(raft::Error::Store(StorageError::SnapshotTemporarilyUnavailable))
     }
 }
 
@@ -156,9 +317,16 @@ impl Storage for ConvexRaftStorage {
 mod tests {
     use super::*;
 
+    fn test_engine() -> Arc<Engine> {
+        let dir = tempfile::tempdir().unwrap();
+        ConvexRaftStorage::open_engine(dir.path().to_str().unwrap()).unwrap()
+    }
+
     #[test]
     fn test_create_storage() {
-        let storage = ConvexRaftStorage::new(PartitionId(0), 1, vec![1, 2, 3]);
+        let engine = test_engine();
+        let storage =
+            ConvexRaftStorage::new(PartitionId(0), engine, 1, vec![1, 2, 3]).unwrap();
         assert_eq!(storage.partition_id(), PartitionId(0));
         assert!(storage.first_index().is_ok());
         assert!(storage.last_index().is_ok());
@@ -166,40 +334,97 @@ mod tests {
 
     #[test]
     fn test_append_and_read_entries() {
-        let storage = ConvexRaftStorage::new(PartitionId(0), 1, vec![1]);
+        let engine = test_engine();
+        let storage =
+            ConvexRaftStorage::new(PartitionId(0), engine, 1, vec![1]).unwrap();
+
         let mut entry = Entry::default();
-        entry.index = 1;
-        entry.term = 1;
-        entry.data = b"test data".to_vec().into();
+        entry.set_index(1);
+        entry.set_term(1);
+        entry.set_data(b"test data".to_vec().into());
         storage.append_entries(&[entry]).unwrap();
 
         let entries = storage
             .entries(1, 2, None, GetEntriesContext::empty(false))
             .unwrap();
         assert_eq!(entries.len(), 1);
-        assert_eq!(&entries[0].data[..], b"test data");
+        assert_eq!(&entries[0].get_data()[..], b"test data");
     }
 
     #[test]
     fn test_hardstate_persistence() {
-        let storage = ConvexRaftStorage::new(PartitionId(0), 1, vec![1]);
-        let mut hs = HardState::default();
-        hs.term = 5;
-        hs.vote = 2;
-        hs.commit = 10;
-        storage.set_hardstate(hs.clone());
+        let engine = test_engine();
+        let storage =
+            ConvexRaftStorage::new(PartitionId(0), engine, 1, vec![1]).unwrap();
 
-        let retrieved = storage.hard_state();
-        assert_eq!(retrieved.term, 5);
-        assert_eq!(retrieved.vote, 2);
-        assert_eq!(retrieved.commit, 10);
+        let mut hs = HardState::default();
+        hs.set_term(5);
+        hs.set_vote(2);
+        hs.set_commit(10);
+        storage.set_hardstate(&hs).unwrap();
+
+        let retrieved = storage.hard_state().unwrap();
+        assert_eq!(retrieved.get_term(), 5);
+        assert_eq!(retrieved.get_vote(), 2);
+        assert_eq!(retrieved.get_commit(), 10);
     }
 
     #[test]
     fn test_initial_state_with_peers() {
-        let storage = ConvexRaftStorage::new(PartitionId(1), 2, vec![1, 2, 3]);
+        let engine = test_engine();
+        let storage =
+            ConvexRaftStorage::new(PartitionId(1), engine, 2, vec![1, 2, 3]).unwrap();
         let state = storage.initial_state().unwrap();
-        let voters = state.conf_state.voters;
+        let voters = state.conf_state.get_voters().to_vec();
         assert_eq!(voters, vec![1, 2, 3]);
+    }
+
+    #[test]
+    fn test_state_survives_reopen() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().to_str().unwrap();
+
+        // First boot: write entries and hard state.
+        {
+            let engine = ConvexRaftStorage::open_engine(path).unwrap();
+            let storage =
+                ConvexRaftStorage::new(PartitionId(0), engine, 1, vec![1, 2, 3]).unwrap();
+
+            let mut entry = Entry::default();
+            entry.set_index(1);
+            entry.set_term(1);
+            entry.set_data(b"persisted".to_vec().into());
+
+            let mut hs = HardState::default();
+            hs.set_term(1);
+            hs.set_vote(1);
+            hs.set_commit(1);
+
+            storage
+                .append_entries_and_hardstate(&[entry], &hs)
+                .unwrap();
+        }
+        // Engine dropped, simulating restart.
+
+        // Reopen: verify state survived.
+        {
+            let engine = ConvexRaftStorage::open_engine(path).unwrap();
+            let storage =
+                ConvexRaftStorage::new(PartitionId(0), engine, 1, vec![1, 2, 3]).unwrap();
+
+            // Hard state persisted.
+            let state = storage.initial_state().unwrap();
+            assert_eq!(state.hard_state.get_term(), 1);
+            assert_eq!(state.hard_state.get_vote(), 1);
+            assert_eq!(state.conf_state.get_voters(), &[1, 2, 3]);
+
+            // Entries persisted.
+            assert_eq!(storage.last_index().unwrap(), 1);
+            let entries = storage
+                .entries(1, 2, None, GetEntriesContext::empty(false))
+                .unwrap();
+            assert_eq!(entries.len(), 1);
+            assert_eq!(&entries[0].get_data()[..], b"persisted");
+        }
     }
 }

--- a/crates/database/src/raft_transport.rs
+++ b/crates/database/src/raft_transport.rs
@@ -28,19 +28,17 @@ use crate::raft_node::RaftMessage;
 
 /// Encode a raft-rs Message to bytes for transport.
 ///
-/// raft-rs uses prost 0.11 internally, so we use raft-proto's prost
-/// re-export for encode/decode to avoid version mismatches.
+/// With protobuf-codec, raft-rs types implement protobuf::Message directly.
+/// This is the same serialization TiKV uses — no prost version mismatch.
 pub fn encode_raft_message(msg: &Message) -> Vec<u8> {
-    use prost_011::Message as ProstMsg;
-    let mut buf = Vec::with_capacity(ProstMsg::encoded_len(msg));
-    ProstMsg::encode(msg, &mut buf).expect("Raft message encoding failed");
-    buf
+    use protobuf::Message as ProtoMsg;
+    msg.write_to_bytes().expect("Raft message encoding failed")
 }
 
 /// Decode bytes back to a raft-rs Message.
 pub fn decode_raft_message(data: &[u8]) -> anyhow::Result<Message> {
-    use prost_011::Message as ProstMsg;
-    <Message as ProstMsg>::decode(data).context("Failed to decode Raft message")
+    use protobuf::Message as ProtoMsg;
+    Message::parse_from_bytes(data).context("Failed to decode Raft message")
 }
 
 /// Client for sending Raft messages to a remote node.
@@ -233,21 +231,21 @@ mod tests {
     #[test]
     fn test_encode_decode_roundtrip() {
         let mut msg = Message::default();
-        msg.msg_type = raft::prelude::MessageType::MsgAppend as i32;
-        msg.to = 2;
-        msg.from = 1;
-        msg.term = 5;
-        msg.log_term = 4;
-        msg.index = 10;
+        msg.set_msg_type(raft::prelude::MessageType::MsgAppend);
+        msg.set_to(2);
+        msg.set_from(1);
+        msg.set_term(5);
+        msg.set_log_term(4);
+        msg.set_index(10);
 
         let encoded = encode_raft_message(&msg);
         let decoded = decode_raft_message(&encoded).unwrap();
 
-        assert_eq!(decoded.to, 2);
-        assert_eq!(decoded.from, 1);
-        assert_eq!(decoded.term, 5);
-        assert_eq!(decoded.log_term, 4);
-        assert_eq!(decoded.index, 10);
+        assert_eq!(decoded.get_to(), 2);
+        assert_eq!(decoded.get_from(), 1);
+        assert_eq!(decoded.get_term(), 5);
+        assert_eq!(decoded.get_log_term(), 4);
+        assert_eq!(decoded.get_index(), 10);
     }
 
     #[test]

--- a/crates/database/src/tests/raft_failover_tests.rs
+++ b/crates/database/src/tests/raft_failover_tests.rs
@@ -9,7 +9,10 @@
 //!   - TiKV fail-rs chaos testing
 //!   - YugabyteDB Jepsen nightly resilience benchmarks
 
-use std::collections::HashMap;
+use std::{
+    collections::HashMap,
+    sync::Arc,
+};
 
 use raft::StateRole;
 use tokio::sync::mpsc;
@@ -21,16 +24,23 @@ use crate::{
         RaftNode,
         RaftNodeConfig,
     },
+    raft_storage::ConvexRaftStorage,
 };
 
-/// Create a 3-node Raft group with in-memory channels.
+fn test_engine() -> Arc<raft_engine::Engine> {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.into_path();
+    ConvexRaftStorage::open_engine(path.to_str().unwrap()).unwrap()
+}
+
+/// Create a 3-node Raft group with persistent storage.
 fn create_three_node_group() -> Vec<RaftNode> {
     let peer_ids = vec![1u64, 2, 3];
     let mut nodes = Vec::new();
 
     for &id in &peer_ids {
+        let engine = test_engine();
         let (_, rx) = mpsc::unbounded_channel();
-        // Peer senders not used — we route messages via direct step() calls.
         let config = RaftNodeConfig {
             node_id: id,
             partition_id: PartitionId(0),
@@ -38,7 +48,7 @@ fn create_three_node_group() -> Vec<RaftNode> {
             election_tick: 10,
             heartbeat_tick: 3,
         };
-        let node = RaftNode::new(config, rx, HashMap::new()).unwrap();
+        let node = RaftNode::new(config, engine, rx, HashMap::new()).unwrap();
         nodes.push(node);
     }
 
@@ -72,7 +82,7 @@ fn tick_cycle(nodes: &mut [RaftNode], active: &[bool]) -> Vec<Vec<u8>> {
 
             node.storage.append_entries(ready.entries()).unwrap();
             if let Some(hs) = ready.hs() {
-                node.storage.set_hardstate(hs.clone());
+                node.storage.set_hardstate(hs).unwrap();
             }
 
             for entry in ready.take_committed_entries() {

--- a/crates/local_backend/src/lib.rs
+++ b/crates/local_backend/src/lib.rs
@@ -463,6 +463,7 @@ pub async fn make_app(
         use database::{
             raft_node::RaftNodeConfig,
             raft_partition::RaftPartitionManager,
+            raft_storage::ConvexRaftStorage,
             raft_transport,
         };
 
@@ -489,11 +490,18 @@ pub async fn make_app(
             heartbeat_tick: 3, // 300ms
         };
 
+        // Open raft-engine for persistent Raft log storage (TiKV pattern).
+        // One engine per node, shared across all partitions. Data survives
+        // restarts — this prevents the "to_commit X out of range" panic
+        // that MemStorage caused.
+        let raft_engine_path = "/convex/data/raft-engine";
+        let raft_engine = ConvexRaftStorage::open_engine(raft_engine_path)?;
+
         // Create transport channels for peer communication.
         let (peer_senders, transport_clients) =
             raft_transport::create_transport(&peer_addresses, raft_node_id);
 
-        let mut manager = RaftPartitionManager::new(raft_config, peer_senders)?;
+        let mut manager = RaftPartitionManager::new(raft_config, raft_engine, peer_senders)?;
         let raft_state = manager.state();
         let mb_tx = manager.mailbox_tx();
         raft_mailbox_tx = Some(mb_tx);

--- a/self-hosted/docker/docker-compose.yml
+++ b/self-hosted/docker/docker-compose.yml
@@ -15,6 +15,7 @@
 
 x-backend-common: &backend-common
   image: ghcr.io/martinkalema/convex-horizontal-scaling:backend-latest
+  pull_policy: always
   stop_grace_period: 10s
   stop_signal: SIGINT
   healthcheck:


### PR DESCRIPTION
## Summary
- Replace MemStorage with TiKV's raft-engine for persistent Raft log storage
- Fixes node restart panic: "to_commit X is out of range [last_index 0]"
- Entries + hard state written atomically via LogBatch (TiKV WriteBatch pattern)
- Switch from prost-codec to protobuf-codec for raft-engine compatibility
- TiKV moved from RocksDB to raft-engine in v6.1 for ~1x write amplification (vs 30x)

## Test plan
- [x] 5 raft storage unit tests pass (including `test_state_survives_reopen`)
- [x] `cargo check -p database --tests` compiles clean
- [x] `cargo check -p local_backend` compiles clean
- [ ] Docker build and cluster deployment
- [ ] Node restart no longer panics
- [ ] `./test.sh failover` passes (kill leader, restart, rejoin)