### PR TITLE
docs: add raft-engine persistent storage to documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ We took the best engineering from five distributed databases and combined them:
 | Raft transport | gRPC with batched messages and exponential backoff retry | TiKV RaftClient |
 | Leadership lifecycle | Committer starts on election, stops on demotion via SoftState | TiKV, CockroachDB |
 | Deployment state replication | GLOBAL table locality — `_modules`, `_udf_config`, `_source_packages` replicate to all nodes | CockroachDB GLOBAL tables, YugabyteDB system catalog |
+| Persistent Raft log | raft-engine — append-only WAL with ~1x write amplification, crash-safe atomic batches | TiKV raft-engine (replaced RocksDB in v6.1) |
 
 The combination — real-time subscriptions + in-memory OCC + partitioned multi-writer + delta replication + 2PC — doesn't exist in any of those systems. CockroachDB doesn't have subscriptions. TiDB doesn't have in-memory snapshots. Vitess doesn't have OCC. We kept Convex's unique architecture and grafted distributed database patterns onto it.
 
@@ -251,7 +252,7 @@ Observed idle memory usage per backend node: ~20 MB. Under load with in-memory s
 | RaftNode | `raft_node.rs` | Raft loop: tick, receive, propose, process Ready, advance. Leadership callbacks via SoftState |
 | RaftPartitionManager | `raft_partition.rs` | Wraps RaftNode, activates/deactivates Committer on leader election/demotion |
 | RaftTransport | `raft_transport.rs` | gRPC transport with batched messages, exponential backoff retry (TiKV RaftClient pattern) |
-| RaftStorage | `raft_storage.rs` | MemStorage wrapper with partition awareness for raft-rs |
+| RaftStorage | `raft_storage.rs` | Persistent Raft log backed by TiKV raft-engine — entries + hard state survive restarts |
 | RaftStateMachine | `raft_state_machine.rs` | Serialization format for Raft log entries, bridges committed entries to Committer |
 | CommitDelta | `commit_delta.rs` | Captures everything changed in a transaction — documents, indexes, table mappings |
 | NatsDistributedLog | `nats_distributed_log.rs` | Publishes/subscribes deltas via NATS JetStream with per-partition subjects and self-delta skip |

--- a/docs/raft-integration.md
+++ b/docs/raft-integration.md
@@ -83,7 +83,7 @@ loop {
 
 | raft-rs Component | Convex Component | Implementation |
 | --- | --- | --- |
-| `Storage` trait | `RaftLogStorage` | PostgreSQL-backed: entries, hard state, snapshots |
+| `Storage` trait | `ConvexRaftStorage` | TiKV raft-engine: persistent append-only WAL with ~1x write amplification |
 | State machine apply | `Committer::apply_raft_entry()` | Deserialize entry → execute mutation → commit |
 | `propose()` | Client mutation arrives | Serialize FinalTransaction → propose to Raft |
 | `Ready::messages` | `RaftTransport` | gRPC service: AppendEntries, Vote, InstallSnapshot |
@@ -112,7 +112,7 @@ After: Committer starts when this node becomes Raft leader for a partition. Stop
 | File | What it does |
 | --- | --- |
 | `crates/database/src/raft_node.rs` | Raft loop: tick, propose, on_ready, advance |
-| `crates/database/src/raft_storage.rs` | PostgreSQL-backed Storage trait implementation |
+| `crates/database/src/raft_storage.rs` | raft-engine backed Storage trait — persistent entries, hard state, conf state |
 | `crates/database/src/raft_transport.rs` | gRPC transport for Raft messages |
 | `crates/database/src/raft_state_machine.rs` | Bridges Raft committed entries to Committer |
 | `crates/pb/protos/raft_rpc.proto` | Protobuf: AppendEntries, Vote, InstallSnapshot RPCs |
@@ -128,7 +128,7 @@ After: Committer starts when this node becomes Raft leader for a partition. Stop
 
 ## Implementation Sequence
 
-1. **Raft Storage**: PostgreSQL-backed log and hard state persistence
+1. **Raft Storage**: raft-engine backed log and hard state persistence (TiKV pattern)
 2. **Raft Transport**: gRPC service for Raft message passing
 3. **Raft Node**: The loop that drives the consensus module
 4. **State Machine Bridge**: Connect committed entries to the Committer

--- a/docs/what-we-built.md
+++ b/docs/what-we-built.md
@@ -14,8 +14,9 @@ No single system we studied has all of these together:
 | TypeScript function execution | No | No | No | No | No | Yes |
 | Horizontal read scaling | Yes | Yes | Yes | Yes | Yes | Yes |
 | Horizontal write scaling | Yes | Yes | Yes | Yes | Yes | Yes |
+| Automatic leader failover (Raft) | Yes | Yes | No | Yes | Yes | Yes |
 
-We added the last two rows while keeping the first four — the things that make Convex unique.
+We added the last three rows while keeping the first four — the things that make Convex unique.
 
 ## What We Took from Each System
 
@@ -82,6 +83,16 @@ We added the last two rows while keeping the first four — the things that make
 **Their solution**: A single background thread processes all state machine updates sequentially. etcd's `commitC` channel, TiKV's Apply Worker, Kafka KRaft's state machine callback — all the same pattern. One inbox, one reader, serial processing.
 
 **What we built**: The Convex Committer already used this pattern for local commits. We extended it: replica deltas go through the same `mpsc` channel as local commits, processed by the same single-threaded `go()` loop. The `ApplyReplicaDelta` message variant sits alongside `Commit`, `BumpMaxRepeatableTs`, and the 2PC handlers — all serialized.
+
+### TiKV: raft-engine for Persistent Raft Log
+
+**Problem**: Raft log entries and hard state must survive node restarts. Without persistence, a restarted node has an empty log (`last_index=0`) but the cluster has moved forward (`commit_index=2`), causing a fatal panic: `"to_commit 2 is out of range [last_index 0]"`.
+
+**TiKV's solution**: TiKV moved from RocksDB to raft-engine as the default Raft log storage in v6.1. RocksDB's LSM-tree has up to 30x write amplification and compaction stalls — unnecessary for Raft logs which follow a FIFO pattern (append, read briefly, truncate). raft-engine is an append-only WAL with ~1x write amplification, no compaction, and atomic batch writes.
+
+**What we built**: `ConvexRaftStorage` in `raft_storage.rs` backed by raft-engine. Entries and hard state are written atomically in a single `LogBatch` (TiKV WriteBatch pattern). On restart, `initial_state()` loads the persisted hard state and `entries()` reads from the engine. The `applied` index is set from the persisted commit index so raft-rs picks up where it left off. One raft-engine instance per node, partitions isolated by `region_id`.
+
+**Source**: [TiKV raft-engine](https://github.com/tikv/raft-engine), [PingCAP Blog](https://www.pingcap.com/blog/raft-engine-a-log-structured-embedded-storage-engine-for-multi-raft-logs-in-tikv/)
 
 ## What's New: The Combination
 


### PR DESCRIPTION
## Summary
- Add TiKV raft-engine pattern to what-we-built.md (why RocksDB was replaced, ~1x write amplification)
- Update raft-integration.md: Storage trait now backed by raft-engine, not PostgreSQL
- Update README: persistent Raft log in pattern table, updated RaftStorage component description
- Add automatic leader failover to capability comparison table