### PR TITLE
fix(database): enforce strict cross-partition OCC frontiers

### DIFF
--- a/crates/common/src/persistence.rs
+++ b/crates/common/src/persistence.rs
@@ -157,6 +157,11 @@ pub enum PersistenceGlobalKey {
     /// timestamp > this timestamp.
     MaxRepeatableTimestamp,
 
+    /// Latest locally-applied freshness frontier per source partition.
+    /// Used to prove that remote-partition reads were validated against a
+    /// replica that had caught up through the transaction's snapshot.
+    ReplicationFrontiers,
+
     /// Latest snapshot of all tables' summaries, cached to speed up startup.
     TableSummary,
 
@@ -186,6 +191,7 @@ impl From<PersistenceGlobalKey> for String {
                 "document_confirmed_deleted_ts".to_string()
             },
             PersistenceGlobalKey::MaxRepeatableTimestamp => "max_repeatable_ts".to_string(),
+            PersistenceGlobalKey::ReplicationFrontiers => "replication_frontiers_v1".to_string(),
             PersistenceGlobalKey::TableSummary => "table_summary_v2".to_string(),
             PersistenceGlobalKey::TablesByIdIndex => "tables_by_id".to_string(),
             PersistenceGlobalKey::IndexByIdIndex => "index_by_id".to_string(),
@@ -205,6 +211,7 @@ impl FromStr for PersistenceGlobalKey {
             "document_min_snapshot_ts" => Ok(Self::DocumentRetentionMinSnapshotTimestamp),
             "document_confirmed_deleted_ts" => Ok(Self::DocumentRetentionConfirmedDeletedTimestamp),
             "max_repeatable_ts" => Ok(Self::MaxRepeatableTimestamp),
+            "replication_frontiers_v1" => Ok(Self::ReplicationFrontiers),
             "table_summary_v2" => Ok(Self::TableSummary),
             "tables_by_id" => Ok(Self::TablesByIdIndex),
             "tables_table_id" => Ok(Self::TablesTabletId),

--- a/crates/database/src/commit_delta.rs
+++ b/crates/database/src/commit_delta.rs
@@ -25,7 +25,10 @@ use value::{
     TabletId,
 };
 
-use crate::write_log::WriteSource;
+use crate::{
+    partition::PartitionId,
+    write_log::WriteSource,
+};
 
 /// Everything that changed in a single committed transaction.
 ///
@@ -61,6 +64,13 @@ pub struct CommitDelta {
     /// Replicas use this to remap document IDs to their own local TabletIds
     /// since each database instance generates unique TabletIds.
     pub tablet_id_to_table_name: BTreeMap<TabletId, TableName>,
+
+    /// Partition that originated this replicated event.
+    ///
+    /// Used to advance per-partition freshness frontiers on replicas, so
+    /// remote reads can prove they were validated against a sufficiently
+    /// up-to-date replica state.
+    pub source_partition: Option<PartitionId>,
 }
 
 /// Abstraction over the transport that carries [`CommitDelta`]s between

--- a/crates/database/src/committer.rs
+++ b/crates/database/src/committer.rs
@@ -1,6 +1,9 @@
 use std::{
     cmp,
-    collections::BTreeSet,
+    collections::{
+        BTreeMap,
+        BTreeSet,
+    },
     ops::Bound,
     sync::Arc,
     time::Duration,
@@ -81,6 +84,7 @@ use errors::ErrorMetadata;
 use fastrace::prelude::*;
 use futures::{
     future::{
+        join_all,
         BoxFuture,
         Either,
     },
@@ -134,7 +138,10 @@ use crate::{
         stream_revision_pairs_for_indexes,
         BootstrappedSearchIndexes,
     },
-    snapshot_manager::SnapshotManager,
+    snapshot_manager::{
+        replication_frontiers_to_json,
+        SnapshotManager,
+    },
     table_summary::{
         self,
     },
@@ -195,6 +202,7 @@ enum PersistenceWrite {
         remapped_updates: Vec<common::document::DocumentUpdate>,
         write_source: WriteSource,
         write_bytes: u64,
+        source_partition: Option<crate::partition::PartitionId>,
         result: oneshot::Sender<anyhow::Result<Timestamp>>,
         commit_id: usize,
     },
@@ -211,6 +219,63 @@ impl PersistenceWrite {
 }
 
 pub const AFTER_PENDING_WRITE_SNAPSHOT: &str = "after_pending_write_snapshot";
+
+fn remote_read_partitions(
+    transaction: &FinalTransaction,
+    partition_map: &crate::partition::PartitionMap,
+) -> BTreeSet<crate::partition::PartitionId> {
+    let mut partitions = BTreeSet::new();
+    let mut visit_tablet = |tablet_id| {
+        if let Ok(table_name) = transaction.table_mapping.tablet_name(tablet_id) {
+            if table_name.is_system() {
+                return;
+            }
+            let partition = partition_map.partition_for_table(&table_name);
+            if partition != partition_map.local_partition() {
+                partitions.insert(partition);
+            }
+        }
+    };
+
+    for (index_name, _) in transaction.reads.read_set().iter_indexed() {
+        visit_tablet(*index_name.table());
+    }
+    for (index_name, _) in transaction.reads.read_set().iter_search() {
+        visit_tablet(*index_name.table());
+    }
+    partitions
+}
+
+fn stale_replica_frontiers(
+    snapshot_manager: &SnapshotManager,
+    transaction: &FinalTransaction,
+    partition_map: &crate::partition::PartitionMap,
+) -> Vec<(crate::partition::PartitionId, Timestamp)> {
+    let begin_ts = *transaction.begin_timestamp;
+    remote_read_partitions(transaction, partition_map)
+        .into_iter()
+        .filter_map(|partition| {
+            let frontier = snapshot_manager
+                .replication_frontier(partition)
+                .unwrap_or(Timestamp::MIN);
+            (frontier < begin_ts).then_some((partition, frontier))
+        })
+        .collect()
+}
+
+fn has_nonlocal_user_writes(
+    transaction: &FinalTransaction,
+    partition_map: &crate::partition::PartitionMap,
+) -> bool {
+    transaction.writes.coalesced_writes().any(|write| {
+        transaction
+            .table_mapping
+            .tablet_name(write.id.tablet_id)
+            .ok()
+            .filter(|table_name| !table_name.is_system())
+            .is_some_and(|table_name| !partition_map.is_local(&table_name))
+    })
+}
 
 pub struct Committer<RT: Runtime> {
     // Internal staged commits for conflict checking.
@@ -406,6 +471,7 @@ impl<RT: Runtime> Committer<RT> {
                             remapped_updates,
                             write_source,
                             write_bytes,
+                            source_partition,
                             result,
                             ..
                         } => {
@@ -418,6 +484,9 @@ impl<RT: Runtime> Committer<RT> {
                             self.log.append(commit_ts, writes, write_source);
                             let mut sm = self.snapshot_manager.write();
                             sm.push(commit_ts, snapshot, write_bytes);
+                            if let Some(source_partition) = source_partition {
+                                sm.update_replication_frontier(source_partition, commit_ts)?;
+                            }
                             let _ = result.send(Ok(commit_ts));
                         },
                     }
@@ -789,14 +858,86 @@ impl<RT: Runtime> Committer<RT> {
         // Bump the latest snapshot in snapshot_manager so reads on this leader
         // can know this timestamp is repeatable.
         let mut snapshot_manager = self.snapshot_manager.write();
-        if snapshot_manager.bump_persisted_max_repeatable_ts(new_max_repeatable)? {
+        let advanced = snapshot_manager.bump_persisted_max_repeatable_ts(new_max_repeatable)?;
+        if advanced {
             self.log.append(
                 new_max_repeatable,
                 WithHeapSize::default(),
                 "publish_max_repeatable_ts".into(),
             );
         }
+        drop(snapshot_manager);
+        if advanced {
+            self.publish_replication_frontier_heartbeat(new_max_repeatable);
+        }
         Ok(())
+    }
+
+    fn publish_replication_frontier_heartbeat(&self, frontier_ts: Timestamp) {
+        let Some(partition_map) = self.partition_map.as_ref() else {
+            return;
+        };
+        if partition_map.num_partitions() <= 1 {
+            return;
+        }
+        if self
+            .raft_state
+            .as_ref()
+            .is_some_and(|raft_state| !raft_state.is_leader())
+        {
+            return;
+        }
+
+        let delta = CommitDelta {
+            ts: frontier_ts,
+            document_writes: Arc::new(Vec::new()),
+            document_updates: Vec::new(),
+            index_writes: Arc::new(Vec::new()),
+            write_source: WriteSource::new("replication_frontier_heartbeat"),
+            write_bytes: 0,
+            tablet_id_to_table_name: BTreeMap::new(),
+            source_partition: Some(partition_map.local_partition()),
+        };
+        let distributed_log = self.distributed_log.clone();
+        tokio_spawn("publish_replication_frontier_heartbeat", async move {
+            if let Err(e) = distributed_log.publish(delta).await {
+                tracing::error!(
+                    "Failed to publish replication frontier heartbeat at ts={}: {e:#}",
+                    u64::from(frontier_ts),
+                );
+            }
+        });
+    }
+
+    fn validate_remote_read_frontiers(
+        &self,
+        transaction: &FinalTransaction,
+        write_source: &WriteSource,
+    ) -> anyhow::Result<()> {
+        let Some(partition_map) = self.partition_map.as_ref() else {
+            return Ok(());
+        };
+
+        let begin_ts = *transaction.begin_timestamp;
+        let stale = {
+            let snapshot_manager = self.snapshot_manager.read();
+            stale_replica_frontiers(&snapshot_manager, transaction, partition_map)
+        };
+        if stale.is_empty() {
+            return Ok(());
+        }
+
+        let details = stale
+            .iter()
+            .map(|(partition, frontier)| format!("{partition}: frontier={frontier}"))
+            .join(", ");
+        let metadata = ErrorMetadata::system_occ(
+            Some(u64::from(begin_ts)),
+            write_source.as_str().map(|source| source.to_string()),
+        );
+        Err(anyhow::anyhow!(metadata).context(format!(
+            "Cross-partition OCC requires remote read frontiers >= {begin_ts}, but found {details}",
+        )))
     }
 
     /// First, check that it's valid to apply this transaction in-memory. If it
@@ -850,48 +991,7 @@ impl<RT: Runtime> Committer<RT> {
             }
         }
 
-        // Cross-partition OCC: if partitioning is enabled and this
-        // transaction reads from remote tables, verify the local replica
-        // of remote partitions is caught up to the transaction's begin
-        // timestamp. If not, the write log might be missing remote writes
-        // that conflict with this transaction's reads.
-        //
-        // The write log already contains entries from replicated deltas
-        // (applied via apply_replica_delta). We just need to ensure
-        // the replication has caught up far enough. The SnapshotManager's
-        // latest_ts reflects the latest applied delta.
-        if let Some(ref partition_map) = self.partition_map {
-            let latest_replicated_ts = *self.snapshot_manager.read().latest_ts();
-            let begin_ts = *transaction.begin_timestamp;
-            if latest_replicated_ts < begin_ts {
-                // Check if any reads are from remote partitions.
-                let has_remote_reads =
-                    transaction
-                        .reads
-                        .read_set()
-                        .iter_indexed()
-                        .any(|(index_name, _)| {
-                            let tablet_id = index_name.table();
-                            if let Ok(name) = transaction.table_mapping.tablet_name(*tablet_id) {
-                                !partition_map.is_local(&name)
-                            } else {
-                                false
-                            }
-                        });
-                if has_remote_reads {
-                    tracing::warn!(
-                        "Cross-partition OCC: local replica behind (latest={}, begin={}). Remote \
-                         reads may miss conflicts. Proceeding with best-effort validation.",
-                        latest_replicated_ts,
-                        begin_ts,
-                    );
-                    // In a production implementation, we would wait for the
-                    // replica to catch up or reject the transaction. For now,
-                    // we proceed with best-effort validation using whatever
-                    // data is in the write log.
-                }
-            }
-        }
+        self.validate_remote_read_frontiers(&transaction, &write_source)?;
 
         let commit_ts = self.next_commit_ts()?;
         let timer = metrics::commit_is_stale_timer();
@@ -1107,6 +1207,10 @@ impl<RT: Runtime> Committer<RT> {
             write_source,
             write_bytes,
             tablet_id_to_table_name,
+            source_partition: self
+                .partition_map
+                .as_ref()
+                .map(|partition_map| partition_map.local_partition()),
         };
 
         // Propose delta to Raft for intra-partition replication (if Raft enabled).
@@ -1263,9 +1367,9 @@ impl<RT: Runtime> Committer<RT> {
         // YugabyteDB's pg_proc (stored procedures), and TiDB's mysql.tidb
         // (DDL schema state).
         let global_deployment_tables: &[&str] = &[
-            "_modules",          // JavaScript/TypeScript function source code
-            "_udf_config",       // UDF runtime configuration
-            "_source_packages",  // Bundled source packages
+            "_modules",         // JavaScript/TypeScript function source code
+            "_udf_config",      // UDF runtime configuration
+            "_source_packages", // Bundled source packages
         ];
         let is_global_deployment_table = |name: &value::TableName| -> bool {
             let name_str = name.to_string();
@@ -1350,10 +1454,8 @@ impl<RT: Runtime> Committer<RT> {
         // the table number to a locally-unique value, preserving only the
         // table name and TabletId (derived from developer_id) for remapping.
         if !tables_updates.is_empty() {
-            use common::document::CreationTime;
             use value::{
                 ConvexObject,
-                TableNamespace,
                 TableNumber,
             };
 
@@ -1523,6 +1625,16 @@ impl<RT: Runtime> Committer<RT> {
         let num_doc_writes = document_writes.len();
         let num_remapped = all_remapped_updates.len();
         let skipped = delta.document_updates.len() - num_remapped;
+        let updated_replication_frontiers = delta.source_partition.map(|source_partition| {
+            let mut frontiers = self.snapshot_manager.read().replication_frontiers();
+            let should_update = frontiers
+                .get(&source_partition)
+                .is_none_or(|current| *current < commit_ts);
+            if should_update {
+                frontiers.insert(source_partition, commit_ts);
+            }
+            frontiers
+        });
 
         let persistence = self.persistence.clone();
         let (tx, _rx) = oneshot::channel();
@@ -1531,6 +1643,8 @@ impl<RT: Runtime> Committer<RT> {
         self.persistence_writes.push_back({
             let doc_writes = document_writes.clone();
             let idx_writes = index_writes.clone();
+            let replication_frontiers = updated_replication_frontiers.clone();
+            let source_partition = delta.source_partition;
             async move {
                 // Write to persistence (so function runner can load modules).
                 persistence
@@ -1545,6 +1659,15 @@ impl<RT: Runtime> Committer<RT> {
                     )
                     .await?;
 
+                if let Some(frontiers) = replication_frontiers {
+                    persistence
+                        .write_persistence_global(
+                            PersistenceGlobalKey::ReplicationFrontiers,
+                            replication_frontiers_to_json(&frontiers),
+                        )
+                        .await?;
+                }
+
                 Ok(PersistenceWrite::ReplicaDelta {
                     commit_ts,
                     snapshot,
@@ -1553,6 +1676,7 @@ impl<RT: Runtime> Committer<RT> {
                     remapped_updates: all_remapped_updates,
                     write_source: delta.write_source,
                     write_bytes: delta.write_bytes,
+                    source_partition,
                     result: tx,
                     commit_id: commit_id_val,
                 })
@@ -1592,6 +1716,7 @@ impl<RT: Runtime> Committer<RT> {
         // Skip partition ownership check — the coordinator already routed
         // the correct subset of writes to this partition. Run the rest of
         // validation (OCC conflict check, compute writes).
+        self.validate_remote_read_frontiers(&transaction, &write_source)?;
         let commit_ts = self.next_commit_ts()?;
         let timer = metrics::commit_is_stale_timer();
         if let Some(conflicting_read) = self.commit_has_conflict(
@@ -2124,6 +2249,48 @@ impl CommitterClient {
         self.persistence_reader.clone()
     }
 
+    async fn wait_for_remote_read_frontiers(
+        &self,
+        transaction: &FinalTransaction,
+    ) -> anyhow::Result<()> {
+        let Some(partition_map) = self.partition_map.as_ref() else {
+            return Ok(());
+        };
+
+        let required = remote_read_partitions(transaction, partition_map);
+        if required.is_empty() {
+            return Ok(());
+        }
+
+        let begin_ts = *transaction.begin_timestamp;
+        let waits: Vec<_> = {
+            let snapshot_reader = self.snapshot_reader.lock();
+            required
+                .iter()
+                .filter_map(|partition| {
+                    let frontier = snapshot_reader
+                        .replication_frontier(*partition)
+                        .unwrap_or(Timestamp::MIN);
+                    (frontier < begin_ts).then(|| {
+                        snapshot_reader.wait_for_replication_frontier(*partition, begin_ts)
+                    })
+                })
+                .collect()
+        };
+
+        if waits.is_empty() {
+            return Ok(());
+        }
+
+        tracing::info!(
+            "Waiting for remote read frontiers to reach begin_ts={} on partitions {:?}",
+            begin_ts,
+            required,
+        );
+        join_all(waits).await;
+        Ok(())
+    }
+
     pub fn commit<RT: Runtime>(
         &self,
         transaction: Transaction<RT>,
@@ -2143,6 +2310,13 @@ impl CommitterClient {
 
         // Finish reading everything from persistence.
         let transaction = transaction.finalize()?;
+        if !self
+            .partition_map
+            .as_ref()
+            .is_some_and(|partition_map| has_nonlocal_user_writes(&transaction, partition_map))
+        {
+            self.wait_for_remote_read_frontiers(&transaction).await?;
+        }
 
         // Note that we do a best effort validation for memory index sizes. We
         // use the latest snapshot instead of the transaction base snapshot. This
@@ -2205,6 +2379,7 @@ impl CommitterClient {
         transaction: FinalTransaction,
         write_source: WriteSource,
     ) -> anyhow::Result<crate::two_phase::PrepareResult> {
+        self.wait_for_remote_read_frontiers(&transaction).await?;
         let (tx, rx) = oneshot::channel();
         let message = CommitterMessage::Prepare {
             transaction_id,

--- a/crates/database/src/committer.rs
+++ b/crates/database/src/committer.rs
@@ -170,7 +170,6 @@ struct PreparedTransaction {
     write_bytes: u64,
     document_writes: Arc<Vec<DocumentLogEntry>>,
     index_writes: Arc<Vec<PersistenceIndexEntry>>,
-    write_source: WriteSource,
 }
 
 enum PersistenceWrite {
@@ -197,8 +196,6 @@ enum PersistenceWrite {
     ReplicaDelta {
         commit_ts: Timestamp,
         snapshot: Snapshot,
-        document_writes: Vec<DocumentLogEntry>,
-        index_writes: Vec<PersistenceIndexEntry>,
         remapped_updates: Vec<common::document::DocumentUpdate>,
         write_source: WriteSource,
         write_bytes: u64,
@@ -1671,8 +1668,6 @@ impl<RT: Runtime> Committer<RT> {
                 Ok(PersistenceWrite::ReplicaDelta {
                     commit_ts,
                     snapshot,
-                    document_writes: document_writes.clone(),
-                    index_writes: index_writes.clone(),
                     remapped_updates: all_remapped_updates,
                     write_source: delta.write_source,
                     write_bytes: delta.write_bytes,
@@ -1784,7 +1779,6 @@ impl<RT: Runtime> Committer<RT> {
                 write_bytes,
                 document_writes: Arc::new(doc_entries),
                 index_writes: Arc::new(idx_entries),
-                write_source,
             },
         );
 

--- a/crates/database/src/database.rs
+++ b/crates/database/src/database.rs
@@ -190,6 +190,7 @@ use crate::{
     schema_registry::SchemaRegistry,
     search_index_bootstrap::SearchIndexBootstrapWorker,
     snapshot_manager::{
+        replication_frontiers_from_json,
         Snapshot,
         SnapshotManager,
         TableSummaries,
@@ -1024,7 +1025,24 @@ impl<RT: Runtime> Database<RT> {
             ..
         } = db_snapshot;
 
-        let snapshot_manager = SnapshotManager::new(*ts, snapshot);
+        let replication_frontiers = match reader
+            .get_persistence_global(PersistenceGlobalKey::ReplicationFrontiers)
+            .await?
+        {
+            Some(value) => replication_frontiers_from_json(value)?,
+            None => partition_map
+                .as_ref()
+                .map(|map| {
+                    map.all_partitions()
+                        .into_iter()
+                        .filter(|partition| *partition != map.local_partition())
+                        .map(|partition| (partition, Timestamp::MIN))
+                        .collect()
+                })
+                .unwrap_or_default(),
+        };
+
+        let snapshot_manager = SnapshotManager::new(*ts, snapshot, replication_frontiers);
         let (snapshot_reader, snapshot_writer) = new_split_rw_lock(snapshot_manager);
 
         let retention_workers = retention_worker_seed
@@ -1126,6 +1144,19 @@ impl<RT: Runtime> Database<RT> {
 
     pub async fn finish_table_summary_bootstrap(&self) -> anyhow::Result<()> {
         self.committer.finish_table_summary_bootstrap().await
+    }
+
+    #[cfg(any(test, feature = "testing"))]
+    pub(crate) fn committer_for_test(&self) -> CommitterClient {
+        self.committer.clone()
+    }
+
+    #[cfg(any(test, feature = "testing"))]
+    pub(crate) fn replication_frontier_for_test(
+        &self,
+        partition: crate::partition::PartitionId,
+    ) -> Option<Timestamp> {
+        self.snapshot_manager.lock().replication_frontier(partition)
     }
 
     #[cfg(test)]

--- a/crates/database/src/nats_distributed_log.rs
+++ b/crates/database/src/nats_distributed_log.rs
@@ -34,6 +34,7 @@ use crate::{
         CommitDelta,
         DistributedLog,
     },
+    partition::PartitionId,
     write_log::WriteSource,
 };
 
@@ -144,6 +145,9 @@ pub struct DeltaEnvelope {
     /// Consumers skip deltas from their own node to avoid double-applying.
     #[serde(default)]
     source_node: String,
+    /// Partition that originated this replication event.
+    #[serde(default)]
+    source_partition: Option<u32>,
 }
 
 impl DeltaEnvelope {
@@ -170,6 +174,7 @@ impl DeltaEnvelope {
             document_updates_proto,
             tablet_mapping,
             source_node: source_node.to_string(),
+            source_partition: delta.source_partition.map(|partition| partition.0),
         })
     }
 
@@ -208,6 +213,7 @@ impl DeltaEnvelope {
                     Some((tablet_id, name))
                 })
                 .collect(),
+            source_partition: self.source_partition.map(PartitionId),
         })
     }
 }

--- a/crates/database/src/raft_node.rs
+++ b/crates/database/src/raft_node.rs
@@ -88,6 +88,9 @@ pub struct LeadershipCallbacks {
     /// Called when this node becomes the Raft leader.
     /// The Committer should start accepting writes for this partition.
     pub on_became_leader: Box<dyn FnMut() + Send>,
+    /// Called whenever the Raft-reported leader changes.
+    /// Allows callers to publish the exact leader ID for routing.
+    pub on_leader_changed: Box<dyn FnMut(u64) + Send>,
     /// Called when this node loses leadership (stepped down or partitioned).
     /// The Committer should stop accepting writes and drain pending proposals.
     pub on_lost_leadership: Box<dyn FnMut() + Send>,
@@ -97,6 +100,7 @@ impl Default for LeadershipCallbacks {
     fn default() -> Self {
         Self {
             on_became_leader: Box::new(|| {}),
+            on_leader_changed: Box::new(|_| {}),
             on_lost_leadership: Box::new(|| {}),
         }
     }
@@ -147,7 +151,9 @@ impl RaftNode {
         // On restart, pick up where we left off (applied index from
         // the persisted hard state's commit). This prevents raft-rs
         // from re-applying already-committed entries.
-        let initial_state = storage.initial_state().map_err(|e| anyhow::anyhow!("{e}"))?;
+        let initial_state = storage
+            .initial_state()
+            .map_err(|e| anyhow::anyhow!("{e}"))?;
         let applied = initial_state.hard_state.get_commit();
 
         let raft_config = Config {
@@ -231,6 +237,7 @@ impl RaftNode {
                 // Detect leadership changes (TiKV SoftState pattern).
                 // SoftState is present in Ready only when it changes.
                 if let Some(ss) = ready.ss() {
+                    (self.leadership_callbacks.on_leader_changed)(ss.leader_id);
                     let now_leader = ss.raft_state == StateRole::Leader;
                     if now_leader && !self.is_leader_flag {
                         tracing::info!(
@@ -302,7 +309,9 @@ impl RaftNode {
                             // Configuration change — apply to Raft membership.
                             let cc = ConfChange::default();
                             if let Ok(cs) = self.raw_node.apply_conf_change(&cc) {
-                                self.storage.set_conf_state(cs);
+                                if let Err(e) = self.storage.set_conf_state(cs) {
+                                    tracing::error!("Failed to persist conf state: {e}");
+                                }
                             }
                         },
                         EntryType::EntryNormal => {
@@ -396,6 +405,7 @@ impl RaftNode {
 
         // Track leadership and fire callbacks.
         if let Some(ss) = ready.ss() {
+            (self.leadership_callbacks.on_leader_changed)(ss.leader_id);
             let now_leader = ss.raft_state == StateRole::Leader;
             if now_leader && !self.is_leader_flag {
                 self.is_leader_flag = true;
@@ -520,10 +530,15 @@ mod tests {
 
         let became_leader = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
         let became_leader_clone = became_leader.clone();
+        let leader_id = std::sync::Arc::new(std::sync::atomic::AtomicU64::new(0));
+        let leader_id_clone = leader_id.clone();
 
         node.set_leadership_callbacks(LeadershipCallbacks {
             on_became_leader: Box::new(move || {
                 became_leader_clone.store(true, std::sync::atomic::Ordering::SeqCst);
+            }),
+            on_leader_changed: Box::new(move |new_leader_id| {
+                leader_id_clone.store(new_leader_id, std::sync::atomic::Ordering::SeqCst);
             }),
             on_lost_leadership: Box::new(|| {}),
         });
@@ -537,6 +552,7 @@ mod tests {
         node.process_ready_test();
 
         assert!(node.is_leader());
+        assert_eq!(leader_id.load(std::sync::atomic::Ordering::SeqCst), 1);
         assert!(
             became_leader.load(std::sync::atomic::Ordering::SeqCst),
             "on_became_leader callback should have fired"

--- a/crates/database/src/raft_partition.rs
+++ b/crates/database/src/raft_partition.rs
@@ -137,6 +137,9 @@ impl RaftPartitionManager {
                     partition_id,
                 );
             }),
+            on_leader_changed: Box::new(move |new_leader_id| {
+                leader_id_cb.store(new_leader_id, Ordering::SeqCst);
+            }),
             on_lost_leadership: Box::new({
                 let is_leader_lost = is_leader.clone();
                 let partition_id_lost = partition_id;
@@ -233,6 +236,7 @@ mod tests {
 
         // The shared state should now reflect leadership.
         assert!(state.is_leader());
+        assert_eq!(state.leader_id(), 1);
     }
 
     #[test]

--- a/crates/database/src/raft_storage.rs
+++ b/crates/database/src/raft_storage.rs
@@ -91,7 +91,7 @@ impl ConvexRaftStorage {
     pub fn new(
         partition_id: PartitionId,
         engine: Arc<Engine>,
-        node_id: u64,
+        _node_id: u64,
         peers: Vec<u64>,
     ) -> anyhow::Result<Self> {
         let region_id = partition_id.0 as u64;
@@ -293,23 +293,19 @@ impl Storage for ConvexRaftStorage {
     }
 
     fn first_index(&self) -> RaftResult<u64> {
-        Ok(self
-            .engine
-            .first_index(self.region_id())
-            .unwrap_or(1))
+        Ok(self.engine.first_index(self.region_id()).unwrap_or(1))
     }
 
     fn last_index(&self) -> RaftResult<u64> {
-        Ok(self
-            .engine
-            .last_index(self.region_id())
-            .unwrap_or(0))
+        Ok(self.engine.last_index(self.region_id()).unwrap_or(0))
     }
 
     fn snapshot(&self, _request_index: u64, _to: u64) -> RaftResult<Snapshot> {
         // Snapshot transfer not yet implemented.
         // For now, nodes that fall too far behind must re-bootstrap.
-        Err(raft::Error::Store(StorageError::SnapshotTemporarilyUnavailable))
+        Err(raft::Error::Store(
+            StorageError::SnapshotTemporarilyUnavailable,
+        ))
     }
 }
 
@@ -325,8 +321,7 @@ mod tests {
     #[test]
     fn test_create_storage() {
         let engine = test_engine();
-        let storage =
-            ConvexRaftStorage::new(PartitionId(0), engine, 1, vec![1, 2, 3]).unwrap();
+        let storage = ConvexRaftStorage::new(PartitionId(0), engine, 1, vec![1, 2, 3]).unwrap();
         assert_eq!(storage.partition_id(), PartitionId(0));
         assert!(storage.first_index().is_ok());
         assert!(storage.last_index().is_ok());
@@ -335,8 +330,7 @@ mod tests {
     #[test]
     fn test_append_and_read_entries() {
         let engine = test_engine();
-        let storage =
-            ConvexRaftStorage::new(PartitionId(0), engine, 1, vec![1]).unwrap();
+        let storage = ConvexRaftStorage::new(PartitionId(0), engine, 1, vec![1]).unwrap();
 
         let mut entry = Entry::default();
         entry.set_index(1);
@@ -354,8 +348,7 @@ mod tests {
     #[test]
     fn test_hardstate_persistence() {
         let engine = test_engine();
-        let storage =
-            ConvexRaftStorage::new(PartitionId(0), engine, 1, vec![1]).unwrap();
+        let storage = ConvexRaftStorage::new(PartitionId(0), engine, 1, vec![1]).unwrap();
 
         let mut hs = HardState::default();
         hs.set_term(5);
@@ -372,8 +365,7 @@ mod tests {
     #[test]
     fn test_initial_state_with_peers() {
         let engine = test_engine();
-        let storage =
-            ConvexRaftStorage::new(PartitionId(1), engine, 2, vec![1, 2, 3]).unwrap();
+        let storage = ConvexRaftStorage::new(PartitionId(1), engine, 2, vec![1, 2, 3]).unwrap();
         let state = storage.initial_state().unwrap();
         let voters = state.conf_state.get_voters().to_vec();
         assert_eq!(voters, vec![1, 2, 3]);
@@ -387,8 +379,7 @@ mod tests {
         // First boot: write entries and hard state.
         {
             let engine = ConvexRaftStorage::open_engine(path).unwrap();
-            let storage =
-                ConvexRaftStorage::new(PartitionId(0), engine, 1, vec![1, 2, 3]).unwrap();
+            let storage = ConvexRaftStorage::new(PartitionId(0), engine, 1, vec![1, 2, 3]).unwrap();
 
             let mut entry = Entry::default();
             entry.set_index(1);
@@ -400,17 +391,14 @@ mod tests {
             hs.set_vote(1);
             hs.set_commit(1);
 
-            storage
-                .append_entries_and_hardstate(&[entry], &hs)
-                .unwrap();
+            storage.append_entries_and_hardstate(&[entry], &hs).unwrap();
         }
         // Engine dropped, simulating restart.
 
         // Reopen: verify state survived.
         {
             let engine = ConvexRaftStorage::open_engine(path).unwrap();
-            let storage =
-                ConvexRaftStorage::new(PartitionId(0), engine, 1, vec![1, 2, 3]).unwrap();
+            let storage = ConvexRaftStorage::new(PartitionId(0), engine, 1, vec![1, 2, 3]).unwrap();
 
             // Hard state persisted.
             let state = storage.initial_state().unwrap();

--- a/crates/database/src/raft_transport.rs
+++ b/crates/database/src/raft_transport.rs
@@ -15,10 +15,7 @@
 //!
 //! Reference: [TiKV Raft Transport](https://www.pingcap.com/blog/raft-in-tikv/)
 
-use std::{
-    collections::HashMap,
-    sync::Arc,
-};
+use std::collections::HashMap;
 
 use anyhow::Context;
 use raft::prelude::Message;
@@ -92,7 +89,6 @@ impl RaftTransportClient {
                 Ok(c) => {
                     tracing::info!("Raft transport: connected to {}", self.address);
                     client = c;
-                    backoff = std::time::Duration::from_secs(1);
                     break;
                 },
                 Err(_) => {
@@ -127,18 +123,17 @@ impl RaftTransportClient {
                     self.address
                 );
                 // Reconnect with exponential backoff (TiKV/CockroachDB pattern).
-                backoff = std::time::Duration::from_secs(1);
+                let mut reconnect_backoff = std::time::Duration::from_secs(1);
                 loop {
                     match RaftTransportServiceClient::connect(self.address.clone()).await {
                         Ok(c) => {
                             client = c;
                             tracing::info!("Raft transport: reconnected to {}", self.address);
-                            backoff = std::time::Duration::from_secs(1);
                             break;
                         },
                         Err(_) => {
-                            tokio::time::sleep(backoff).await;
-                            backoff = std::cmp::min(backoff * 2, max_backoff);
+                            tokio::time::sleep(reconnect_backoff).await;
+                            reconnect_backoff = std::cmp::min(reconnect_backoff * 2, max_backoff);
                         },
                     }
                 }

--- a/crates/database/src/snapshot_checkpointer.rs
+++ b/crates/database/src/snapshot_checkpointer.rs
@@ -42,9 +42,6 @@ use crate::checkpoint::{
 /// How often the Primary writes a new checkpoint.
 const CHECKPOINT_INTERVAL: Duration = Duration::from_secs(30);
 
-/// Well-known key for the latest checkpoint pointer.
-const LATEST_KEY: &str = "checkpoint-latest";
-
 /// Background task that periodically writes checkpoints to object storage.
 pub struct SnapshotCheckpointer {
     _handle: Box<dyn SpawnHandle>,
@@ -133,7 +130,7 @@ impl SnapshotCheckpointer {
         latest_upload
             .write(Bytes::from(checkpoint_key.into_bytes()))
             .await?;
-        latest_upload.complete().await?;
+        let _ = latest_upload.complete().await?;
 
         Ok(ts)
     }

--- a/crates/database/src/snapshot_manager.rs
+++ b/crates/database/src/snapshot_manager.rs
@@ -44,6 +44,7 @@ use search::{
     TextIndexManager,
     TextIndexWriteSize,
 };
+use serde_json::Value as JsonValue;
 use tokio::sync::oneshot;
 use value::{
     ResolvedDocumentId,
@@ -58,6 +59,7 @@ use vector::{
 };
 
 use crate::{
+    partition::PartitionId,
     schema_registry::SchemaRegistry,
     table_registry::{
         TableUpdate,
@@ -88,8 +90,10 @@ use crate::{
 pub struct SnapshotManager {
     persisted_max_repeatable_ts: Timestamp,
     versions: VecDeque<(Timestamp, Snapshot)>,
+    replication_frontiers: BTreeMap<PartitionId, Timestamp>,
     write_throughput_limiter: WriteThroughputLimiter,
     waiters: Mutex<VecDeque<(Timestamp, oneshot::Sender<()>)>>,
+    replication_waiters: Mutex<BTreeMap<PartitionId, VecDeque<(Timestamp, oneshot::Sender<()>)>>>,
 }
 
 #[derive(Clone)]
@@ -552,14 +556,20 @@ impl Snapshot {
 }
 
 impl SnapshotManager {
-    pub fn new(initial_ts: Timestamp, initial_snapshot: Snapshot) -> Self {
+    pub fn new(
+        initial_ts: Timestamp,
+        initial_snapshot: Snapshot,
+        replication_frontiers: BTreeMap<PartitionId, Timestamp>,
+    ) -> Self {
         let mut versions = VecDeque::new();
         versions.push_back((initial_ts, initial_snapshot));
         Self {
             versions,
             persisted_max_repeatable_ts: initial_ts,
+            replication_frontiers,
             write_throughput_limiter: WriteThroughputLimiter::new(),
             waiters: Mutex::new(VecDeque::new()),
+            replication_waiters: Mutex::new(BTreeMap::new()),
         }
     }
 
@@ -613,6 +623,30 @@ impl SnapshotManager {
         }
     }
 
+    fn notify_replication_waiters(&self, partition: PartitionId) {
+        let Some(frontier) = self.replication_frontiers.get(&partition).copied() else {
+            return;
+        };
+        let mut waiters = self.replication_waiters.lock();
+        let Some(partition_waiters) = waiters.get_mut(&partition) else {
+            return;
+        };
+        let mut i = 0;
+        while i < partition_waiters.len() {
+            if frontier >= partition_waiters[i].0 || partition_waiters[i].1.is_closed() {
+                let waiter = partition_waiters
+                    .swap_remove_back(i)
+                    .expect("checked above");
+                let _ = waiter.1.send(());
+                continue;
+            }
+            i += 1;
+        }
+        if partition_waiters.is_empty() {
+            waiters.remove(&partition);
+        }
+    }
+
     /// Returns a future that blocks until the snapshot manager has advanced
     /// past the given timestamp.
     pub fn wait_for_higher_ts(&self, target_ts: Timestamp) -> impl Future<Output = ()> + use<> {
@@ -625,6 +659,63 @@ impl SnapshotManager {
             Some(receiver)
         } else {
             None
+        };
+
+        async move {
+            if let Some(receiver) = receiver {
+                _ = receiver.await;
+            }
+        }
+    }
+
+    pub fn replication_frontier(&self, partition: PartitionId) -> Option<Timestamp> {
+        self.replication_frontiers.get(&partition).copied()
+    }
+
+    pub fn replication_frontiers(&self) -> BTreeMap<PartitionId, Timestamp> {
+        self.replication_frontiers.clone()
+    }
+
+    pub fn update_replication_frontier(
+        &mut self,
+        partition: PartitionId,
+        ts: Timestamp,
+    ) -> anyhow::Result<bool> {
+        if let Some(current) = self.replication_frontiers.get(&partition) {
+            anyhow::ensure!(
+                ts >= *current,
+                "replication frontier for {partition} went backward from {current:?} to {ts:?}",
+            );
+            if ts == *current {
+                return Ok(false);
+            }
+        }
+        self.replication_frontiers.insert(partition, ts);
+        self.notify_replication_waiters(partition);
+        Ok(true)
+    }
+
+    pub fn wait_for_replication_frontier(
+        &self,
+        partition: PartitionId,
+        target_ts: Timestamp,
+    ) -> impl Future<Output = ()> + use<> {
+        self.notify_replication_waiters(partition);
+
+        let receiver = if self
+            .replication_frontiers
+            .get(&partition)
+            .is_some_and(|frontier| *frontier >= target_ts)
+        {
+            None
+        } else {
+            let (sender, receiver) = oneshot::channel();
+            self.replication_waiters
+                .lock()
+                .entry(partition)
+                .or_default()
+                .push_back((target_ts, sender));
+            Some(receiver)
         };
 
         async move {
@@ -793,4 +884,30 @@ impl SnapshotManager {
             Ok(false)
         }
     }
+}
+
+pub fn replication_frontiers_to_json(frontiers: &BTreeMap<PartitionId, Timestamp>) -> JsonValue {
+    JsonValue::Object(
+        frontiers
+            .iter()
+            .map(|(partition, ts)| (partition.0.to_string(), JsonValue::from(u64::from(*ts))))
+            .collect(),
+    )
+}
+
+pub fn replication_frontiers_from_json(
+    value: JsonValue,
+) -> anyhow::Result<BTreeMap<PartitionId, Timestamp>> {
+    let JsonValue::Object(entries) = value else {
+        anyhow::bail!("replication frontiers must be a JSON object");
+    };
+
+    entries
+        .into_iter()
+        .map(|(partition, ts)| {
+            let partition_id = partition.parse::<u32>()?;
+            let ts = Timestamp::try_from(ts)?;
+            anyhow::Ok((PartitionId(partition_id), ts))
+        })
+        .collect()
 }

--- a/crates/database/src/tests/raft_failover_tests.rs
+++ b/crates/database/src/tests/raft_failover_tests.rs
@@ -20,7 +20,6 @@ use tokio::sync::mpsc;
 use crate::{
     partition::PartitionId,
     raft_node::{
-        RaftMessage,
         RaftNode,
         RaftNodeConfig,
     },

--- a/crates/database/src/tests/write_scaling_tests.rs
+++ b/crates/database/src/tests/write_scaling_tests.rs
@@ -5,30 +5,44 @@
 //! via self-hosted/docker/test-write-scaling.sh (CockroachDB roachtest
 //! pattern).
 
-use std::sync::Arc;
+use std::{
+    sync::Arc,
+    time::Duration,
+};
 
 use common::{
     assert_obj,
+    bootstrap_model::index::database_index::IndexedFields,
+    interval::Interval,
     runtime::{
         new_unlimited_rate_limiter,
         testing::TestRuntime,
     },
     shutdown::ShutdownSignal,
     testing::TestPersistence,
+    types::TabletIndexName,
 };
 use keybroker::Identity;
 use search::searcher::SearcherStub;
 use storage::LocalDirStorage;
-use value::TableName;
+use value::{
+    TableName,
+    TableNamespace,
+};
 
 use crate::{
-    commit_delta::testing::InMemoryDistributedLog,
+    commit_delta::{
+        testing::InMemoryDistributedLog,
+        CommitDelta,
+    },
     partition::{
         PartitionId,
         PartitionMap,
     },
+    two_phase::TwoPhaseTransactionId,
     Database,
     TestFacingModel,
+    WriteSource,
 };
 
 async fn create_node(
@@ -36,7 +50,21 @@ async fn create_node(
     distributed_log: Arc<InMemoryDistributedLog>,
     partition_map: Option<PartitionMap>,
 ) -> anyhow::Result<Database<TestRuntime>> {
-    let tp = Arc::new(TestPersistence::new());
+    create_node_with_persistence(
+        rt,
+        Arc::new(TestPersistence::new()),
+        distributed_log,
+        partition_map,
+    )
+    .await
+}
+
+async fn create_node_with_persistence(
+    rt: &TestRuntime,
+    tp: Arc<TestPersistence>,
+    distributed_log: Arc<InMemoryDistributedLog>,
+    partition_map: Option<PartitionMap>,
+) -> anyhow::Result<Database<TestRuntime>> {
     let searcher: Arc<dyn search::Searcher> = Arc::new(SearcherStub {});
     let (deleted_tablet_sender, _) = tokio::sync::mpsc::channel(100);
     let db = Database::load(
@@ -59,6 +87,10 @@ async fn create_node(
     let handle = db.start_search_and_vector_bootstrap();
     handle.join().await?;
     Ok(db)
+}
+
+fn partitioned_map(local_partition: PartitionId) -> PartitionMap {
+    PartitionMap::from_config("messages=0,projects=1", local_partition, 2)
 }
 
 async fn insert_doc(
@@ -304,6 +336,269 @@ async fn test_bank_invariant(rt: TestRuntime) -> anyhow::Result<()> {
         "Expected at least {} deltas with document inserts, got {}",
         balances.len(),
         account_deltas.len(),
+    );
+
+    Ok(())
+}
+
+#[convex_macro::test_runtime]
+async fn test_cross_partition_prepare_waits_for_remote_frontier(
+    rt: TestRuntime,
+) -> anyhow::Result<()> {
+    let log = Arc::new(InMemoryDistributedLog::new());
+    let node_a = create_node(&rt, log.clone(), Some(partitioned_map(PartitionId(0)))).await?;
+    let node_b = create_node(&rt, log.clone(), Some(partitioned_map(PartitionId(1)))).await?;
+
+    insert_doc(&node_b, "projects", assert_obj!("name" => "seed")).await?;
+    let initial_delta = log
+        .deltas()
+        .into_iter()
+        .last()
+        .expect("seed project should publish a delta");
+    node_a
+        .committer_for_test()
+        .apply_replica_delta(initial_delta)
+        .await?;
+
+    // Advance node A's snapshot without advancing partition 1's frontier.
+    insert_doc(&node_a, "messages", assert_obj!("text" => "lag-maker")).await?;
+
+    let mut tx = node_a.begin(Identity::system()).await?;
+    TestFacingModel::new(&mut tx)
+        .insert(&"messages".parse()?, assert_obj!("text" => "prepared"))
+        .await?;
+    let mut final_tx = tx.finalize()?;
+    let remote_tablet = final_tx
+        .table_mapping
+        .namespace(TableNamespace::Global)
+        .name_to_tablet()("projects".parse()?)?;
+    final_tx.reads.record_indexed_derived(
+        TabletIndexName::by_id(remote_tablet),
+        IndexedFields::by_id(),
+        Interval::all(),
+    );
+
+    let committer = node_a.committer_for_test();
+    let prepare = tokio::spawn(async move {
+        committer
+            .prepare(
+                TwoPhaseTransactionId::new(),
+                final_tx,
+                WriteSource::new("cross_partition_wait_test"),
+            )
+            .await
+    });
+
+    tokio::time::sleep(Duration::from_millis(50)).await;
+    assert!(
+        !prepare.is_finished(),
+        "prepare should wait for the remote partition frontier to catch up",
+    );
+
+    let heartbeat_ts = node_b.bump_max_repeatable_ts().await?;
+    node_a
+        .committer_for_test()
+        .apply_replica_delta(CommitDelta {
+            ts: heartbeat_ts,
+            document_writes: Arc::new(Vec::new()),
+            document_updates: Vec::new(),
+            index_writes: Arc::new(Vec::new()),
+            write_source: WriteSource::new("replication_frontier_heartbeat_test"),
+            write_bytes: 0,
+            tablet_id_to_table_name: Default::default(),
+            source_partition: Some(PartitionId(1)),
+        })
+        .await?;
+
+    let prepare_result = tokio::time::timeout(Duration::from_secs(1), prepare).await??;
+    prepare_result?;
+    Ok(())
+}
+
+#[convex_macro::test_runtime]
+async fn test_local_only_prepare_does_not_wait_for_remote_frontier(
+    rt: TestRuntime,
+) -> anyhow::Result<()> {
+    let log = Arc::new(InMemoryDistributedLog::new());
+    let node_a = create_node(&rt, log.clone(), Some(partitioned_map(PartitionId(0)))).await?;
+    let node_b = create_node(&rt, log.clone(), Some(partitioned_map(PartitionId(1)))).await?;
+
+    insert_doc(&node_b, "projects", assert_obj!("name" => "seed")).await?;
+    let initial_delta = log
+        .deltas()
+        .into_iter()
+        .last()
+        .expect("seed project should publish a delta");
+    node_a
+        .committer_for_test()
+        .apply_replica_delta(initial_delta)
+        .await?;
+
+    // Advance node A's snapshot beyond partition 1's persisted frontier.
+    insert_doc(&node_a, "messages", assert_obj!("text" => "lag-maker")).await?;
+
+    let mut tx = node_a.begin(Identity::system()).await?;
+    TestFacingModel::new(&mut tx)
+        .insert(&"messages".parse()?, assert_obj!("text" => "prepared"))
+        .await?;
+    let final_tx = tx.finalize()?;
+
+    let result = tokio::time::timeout(
+        Duration::from_millis(250),
+        node_a.committer_for_test().prepare(
+            TwoPhaseTransactionId::new(),
+            final_tx,
+            WriteSource::new("local_only_prepare_test"),
+        ),
+    )
+    .await?;
+    result?;
+    Ok(())
+}
+
+#[convex_macro::test_runtime]
+async fn test_local_commit_waits_for_remote_frontier(rt: TestRuntime) -> anyhow::Result<()> {
+    let log = Arc::new(InMemoryDistributedLog::new());
+    let node_a = create_node(&rt, log.clone(), Some(partitioned_map(PartitionId(0)))).await?;
+    let node_b = create_node(&rt, log.clone(), Some(partitioned_map(PartitionId(1)))).await?;
+
+    insert_doc(&node_b, "projects", assert_obj!("name" => "seed")).await?;
+    let initial_delta = log
+        .deltas()
+        .into_iter()
+        .last()
+        .expect("seed project should publish a delta");
+    node_a
+        .committer_for_test()
+        .apply_replica_delta(initial_delta)
+        .await?;
+
+    // Advance node A's local snapshot without advancing partition 1's frontier.
+    insert_doc(&node_a, "messages", assert_obj!("text" => "lag-maker")).await?;
+
+    let mut tx = node_a.begin(Identity::system()).await?;
+    TestFacingModel::new(&mut tx)
+        .insert(&"messages".parse()?, assert_obj!("text" => "commit"))
+        .await?;
+    let remote_tablet = tx
+        .table_mapping()
+        .namespace(TableNamespace::Global)
+        .name_to_tablet()("projects".parse()?)?;
+    tx.reads.record_indexed_derived(
+        TabletIndexName::by_id(remote_tablet),
+        IndexedFields::by_id(),
+        Interval::all(),
+    );
+
+    let node_a_for_commit = node_a.clone();
+    let commit = tokio::spawn(async move { node_a_for_commit.commit(tx).await });
+
+    tokio::time::sleep(Duration::from_millis(50)).await;
+    assert!(
+        !commit.is_finished(),
+        "commit should wait for the remote partition frontier to catch up",
+    );
+
+    let heartbeat_ts = node_b.bump_max_repeatable_ts().await?;
+    node_a
+        .committer_for_test()
+        .apply_replica_delta(CommitDelta {
+            ts: heartbeat_ts,
+            document_writes: Arc::new(Vec::new()),
+            document_updates: Vec::new(),
+            index_writes: Arc::new(Vec::new()),
+            write_source: WriteSource::new("replication_frontier_heartbeat_commit_test"),
+            write_bytes: 0,
+            tablet_id_to_table_name: Default::default(),
+            source_partition: Some(PartitionId(1)),
+        })
+        .await?;
+
+    let commit_result = tokio::time::timeout(Duration::from_secs(1), commit).await??;
+    commit_result?;
+    Ok(())
+}
+
+#[convex_macro::test_runtime]
+async fn test_local_only_commit_does_not_wait_for_remote_frontier(
+    rt: TestRuntime,
+) -> anyhow::Result<()> {
+    let log = Arc::new(InMemoryDistributedLog::new());
+    let node_a = create_node(&rt, log.clone(), Some(partitioned_map(PartitionId(0)))).await?;
+    let node_b = create_node(&rt, log.clone(), Some(partitioned_map(PartitionId(1)))).await?;
+
+    insert_doc(&node_b, "projects", assert_obj!("name" => "seed")).await?;
+    let initial_delta = log
+        .deltas()
+        .into_iter()
+        .last()
+        .expect("seed project should publish a delta");
+    node_a
+        .committer_for_test()
+        .apply_replica_delta(initial_delta)
+        .await?;
+
+    // Advance node A's snapshot beyond partition 1's persisted frontier.
+    insert_doc(&node_a, "messages", assert_obj!("text" => "lag-maker")).await?;
+
+    let mut tx = node_a.begin(Identity::system()).await?;
+    TestFacingModel::new(&mut tx)
+        .insert(&"messages".parse()?, assert_obj!("text" => "commit"))
+        .await?;
+
+    let result = tokio::time::timeout(Duration::from_millis(250), node_a.commit(tx)).await?;
+    result?;
+    Ok(())
+}
+
+#[convex_macro::test_runtime]
+async fn test_replication_frontier_persists_across_restart(rt: TestRuntime) -> anyhow::Result<()> {
+    let log = Arc::new(InMemoryDistributedLog::new());
+    let tp = Arc::new(TestPersistence::new());
+    let node_a = create_node_with_persistence(
+        &rt,
+        tp.clone(),
+        log.clone(),
+        Some(partitioned_map(PartitionId(0))),
+    )
+    .await?;
+    let node_b = create_node(&rt, log.clone(), Some(partitioned_map(PartitionId(1)))).await?;
+
+    insert_doc(&node_b, "projects", assert_obj!("name" => "seed")).await?;
+    let initial_delta = log
+        .deltas()
+        .into_iter()
+        .last()
+        .expect("seed project should publish a delta");
+    node_a
+        .committer_for_test()
+        .apply_replica_delta(initial_delta)
+        .await?;
+
+    let heartbeat_ts = node_b.bump_max_repeatable_ts().await?;
+    node_a
+        .committer_for_test()
+        .apply_replica_delta(CommitDelta {
+            ts: heartbeat_ts,
+            document_writes: Arc::new(Vec::new()),
+            document_updates: Vec::new(),
+            index_writes: Arc::new(Vec::new()),
+            write_source: WriteSource::new("replication_frontier_persist_test"),
+            write_bytes: 0,
+            tablet_id_to_table_name: Default::default(),
+            source_partition: Some(PartitionId(1)),
+        })
+        .await?;
+
+    let persisted_frontier = node_a
+        .replication_frontier_for_test(PartitionId(1))
+        .expect("partition 1 frontier should be recorded");
+
+    let restarted =
+        create_node_with_persistence(&rt, tp, log, Some(partitioned_map(PartitionId(0)))).await?;
+    assert_eq!(
+        restarted.replication_frontier_for_test(PartitionId(1)),
+        Some(persisted_frontier),
     );
 
     Ok(())

--- a/crates/database/src/timestamp_oracle.rs
+++ b/crates/database/src/timestamp_oracle.rs
@@ -21,8 +21,6 @@
 //! - [`BatchTimestampOracle`]: Reserves batches from NATS KV for multi-node
 //!   deployments.
 
-use std::sync::Arc;
-
 use anyhow::Context;
 use async_trait::async_trait;
 use common::{
@@ -191,7 +189,7 @@ impl BatchTimestampOracle {
     async fn reserve_batch(&self) -> anyhow::Result<(u64, u64)> {
         let jetstream = async_nats::jetstream::new(self.nats_client.clone());
         let kv = jetstream
-            .get_key_value("convex_tso")
+            .get_key_value(&self.kv_bucket)
             .await
             .context("TSO: Failed to get KV bucket")?;
 
@@ -266,7 +264,7 @@ impl TimestampOracle for BatchTimestampOracle {
         // Read from NATS KV for cross-node consistency.
         let jetstream = async_nats::jetstream::new(self.nats_client.clone());
         let kv = jetstream
-            .get_key_value("convex_tso")
+            .get_key_value(&self.kv_bucket)
             .await
             .context("TSO: Failed to get KV bucket")?;
 
@@ -299,7 +297,7 @@ impl TimestampOracle for BatchTimestampOracle {
         // Update NATS KV (best-effort, non-blocking for the commit path).
         let jetstream = async_nats::jetstream::new(self.nats_client.clone());
         let kv = jetstream
-            .get_key_value("convex_tso")
+            .get_key_value(&self.kv_bucket)
             .await
             .context("TSO: Failed to get KV bucket")?;
 

--- a/crates/database/src/two_phase.rs
+++ b/crates/database/src/two_phase.rs
@@ -17,13 +17,7 @@
 
 use std::collections::BTreeMap;
 
-use common::{
-    persistence::{
-        DocumentLogEntry,
-        PersistenceIndexEntry,
-    },
-    types::Timestamp,
-};
+use common::types::Timestamp;
 use serde::{
     Deserialize,
     Serialize,

--- a/crates/database/src/two_phase_coordinator.rs
+++ b/crates/database/src/two_phase_coordinator.rs
@@ -13,13 +13,9 @@
 //!   - Vitess: https://vitess.io/docs/22.0/reference/features/distributed-transaction/
 //!   - CockroachDB: https://www.cockroachlabs.com/blog/parallel-commits/
 
-use std::{
-    collections::BTreeMap,
-    sync::Arc,
-};
+use std::collections::BTreeMap;
 
 use common::types::Timestamp;
-use value::TableName;
 
 use crate::{
     committer::CommitterClient,
@@ -28,10 +24,7 @@ use crate::{
         PartitionMap,
     },
     transaction::FinalTransaction,
-    two_phase::{
-        TwoPhaseDecision,
-        TwoPhaseTransactionId,
-    },
+    two_phase::TwoPhaseTransactionId,
     write_log::WriteSource,
 };
 
@@ -91,7 +84,7 @@ pub async fn coordinate_two_phase_commit(
     local_committer: &CommitterClient,
     transaction: FinalTransaction,
     write_source: WriteSource,
-    partition_map: &PartitionMap,
+    _partition_map: &PartitionMap,
 ) -> anyhow::Result<Timestamp> {
     let txn_id = TwoPhaseTransactionId::new();
 

--- a/crates/database/src/two_phase_watcher.rs
+++ b/crates/database/src/two_phase_watcher.rs
@@ -11,12 +11,8 @@
 //! Follows Vitess's watcher pattern:
 //! https://vitess.io/docs/22.0/reference/features/distributed-transaction/
 
-use std::{
-    sync::Arc,
-    time::Duration,
-};
+use std::time::Duration;
 
-use anyhow::Context;
 use common::runtime::Runtime;
 
 use crate::{
@@ -24,7 +20,6 @@ use crate::{
     two_phase::{
         TwoPhaseDecision,
         TwoPhaseTransactionId,
-        PREPARE_TIMEOUT_SECS,
         TWO_PHASE_KV_BUCKET,
         TWO_PHASE_KV_PREFIX,
     },


### PR DESCRIPTION
## Summary
- replace the best-effort cross-partition OCC warning with strict per-partition replication frontiers
- persist and replicate frontier progress using source-partition metadata plus frontier heartbeat deltas
- wait for stale remote frontiers in commit and prepare while keeping committer-side validation as a hard correctness backstop
- add restart durability coverage plus commit/prepare wait and no-wait regression tests

## Testing
- cargo test --target-dir /Users/martin/Desktop/convex-horizontal-scaling/target -p database write_scaling_tests -- --nocapture
- cargo test --target-dir /Users/martin/Desktop/convex-horizontal-scaling/target -p database write_ts -- --nocapture