### PR TITLE
fix: propagate leader_id and strengthen regression coverage

### DIFF
--- a/crates/database/src/raft_node.rs
+++ b/crates/database/src/raft_node.rs
@@ -530,16 +530,24 @@ mod tests {
 
         let became_leader = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
         let became_leader_clone = became_leader.clone();
+        let observed_leader_id = std::sync::Arc::new(std::sync::atomic::AtomicU64::new(0));
+        let observed_leader_id_clone = observed_leader_id.clone();
 
         node.set_leadership_callbacks(LeadershipCallbacks {
             on_became_leader: Box::new(move || {
                 became_leader_clone.store(true, std::sync::atomic::Ordering::SeqCst);
             }),
             on_lost_leadership: Box::new(|| {}),
-            on_leader_changed: Box::new(|_| {}),
+            on_leader_changed: Box::new(move |leader_id| {
+                observed_leader_id_clone.store(leader_id, std::sync::atomic::Ordering::SeqCst);
+            }),
         });
 
         assert!(!became_leader.load(std::sync::atomic::Ordering::SeqCst));
+        assert_eq!(
+            observed_leader_id.load(std::sync::atomic::Ordering::SeqCst),
+            0
+        );
 
         // Trigger election.
         for _ in 0..20 {
@@ -551,6 +559,11 @@ mod tests {
         assert!(
             became_leader.load(std::sync::atomic::Ordering::SeqCst),
             "on_became_leader callback should have fired"
+        );
+        assert_eq!(
+            observed_leader_id.load(std::sync::atomic::Ordering::SeqCst),
+            1,
+            "on_leader_changed should publish the elected leader ID"
         );
     }
 }

--- a/crates/database/src/raft_partition.rs
+++ b/crates/database/src/raft_partition.rs
@@ -126,7 +126,6 @@ impl RaftPartitionManager {
 
         // Set up leadership callbacks that update shared atomic state.
         let is_leader_cb = is_leader.clone();
-        let leader_id_cb = leader_id.clone();
         let partition_id = config.partition_id;
 
         node.set_leadership_callbacks(LeadershipCallbacks {
@@ -248,6 +247,11 @@ mod tests {
 
         // The shared state should now reflect leadership.
         assert!(state.is_leader());
+        assert_eq!(
+            state.leader_id(),
+            1,
+            "Shared state should expose the elected leader ID"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- propagate the current Raft leader ID into shared `RaftPartitionState`
- assert that `on_leader_changed` publishes the elected leader ID in `raft_node` tests
- assert that `RaftPartitionState::leader_id()` is updated after election in `raft_partition` tests

## Why
`main` is production, and this work should land through `dev`.

This PR now carries both commits needed for `#75`:
- `9ecafcb` `fix: propagate current leader ID into shared RaftPartitionState`
- `70be378` `test: strengthen leader_id regression coverage`

The original implementation bug was real: follower rejection/redirect logic read leader ID from shared state, but that value stayed at `0` because only the `is_leader` boolean was updated.

## Verification
- `CARGO_TARGET_DIR=/Users/martin/Desktop/convex-horizontal-scaling/target cargo test -p database test_leadership_callback -- --nocapture`
- `CARGO_TARGET_DIR=/Users/martin/Desktop/convex-horizontal-scaling/target cargo test -p database test_leadership_updates_shared_state -- --nocapture`
- `CARGO_TARGET_DIR=/Users/martin/Desktop/convex-horizontal-scaling/target cargo test -p database raft_failover_tests -- --nocapture`