### PR TITLE
refactor(persistence): drop replication frontier key version suffix

### DIFF
--- a/crates/common/src/persistence.rs
+++ b/crates/common/src/persistence.rs
@@ -192,7 +192,7 @@ impl From<PersistenceGlobalKey> for String {
             },
             PersistenceGlobalKey::MaxRepeatableTimestamp => "max_repeatable_ts".to_string(),
             PersistenceGlobalKey::ReplicationFrontiers => "replication_frontiers".to_string(),
-            PersistenceGlobalKey::TableSummary => "table_summary_v2".to_string(),
+            PersistenceGlobalKey::TableSummary => "table_summary".to_string(),
             PersistenceGlobalKey::TablesByIdIndex => "tables_by_id".to_string(),
             PersistenceGlobalKey::IndexByIdIndex => "index_by_id".to_string(),
             // NB: For compatibility, these are referred to as "table_id"s, not "tablet_id"s.
@@ -212,7 +212,7 @@ impl FromStr for PersistenceGlobalKey {
             "document_confirmed_deleted_ts" => Ok(Self::DocumentRetentionConfirmedDeletedTimestamp),
             "max_repeatable_ts" => Ok(Self::MaxRepeatableTimestamp),
             "replication_frontiers" => Ok(Self::ReplicationFrontiers),
-            "table_summary_v2" => Ok(Self::TableSummary),
+            "table_summary" => Ok(Self::TableSummary),
             "tables_by_id" => Ok(Self::TablesByIdIndex),
             "tables_table_id" => Ok(Self::TablesTabletId),
             "index_by_id" => Ok(Self::IndexByIdIndex),

--- a/crates/common/src/persistence.rs
+++ b/crates/common/src/persistence.rs
@@ -191,7 +191,7 @@ impl From<PersistenceGlobalKey> for String {
                 "document_confirmed_deleted_ts".to_string()
             },
             PersistenceGlobalKey::MaxRepeatableTimestamp => "max_repeatable_ts".to_string(),
-            PersistenceGlobalKey::ReplicationFrontiers => "replication_frontiers_v1".to_string(),
+            PersistenceGlobalKey::ReplicationFrontiers => "replication_frontiers".to_string(),
             PersistenceGlobalKey::TableSummary => "table_summary_v2".to_string(),
             PersistenceGlobalKey::TablesByIdIndex => "tables_by_id".to_string(),
             PersistenceGlobalKey::IndexByIdIndex => "index_by_id".to_string(),
@@ -211,7 +211,7 @@ impl FromStr for PersistenceGlobalKey {
             "document_min_snapshot_ts" => Ok(Self::DocumentRetentionMinSnapshotTimestamp),
             "document_confirmed_deleted_ts" => Ok(Self::DocumentRetentionConfirmedDeletedTimestamp),
             "max_repeatable_ts" => Ok(Self::MaxRepeatableTimestamp),
-            "replication_frontiers_v1" => Ok(Self::ReplicationFrontiers),
+            "replication_frontiers" => Ok(Self::ReplicationFrontiers),
             "table_summary_v2" => Ok(Self::TableSummary),
             "tables_by_id" => Ok(Self::TablesByIdIndex),
             "tables_table_id" => Ok(Self::TablesTabletId),


### PR DESCRIPTION
## Summary
- rename the new replication frontier persistence key from `replication_frontiers_v1` to `replication_frontiers`
- keep the strict OCC implementation unchanged while aligning the stored key with the preference for canonical, non-versioned names

## Testing
- cargo test --target-dir /Users/martin/Desktop/convex-horizontal-scaling/target -p database write_scaling_tests -- --nocapture