### PR TITLE
feat(database): add raft snapshot catch-up and recovery hardening

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,9 @@ The combination — real-time subscriptions + in-memory OCC + partitioned multi-
 
 Full details: [docs/what-we-built.md](docs/what-we-built.md)
 
+Issue journal for regressions, fixes, and validation history:
+[docs/issue-journal.md](docs/issue-journal.md)
+
 ## Results
 
 ### Raft Failover Tests

--- a/crates/application/src/airbyte_import.rs
+++ b/crates/application/src/airbyte_import.rs
@@ -12,8 +12,8 @@ use fivetran_destination::constants::{
 use serde::Deserialize;
 use serde_json::Value as JsonValue;
 use value::{
-    ConvexObject,
     ConvexValue,
+    DocumentObject,
     FieldName,
     FieldPath,
     IdentifierFieldName,
@@ -43,12 +43,12 @@ static CDC_PREFIX: LazyLock<String> = LazyLock::new(|| format!("{IDENTIFIER_PREF
 pub struct AirbyteRecord {
     table_name: TableName,
     deleted: bool,
-    record: ConvexObject,
+    record: DocumentObject,
 }
 
 impl AirbyteRecord {
     #[cfg(any(test, feature = "testing"))]
-    pub fn new(table_name: TableName, deleted: bool, record: ConvexObject) -> Self {
+    pub fn new(table_name: TableName, deleted: bool, record: DocumentObject) -> Self {
         Self {
             table_name,
             deleted,
@@ -64,7 +64,7 @@ impl AirbyteRecord {
         self.deleted
     }
 
-    pub fn into_object(self) -> ConvexObject {
+    pub fn into_object(self) -> DocumentObject {
         self.record
     }
 }
@@ -118,7 +118,7 @@ impl TryFrom<AirbyteRecordMessage> for AirbyteRecord {
 
     fn try_from(msg: AirbyteRecordMessage) -> anyhow::Result<AirbyteRecord> {
         let table_name = msg.table_name.parse::<ValidIdentifier<TableName>>()?.0;
-        let object: ConvexObject = valid_json(msg.data)?.try_into()?;
+        let object: DocumentObject = valid_json(msg.data)?.try_into()?;
         let deleted = match object.get(&*CDC_DELETED_FIELD) {
             Some(ts) => ts != &ConvexValue::Null,
             None => false,
@@ -130,7 +130,7 @@ impl TryFrom<AirbyteRecordMessage> for AirbyteRecord {
             .into_iter()
             .filter(|(field_name, _value)| !field_name.starts_with(&CDC_PREFIX.clone()))
             .collect();
-        let record: ConvexObject = fields_and_values.try_into()?;
+        let record: DocumentObject = fields_and_values.try_into()?;
         Ok(Self {
             table_name,
             deleted,
@@ -204,18 +204,18 @@ impl TryFrom<AirbyteStream> for ValidatedAirbyteStream {
     }
 }
 
-pub fn mark_as_soft_deleted(object: ConvexObject) -> anyhow::Result<ConvexObject> {
+pub fn mark_as_soft_deleted(object: DocumentObject) -> anyhow::Result<DocumentObject> {
     let metadata_key = FieldName::from(METADATA_CONVEX_FIELD_NAME.clone());
 
     let mut new_value: BTreeMap<FieldName, ConvexValue> = object.into();
     let metadata_object = match new_value.remove(&metadata_key) {
         Some(ConvexValue::Object(object)) => object,
-        _ => ConvexObject::empty(),
+        _ => DocumentObject::empty(),
     };
 
     new_value.insert(
         metadata_key,
-        ConvexValue::Object(metadata_object.shallow_merge(ConvexObject::for_value(
+        ConvexValue::Object(metadata_object.shallow_merge(DocumentObject::for_value(
             FieldName::from(SOFT_DELETE_CONVEX_FIELD_NAME.clone()),
             ConvexValue::Boolean(true),
         )?)?),

--- a/crates/application/src/api.rs
+++ b/crates/application/src/api.rs
@@ -57,7 +57,7 @@ use udf::{
 };
 use value::{
     sha256::Sha256Digest,
-    DeveloperDocumentId,
+    PublicDocumentId,
 };
 
 use crate::{
@@ -224,7 +224,7 @@ pub trait ApplicationApi: Send + Sync {
         content_type: Option<ContentType>,
         expected_sha256: Option<Sha256Digest>,
         body: BoxStream<'_, anyhow::Result<Bytes>>,
-    ) -> anyhow::Result<DeveloperDocumentId>;
+    ) -> anyhow::Result<PublicDocumentId>;
 
     async fn get_file_range(
         &self,
@@ -501,7 +501,7 @@ impl<RT: Runtime> ApplicationApi for Application<RT> {
         content_type: Option<ContentType>,
         expected_sha256: Option<Sha256Digest>,
         body: BoxStream<'_, anyhow::Result<Bytes>>,
-    ) -> anyhow::Result<DeveloperDocumentId> {
+    ) -> anyhow::Result<PublicDocumentId> {
         self.store_file(
             component,
             content_length,

--- a/crates/application/src/application_function_runner/mod.rs
+++ b/crates/application/src/application_function_runner/mod.rs
@@ -184,7 +184,7 @@ use usage_tracking::{
     OccInfo,
 };
 use value::{
-    id_v6::DeveloperDocumentId,
+    id_v6::PublicDocumentId,
     identifier::Identifier,
     serialized_args_ext::SerializedArgsExt,
     JsonPackedValue,
@@ -2082,7 +2082,7 @@ impl<RT: Runtime> ActionCallbacks for ApplicationFunctionRunner<RT> {
         identity: Identity,
         component: ComponentId,
         entry: FileStorageEntry,
-    ) -> anyhow::Result<(ComponentPath, DeveloperDocumentId)> {
+    ) -> anyhow::Result<(ComponentPath, PublicDocumentId)> {
         let mut tx = self.database.begin(identity.clone()).await?;
         self.bail_if_backend_not_running(&mut tx).await?;
         let (_ts, r, _stats) = self
@@ -2145,7 +2145,7 @@ impl<RT: Runtime> ActionCallbacks for ApplicationFunctionRunner<RT> {
         udf_args: SerializedArgs,
         scheduled_ts: UnixTimestamp,
         context: ExecutionContext,
-    ) -> anyhow::Result<DeveloperDocumentId> {
+    ) -> anyhow::Result<PublicDocumentId> {
         let (_ts, (virtual_id, arg_size), _stats) = self
             .database
             .execute_with_occ_retries(
@@ -2198,7 +2198,7 @@ impl<RT: Runtime> ActionCallbacks for ApplicationFunctionRunner<RT> {
     async fn cancel_job(
         &self,
         identity: Identity,
-        virtual_id: DeveloperDocumentId,
+        virtual_id: PublicDocumentId,
     ) -> anyhow::Result<()> {
         self.database
             .execute_with_occ_retries(

--- a/crates/application/src/cron_jobs/mod.rs
+++ b/crates/application/src/cron_jobs/mod.rs
@@ -817,7 +817,7 @@ impl<RT: Runtime> CronJobContext<RT> {
             next_ts = compute_next_ts(&job.cron_spec, Some(next_ts), now)?;
         }
         if num_skipped > 0 {
-            let job_id = job.id.developer_id;
+            let job_id = job.id.document_id;
             tracing::info!(
                 "Skipping {num_skipped} run(s) of job {job_id} because multiple scheduled runs \
                  are in the past"
@@ -901,7 +901,7 @@ impl<RT: Runtime> CronJobContext<RT> {
         }
 
         let next_run = CronNextRun {
-            cron_job_id: job.id.developer_id,
+            cron_job_id: job.id.document_id,
             state: CronJobState::Pending,
             prev_ts: Some(prev_ts),
             next_ts,

--- a/crates/application/src/deploy_config.rs
+++ b/crates/application/src/deploy_config.rs
@@ -131,7 +131,7 @@ use usage_tracking::FunctionUsageTracker;
 use value::{
     identifier::Identifier,
     sha256::Sha256Digest,
-    DeveloperDocumentId,
+    PublicDocumentId,
     ResolvedDocumentId,
     TableNamespace,
 };
@@ -571,7 +571,7 @@ impl<RT: Runtime> Application<RT> {
             let schema_table_number = tx.table_mapping().tablet_number(schema_id.table())?;
             let schema_id = ResolvedDocumentId::new(
                 schema_id.table(),
-                DeveloperDocumentId::new(schema_table_number, schema_id.internal_id()),
+                PublicDocumentId::new(schema_table_number, schema_id.internal_id()),
             );
             let document = tx
                 .get(schema_id)
@@ -905,7 +905,7 @@ impl<RT: Runtime> InitializerEvaluator for ApplicationInitializerEvaluator<'_, R
     }
 }
 
-#[derive(Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct StartPushRequest {
     pub admin_key: String,
@@ -981,7 +981,7 @@ impl From<NodeDependencyJson> for NodeDependency {
     }
 }
 
-#[derive(Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct AppDefinitionConfigJson {
     pub definition: Option<ModuleJson>,
@@ -1053,7 +1053,7 @@ mod tests {
     }
 }
 
-#[derive(Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct ComponentDefinitionConfigJson {
     pub definition_path: String,
@@ -1202,7 +1202,7 @@ pub fn parse_module_path(path: &str) -> anyhow::Result<ModulePath> {
     })
 }
 
-#[derive(Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct NodeDependencyJson {
     name: String,

--- a/crates/application/src/lib.rs
+++ b/crates/application/src/lib.rs
@@ -361,7 +361,7 @@ use usage_tracking::{
     UsageCounter,
 };
 use value::{
-    id_v6::DeveloperDocumentId,
+    id_v6::PublicDocumentId,
     sha256::Sha256Digest,
     JsonPackedValue,
     Namespace,
@@ -1515,7 +1515,7 @@ impl<RT: Runtime> Application<RT> {
         component: ComponentId,
         requestor: ExportRequestor,
         expiration_ts_ns: Option<u64>,
-    ) -> anyhow::Result<DeveloperDocumentId> {
+    ) -> anyhow::Result<PublicDocumentId> {
         anyhow::ensure!(
             identity.is_admin() || identity.is_system(),
             unauthorized_error("request_export")
@@ -1570,7 +1570,7 @@ impl<RT: Runtime> Application<RT> {
     pub async fn get_zip_export(
         &self,
         identity: Identity,
-        id: Either<DeveloperDocumentId, Timestamp>,
+        id: Either<PublicDocumentId, Timestamp>,
     ) -> anyhow::Result<(StorageGetStream, String)> {
         let (object_key, snapshot_ts) = {
             let mut tx = self.begin(identity).await?;
@@ -2353,7 +2353,7 @@ impl<RT: Runtime> Application<RT> {
         component_path: ComponentPath,
         upload_token: ClientDrivenUploadToken,
         part_tokens: Vec<ClientDrivenUploadPartToken>,
-    ) -> anyhow::Result<DeveloperDocumentId> {
+    ) -> anyhow::Result<PublicDocumentId> {
         if !identity.is_admin() {
             anyhow::bail!(ErrorMetadata::forbidden(
                 "InvalidImport",
@@ -2782,7 +2782,7 @@ impl<RT: Runtime> Application<RT> {
         content_type: Option<ContentType>,
         expected_sha256: Option<Sha256Digest>,
         body: BoxStream<'_, anyhow::Result<Bytes>>,
-    ) -> anyhow::Result<DeveloperDocumentId> {
+    ) -> anyhow::Result<PublicDocumentId> {
         self.bail_if_not_running().await?;
         let storage_id = self
             .file_storage
@@ -2802,7 +2802,7 @@ impl<RT: Runtime> Application<RT> {
         &self,
         component: ComponentId,
         entry: FileStorageEntry,
-    ) -> anyhow::Result<DeveloperDocumentId> {
+    ) -> anyhow::Result<PublicDocumentId> {
         let storage_id = self
             .file_storage
             .store_entry(component.into(), entry, &self.usage_counter)
@@ -2857,7 +2857,7 @@ impl<RT: Runtime> Application<RT> {
             )
             .into());
         };
-        let doc_id = parsed_doc.developer_id().to_string();
+        let doc_id = parsed_doc.document_id().to_string();
         let file_entry = parsed_doc.into_value();
         let mut file_stream = self
             .file_storage
@@ -2907,7 +2907,7 @@ impl<RT: Runtime> Application<RT> {
             )
             .into());
         };
-        let doc_id = parsed_doc.developer_id().to_string();
+        let doc_id = parsed_doc.document_id().to_string();
         let file_entry = parsed_doc.into_value();
         let mut file_stream = self
             .file_storage
@@ -3410,7 +3410,7 @@ impl<RT: Runtime> Application<RT> {
                 // Replace or delete the record or insert if there is no existing record that
                 // matches this value for the primary key.
                 if let Some(doc) = query_stream.expect_at_most_one(tx).await? {
-                    let doc_id = DeveloperDocumentId::from(doc.id());
+                    let doc_id = PublicDocumentId::from(doc.id());
                     if deleted {
                         UserFacingModel::new(tx, namespace).delete(doc_id).await?;
                     } else {

--- a/crates/application/src/log_streaming.rs
+++ b/crates/application/src/log_streaming.rs
@@ -21,7 +21,7 @@ use model::{
     },
 };
 use value::{
-    DeveloperDocumentId,
+    PublicDocumentId,
     ResolvedDocumentId,
     TableNamespace,
 };
@@ -66,7 +66,7 @@ impl<RT: Runtime> Application<RT> {
         let mut tx = self.begin(Identity::system()).await?;
 
         let id = tx.resolve_developer_id(
-            &DeveloperDocumentId::decode(id).map_err(|_| {
+            &PublicDocumentId::decode(id).map_err(|_| {
                 anyhow::anyhow!(ErrorMetadata::bad_request(
                     "InvalidLogStreamId",
                     "The log stream id is invalid"
@@ -85,7 +85,7 @@ impl<RT: Runtime> Application<RT> {
         let mut tx = self.begin(Identity::system()).await?;
 
         let id = tx.resolve_developer_id(
-            &DeveloperDocumentId::decode(id).map_err(|_| {
+            &PublicDocumentId::decode(id).map_err(|_| {
                 anyhow::anyhow!(ErrorMetadata::bad_request(
                     "InvalidLogStreamId",
                     "The log stream id is invalid"
@@ -116,7 +116,7 @@ impl<RT: Runtime> Application<RT> {
         let mut tx = self.begin(Identity::system()).await?;
 
         let id = tx.resolve_developer_id(
-            &DeveloperDocumentId::decode(id).map_err(|_| {
+            &PublicDocumentId::decode(id).map_err(|_| {
                 anyhow::anyhow!(ErrorMetadata::bad_request(
                     "InvalidLogStreamId",
                     "The log stream id is invalid"

--- a/crates/application/src/snapshot_import/import_file_storage.rs
+++ b/crates/application/src/snapshot_import/import_file_storage.rs
@@ -45,10 +45,10 @@ use usage_tracking::{
     StorageUsageTracker,
 };
 use value::{
-    id_v6::DeveloperDocumentId,
+    id_v6::PublicDocumentId,
     sha256::Sha256Digest,
     val,
-    ConvexObject,
+    DocumentObject,
     ResolvedDocumentId,
     TableMapping,
     TabletIdAndTableNumber,
@@ -70,7 +70,7 @@ pub async fn import_storage_table<RT: Runtime>(
     table_id: TabletIdAndTableNumber,
     component_path: &ComponentPath,
     mut documents: impl Stream<Item = anyhow::Result<JsonValue>> + Unpin,
-    storage_files: Vec<(DeveloperDocumentId, ImportStorageFileStream)>,
+    storage_files: Vec<(PublicDocumentId, ImportStorageFileStream)>,
     usage: &FunctionUsageTracker,
     import_id: Option<ResolvedDocumentId>,
     num_to_skip: u64,
@@ -85,7 +85,7 @@ pub async fn import_storage_table<RT: Runtime>(
         lineno += 1;
         let metadata: FileStorageZipMetadata = serde_json::from_value(exported_value)
             .map_err(|e| ImportError::InvalidConvexValue(lineno, e.into()))?;
-        let id = DeveloperDocumentId::decode(&metadata.id)
+        let id = PublicDocumentId::decode(&metadata.id)
             .map_err(|e| ImportError::InvalidConvexValue(lineno, e.into()))?;
         anyhow::ensure!(
             id.table() == virtual_table_number,
@@ -161,7 +161,7 @@ pub async fn import_storage_table<RT: Runtime>(
                 |tx| {
                     async {
                         let mut entry_object_map =
-                            BTreeMap::from(ConvexObject::try_from(entry.clone())?);
+                            BTreeMap::from(DocumentObject::try_from(entry.clone())?);
                         entry_object_map.insert(ID_FIELD.clone().into(), val!(id));
                         if let Some(creation_time) = creation_time {
                             entry_object_map.insert(
@@ -169,7 +169,7 @@ pub async fn import_storage_table<RT: Runtime>(
                                 val!(f64::from(creation_time)),
                             );
                         }
-                        let entry_object = ConvexObject::try_from(entry_object_map)?;
+                        let entry_object = DocumentObject::try_from(entry_object_map)?;
                         ImportFacingModel::new(tx)
                             .insert(
                                 table_id,

--- a/crates/application/src/snapshot_import/mod.rs
+++ b/crates/application/src/snapshot_import/mod.rs
@@ -135,9 +135,9 @@ use usage_tracking::{
     UsageCounter,
 };
 use value::{
-    id_v6::DeveloperDocumentId,
-    ConvexObject,
+    id_v6::PublicDocumentId,
     ConvexValue,
+    DocumentObject,
     IdentifierFieldName,
     ResolvedDocumentId,
     Size,
@@ -502,7 +502,7 @@ pub async fn start_stored_import<RT: Runtime>(
     component_path: ComponentPath,
     fq_object_key: FullyQualifiedObjectKey,
     requestor: ImportRequestor,
-) -> anyhow::Result<DeveloperDocumentId> {
+) -> anyhow::Result<PublicDocumentId> {
     if !(identity.is_admin() || identity.is_system()) {
         anyhow::bail!(ImportError::Unauthorized);
     }
@@ -535,7 +535,7 @@ pub async fn start_stored_import<RT: Runtime>(
 pub async fn perform_import<RT: Runtime>(
     application: &Application<RT>,
     identity: Identity,
-    import_id: DeveloperDocumentId,
+    import_id: PublicDocumentId,
 ) -> anyhow::Result<()> {
     if !identity.is_admin() {
         anyhow::bail!(ImportError::Unauthorized);
@@ -563,7 +563,7 @@ pub async fn perform_import<RT: Runtime>(
 pub async fn cancel_import<RT: Runtime>(
     application: &Application<RT>,
     identity: Identity,
-    import_id: DeveloperDocumentId,
+    import_id: PublicDocumentId,
 ) -> anyhow::Result<()> {
     if !identity.is_admin() {
         anyhow::bail!(ImportError::Unauthorized);
@@ -591,7 +591,7 @@ pub async fn cancel_import<RT: Runtime>(
 async fn wait_for_import_worker<RT: Runtime>(
     application: &Application<RT>,
     identity: Identity,
-    import_id: DeveloperDocumentId,
+    import_id: PublicDocumentId,
 ) -> anyhow::Result<ParsedDocument<SnapshotImport>> {
     let snapshot_import = loop {
         let mut tx = application.begin(identity.clone()).await?;
@@ -869,7 +869,7 @@ async fn import_objects<RT: Runtime>(
 
     let mut storage_files_by_component: BTreeMap<
         ComponentPath,
-        Vec<(DeveloperDocumentId, ImportStorageFileStream)>,
+        Vec<(PublicDocumentId, ImportStorageFileStream)>,
     > = BTreeMap::new();
     let mut storage_files = import.storage_files;
     while let Some((component_path, id, stream)) = storage_files.try_next().await? {
@@ -1272,7 +1272,7 @@ async fn import_single_table<RT: Runtime>(
     mut objects: Peekable<ImportDocumentStream>,
     storage_files_by_component: &mut BTreeMap<
         ComponentPath,
-        Vec<(DeveloperDocumentId, ImportStorageFileStream)>,
+        Vec<(PublicDocumentId, ImportStorageFileStream)>,
     >,
     mut generated_schema: Option<&mut GeneratedSchema<ProdConfig>>,
     table_mapping_for_schema: &TableMapping,
@@ -1410,7 +1410,7 @@ async fn import_single_table<RT: Runtime>(
 async fn insert_import_objects<RT: Runtime>(
     database: &Database<RT>,
     identity: &Identity,
-    objects_to_insert: Vec<ConvexObject>,
+    objects_to_insert: Vec<DocumentObject>,
     table_name: &TableName,
     table_id: TabletIdAndTableNumber,
     table_mapping_for_schema: &TableMapping,
@@ -1667,7 +1667,7 @@ async fn table_number_for_import(
     let JsonValue::String(id) = first_id else {
         return None;
     };
-    let id_v6 = DeveloperDocumentId::decode(id).ok()?;
+    let id_v6 = PublicDocumentId::decode(id).ok()?;
     Some(id_v6.table())
 }
 

--- a/crates/application/src/snapshot_import/parse.rs
+++ b/crates/application/src/snapshot_import/parse.rs
@@ -67,7 +67,7 @@ use tokio::io::{
 };
 use tokio_util::io::ReaderStream;
 use value::{
-    id_v6::DeveloperDocumentId,
+    id_v6::PublicDocumentId,
     TableName,
 };
 
@@ -81,7 +81,7 @@ pub struct ParsedImport {
     pub documents: Vec<(ComponentPath, TableName, ImportDocumentStream)>,
     pub storage_files: BoxStream<
         'static,
-        anyhow::Result<(ComponentPath, DeveloperDocumentId, ImportStorageFileStream)>,
+        anyhow::Result<(ComponentPath, PublicDocumentId, ImportStorageFileStream)>,
     >,
 }
 
@@ -373,7 +373,7 @@ fn parse_table_filename(
 fn parse_storage_filename(
     filename: &str,
     base_component_path: &ComponentPath,
-) -> anyhow::Result<Option<(ComponentPath, DeveloperDocumentId)>> {
+) -> anyhow::Result<Option<(ComponentPath, PublicDocumentId)>> {
     match STORAGE_FILE_PATTERN.captures(filename) {
         None => Ok(None),
         Some(captures) => {
@@ -384,7 +384,7 @@ fn parse_storage_filename(
             if storage_id_str == "documents" {
                 return Ok(None);
             }
-            let storage_id = DeveloperDocumentId::decode(storage_id_str).map_err(|e| {
+            let storage_id = PublicDocumentId::decode(storage_id_str).map_err(|e| {
                 ErrorMetadata::bad_request(
                     "InvalidStorageId",
                     format!("_storage id '{storage_id_str}' invalid: {e}"),
@@ -475,7 +475,7 @@ async fn parse_generated_schema<T: ShapeConfig>(
         let export_context = ExportContext::try_from(value.clone())
             .map_err(|e| ImportError::InvalidConvexValue(lineno, e))?;
         overrides.insert(
-            DeveloperDocumentId::decode(key)
+            PublicDocumentId::decode(key)
                 .map_err(|e| ImportError::InvalidConvexValue(lineno, e.into()))?,
             export_context,
         );

--- a/crates/application/src/snapshot_import/prepare_component.rs
+++ b/crates/application/src/snapshot_import/prepare_component.rs
@@ -49,7 +49,7 @@ where
         let component_id = if metadata.component_type.is_root() {
             ComponentId::Root
         } else {
-            ComponentId::Child(metadata.developer_id())
+            ComponentId::Child(metadata.document_id())
         };
         return Ok(component_id);
     }
@@ -109,7 +109,7 @@ async fn create_unmounted_component<RT: Runtime>(
                 .context(format!(
                     "{parent_path:?} not found in create_unmounted_component"
                 ))?
-                .developer_id(),
+                .document_id(),
             name: component_name,
             args: btreemap! {},
         },

--- a/crates/application/src/snapshot_import/tests.rs
+++ b/crates/application/src/snapshot_import/tests.rs
@@ -101,10 +101,10 @@ use usage_tracking::FunctionUsageTracker;
 use value::{
     assert_obj,
     assert_val,
-    id_v6::DeveloperDocumentId,
+    id_v6::PublicDocumentId,
     val,
     ConvexArray,
-    ConvexObject,
+    DocumentObject,
     FieldName,
     InternalId,
     TableName,
@@ -657,7 +657,7 @@ async fn import_referencing_virtual_table(rt: TestRuntime) -> anyhow::Result<()>
     let scheduled_functions = SCHEDULED_JOBS_VIRTUAL_TABLE.clone();
     let file_storage = FILE_STORAGE_VIRTUAL_TABLE.clone();
 
-    let storage_id: DeveloperDocumentId = "kg21pzwemsm55e1fnt2kcsvgjh6h6gtf".parse()?;
+    let storage_id: PublicDocumentId = "kg21pzwemsm55e1fnt2kcsvgjh6h6gtf".parse()?;
     {
         let mut tx = app.begin(identity.clone()).await?;
         let job_id = VirtualSchedulerModel::new(&mut tx, TableNamespace::Global)
@@ -1007,7 +1007,7 @@ async fn import_conflicting_table_numbers(rt: TestRuntime) -> anyhow::Result<()>
     let app = Application::new_for_tests(&rt).await?;
     let identity = new_admin_id();
 
-    let id_table10001 = DeveloperDocumentId::new(TableNumber::try_from(10001)?, InternalId::MAX);
+    let id_table10001 = PublicDocumentId::new(TableNumber::try_from(10001)?, InternalId::MAX);
 
     let test_cases = [
         // _tables has two conflicting table numbers
@@ -1118,7 +1118,7 @@ async fn import_table_number_conflict_race(
     let app = Application::new_for_tests(&rt).await?;
     let identity = new_admin_id();
 
-    let id_table10001 = DeveloperDocumentId::new(TableNumber::try_from(10001)?, InternalId::MAX);
+    let id_table10001 = PublicDocumentId::new(TableNumber::try_from(10001)?, InternalId::MAX);
 
     let test_case = make_zip(&[(
         "table1/documents.jsonl",
@@ -1352,7 +1352,7 @@ async fn test_import_counts_bandwidth(rt: TestRuntime) -> anyhow::Result<()> {
     let identity = new_admin_id();
 
     let storage_id = "kg21pzwemsm55e1fnt2kcsvgjh6h6gtf";
-    let storage_idv6 = DeveloperDocumentId::decode(storage_id)?;
+    let storage_idv6 = PublicDocumentId::decode(storage_id)?;
 
     // Calculate expected sizes
     let storage_file_bytes = b"foobarbaz";
@@ -1440,7 +1440,7 @@ async fn test_import_counts_bandwidth(rt: TestRuntime) -> anyhow::Result<()> {
 #[convex_macro::test_runtime]
 async fn test_import_file_storage_changing_table_number(rt: TestRuntime) -> anyhow::Result<()> {
     let app = Application::new_for_tests(&rt).await?;
-    let old_storage_id: DeveloperDocumentId = "4d9wy5r5x7rmjdjqnx45ct829fff4ar".parse()?;
+    let old_storage_id: PublicDocumentId = "4d9wy5r5x7rmjdjqnx45ct829fff4ar".parse()?;
     let import = ParsedImport {
         generated_schemas: vec![],
         documents: vec![(
@@ -1570,7 +1570,7 @@ async fn load_fields_as_maps<'a, RT: Runtime>(
         }
     }
 
-    let objects: Vec<ConvexObject> = docs.into_iter().map(|doc| doc.into_value().0).collect();
+    let objects: Vec<DocumentObject> = docs.into_iter().map(|doc| doc.into_value().0).collect();
 
     let mut fields_list: Vec<BTreeMap<&str, ConvexValue>> = Vec::default();
     for object in objects {

--- a/crates/application/src/system_table_cleanup/mod.rs
+++ b/crates/application/src/system_table_cleanup/mod.rs
@@ -490,7 +490,7 @@ impl<RT: Runtime> SystemTableCleanupWorker<RT> {
                 .all()
                 .await?
             {
-                let id = SourcePackageId::from(source_package.id().developer_id);
+                let id = SourcePackageId::from(source_package.id().document_id);
                 if !source_package_ids.contains(&id) {
                     SystemMetadataModel::new(&mut tx, namespace)
                         .delete(source_package.id())

--- a/crates/application/src/tests/components.rs
+++ b/crates/application/src/tests/components.rs
@@ -39,8 +39,8 @@ use sync_types::{
 };
 use value::{
     assert_obj,
-    ConvexObject,
     ConvexValue,
+    DocumentObject,
     TableName,
     TableNamespace,
 };
@@ -312,7 +312,7 @@ pub async fn unmount_component(
     Ok(component_id)
 }
 
-fn example_message() -> ConvexObject {
+fn example_message() -> DocumentObject {
     assert_obj!("channel" => "sports", "text" => "the celtics won!")
 }
 

--- a/crates/application/src/tests/storage.rs
+++ b/crates/application/src/tests/storage.rs
@@ -339,7 +339,7 @@ async fn test_storage_api_bandwidth_log_events(rt: TestRuntime) -> anyhow::Resul
         .await?;
 
     let mut file_stream = app
-        .get_file(ComponentId::Root, FileStorageId::DocumentId(doc_id))
+        .get_file(ComponentId::Root, FileStorageId::PublicDocumentId(doc_id))
         .await?;
     let mut total = 0u64;
     while let Some(chunk) = file_stream.next().await {
@@ -368,7 +368,7 @@ async fn test_storage_api_bandwidth_log_events(rt: TestRuntime) -> anyhow::Resul
         .await?;
 
     let mut file_stream = app
-        .get_file(ComponentId::Root, FileStorageId::DocumentId(doc_id))
+        .get_file(ComponentId::Root, FileStorageId::PublicDocumentId(doc_id))
         .await?;
     let _first_chunk = file_stream.next().await;
     // Drop without fully consuming.
@@ -395,7 +395,11 @@ async fn test_storage_api_bandwidth_log_events(rt: TestRuntime) -> anyhow::Resul
 
     let range = (Bound::Included(0), Bound::Included(1023));
     let mut file_stream = app
-        .get_file_range(ComponentId::Root, FileStorageId::DocumentId(doc_id), range)
+        .get_file_range(
+            ComponentId::Root,
+            FileStorageId::PublicDocumentId(doc_id),
+            range,
+        )
         .await?;
     let mut total = 0u64;
     while let Some(chunk) = file_stream.next().await {

--- a/crates/common/src/bootstrap_model/components/handles.rs
+++ b/crates/common/src/bootstrap_model/components/handles.rs
@@ -10,7 +10,7 @@ use sync_types::{
 };
 use value::{
     codegen_convex_serialization,
-    DeveloperDocumentId,
+    PublicDocumentId,
 };
 
 use crate::components::ComponentId;
@@ -64,15 +64,15 @@ codegen_convex_serialization!(FunctionHandleMetadata, SerializedFunctionHandleMe
 pub const FUNCTION_HANDLE_PREFIX: &str = "function://";
 
 #[derive(Debug, Clone, PartialEq, Eq, Ord, PartialOrd, Hash)]
-pub struct FunctionHandle(DeveloperDocumentId);
+pub struct FunctionHandle(PublicDocumentId);
 
 impl FunctionHandle {
-    pub fn new(handle_id: DeveloperDocumentId) -> Self {
+    pub fn new(handle_id: PublicDocumentId) -> Self {
         Self(handle_id)
     }
 }
 
-impl From<FunctionHandle> for DeveloperDocumentId {
+impl From<FunctionHandle> for PublicDocumentId {
     fn from(handle: FunctionHandle) -> Self {
         handle.0
     }

--- a/crates/common/src/bootstrap_model/components/mod.rs
+++ b/crates/common/src/bootstrap_model/components/mod.rs
@@ -10,7 +10,7 @@ use serde::{
 use value::{
     codegen_convex_serialization,
     identifier::Identifier,
-    DeveloperDocumentId,
+    PublicDocumentId,
 };
 
 use crate::components::{
@@ -22,7 +22,7 @@ use crate::components::{
 #[derive(Debug, Clone, Eq, PartialEq)]
 #[cfg_attr(any(test, feature = "testing"), derive(proptest_derive::Arbitrary))]
 pub struct ComponentMetadata {
-    pub definition_id: DeveloperDocumentId,
+    pub definition_id: PublicDocumentId,
     pub component_type: ComponentType,
     pub state: ComponentState,
 }
@@ -38,7 +38,7 @@ pub enum ComponentState {
 }
 
 impl ComponentMetadata {
-    pub fn parent_and_name(&self) -> Option<(DeveloperDocumentId, ComponentName)> {
+    pub fn parent_and_name(&self) -> Option<(PublicDocumentId, ComponentName)> {
         match &self.component_type {
             ComponentType::App => None,
             ComponentType::ChildComponent { parent, name, .. } => Some((*parent, name.clone())),
@@ -51,7 +51,7 @@ impl ComponentMetadata {
 pub enum ComponentType {
     App,
     ChildComponent {
-        parent: DeveloperDocumentId,
+        parent: PublicDocumentId,
         name: ComponentName,
         args: BTreeMap<Identifier, Resource>,
     },

--- a/crates/common/src/bootstrap_model/index/database_index/index_config.rs
+++ b/crates/common/src/bootstrap_model/index/database_index/index_config.rs
@@ -10,7 +10,7 @@ use crate::paths::FieldPath;
 #[cfg_attr(any(test, feature = "testing"), derive(proptest_derive::Arbitrary))]
 pub struct DatabaseIndexSpec {
     /// Ordered field(s) to index. The "unindexed" primary key ordering of
-    /// documents by [`DocumentId`] is represented by an empty vector.
+    /// documents by [`PublicDocumentId`] is represented by an empty vector.
     pub fields: IndexedFields,
 }
 

--- a/crates/common/src/bootstrap_model/index/database_index/mod.rs
+++ b/crates/common/src/bootstrap_model/index/database_index/mod.rs
@@ -25,14 +25,14 @@ mod tests {
 
     use value::{
         obj,
-        ConvexObject,
+        DocumentObject,
     };
 
     use super::*;
 
     #[test]
     fn test_backfilled_metadata_is_deserialized_as_backfilled() -> anyhow::Result<()> {
-        let object: ConvexObject = obj!("type" => "Backfilled2")?;
+        let object: DocumentObject = obj!("type" => "Backfilled2")?;
         let index_state: DatabaseIndexState = object.try_into()?;
         assert_matches!(
             index_state,
@@ -44,7 +44,7 @@ mod tests {
     #[test]
     fn test_backfilled_metadata_is_serialized_as_backfilled() -> anyhow::Result<()> {
         let index_state = DatabaseIndexState::Backfilled { staged: true };
-        let object: ConvexObject = index_state.try_into()?;
+        let object: DocumentObject = index_state.try_into()?;
         let index_state: DatabaseIndexState = object.try_into()?;
         assert_matches!(index_state, DatabaseIndexState::Backfilled { staged: true });
         Ok(())

--- a/crates/common/src/bootstrap_model/index/text_index/index_snapshot.rs
+++ b/crates/common/src/bootstrap_model/index/text_index/index_snapshot.rs
@@ -5,7 +5,7 @@ use serde::{
 };
 use value::{
     serde::WithUnknown,
-    ConvexObject,
+    DocumentObject,
 };
 
 use crate::types::{
@@ -32,7 +32,7 @@ pub enum TextIndexSnapshotData {
     /// Used because we don't want to delete / recreate index metadata
     /// unintentionally when changing versions and rolling services
     /// backwards/forwards.
-    Unknown(ConvexObject),
+    Unknown(DocumentObject),
 }
 
 impl From<FragmentedTextSegment> for pb::searchlight::FragmentedTextSegment {
@@ -102,7 +102,7 @@ mod proptest {
             RestrictNaNs,
             ValueBranching,
         },
-        ConvexObject,
+        DocumentObject,
         FieldType,
     };
 
@@ -118,7 +118,7 @@ mod proptest {
         fn arbitrary_with(_args: Self::Parameters) -> Self::Strategy {
             prop_oneof![
                 any::<Vec<FragmentedTextSegment>>().prop_map(TextIndexSnapshotData::MultiSegment),
-                any_with::<ConvexObject>((
+                any_with::<DocumentObject>((
                     size_range(0..=4),
                     FieldType::User,
                     ValueBranching::default(),

--- a/crates/common/src/bootstrap_model/index/vector_index/index_snapshot.rs
+++ b/crates/common/src/bootstrap_model/index/vector_index/index_snapshot.rs
@@ -5,7 +5,7 @@ use serde::{
 use sync_types::Timestamp;
 use value::{
     serde::WithUnknown,
-    ConvexObject,
+    DocumentObject,
 };
 
 use super::segment::{
@@ -51,7 +51,7 @@ impl TryFrom<SerializedVectorIndexSnapshot> for VectorIndexSnapshot {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum VectorIndexSnapshotData {
     MultiSegment(Vec<FragmentedVectorSegment>),
-    Unknown(ConvexObject),
+    Unknown(DocumentObject),
 }
 
 #[cfg(any(test, feature = "testing"))]
@@ -65,7 +65,7 @@ mod proptest {
             RestrictNaNs,
             ValueBranching,
         },
-        ConvexObject,
+        DocumentObject,
         FieldType,
     };
 
@@ -80,7 +80,7 @@ mod proptest {
             prop_oneof![
                 any::<Vec<FragmentedVectorSegment>>()
                     .prop_map(VectorIndexSnapshotData::MultiSegment),
-                any_with::<ConvexObject>((
+                any_with::<DocumentObject>((
                     size_range(0..=4),
                     FieldType::User,
                     ValueBranching::default(),

--- a/crates/common/src/bootstrap_model/schema.rs
+++ b/crates/common/src/bootstrap_model/schema.rs
@@ -2,7 +2,7 @@ use std::str::FromStr;
 
 use errors::ErrorMetadata;
 use value::{
-    id_v6::DeveloperDocumentId,
+    id_v6::PublicDocumentId,
     InternalDocumentId,
     ResolvedDocumentId,
     TableMapping,
@@ -24,7 +24,7 @@ pub fn parse_schema_id(
         Ok(s) => Ok(s.to_resolved(table_mapping.tablet_number(s.table())?)),
         Err(_) => {
             // Try parsing as an IDv6 ID
-            let id = DeveloperDocumentId::decode(schema_id)?;
+            let id = PublicDocumentId::decode(schema_id)?;
             id.to_resolved(table_mapping.namespace(namespace).number_to_tablet())
         },
     }

--- a/crates/common/src/bootstrap_model/tables.rs
+++ b/crates/common/src/bootstrap_model/tables.rs
@@ -168,7 +168,7 @@ mod tests {
     use value::{
         assert_obj,
         obj,
-        ConvexObject,
+        DocumentObject,
         TableNamespace,
     };
 
@@ -203,7 +203,7 @@ mod tests {
             state: TableState::Active,
             namespace: TableNamespace::Global,
         };
-        let serialized: ConvexObject = table.try_into()?;
+        let serialized: DocumentObject = table.try_into()?;
         assert_eq!(
             serialized,
             assert_obj!(

--- a/crates/common/src/components/mod.rs
+++ b/crates/common/src/components/mod.rs
@@ -1,7 +1,7 @@
 use std::str::FromStr;
 
 use value::{
-    DeveloperDocumentId,
+    PublicDocumentId,
     TableNamespace,
 };
 
@@ -38,11 +38,11 @@ pub use self::{
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Hash)]
 pub enum ComponentId {
     Root,
-    Child(DeveloperDocumentId),
+    Child(PublicDocumentId),
 }
 
 impl ComponentId {
-    pub fn new(is_root: bool, id: DeveloperDocumentId) -> Self {
+    pub fn new(is_root: bool, id: PublicDocumentId) -> Self {
         if is_root {
             ComponentId::Root
         } else {
@@ -72,7 +72,7 @@ impl ComponentId {
     pub fn deserialize_from_string(s: Option<&str>) -> anyhow::Result<Self> {
         match s {
             None => Ok(ComponentId::Root),
-            Some(s) => Ok(ComponentId::Child(DeveloperDocumentId::from_str(s)?)),
+            Some(s) => Ok(ComponentId::Child(PublicDocumentId::from_str(s)?)),
         }
     }
 }
@@ -126,7 +126,7 @@ mod proptests {
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Hash)]
 pub enum ComponentDefinitionId {
     Root,
-    Child(DeveloperDocumentId),
+    Child(PublicDocumentId),
 }
 
 impl ComponentDefinitionId {

--- a/crates/common/src/components/reference.rs
+++ b/crates/common/src/components/reference.rs
@@ -6,7 +6,7 @@ use sync_types::{
 };
 use value::{
     identifier::Identifier,
-    DeveloperDocumentId,
+    PublicDocumentId,
 };
 
 use super::ComponentName;
@@ -80,7 +80,7 @@ pub enum Reference {
     },
 
     CurrentSystemUdfInComponent {
-        component_id: DeveloperDocumentId,
+        component_id: PublicDocumentId,
     },
 }
 

--- a/crates/common/src/document.rs
+++ b/crates/common/src/document.rs
@@ -44,15 +44,15 @@ pub use value::InternalId;
 use value::{
     export::ValueFormat,
     heap_size::HeapSize,
-    id_v6::DeveloperDocumentId,
+    id_v6::PublicDocumentId,
     serde::ConvexSerializable,
     sorting::{
         write_sort_key,
         write_sort_key_or_undefined,
     },
     walk::ConvexValueType,
-    ConvexObject,
     ConvexValue,
+    DocumentObject,
     FieldName,
     FieldPath,
     IdentifierFieldName,
@@ -237,9 +237,9 @@ impl CreationTime {
 /// DeveloperDocument is the public-facing document type.
 #[derive(Clone, Eq, PartialEq)]
 pub struct DeveloperDocument {
-    id: DeveloperDocumentId,
+    id: PublicDocumentId,
     creation_time: CreationTime,
-    value: PII<ConvexObject>,
+    value: PII<DocumentObject>,
 }
 
 impl DeveloperDocument {
@@ -253,12 +253,12 @@ impl DeveloperDocument {
     }
 
     /// The body/payload of the document
-    pub fn value(&self) -> &PII<ConvexObject> {
+    pub fn value(&self) -> &PII<DocumentObject> {
         &self.value
     }
 
     /// Consume the document's value.
-    pub fn into_value(self) -> PII<ConvexObject> {
+    pub fn into_value(self) -> PII<DocumentObject> {
         self.value
     }
 
@@ -326,7 +326,7 @@ impl TryFrom<ResolvedDocument> for ResolvedDocumentProto {
         let value = value.0.json_serialize()?.into_bytes();
         let id = ResolvedDocumentId {
             tablet_id,
-            developer_id: id,
+            document_id: id,
         };
         Ok(Self {
             id: Some(id.into()),
@@ -352,7 +352,7 @@ impl TryFrom<ResolvedDocumentProto> for ResolvedDocument {
         let creation_time = creation_time
             .ok_or_else(|| anyhow::anyhow!("Missing creation time"))?
             .try_into()?;
-        let value: ConvexObject = serde_json::from_slice::<JsonValue>(
+        let value: DocumentObject = serde_json::from_slice::<JsonValue>(
             &value.ok_or_else(|| anyhow::anyhow!("Missing value"))?,
         )?
         .try_into()?;
@@ -372,7 +372,7 @@ impl ResolvedDocument {
     pub fn new(
         id: ResolvedDocumentId,
         creation_time: CreationTime,
-        mut value: ConvexObject,
+        mut value: DocumentObject,
     ) -> anyhow::Result<Self> {
         let id_value: ConvexValue = id.into();
         if let Some(existing_value) = value.get(&FieldName::from(ID_FIELD.clone())) {
@@ -446,7 +446,7 @@ impl ResolvedDocument {
 
         match self.value.get(&FieldName::from(ID_FIELD.clone())) {
             Some(ConvexValue::String(s)) => {
-                if let Ok(document_id) = DeveloperDocumentId::decode(s) {
+                if let Ok(document_id) = PublicDocumentId::decode(s) {
                     if document_id.table() != self.id.table() {
                         violations.push(DocumentValidationError::IdWrongTable);
                     } else if document_id.internal_id() != self.internal_id() {
@@ -504,7 +504,7 @@ impl ResolvedDocument {
                 values.push(None);
             }
         }
-        IndexKey::new_allow_missing(values, self.developer_id())
+        IndexKey::new_allow_missing(values, self.document_id())
     }
 
     /// Create a copy of this document with a different TabletId.
@@ -521,9 +521,9 @@ impl ResolvedDocument {
     /// This method assumes that system-provided fields, like `_id`, have
     /// already been inserted into `value`.
     pub fn from_database(tablet_id: TabletId, value: ConvexValue) -> anyhow::Result<Self> {
-        let object: ConvexObject = value.try_into()?;
+        let object: DocumentObject = value.try_into()?;
         let id = match object.get(&FieldName::from(ID_FIELD.clone())) {
-            Some(ConvexValue::String(s)) => DeveloperDocumentId::decode(s)?,
+            Some(ConvexValue::String(s)) => PublicDocumentId::decode(s)?,
             _ => anyhow::bail!("Object {} missing _id field", object),
         };
         let creation_time = match object.get(&FieldName::from(CREATION_TIME_FIELD.clone())) {
@@ -545,7 +545,7 @@ impl ResolvedDocument {
         value: ConvexValue,
         document_id: ResolvedDocumentId,
     ) -> anyhow::Result<Self> {
-        let object: ConvexObject = value.try_into()?;
+        let object: DocumentObject = value.try_into()?;
         let creation_time = match object.get(&FieldName::from(CREATION_TIME_FIELD.clone())) {
             Some(ConvexValue::Float64(ts)) => (*ts).try_into()?,
             None => anyhow::bail!("Object {object} missing _creationTime field"),
@@ -564,11 +564,11 @@ impl ResolvedDocument {
     /// Return a new [`Document`] with the value updated to `new_value`. If
     /// `new_value` contains an `_id` field, it must match the current `_id`
     /// field's value.
-    pub fn replace_value(&self, new_value: ConvexObject) -> anyhow::Result<Self> {
+    pub fn replace_value(&self, new_value: DocumentObject) -> anyhow::Result<Self> {
         Self::new(self.id(), self.creation_time, new_value)
     }
 
-    pub fn into_value(self) -> PII<ConvexObject> {
+    pub fn into_value(self) -> PII<DocumentObject> {
         self.document.into_value()
     }
 
@@ -584,7 +584,7 @@ impl ResolvedDocument {
         ResolvedDocumentId::new(self.tablet_id, self.id)
     }
 
-    pub fn developer_id(&self) -> DeveloperDocumentId {
+    pub fn document_id(&self) -> PublicDocumentId {
         self.id
     }
 
@@ -592,7 +592,7 @@ impl ResolvedDocument {
         self.document.into_value().0.export(format)
     }
 
-    /// Enforce that the size of the underlying ConvexObject doesn't exceed
+    /// Enforce that the size of the underlying DocumentObject doesn't exceed
     /// `MAX_USER_SIZE`.
     pub fn check_user_size(&self) -> anyhow::Result<()> {
         let size = self.value.size();
@@ -762,7 +762,7 @@ impl DocumentUpdateRef for DocumentUpdate {
 }
 
 impl DeveloperDocument {
-    pub fn new(id: DeveloperDocumentId, creation_time: CreationTime, value: ConvexObject) -> Self {
+    pub fn new(id: PublicDocumentId, creation_time: CreationTime, value: DocumentObject) -> Self {
         Self {
             id,
             creation_time,
@@ -777,7 +777,7 @@ impl DeveloperDocument {
         }
     }
 
-    pub fn id(&self) -> DeveloperDocumentId {
+    pub fn id(&self) -> PublicDocumentId {
         self.id
     }
 
@@ -825,8 +825,8 @@ impl PackedDocument {
         self.id
     }
 
-    pub fn developer_id(&self) -> DeveloperDocumentId {
-        self.id().developer_id
+    pub fn document_id(&self) -> PublicDocumentId {
+        self.id().document_id
     }
 
     pub fn value(&self) -> &PackedValue<ByteBuffer> {
@@ -853,7 +853,7 @@ impl PackedDocument {
             write_sort_key_or_undefined(value, out).expect("failed to unpack opened value");
         }
         let Ok(()) = write_sort_key(
-            self.id().developer_id.encode_into(&mut Default::default()),
+            self.id().document_id.encode_into(&mut Default::default()),
             out,
         );
         &buffer.0
@@ -893,7 +893,7 @@ impl<D> ParsedDocument<D> {
         self.id
     }
 
-    pub fn developer_id(&self) -> DeveloperDocumentId {
+    pub fn document_id(&self) -> PublicDocumentId {
         self.id.into()
     }
 
@@ -926,10 +926,10 @@ pub trait ParseDocument<D> {
 }
 
 // this impl can't use ConvexSerializable because it's used with some types that
-// directly impl `From<ConvexObject>`
+// directly impl `From<DocumentObject>`
 impl<D> ParseDocument<D> for ResolvedDocument
 where
-    D: TryFrom<ConvexObject, Error = anyhow::Error>,
+    D: TryFrom<DocumentObject, Error = anyhow::Error>,
 {
     fn parse(self) -> anyhow::Result<ParsedDocument<D>> {
         let id = self.id();
@@ -1019,7 +1019,7 @@ pub enum DocumentValidationError {
     #[error("The document belongs to a different table than its '_id' field")]
     IdWrongTable,
     #[error("The document has id {0}, but its '_id' field is {1}")]
-    IdMismatch(DeveloperDocumentId, ConvexValue),
+    IdMismatch(PublicDocumentId, ConvexValue),
     #[error("The '_id' field {0} must be an Id")]
     IdBadType(ConvexValue),
     #[error("The '_id' field is missing")]
@@ -1064,7 +1064,7 @@ impl proptest::arbitrary::Arbitrary for ResolvedDocument {
             RestrictNaNs,
             ValueBranching,
         };
-        any_with::<(ResolvedDocumentId, CreationTime, ConvexObject)>((
+        any_with::<(ResolvedDocumentId, CreationTime, DocumentObject)>((
             (),
             (),
             (
@@ -1083,7 +1083,7 @@ impl proptest::arbitrary::Arbitrary for ResolvedDocument {
                     CREATION_TIME_FIELD.clone().into(),
                     ConvexValue::from(f64::from(creation_time)),
                 );
-                let value = ConvexObject::try_from(object).unwrap();
+                let value = DocumentObject::try_from(object).unwrap();
                 let doc = ResolvedDocument::new(id, creation_time, value);
                 doc.ok()
             },
@@ -1103,13 +1103,13 @@ mod tests {
     use proptest::prelude::*;
     use sync_types::testing::assert_roundtrips;
     use value::{
-        id_v6::DeveloperDocumentId,
+        id_v6::PublicDocumentId,
         proptest::{
             RestrictNaNs,
             ValueBranching,
         },
-        ConvexObject,
         ConvexValue,
+        DocumentObject,
         FieldType,
         IdentifierFieldName,
         InternalId,
@@ -1154,10 +1154,7 @@ mod tests {
             table_name,
         );
         let doc = ResolvedDocument::new(
-            ResolvedDocumentId::new(
-                tablet_id,
-                DeveloperDocumentId::new(table_number, internal_id),
-            ),
+            ResolvedDocumentId::new(tablet_id, PublicDocumentId::new(table_number, internal_id)),
             CreationTime::ONE,
             assert_obj!(
                 "f" => 5
@@ -1194,7 +1191,7 @@ mod tests {
         fn test_packed_document_index_key_matches(
             id in any::<ResolvedDocumentId>(),
             creation_time in any::<CreationTime>(),
-            value in any_with::<ConvexObject>((
+            value in any_with::<DocumentObject>((
                 prop::collection::SizeRange::default(),
                 FieldType::UserIdentifier,
                 ValueBranching::medium(),
@@ -1214,7 +1211,7 @@ mod tests {
                 CREATION_TIME_FIELD.clone().into(),
                 ConvexValue::from(f64::from(creation_time)),
             );
-            let value = ConvexObject::try_from(object).unwrap();
+            let value = DocumentObject::try_from(object).unwrap();
             let doc = ResolvedDocument::new(id, creation_time, value).unwrap();
             // Generate field paths that have a chance of resolving to something for `doc`
             let mut current_doc = Some(&**doc.value());
@@ -1251,7 +1248,7 @@ mod tests {
             ResolvedDocumentId::MIN,
             CreationTime::ONE,
             assert_obj!(
-                "_id" => DeveloperDocumentId::MIN,
+                "_id" => PublicDocumentId::MIN,
                 "foo" => {
                     "bar" => 5,
                     "baz" => false,
@@ -1262,7 +1259,7 @@ mod tests {
             ResolvedDocumentId::MIN,
             CreationTime::ONE,
             assert_obj!(
-                "_id" => DeveloperDocumentId::MIN,
+                "_id" => PublicDocumentId::MIN,
                 "foo" => {"bar" => 5},
             ),
         )?;

--- a/crates/common/src/execution_context.rs
+++ b/crates/common/src/execution_context.rs
@@ -15,7 +15,7 @@ use sync_types::types::SessionId;
 use uuid::Uuid;
 use value::{
     heap_size::HeapSize,
-    id_v6::DeveloperDocumentId,
+    id_v6::PublicDocumentId,
     sha256,
 };
 
@@ -33,7 +33,7 @@ pub struct ExecutionContext {
     // function ExecutionId.
     pub execution_id: ExecutionId,
     /// The id of the scheduled job that triggered this UDF, if any.
-    pub parent_scheduled_job: Option<(ComponentId, DeveloperDocumentId)>,
+    pub parent_scheduled_job: Option<(ComponentId, PublicDocumentId)>,
     /// False if this function was called as part of a request (e.g. action
     /// calling a mutation) TODO: This is a stop gap solution. The richer
     /// version of this would be something like parent_execution_id:
@@ -54,7 +54,7 @@ impl ExecutionContext {
     pub fn new_from_parts(
         request_id: RequestId,
         execution_id: ExecutionId,
-        parent_scheduled_job: Option<(ComponentId, DeveloperDocumentId)>,
+        parent_scheduled_job: Option<(ComponentId, PublicDocumentId)>,
         is_root: bool,
     ) -> Self {
         Self {

--- a/crates/common/src/index.rs
+++ b/crates/common/src/index.rs
@@ -5,7 +5,7 @@ use std::{
 
 use derive_more::Deref;
 use value::{
-    id_v6::DeveloperDocumentId,
+    id_v6::PublicDocumentId,
     ConvexValue,
     InternalId,
     Size,
@@ -72,14 +72,14 @@ impl Borrow<[u8]> for IndexKeyBytes {
 /// will hold `(doc.a, doc.b, doc._id)`.
 pub struct IndexKey {
     values_with_id: Vec<Option<ConvexValue>>,
-    id: DeveloperDocumentId,
+    id: PublicDocumentId,
 }
 
 impl IndexKey {
     /// Construct an `IndexKey`.
     pub fn new_allow_missing(
         mut index_values: Vec<Option<ConvexValue>>,
-        id: DeveloperDocumentId,
+        id: PublicDocumentId,
     ) -> Self {
         let id_value: ConvexValue = id.into();
         index_values.push(Some(id_value));
@@ -89,7 +89,7 @@ impl IndexKey {
         }
     }
 
-    pub fn new(index_values: Vec<ConvexValue>, id: DeveloperDocumentId) -> Self {
+    pub fn new(index_values: Vec<ConvexValue>, id: PublicDocumentId) -> Self {
         Self::new_allow_missing(index_values.into_iter().map(Some).collect(), id)
     }
 
@@ -115,7 +115,7 @@ impl IndexKey {
     }
 }
 
-impl From<IndexKey> for (Vec<Option<ConvexValue>>, DeveloperDocumentId) {
+impl From<IndexKey> for (Vec<Option<ConvexValue>>, PublicDocumentId) {
     fn from(k: IndexKey) -> Self {
         let mut values = k.values_with_id;
         values.pop();
@@ -138,7 +138,7 @@ impl PartialOrd for IndexKey {
 mod proptest {
     use proptest::prelude::*;
     use value::{
-        id_v6::DeveloperDocumentId,
+        id_v6::PublicDocumentId,
         ConvexValue,
     };
 
@@ -150,7 +150,7 @@ mod proptest {
         type Strategy = impl Strategy<Value = IndexKey>;
 
         fn arbitrary_with((): Self::Parameters) -> Self::Strategy {
-            any::<(Vec<Option<ConvexValue>>, DeveloperDocumentId)>()
+            any::<(Vec<Option<ConvexValue>>, PublicDocumentId)>()
                 .prop_map(|(values, id)| IndexKey::new_allow_missing(values, id))
         }
     }

--- a/crates/common/src/knobs.rs
+++ b/crates/common/src/knobs.rs
@@ -375,6 +375,21 @@ pub static MAX_REPEATABLE_TIMESTAMP_IDLE_FREQUENCY: LazyLock<Duration> = LazyLoc
     ))
 });
 
+/// How often an idle partition leader should publish a lightweight
+/// replication-frontier heartbeat to other partitions.
+///
+/// This is separate from `MAX_REPEATABLE_TIMESTAMP_IDLE_FREQUENCY` because
+/// cross-partition OCC needs a much fresher "safe frontier" than follower
+/// persistence readers do. The heartbeat is the distributed equivalent of
+/// CockroachDB's closed timestamp side transport: even if a partition is idle,
+/// peers still learn that reads below this timestamp are safe.
+pub static REPLICATION_FRONTIER_HEARTBEAT_INTERVAL: LazyLock<Duration> = LazyLock::new(|| {
+    Duration::from_millis(env_config(
+        "REPLICATION_FRONTIER_HEARTBEAT_INTERVAL_MS",
+        200,
+    ))
+});
+
 /// This is the max duration between a Commit and bumping max_repeatable_ts.
 /// When reading from a follower persistence, we can only read commits at
 /// timestamps <= max_repeatable_ts (because commits > max_repeatable_ts are

--- a/crates/common/src/log_lines.rs
+++ b/crates/common/src/log_lines.rs
@@ -37,8 +37,8 @@ use value::{
     remove_string,
     remove_vec,
     remove_vec_of_strings,
-    ConvexObject,
     ConvexValue,
+    DocumentObject,
 };
 
 use crate::{
@@ -109,10 +109,10 @@ impl HeapSize for SystemLogMetadata {
     }
 }
 
-impl TryFrom<ConvexObject> for SystemLogMetadata {
+impl TryFrom<DocumentObject> for SystemLogMetadata {
     type Error = anyhow::Error;
 
-    fn try_from(value: ConvexObject) -> Result<Self, Self::Error> {
+    fn try_from(value: DocumentObject) -> Result<Self, Self::Error> {
         let mut fields = BTreeMap::from(value);
         let code = remove_string(&mut fields, "code")?;
         Ok(SystemLogMetadata { code })

--- a/crates/common/src/pii.rs
+++ b/crates/common/src/pii.rs
@@ -44,14 +44,14 @@ impl<T: fmt::Debug> fmt::Debug for PII<T> {
 mod tests {
     use value::{
         assert_obj,
-        ConvexObject,
+        DocumentObject,
     };
 
     use super::PII;
 
     #[test]
     fn test_pii_debug_by_ref() -> anyhow::Result<()> {
-        let obj: ConvexObject = assert_obj!("ssn" => 123456789);
+        let obj: DocumentObject = assert_obj!("ssn" => 123456789);
         let pii_obj = PII(obj);
         let debug_pii = format!("{:?}", &pii_obj);
         // This is a test, so we print the PII wrapped in PII().

--- a/crates/common/src/query.rs
+++ b/crates/common/src/query.rs
@@ -31,11 +31,11 @@ use sha2::{
 };
 use value::{
     heap_size::HeapSize,
-    id_v6::DeveloperDocumentId,
+    id_v6::PublicDocumentId,
     utils::display_sequence,
     val,
-    ConvexObject,
     ConvexValue,
+    DocumentObject,
     TabletId,
 };
 
@@ -916,7 +916,7 @@ mod proptest {
 
 fn binary_arithmetic<I, F>(
     name: &'static str,
-    environ: &ConvexObject,
+    environ: &DocumentObject,
     l_expr: &Expression,
     r_expr: &Expression,
     do_ints: I,
@@ -953,7 +953,7 @@ where
 impl Expression {
     /// Evaluate the expression and return the result. Expression::Fields are
     /// evaluated on `environ`.
-    pub fn eval(&self, environ: &ConvexObject) -> anyhow::Result<MaybeValue> {
+    pub fn eval(&self, environ: &DocumentObject) -> anyhow::Result<MaybeValue> {
         // Convert input value into a value that compares with ==, !=, >, <, etc. in
         // the same order as they would be compared in an index.
         let comparable_value = |v: MaybeValue| v.0;
@@ -1122,7 +1122,7 @@ impl Query {
         }
     }
 
-    pub fn get(table_name: TableName, id: DeveloperDocumentId) -> Self {
+    pub fn get(table_name: TableName, id: PublicDocumentId) -> Self {
         Self::index_range(IndexRange {
             index_name: IndexName::by_id(table_name),
             range: vec![IndexRangeExpression::Eq(

--- a/crates/common/src/schemas/mod.rs
+++ b/crates/common/src/schemas/mod.rs
@@ -24,9 +24,9 @@ use shape_inference::{
 #[cfg(any(test, feature = "testing"))]
 use value::TableType;
 use value::{
-    id_v6::DeveloperDocumentId,
-    ConvexObject,
+    id_v6::PublicDocumentId,
     ConvexValue,
+    DocumentObject,
     IdentifierFieldName,
     Namespace,
     NamespacedTableMapping,
@@ -71,7 +71,7 @@ pub enum SchemaValidationError {
     ExistingDocument {
         validation_error: ValidationError,
         table_name: TableName,
-        id: DeveloperDocumentId,
+        id: PublicDocumentId,
     },
 
     // TODO: Figure out if it's possible to surface the document ID here,
@@ -343,7 +343,7 @@ impl DatabaseSchema {
             .map_err(|validation_error| SchemaValidationError::ExistingDocument {
                 validation_error,
                 table_name,
-                id: doc.developer_id(),
+                id: doc.document_id(),
             })
     }
 
@@ -782,7 +782,7 @@ pub enum DocumentSchema {
 impl DocumentSchema {
     fn check_value(
         &self,
-        value: &ConvexObject,
+        value: &DocumentObject,
         table_mapping: &NamespacedTableMapping,
         virtual_system_mapping: &VirtualSystemMapping,
     ) -> Result<(), ValidationError> {

--- a/crates/common/src/schemas/tests.rs
+++ b/crates/common/src/schemas/tests.rs
@@ -3,7 +3,7 @@ use proptest::prelude::*;
 use serde_json::json;
 use value::{
     assert_obj,
-    ConvexObject,
+    DocumentObject,
     FieldName,
     NamespacedTableMapping,
     TableMapping,
@@ -37,7 +37,7 @@ proptest! {
     }
 
     #[test]
-    fn test_any_matches_all(v in any::<ConvexObject>()) {
+    fn test_any_matches_all(v in any::<DocumentObject>()) {
         let document_schema = DocumentSchema::Any;
         document_schema.check_value(
             &v,
@@ -700,7 +700,7 @@ mod tables_to_revalidate {
     use value::{
         assert_obj,
         assert_val,
-        id_v6::DeveloperDocumentId,
+        id_v6::PublicDocumentId,
         ConvexValue,
         ResolvedDocumentId,
         TableName,
@@ -1032,7 +1032,7 @@ mod tables_to_revalidate {
     #[test]
     fn test_skips_validation_from_virtual_ids_in_shapes() -> anyhow::Result<()> {
         let mut id_generator = TestIdGenerator::new();
-        let dog_id: DeveloperDocumentId = id_generator.generate_virtual(&"dogs".parse()?);
+        let dog_id: PublicDocumentId = id_generator.generate_virtual(&"dogs".parse()?);
         let document_with_id = assert_val!({"field" => dog_id});
         let shape = CountedShape::<TestConfig>::empty().insert_value(&document_with_id);
 
@@ -1075,7 +1075,7 @@ mod tables_to_revalidate {
     #[test]
     fn test_skips_validation_from_virtual_ids_in_type() -> anyhow::Result<()> {
         let mut id_generator = TestIdGenerator::new();
-        let dog_id: DeveloperDocumentId = id_generator.generate_virtual(&"dogs".parse()?);
+        let dog_id: PublicDocumentId = id_generator.generate_virtual(&"dogs".parse()?);
         let shape = CountedShape::<TestConfig>::empty().insert_value(&dog_id.into());
         assert!(Validator::from_shape(
             &shape,

--- a/crates/common/src/schemas/validator.rs
+++ b/crates/common/src/schemas/validator.rs
@@ -25,14 +25,14 @@ use shape_inference::{
 };
 use value::{
     export::ValueFormat,
-    id_v6::DeveloperDocumentId,
+    id_v6::PublicDocumentId,
     sorting::TotalOrdF64,
     utils::{
         display_map,
         display_sequence,
     },
-    ConvexObject,
     ConvexValue,
+    DocumentObject,
     FieldName,
     FieldPath,
     IdentifierFieldName,
@@ -165,7 +165,7 @@ impl Validator {
     ) -> Result<(), ValidationError> {
         match (self, value) {
             (Validator::Id(validator_table), ConvexValue::String(s)) => {
-                if let Ok(id) = DeveloperDocumentId::decode(s)
+                if let Ok(id) = PublicDocumentId::decode(s)
                     && let Ok(table_name) = all_tables_number_to_name(id.table())
                 {
                     if &table_name != validator_table {
@@ -945,7 +945,7 @@ pub enum ValidationError {
          in validator `v.id(\"{validator_table}\")`.{context}"
     )]
     TableNamesDoNotMatch {
-        id: DeveloperDocumentId,
+        id: PublicDocumentId,
         found_table_name: TableName,
         validator_table: TableName,
         context: ValidationContext,
@@ -955,7 +955,7 @@ pub enum ValidationError {
          `v.id(\"{validator_table}\")`.{context}"
     )]
     SystemTableReference {
-        id: DeveloperDocumentId,
+        id: PublicDocumentId,
         validator_table: TableName,
         context: ValidationContext,
     },
@@ -975,7 +975,7 @@ Object: {object}
 Validator: {object_validator}"
     )]
     MissingRequiredField {
-        object: ConvexObject,
+        object: DocumentObject,
         field_name: IdentifierFieldName,
         object_validator: ObjectValidator,
         context: ValidationContext,
@@ -987,7 +987,7 @@ Object: {object}
 Validator: {object_validator}"
     )]
     ExtraField {
-        object: ConvexObject,
+        object: DocumentObject,
         field_name: FieldName,
         object_validator: ObjectValidator,
         context: ValidationContext,
@@ -1030,13 +1030,13 @@ mod tests {
         assert_obj,
         assert_val,
         export::ValueFormat,
-        id_v6::DeveloperDocumentId,
+        id_v6::PublicDocumentId,
         proptest::{
             RestrictNaNs,
             ValueBranching,
         },
-        ConvexObject,
         ConvexValue,
+        DocumentObject,
         FieldName,
         FieldType,
         InternalId,
@@ -1082,7 +1082,7 @@ mod tests {
                     id_generator,
                     &id_generator.virtual_system_mapping,
                 )(table_name)?;
-                let doc_idv6 = DeveloperDocumentId::new(table_number, id);
+                let doc_idv6 = PublicDocumentId::new(table_number, id);
                 ConvexValue::String(doc_idv6.encode().try_into()?)
             },
             Validator::Null => assert_val!(null),
@@ -1129,7 +1129,7 @@ mod tests {
     fn object_from_schema(
         schema: DocumentSchema,
         id_generator: &TestIdGenerator,
-    ) -> anyhow::Result<ConvexObject> {
+    ) -> anyhow::Result<DocumentObject> {
         match schema {
             DocumentSchema::Any => Ok(btreemap! {}.try_into()?),
             DocumentSchema::Union(objects) => {
@@ -1598,7 +1598,7 @@ mod tests {
         // generate an ID so it's in the table mapping
         id_generator.user_generate(&table1);
         let document_id = id_generator.user_generate(&table2);
-        let id_v6 = DeveloperDocumentId::from(document_id);
+        let id_v6 = PublicDocumentId::from(document_id);
         let value: ConvexValue = id_v6.into();
 
         let err = id_validator

--- a/crates/common/src/shapes/reduced.rs
+++ b/crates/common/src/shapes/reduced.rs
@@ -16,7 +16,7 @@ use shape_inference::{
     UnionShape,
 };
 use value::{
-    id_v6::DeveloperDocumentId,
+    id_v6::PublicDocumentId,
     FieldName,
     IdentifierFieldName,
     TableNumber,
@@ -84,7 +84,7 @@ impl ReducedShape {
             }),
             ShapeEnum::Boolean => ReducedShape::Boolean,
             ShapeEnum::StringLiteral(s) => {
-                if let Ok(id) = DeveloperDocumentId::decode(s)
+                if let Ok(id) = PublicDocumentId::decode(s)
                     && table_exists(id.table())
                 {
                     ReducedShape::Id(id.table())

--- a/crates/common/src/shapes/tests.rs
+++ b/crates/common/src/shapes/tests.rs
@@ -7,7 +7,7 @@ use shape_inference::{
     CountedShape,
 };
 use value::{
-    id_v6::DeveloperDocumentId,
+    id_v6::PublicDocumentId,
     ConvexValue,
     TableName,
     TableNamespace,
@@ -62,13 +62,13 @@ fn test_id_strings() -> anyhow::Result<()> {
     let mut id_generator = TestIdGenerator::new();
 
     // Create three IDs from three different tables
-    let message_id: DeveloperDocumentId = id_generator
+    let message_id: PublicDocumentId = id_generator
         .user_generate(&TableName::from_str("messages")?)
         .into();
     let deleted1_table = TableName::from_str("deleted1")?;
     let deleted2_table = TableName::from_str("deleted2")?;
-    let deleted1_id: DeveloperDocumentId = id_generator.user_generate(&deleted1_table).into();
-    let deleted2_id: DeveloperDocumentId = id_generator.user_generate(&deleted2_table).into();
+    let deleted1_id: PublicDocumentId = id_generator.user_generate(&deleted1_table).into();
+    let deleted2_id: PublicDocumentId = id_generator.user_generate(&deleted2_table).into();
     let table_mapping = id_generator.namespace(TableNamespace::test_user());
 
     // Delete two of the tables

--- a/crates/common/src/sync/split_rw_lock.rs
+++ b/crates/common/src/sync/split_rw_lock.rs
@@ -54,5 +54,4 @@ impl<T> Writer<T> {
     pub fn read(&self) -> RwLockReadGuard<'_, T> {
         self.inner.read()
     }
-
 }

--- a/crates/common/src/testing/persistence_test_suite.rs
+++ b/crates/common/src/testing/persistence_test_suite.rs
@@ -23,11 +23,11 @@ use value::{
     assert_val,
     sha256::Sha256,
     val,
-    ConvexObject,
     ConvexValue,
-    DeveloperDocumentId,
+    DocumentObject,
     InternalDocumentId,
     InternalId,
+    PublicDocumentId,
     ResolvedDocumentId,
     TableMapping,
     TabletId,
@@ -286,7 +286,7 @@ pub async fn write_and_load_from_table<P: Persistence>(p: Arc<P>) -> anyhow::Res
 
     let table2: TableName = str::parse("table2")?;
     let doc_id2 = id_generator.user_generate(&table2);
-    let doc2 = ResolvedDocument::new(doc_id2, CreationTime::ONE, ConvexObject::empty())?;
+    let doc2 = ResolvedDocument::new(doc_id2, CreationTime::ONE, DocumentObject::empty())?;
 
     p.write(
         &[
@@ -601,7 +601,7 @@ pub async fn overwrite_document<P: Persistence>(p: Arc<P>) -> anyhow::Result<()>
     let table: TableName = str::parse("table")?;
     let doc_id = id_generator.user_generate(&table);
 
-    let doc = ResolvedDocument::new(doc_id, CreationTime::ONE, ConvexObject::empty())?;
+    let doc = ResolvedDocument::new(doc_id, CreationTime::ONE, DocumentObject::empty())?;
 
     p.write(
         &[
@@ -819,8 +819,8 @@ pub async fn write_and_load_sorting<P: Persistence>(p: Arc<P>) -> anyhow::Result
     let doc_id1 = id_generator.user_generate(&table1);
     let doc_id2 = id_generator.user_generate(&table2);
 
-    let doc1 = ResolvedDocument::new(doc_id1, CreationTime::ONE, ConvexObject::empty())?;
-    let doc2 = ResolvedDocument::new(doc_id2, CreationTime::ONE, ConvexObject::empty())?;
+    let doc1 = ResolvedDocument::new(doc_id1, CreationTime::ONE, DocumentObject::empty())?;
+    let doc2 = ResolvedDocument::new(doc_id2, CreationTime::ONE, DocumentObject::empty())?;
     p.write(
         &[
             // Write doc1 and doc2. Make sure sorted by TS, not ID
@@ -881,7 +881,7 @@ pub async fn same_internal_id_multiple_tables<P: Persistence>(p: Arc<P>) -> anyh
     let doc1 = ResolvedDocument::new(
         ResolvedDocumentId::new(
             table1_id.tablet_id,
-            DeveloperDocumentId::new(table1_id.table_number, internal_id),
+            PublicDocumentId::new(table1_id.table_number, internal_id),
         ),
         CreationTime::ONE,
         assert_obj!("value" => 1),
@@ -889,7 +889,7 @@ pub async fn same_internal_id_multiple_tables<P: Persistence>(p: Arc<P>) -> anyh
     let doc2 = ResolvedDocument::new(
         ResolvedDocumentId::new(
             table2_id.tablet_id,
-            DeveloperDocumentId::new(table2_id.table_number, internal_id),
+            PublicDocumentId::new(table2_id.table_number, internal_id),
         ),
         CreationTime::ONE,
         assert_obj!("value" => 2),
@@ -1480,7 +1480,7 @@ where
     let mut id_generator = TestIdGenerator::new();
     let doc_id = id_generator.user_generate(&table);
 
-    let doc = ResolvedDocument::new(doc_id, CreationTime::ONE, ConvexObject::empty())?;
+    let doc = ResolvedDocument::new(doc_id, CreationTime::ONE, DocumentObject::empty())?;
 
     p_write
         .write(

--- a/crates/common/src/testing/test_id_generator.rs
+++ b/crates/common/src/testing/test_id_generator.rs
@@ -7,7 +7,7 @@ use std::{
 };
 
 use value::{
-    id_v6::DeveloperDocumentId,
+    id_v6::PublicDocumentId,
     ResolvedDocumentId,
     TableMapping,
     TableNamespace,
@@ -182,7 +182,7 @@ impl TestIdGenerator {
             let table_metadata = TableMetadata::new(namespace, table_name.clone(), table_number);
             let id = ResolvedDocumentId::new(
                 tables_table_id.tablet_id,
-                DeveloperDocumentId::new(tables_table_id.table_number, table_id.0),
+                PublicDocumentId::new(tables_table_id.table_number, table_id.0),
             );
             let doc = ResolvedDocument::new(id, CreationTime::ONE, table_metadata.try_into()?)?;
             let index_update = PersistenceIndexEntry {
@@ -209,7 +209,7 @@ impl TestIdGenerator {
         let table_id = self.user_table_id(table_name);
         ResolvedDocumentId::new(
             table_id.tablet_id,
-            DeveloperDocumentId::new(table_id.table_number, self.generate_internal()),
+            PublicDocumentId::new(table_id.table_number, self.generate_internal()),
         )
     }
 
@@ -218,12 +218,12 @@ impl TestIdGenerator {
         let table_id = self.system_table_id(table_name);
         ResolvedDocumentId::new(
             table_id.tablet_id,
-            DeveloperDocumentId::new(table_id.table_number, self.generate_internal()),
+            PublicDocumentId::new(table_id.table_number, self.generate_internal()),
         )
     }
 
-    pub fn generate_virtual(&mut self, table_name: &TableName) -> DeveloperDocumentId {
+    pub fn generate_virtual(&mut self, table_name: &TableName) -> PublicDocumentId {
         let table_num = self.generate_virtual_table(table_name);
-        DeveloperDocumentId::new(table_num, self.generate_internal())
+        PublicDocumentId::new(table_num, self.generate_internal())
     }
 }

--- a/crates/common/src/types/functions.rs
+++ b/crates/common/src/types/functions.rs
@@ -15,7 +15,7 @@ use serde::{
 };
 use value::{
     heap_size::HeapSize,
-    id_v6::DeveloperDocumentId,
+    id_v6::PublicDocumentId,
 };
 
 use super::HttpActionRoute;
@@ -186,11 +186,11 @@ pub enum FunctionCaller {
     HttpEndpoint,
     Cron,
     Scheduler {
-        job_id: DeveloperDocumentId,
+        job_id: PublicDocumentId,
         component_id: ComponentId,
     },
     Action {
-        parent_scheduled_job: Option<(ComponentId, DeveloperDocumentId)>,
+        parent_scheduled_job: Option<(ComponentId, PublicDocumentId)>,
         parent_execution_id: Option<ExecutionId>,
     },
     #[cfg(any(test, feature = "testing"))]
@@ -214,7 +214,7 @@ impl FunctionCaller {
         .cloned()
     }
 
-    pub fn parent_scheduled_job(&self) -> Option<(ComponentId, DeveloperDocumentId)> {
+    pub fn parent_scheduled_job(&self) -> Option<(ComponentId, PublicDocumentId)> {
         match self {
             FunctionCaller::SyncWorker(_)
             | FunctionCaller::HttpApi(_)

--- a/crates/common/src/virtual_system_mapping.rs
+++ b/crates/common/src/virtual_system_mapping.rs
@@ -5,8 +5,8 @@ use async_trait::async_trait;
 use imbl::OrdMap;
 use semver::Version;
 use value::{
-    DeveloperDocumentId,
     NamespacedTableMapping,
+    PublicDocumentId,
     ResolvedDocumentId,
     TableMapping,
     TableName,
@@ -286,11 +286,11 @@ impl VirtualSystemMapping {
             })
     }
 
-    // Converts a virtual table DeveloperDocumentId to the system table ResolvedId.
+    // Converts a virtual table PublicDocumentId to the system table ResolvedId.
     pub fn virtual_id_v6_to_system_resolved_doc_id(
         &self,
         namespace: TableNamespace,
-        virtual_id_v6: &DeveloperDocumentId,
+        virtual_id_v6: &PublicDocumentId,
         table_mapping: &TableMapping,
     ) -> anyhow::Result<ResolvedDocumentId> {
         let table_number = virtual_id_v6.table();
@@ -302,12 +302,12 @@ impl VirtualSystemMapping {
     }
 
     // Converts a system table ResolvedDocumentId to the equivalent virtual table
-    // DeveloperDocumentId by mapping the TableName and using the same InternalId
+    // PublicDocumentId by mapping the TableName and using the same InternalId
     pub fn system_resolved_id_to_virtual_developer_id(
         &self,
         system_doc_id: ResolvedDocumentId,
-    ) -> anyhow::Result<DeveloperDocumentId> {
-        Ok(system_doc_id.developer_id)
+    ) -> anyhow::Result<PublicDocumentId> {
+        Ok(system_doc_id.document_id)
     }
 }
 

--- a/crates/database/benches/is_stale.rs
+++ b/crates/database/benches/is_stale.rs
@@ -27,7 +27,7 @@ use common::{
         Timestamp,
     },
     value::{
-        id_v6::DeveloperDocumentId,
+        id_v6::PublicDocumentId,
         ConvexValue,
         TabletIdAndTableNumber,
     },
@@ -122,8 +122,8 @@ fn create_write_log_with_standard_index_writes(num_writes: usize) -> Result<(Log
     let field_path: FieldPath = "value".parse()?;
     let mut reads = TransactionReadSet::new();
     // Use IndexKey encoding for interval bounds
-    let start_key = IndexKey::new(vec![val!(0)], DeveloperDocumentId::MIN).to_bytes();
-    let end_key = IndexKey::new(vec![val!(26)], DeveloperDocumentId::MIN).to_bytes();
+    let start_key = IndexKey::new(vec![val!(0)], PublicDocumentId::MIN).to_bytes();
+    let end_key = IndexKey::new(vec![val!(26)], PublicDocumentId::MIN).to_bytes();
     let target_interval = Interval {
         start: StartIncluded(start_key.into()),
         end: End::Excluded(end_key.into()),

--- a/crates/database/benches/subscriptions.rs
+++ b/crates/database/benches/subscriptions.rs
@@ -54,9 +54,9 @@ use serde::Deserialize;
 use tokio::runtime::Runtime;
 use value::{
     ConvexString,
-    DeveloperDocumentId,
     FieldPath,
     InternalId,
+    PublicDocumentId,
     ResolvedDocumentId,
     TabletId,
     TabletIdAndTableNumber,
@@ -124,7 +124,7 @@ fn load_datasets(
             let internal_id = alloc_id();
             let id = ResolvedDocumentId::new(
                 table_id.tablet_id,
-                DeveloperDocumentId::new(table_id.table_number, internal_id),
+                PublicDocumentId::new(table_id.table_number, internal_id),
             );
             let tokenizer = convex_en();
             {

--- a/crates/database/src/bootstrap_model/components/mod.rs
+++ b/crates/database/src/bootstrap_model/components/mod.rs
@@ -38,8 +38,8 @@ use errors::ErrorMetadata;
 use value::{
     identifier::Identifier,
     ConvexValue,
-    DeveloperDocumentId,
     FieldPath,
+    PublicDocumentId,
     ResolvedDocumentId,
     TableName,
     TableNamespace,
@@ -92,7 +92,7 @@ impl<'a, RT: Runtime> BootstrapComponentsModel<'a, RT> {
 
     pub fn component_in_parent(
         &mut self,
-        parent_and_name: Option<(DeveloperDocumentId, ComponentName)>,
+        parent_and_name: Option<(PublicDocumentId, ComponentName)>,
     ) -> anyhow::Result<Option<ParsedDocument<ComponentMetadata>>> {
         self.tx
             .component_registry
@@ -101,7 +101,7 @@ impl<'a, RT: Runtime> BootstrapComponentsModel<'a, RT> {
 
     pub fn component_children(
         &mut self,
-        parent_id: DeveloperDocumentId,
+        parent_id: PublicDocumentId,
     ) -> anyhow::Result<Vec<ParsedDocument<ComponentMetadata>>> {
         self.tx
             .component_registry
@@ -142,7 +142,7 @@ impl<'a, RT: Runtime> BootstrapComponentsModel<'a, RT> {
 
     pub fn resolve_component_id(
         &mut self,
-        component_id: DeveloperDocumentId,
+        component_id: PublicDocumentId,
     ) -> anyhow::Result<ResolvedDocumentId> {
         let component_table = self
             .tx
@@ -157,7 +157,7 @@ impl<'a, RT: Runtime> BootstrapComponentsModel<'a, RT> {
 
     pub fn resolve_component_definition_id(
         &mut self,
-        component_definition_id: DeveloperDocumentId,
+        component_definition_id: PublicDocumentId,
     ) -> anyhow::Result<ResolvedDocumentId> {
         let component_definitions_table = self
             .tx

--- a/crates/database/src/bootstrap_model/defaults.rs
+++ b/crates/database/src/bootstrap_model/defaults.rs
@@ -21,7 +21,7 @@ use common::{
 };
 use maplit::btreemap;
 use value::{
-    DeveloperDocumentId,
+    PublicDocumentId,
     ResolvedDocumentId,
     TableNamespace,
     TableNumber,
@@ -135,14 +135,14 @@ impl BootstrapTableIds {
     pub fn table_resolved_doc_id(&self, table_id: TabletId) -> ResolvedDocumentId {
         ResolvedDocumentId::new(
             self.tables_id.tablet_id,
-            DeveloperDocumentId::new(self.tables_id.table_number, table_id.0),
+            PublicDocumentId::new(self.tables_id.table_number, table_id.0),
         )
     }
 
     pub fn index_resolved_doc_id(&self, index_id: IndexId) -> ResolvedDocumentId {
         ResolvedDocumentId::new(
             self.index_id.tablet_id,
-            DeveloperDocumentId::new(self.index_id.table_number, index_id),
+            PublicDocumentId::new(self.index_id.table_number, index_id),
         )
     }
 

--- a/crates/database/src/bootstrap_model/import_facing.rs
+++ b/crates/database/src/bootstrap_model/import_facing.rs
@@ -10,10 +10,10 @@ use common::{
 };
 use errors::ErrorMetadata;
 use value::{
-    ConvexObject,
     ConvexValue,
-    DeveloperDocumentId,
+    DocumentObject,
     FieldName,
+    PublicDocumentId,
     ResolvedDocumentId,
     TableMapping,
     TableName,
@@ -48,9 +48,9 @@ impl<'a, RT: Runtime> ImportFacingModel<'a, RT> {
         &mut self,
         table_id: TabletIdAndTableNumber,
         table_name: &TableName,
-        value: ConvexObject,
+        value: DocumentObject,
         table_mapping_for_schema: &TableMapping,
-    ) -> anyhow::Result<DeveloperDocumentId> {
+    ) -> anyhow::Result<PublicDocumentId> {
         if self
             .tx
             .virtual_system_mapping()
@@ -77,7 +77,7 @@ impl<'a, RT: Runtime> ImportFacingModel<'a, RT> {
         self.tx.retention_validator.fail_if_falling_behind()?;
         let id_field = FieldName::from(ID_FIELD.clone());
         let internal_id = if let Some(ConvexValue::String(s)) = value.get(&id_field) {
-            let id_v6 = DeveloperDocumentId::decode(s).context(ErrorMetadata::bad_request(
+            let id_v6 = PublicDocumentId::decode(s).context(ErrorMetadata::bad_request(
                 "InvalidId",
                 format!("invalid _id '{s}'"),
             ))?;
@@ -99,7 +99,7 @@ impl<'a, RT: Runtime> ImportFacingModel<'a, RT> {
         };
         let id = ResolvedDocumentId::new(
             table_id.tablet_id,
-            DeveloperDocumentId::new(table_id.table_number, internal_id),
+            PublicDocumentId::new(table_id.table_number, internal_id),
         );
         let namespace = self
             .tx
@@ -130,9 +130,9 @@ impl<'a, RT: Runtime> ImportFacingModel<'a, RT> {
         &mut self,
         table_id: TabletIdAndTableNumber,
         table_name: &TableName,
-        value: ConvexObject,
+        value: DocumentObject,
         table_mapping_for_schema: &TableMapping,
-    ) -> anyhow::Result<DeveloperDocumentId> {
+    ) -> anyhow::Result<PublicDocumentId> {
         if self
             .tx
             .virtual_system_mapping()
@@ -157,8 +157,8 @@ impl<'a, RT: Runtime> ImportFacingModel<'a, RT> {
         }
 
         let id_field = FieldName::from(ID_FIELD.clone());
-        let developer_id = if let Some(ConvexValue::String(s)) = value.get(&id_field) {
-            let id_v6 = DeveloperDocumentId::decode(s).context(ErrorMetadata::bad_request(
+        let document_id = if let Some(ConvexValue::String(s)) = value.get(&id_field) {
+            let id_v6 = PublicDocumentId::decode(s).context(ErrorMetadata::bad_request(
                 "InvalidId",
                 format!("invalid _id '{s}'"),
             ))?;
@@ -176,7 +176,7 @@ impl<'a, RT: Runtime> ImportFacingModel<'a, RT> {
         } else {
             anyhow::bail!("upsert requires _id field");
         };
-        let id = ResolvedDocumentId::new(table_id.tablet_id, developer_id);
+        let id = ResolvedDocumentId::new(table_id.tablet_id, document_id);
         let namespace = self
             .tx
             .table_mapping()
@@ -208,7 +208,7 @@ impl<'a, RT: Runtime> ImportFacingModel<'a, RT> {
         &mut self,
         table_id: TabletIdAndTableNumber,
         table_name: &TableName,
-        developer_id: DeveloperDocumentId,
+        document_id: PublicDocumentId,
     ) -> anyhow::Result<()> {
         if self
             .tx
@@ -233,7 +233,7 @@ impl<'a, RT: Runtime> ImportFacingModel<'a, RT> {
             ));
         }
 
-        let id = ResolvedDocumentId::new(table_id.tablet_id, developer_id);
+        let id = ResolvedDocumentId::new(table_id.tablet_id, document_id);
         let existing_doc = self.tx.get_with_ts(id).await?;
 
         self.tx.apply_validated_write(id, existing_doc, None)?;

--- a/crates/database/src/bootstrap_model/index_backfills/mod.rs
+++ b/crates/database/src/bootstrap_model/index_backfills/mod.rs
@@ -13,8 +13,8 @@ use common::{
 };
 use sync_types::Timestamp;
 use value::{
-    DeveloperDocumentId,
     FieldPath,
+    PublicDocumentId,
     ResolvedDocumentId,
     TableName,
     TableNamespace,
@@ -76,15 +76,15 @@ impl<'a, RT: Runtime> IndexBackfillModel<'a, RT> {
         Self { tx }
     }
 
-    fn index_id_as_developer_id(&mut self, index_id: IndexId) -> DeveloperDocumentId {
+    fn index_id_as_developer_id(&mut self, index_id: IndexId) -> PublicDocumentId {
         let index_table_id = self.tx.bootstrap_tables().index_id;
-        DeveloperDocumentId::new(index_table_id.table_number, index_id)
+        PublicDocumentId::new(index_table_id.table_number, index_id)
     }
 
     #[fastrace::trace]
     pub(crate) async fn existing_backfill_metadata(
         &mut self,
-        index_id: DeveloperDocumentId,
+        index_id: PublicDocumentId,
     ) -> anyhow::Result<Option<Arc<ParsedDocument<IndexBackfillMetadata>>>> {
         self.tx
             .query_system(TableNamespace::Global, &*INDEX_BACKFILLS_BY_INDEX_ID)?
@@ -174,7 +174,7 @@ impl<'a, RT: Runtime> IndexBackfillModel<'a, RT> {
             index_id,
             tablet_id,
             num_docs_indexed,
-            Some(cursor.developer_id),
+            Some(cursor.document_id),
         )
         .await
     }
@@ -190,7 +190,7 @@ impl<'a, RT: Runtime> IndexBackfillModel<'a, RT> {
         index_id: IndexId,
         tablet_id: TabletId,
         num_docs_indexed: u64,
-        cursor: Option<DeveloperDocumentId>,
+        cursor: Option<PublicDocumentId>,
     ) -> anyhow::Result<()> {
         let index_id = self.index_id_as_developer_id(index_id);
         let maybe_existing_backfill_metadata = self.existing_backfill_metadata(index_id).await?;
@@ -254,7 +254,7 @@ impl<'a, RT: Runtime> IndexBackfillModel<'a, RT> {
         index_id: ResolvedDocumentId,
     ) -> anyhow::Result<()> {
         if let Some(existing_backfill_metadata) = self
-            .existing_backfill_metadata(index_id.developer_id)
+            .existing_backfill_metadata(index_id.document_id)
             .await?
         {
             SystemMetadataModel::new_global(self.tx)

--- a/crates/database/src/bootstrap_model/index_backfills/tests.rs
+++ b/crates/database/src/bootstrap_model/index_backfills/tests.rs
@@ -4,8 +4,8 @@ use common::{
 };
 use runtime::testing::TestRuntime;
 use value::{
-    DeveloperDocumentId,
     InternalId,
+    PublicDocumentId,
     ResolvedDocumentId,
     TableNamespace,
     TabletId,
@@ -236,7 +236,7 @@ async fn test_delete_index_backfill_existing(rt: TestRuntime) -> anyhow::Result<
     // For delete_index_backfill, we need to pass the index's ResolvedDocumentId,
     // not the backfill document's ID. Create a fake index document ID.
     let index_table_id = tx.bootstrap_tables().index_id;
-    let index_developer_id = DeveloperDocumentId::new(index_table_id.table_number, index_id);
+    let index_developer_id = PublicDocumentId::new(index_table_id.table_number, index_id);
     let index_resolved_id = ResolvedDocumentId::new(index_table_id.tablet_id, index_developer_id);
 
     // Delete the backfill
@@ -257,7 +257,7 @@ async fn test_delete_index_backfill_nonexistent(rt: TestRuntime) -> anyhow::Resu
 
     // Create a fake index document ID that doesn't exist
     let index_table_id = tx.bootstrap_tables().index_id;
-    let fake_developer_id = DeveloperDocumentId::new(index_table_id.table_number, InternalId::MAX);
+    let fake_developer_id = PublicDocumentId::new(index_table_id.table_number, InternalId::MAX);
     let fake_resolved_id = ResolvedDocumentId::new(index_table_id.tablet_id, fake_developer_id);
 
     // Delete non-existent backfill - should not error (method handles missing
@@ -315,7 +315,7 @@ async fn test_multiple_backfills_different_indexes(rt: TestRuntime) -> anyhow::R
 
     // Delete one backfill using the index's ResolvedDocumentId
     let index_table_id = tx.bootstrap_tables().index_id;
-    let index1_developer_id = DeveloperDocumentId::new(index_table_id.table_number, index_id1);
+    let index1_developer_id = PublicDocumentId::new(index_table_id.table_number, index_id1);
     let index1_resolved_id = ResolvedDocumentId::new(index_table_id.tablet_id, index1_developer_id);
 
     IndexBackfillModel::new(&mut tx)

--- a/crates/database/src/bootstrap_model/index_backfills/types.rs
+++ b/crates/database/src/bootstrap_model/index_backfills/types.rs
@@ -5,7 +5,7 @@ use serde::{
 use sync_types::Timestamp;
 use value::{
     codegen_convex_serialization,
-    DeveloperDocumentId,
+    PublicDocumentId,
 };
 
 /// Cursor for a database index that has an in-progress backfill
@@ -13,7 +13,7 @@ use value::{
 #[cfg_attr(any(test, feature = "testing"), derive(proptest_derive::Arbitrary))]
 pub struct BackfillCursor {
     pub snapshot_ts: Timestamp,
-    pub cursor: Option<DeveloperDocumentId>,
+    pub cursor: Option<PublicDocumentId>,
 }
 
 /// Metadata for tracking index backfill progress.
@@ -30,7 +30,7 @@ pub struct BackfillCursor {
 pub struct IndexBackfillMetadata {
     /// The ID of the index being backfilled. Should correspond to a document in
     /// the index table in `Backfilling` state.
-    pub index_id: DeveloperDocumentId,
+    pub index_id: PublicDocumentId,
     /// Number of documents that have been indexed so far from the snapshot
     /// (does not include documents written since the backfill began).
     pub num_docs_indexed: u64,

--- a/crates/database/src/bootstrap_model/schema/tests.rs
+++ b/crates/database/src/bootstrap_model/schema/tests.rs
@@ -23,7 +23,7 @@ use common::{
         SchemaValidationError,
     },
     value::{
-        id_v6::DeveloperDocumentId,
+        id_v6::PublicDocumentId,
         ConvexValue,
         ResolvedDocumentId,
         TableName,
@@ -223,7 +223,7 @@ async fn test_mark_schema_as_validated(rt: TestRuntime) -> anyhow::Result<()> {
             context: ValidationContext::new(),
         },
         table_name: TableName::from_str("table")?,
-        id: DeveloperDocumentId::MIN,
+        id: PublicDocumentId::MIN,
     };
     model.mark_failed(failed_id, schema_error.clone()).await?;
     let schema_error_string = schema_error.to_string();
@@ -296,7 +296,7 @@ async fn test_mark_schema_as_active(rt: TestRuntime) -> anyhow::Result<()> {
             context: ValidationContext::new(),
         },
         table_name: TableName::from_str("table")?,
-        id: DeveloperDocumentId::MIN,
+        id: PublicDocumentId::MIN,
     };
     model.mark_failed(failed_id, schema_error.clone()).await?;
     let schema_error_string = schema_error.to_string();
@@ -323,7 +323,7 @@ async fn test_mark_schema_as_failed(rt: TestRuntime) -> anyhow::Result<()> {
             context: ValidationContext::new(),
         },
         table_name: TableName::from_str("table")?,
-        id: DeveloperDocumentId::MIN,
+        id: PublicDocumentId::MIN,
     };
     model.mark_failed(id, schema_error.clone()).await?;
 
@@ -556,7 +556,7 @@ async fn mark_schema_as_failed(
             context: ValidationContext::new(),
         },
         table_name: TableName::from_str("table")?,
-        id: DeveloperDocumentId::MIN,
+        id: PublicDocumentId::MIN,
     };
     model.mark_failed(*schema_id, schema_error.clone()).await?;
     Ok(())

--- a/crates/database/src/bootstrap_model/schema_validation_progress/mod.rs
+++ b/crates/database/src/bootstrap_model/schema_validation_progress/mod.rs
@@ -78,7 +78,7 @@ impl<'a, RT: Runtime> SchemaValidationProgressModel<'a, RT> {
     ) -> anyhow::Result<Option<Arc<ParsedDocument<SchemaValidationProgressMetadata>>>> {
         self.tx
             .query_system(self.namespace, &*SCHEMA_VALIDATION_PROGRESS_BY_SCHEMA_ID)?
-            .eq(&[schema_id.developer_id.encode_into(&mut Default::default())])?
+            .eq(&[schema_id.document_id.encode_into(&mut Default::default())])?
             .unique()
             .await
     }
@@ -91,7 +91,7 @@ impl<'a, RT: Runtime> SchemaValidationProgressModel<'a, RT> {
         let maybe_existing_metadata = self.existing_schema_validation_progress(schema_id).await?;
         let mut system_model = SystemMetadataModel::new(self.tx, self.namespace);
         let new_metadata = SchemaValidationProgressMetadata {
-            schema_id: schema_id.developer_id,
+            schema_id: schema_id.document_id,
             total_docs,
             num_docs_validated: 0,
         };
@@ -125,7 +125,7 @@ impl<'a, RT: Runtime> SchemaValidationProgressModel<'a, RT> {
 
         let num_docs_validated = existing_metadata.num_docs_validated + num_docs_validated;
         let new_metadata = SchemaValidationProgressMetadata {
-            schema_id: schema_id.developer_id,
+            schema_id: schema_id.document_id,
             total_docs: existing_metadata.total_docs.or(total_docs),
             num_docs_validated,
         };

--- a/crates/database/src/bootstrap_model/schema_validation_progress/types.rs
+++ b/crates/database/src/bootstrap_model/schema_validation_progress/types.rs
@@ -4,7 +4,7 @@ use serde::{
 };
 use value::{
     codegen_convex_serialization,
-    DeveloperDocumentId,
+    PublicDocumentId,
 };
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -15,7 +15,7 @@ use value::{
 pub struct SchemaValidationProgressMetadata {
     /// The ID of the schema being validated. Should correspond to a document in
     /// the _schemas table in `Pending` state.
-    pub schema_id: DeveloperDocumentId,
+    pub schema_id: PublicDocumentId,
     /// The number of documents that have been validated so far.
     pub num_docs_validated: u64,
     /// The number of total documents that need to be validated. Note this is

--- a/crates/database/src/bootstrap_model/system_metadata.rs
+++ b/crates/database/src/bootstrap_model/system_metadata.rs
@@ -4,9 +4,9 @@ use common::{
     runtime::Runtime,
 };
 use value::{
-    ConvexObject,
-    DeveloperDocumentId,
+    DocumentObject,
     InternalId,
+    PublicDocumentId,
     ResolvedDocumentId,
     TableName,
     TableNamespace,
@@ -54,7 +54,7 @@ impl<'a, RT: Runtime> SystemMetadataModel<'a, RT> {
     pub async fn insert(
         &mut self,
         table: &TableName,
-        value: ConvexObject,
+        value: DocumentObject,
     ) -> anyhow::Result<ResolvedDocumentId> {
         anyhow::ensure!(table.is_system());
         if !(self.tx.identity.is_system() || self.tx.identity.is_admin()) {
@@ -63,7 +63,7 @@ impl<'a, RT: Runtime> SystemMetadataModel<'a, RT> {
         let table_id = self.lookup_table_id(table)?;
         let id = ResolvedDocumentId::new(
             table_id.tablet_id,
-            DeveloperDocumentId::new(
+            PublicDocumentId::new(
                 table_id.table_number,
                 self.tx.id_generator.generate_internal(),
             ),
@@ -82,7 +82,7 @@ impl<'a, RT: Runtime> SystemMetadataModel<'a, RT> {
         &mut self,
         table: &TableName,
         internal_id: InternalId,
-        value: ConvexObject,
+        value: DocumentObject,
     ) -> anyhow::Result<ResolvedDocumentId> {
         anyhow::ensure!(table.is_system());
         if !(self.tx.identity.is_system() || self.tx.identity.is_admin()) {
@@ -91,7 +91,7 @@ impl<'a, RT: Runtime> SystemMetadataModel<'a, RT> {
         let table_id = self.lookup_table_id(table)?;
         let document_id = ResolvedDocumentId::new(
             table_id.tablet_id,
-            DeveloperDocumentId::new(table_id.table_number, internal_id),
+            PublicDocumentId::new(table_id.table_number, internal_id),
         );
         let creation_time = self.tx.next_creation_time.increment()?;
         let document = ResolvedDocument::new(document_id, creation_time, value)?;
@@ -122,7 +122,7 @@ impl<'a, RT: Runtime> SystemMetadataModel<'a, RT> {
     pub async fn insert_metadata(
         &mut self,
         table: &TableName,
-        value: ConvexObject,
+        value: DocumentObject,
     ) -> anyhow::Result<ResolvedDocumentId> {
         TableModel::new(self.tx)
             .insert_table_metadata(self.namespace, table)
@@ -168,7 +168,7 @@ impl<'a, RT: Runtime> SystemMetadataModel<'a, RT> {
     pub async fn replace(
         &mut self,
         id: ResolvedDocumentId,
-        value: ConvexObject,
+        value: DocumentObject,
     ) -> anyhow::Result<ResolvedDocument> {
         anyhow::ensure!(self.tx.table_mapping().is_system_tablet(id.tablet_id));
         self.tx.replace_inner(id, value).await

--- a/crates/database/src/bootstrap_model/test_facing.rs
+++ b/crates/database/src/bootstrap_model/test_facing.rs
@@ -3,7 +3,7 @@ use common::{
     runtime::Runtime,
 };
 use value::{
-    ConvexObject,
+    DocumentObject,
     ResolvedDocumentId,
     TableName,
     TableNamespace,
@@ -27,7 +27,7 @@ impl<'a, RT: Runtime> TestFacingModel<'a, RT> {
     pub async fn insert(
         &mut self,
         table: &TableName,
-        value: ConvexObject,
+        value: DocumentObject,
     ) -> anyhow::Result<ResolvedDocumentId> {
         SystemMetadataModel::new(self.tx, TableNamespace::test_user())
             .insert_metadata(table, value)
@@ -38,7 +38,7 @@ impl<'a, RT: Runtime> TestFacingModel<'a, RT> {
     pub async fn replace(
         &mut self,
         id: ResolvedDocumentId,
-        value: ConvexObject,
+        value: DocumentObject,
     ) -> anyhow::Result<ResolvedDocument> {
         SystemMetadataModel::new(self.tx, TableNamespace::test_user())
             .replace(id, value)
@@ -51,7 +51,7 @@ impl<'a, RT: Runtime> TestFacingModel<'a, RT> {
     pub async fn insert_and_get(
         &mut self,
         table: TableName,
-        value: ConvexObject,
+        value: DocumentObject,
     ) -> anyhow::Result<ResolvedDocument> {
         let id = self.insert(&table, value).await?;
         self.tx

--- a/crates/database/src/bootstrap_model/user_facing.rs
+++ b/crates/database/src/bootstrap_model/user_facing.rs
@@ -27,8 +27,8 @@ use indexing::backend_in_memory_indexes::{
 };
 use itertools::Itertools;
 use value::{
-    ConvexObject,
-    DeveloperDocumentId,
+    DocumentObject,
+    PublicDocumentId,
     ResolvedDocumentId,
     TableName,
     TableNamespace,
@@ -59,7 +59,7 @@ use crate::{
 //  1. System tables are only visible for `Identity::Admin` or
 //     `Identity::System`.
 //  2. We support virtual tables.
-//  3. The interface is in `DeveloperDocumentId`s, not `ResolvedDocumentId`.
+//  3. The interface is in `PublicDocumentId`s, not `ResolvedDocumentId`.
 //  4. We track user size limits for documents, which are more restrictive than
 //     the database's limits.
 //  5. We support branching on the `convex` NPM package's version.
@@ -85,7 +85,7 @@ impl<'a, RT: Runtime> UserFacingModel<'a, RT> {
     #[convex_macro::instrument_future]
     pub async fn get(
         &mut self,
-        id: DeveloperDocumentId,
+        id: PublicDocumentId,
         version: Option<Version>,
     ) -> anyhow::Result<Option<DeveloperDocument>> {
         Ok(self
@@ -98,7 +98,7 @@ impl<'a, RT: Runtime> UserFacingModel<'a, RT> {
     #[convex_macro::instrument_future]
     pub async fn get_with_ts(
         &mut self,
-        id: DeveloperDocumentId,
+        id: PublicDocumentId,
         version: Option<Version>,
     ) -> anyhow::Result<Option<(DeveloperDocument, WriteTimestamp)>> {
         if !self
@@ -137,11 +137,11 @@ impl<'a, RT: Runtime> UserFacingModel<'a, RT> {
     async fn require_active_component(&mut self) -> anyhow::Result<()> {
         match self.namespace {
             TableNamespace::Global => {},
-            TableNamespace::ByComponent(developer_id) => {
+            TableNamespace::ByComponent(document_id) => {
                 let component = BootstrapComponentsModel::new(self.tx)
-                    .load_component(ComponentId::Child(developer_id))
+                    .load_component(ComponentId::Child(document_id))
                     .await?
-                    .with_context(|| format!("Component not found for id: {developer_id}"))?;
+                    .with_context(|| format!("Component not found for id: {document_id}"))?;
 
                 match component.state {
                     ComponentState::Active => {},
@@ -164,8 +164,8 @@ impl<'a, RT: Runtime> UserFacingModel<'a, RT> {
     pub async fn insert(
         &mut self,
         table: TableName,
-        value: ConvexObject,
-    ) -> anyhow::Result<DeveloperDocumentId> {
+        value: DocumentObject,
+    ) -> anyhow::Result<PublicDocumentId> {
         self.require_active_component().await?;
         if self.tx.virtual_system_mapping().is_virtual_table(&table) {
             anyhow::bail!(ErrorMetadata::bad_request(
@@ -209,7 +209,7 @@ impl<'a, RT: Runtime> UserFacingModel<'a, RT> {
         let document = ResolvedDocument::new(
             ResolvedDocumentId::new(
                 table_id.tablet_id,
-                DeveloperDocumentId::new(table_id.table_number, internal_id),
+                PublicDocumentId::new(table_id.table_number, internal_id),
             ),
             creation_time,
             value,
@@ -226,7 +226,7 @@ impl<'a, RT: Runtime> UserFacingModel<'a, RT> {
     #[convex_macro::instrument_future]
     pub async fn patch(
         &mut self,
-        id: DeveloperDocumentId,
+        id: PublicDocumentId,
         value: PatchValue,
     ) -> anyhow::Result<DeveloperDocument> {
         if self.tx.is_system(self.namespace, id.table())
@@ -255,8 +255,8 @@ impl<'a, RT: Runtime> UserFacingModel<'a, RT> {
     #[convex_macro::instrument_future]
     pub async fn replace(
         &mut self,
-        id: DeveloperDocumentId,
-        value: ConvexObject,
+        id: PublicDocumentId,
+        value: DocumentObject,
     ) -> anyhow::Result<DeveloperDocument> {
         if self.tx.is_system(self.namespace, id.table())
             && !(self.tx.identity.is_admin() || self.tx.identity.is_system())
@@ -279,7 +279,7 @@ impl<'a, RT: Runtime> UserFacingModel<'a, RT> {
     /// (e.g. syscalls)
     #[fastrace::trace]
     #[convex_macro::instrument_future]
-    pub async fn delete(&mut self, id: DeveloperDocumentId) -> anyhow::Result<DeveloperDocument> {
+    pub async fn delete(&mut self, id: PublicDocumentId) -> anyhow::Result<DeveloperDocument> {
         if self.tx.is_system(self.namespace, id.table())
             && !(self.tx.identity.is_admin() || self.tx.identity.is_system())
         {

--- a/crates/database/src/checkpoint.rs
+++ b/crates/database/src/checkpoint.rs
@@ -81,21 +81,7 @@ pub async fn create_checkpoint(
         .context("Failed to load documents for checkpoint")?;
 
     let mut globals = BTreeMap::new();
-    if let Some(value) = persistence
-        .get_persistence_global(PersistenceGlobalKey::MaxRepeatableTimestamp)
-        .await?
-    {
-        globals.insert(
-            String::from(PersistenceGlobalKey::MaxRepeatableTimestamp),
-            value,
-        );
-    }
-    for key in [
-        PersistenceGlobalKey::TablesByIdIndex,
-        PersistenceGlobalKey::TablesTabletId,
-        PersistenceGlobalKey::IndexByIdIndex,
-        PersistenceGlobalKey::IndexTabletId,
-    ] {
+    for key in PersistenceGlobalKey::all_keys() {
         if let Some(value) = persistence.get_persistence_global(key).await? {
             globals.insert(String::from(key), value);
         }

--- a/crates/database/src/committer.rs
+++ b/crates/database/src/committer.rs
@@ -3,6 +3,7 @@ use std::{
     collections::{
         BTreeMap,
         BTreeSet,
+        VecDeque,
     },
     ops::Bound,
     sync::Arc,
@@ -28,10 +29,12 @@ use common::{
     },
     document::{
         DocumentUpdateWithPrevTs,
+        PackedDocument,
         ParseDocument,
         ParsedDocument,
         ResolvedDocument,
     },
+    document_index_keys::DocumentIndexKeyValue,
     errors::{
         recapture_stacktrace,
         report_error,
@@ -47,11 +50,13 @@ use common::{
         COMMIT_TRACE_THRESHOLD,
         MAX_REPEATABLE_TIMESTAMP_COMMIT_DELAY,
         MAX_REPEATABLE_TIMESTAMP_IDLE_FREQUENCY,
+        REPLICATION_FRONTIER_HEARTBEAT_INTERVAL,
         TRANSACTION_WARN_READ_SET_INTERVALS,
     },
     persistence::{
         ConflictStrategy,
         DocumentLogEntry,
+        NoopRetentionValidator,
         Persistence,
         PersistenceGlobalKey,
         PersistenceIndexEntry,
@@ -60,6 +65,7 @@ use common::{
         RetentionValidator,
         TimestampRange,
     },
+    query::Order,
     runtime::{
         block_in_place,
         tokio_spawn,
@@ -74,6 +80,7 @@ use common::{
     types::{
         DatabaseIndexUpdate,
         DatabaseIndexValue,
+        RepeatableReason,
         RepeatableTimestamp,
         Timestamp,
         WriteTimestamp,
@@ -99,7 +106,10 @@ use itertools::Itertools;
 use parking_lot::Mutex;
 use prometheus::VMHistogram;
 use rand::Rng;
-use search::TextIndexWriteSize;
+use search::{
+    query::tokenize,
+    TextIndexWriteSize,
+};
 use tokio::sync::{
     mpsc::{
         self,
@@ -111,7 +121,7 @@ use tokio_util::task::AbortOnDropHandle;
 use usage_tracking::FunctionUsageTracker;
 use value::{
     heap_size::WithHeapSize,
-    id_v6::DeveloperDocumentId,
+    id_v6::PublicDocumentId,
     InternalDocumentId,
     TableMapping,
     TableName,
@@ -120,11 +130,18 @@ use vector::VectorIndexWriteSize;
 
 use crate::{
     bootstrap_model::defaults::BootstrapTableIds,
+    checkpoint::{
+        CheckpointData,
+        CheckpointPersistence,
+    },
     commit_delta::{
         CommitDelta,
         DistributedLog,
     },
-    database::ConflictingReadWithWriteSource,
+    database::{
+        ConflictingReadWithWriteSource,
+        DatabaseSnapshot,
+    },
     metrics::{
         self,
         bootstrap_update_timer,
@@ -141,9 +158,11 @@ use crate::{
     snapshot_manager::{
         replication_frontiers_to_json,
         SnapshotManager,
+        TableSummaries,
     },
     table_summary::{
         self,
+        TableSummarySnapshot,
     },
     transaction::FinalTransaction,
     write_log::{
@@ -203,6 +222,19 @@ enum PersistenceWrite {
         result: oneshot::Sender<anyhow::Result<Timestamp>>,
         commit_id: usize,
     },
+    ReplicationFrontierHeartbeat {
+        commit_ts: Timestamp,
+        source_partition: crate::partition::PartitionId,
+        result: oneshot::Sender<anyhow::Result<Timestamp>>,
+        commit_id: usize,
+    },
+    InstallSnapshot {
+        snapshot_ts: Timestamp,
+        snapshot: Snapshot,
+        replication_frontiers: BTreeMap<crate::partition::PartitionId, Timestamp>,
+        result: oneshot::Sender<anyhow::Result<Timestamp>>,
+        commit_id: usize,
+    },
 }
 
 impl PersistenceWrite {
@@ -211,6 +243,8 @@ impl PersistenceWrite {
             Self::Commit { commit_id, .. } => *commit_id,
             Self::MaxRepeatableTimestamp { commit_id, .. } => *commit_id,
             Self::ReplicaDelta { commit_id, .. } => *commit_id,
+            Self::ReplicationFrontierHeartbeat { commit_id, .. } => *commit_id,
+            Self::InstallSnapshot { commit_id, .. } => *commit_id,
         }
     }
 }
@@ -221,15 +255,17 @@ fn remote_read_partitions(
     reads: &ReadSet,
     table_mapping: &TableMapping,
     partition_map: &crate::partition::PartitionMap,
+    write_source: &WriteSource,
 ) -> BTreeSet<crate::partition::PartitionId> {
     let mut partitions = BTreeSet::new();
     let mut visit_tablet = |tablet_id| {
         if let Ok(table_name) = table_mapping.tablet_name(tablet_id) {
-            if table_name.is_system() {
-                return;
-            }
-            let partition = partition_map.partition_for_table(&table_name);
-            if partition != partition_map.local_partition() {
+            if let Some(partition) = crate::partition::routed_partition_for_table(
+                &table_name,
+                partition_map,
+                write_source,
+            ) && partition != partition_map.local_partition()
+            {
                 partitions.insert(partition);
             }
         }
@@ -250,8 +286,9 @@ fn stale_replica_frontiers(
     reads: &ReadSet,
     table_mapping: &TableMapping,
     partition_map: &crate::partition::PartitionMap,
+    write_source: &WriteSource,
 ) -> Vec<(crate::partition::PartitionId, Timestamp)> {
-    remote_read_partitions(reads, table_mapping, partition_map)
+    remote_read_partitions(reads, table_mapping, partition_map, write_source)
         .into_iter()
         .filter_map(|partition| {
             let frontier = snapshot_manager
@@ -262,18 +299,50 @@ fn stale_replica_frontiers(
         .collect()
 }
 
-fn has_nonlocal_user_writes(
-    transaction: &FinalTransaction,
-    partition_map: &crate::partition::PartitionMap,
-) -> bool {
-    transaction.writes.coalesced_writes().any(|write| {
-        transaction
-            .table_mapping
-            .tablet_name(write.id.tablet_id)
-            .ok()
-            .filter(|table_name| !table_name.is_system())
-            .is_some_and(|table_name| !partition_map.is_local(&table_name))
-    })
+fn compact_checkpoint_documents(checkpoint: &CheckpointData) -> Vec<DocumentLogEntry> {
+    let mut latest_documents = BTreeMap::new();
+    for entry in &checkpoint.documents {
+        latest_documents.insert(entry.id, entry.clone());
+    }
+    latest_documents
+        .into_values()
+        .filter(|entry| entry.value.is_some())
+        .collect()
+}
+
+fn checkpoint_index_entries(
+    snapshot: &Snapshot,
+    documents: &[DocumentLogEntry],
+    ts: Timestamp,
+) -> Vec<PersistenceIndexEntry> {
+    let mut index_entries = Vec::new();
+    for entry in documents {
+        let Some(document) = entry.value.as_ref() else {
+            continue;
+        };
+        let keys = snapshot
+            .index_registry
+            .document_index_keys(&PackedDocument::pack(document), tokenize);
+        for (index_name, key_value) in keys.iter() {
+            let DocumentIndexKeyValue::Standard(index_key) = key_value else {
+                continue;
+            };
+            let Some(index) = snapshot.index_registry.get_enabled(index_name) else {
+                continue;
+            };
+            index_entries.push(PersistenceIndexEntry {
+                ts,
+                index_id: index.id(),
+                key: index_key.clone(),
+                value: Some(InternalDocumentId::new(
+                    document.id().tablet_id,
+                    document.id().internal_id(),
+                )),
+            });
+        }
+    }
+    index_entries.sort();
+    index_entries
 }
 
 pub struct Committer<RT: Runtime> {
@@ -315,6 +384,12 @@ pub struct Committer<RT: Runtime> {
     prepared_transactions:
         std::collections::HashMap<crate::two_phase::TwoPhaseTransactionId, PreparedTransaction>,
 
+    // Snapshots for queued-but-not-yet-published state machine writes.
+    // Local commits and replica deltas must both build on the latest queued
+    // snapshot, not just the latest published one, or a later publish can
+    // erase earlier in-flight catalog changes from the next transaction view.
+    queued_snapshots: VecDeque<(usize, Timestamp, Snapshot)>,
+
     // Raft partition state for leadership checking.
     // When set, the Committer rejects writes if this node is not the Raft leader.
     // None means no Raft (existing behavior — always accept writes).
@@ -322,6 +397,51 @@ pub struct Committer<RT: Runtime> {
 }
 
 impl<RT: Runtime> Committer<RT> {
+    fn latest_queued_snapshot(&self) -> Option<(Timestamp, Snapshot)> {
+        self.queued_snapshots
+            .back()
+            .map(|(_, ts, snapshot)| (*ts, snapshot.clone()))
+    }
+
+    fn base_snapshot_for_new_writes(&self) -> Snapshot {
+        let queued = self.latest_queued_snapshot();
+        let pending = self.pending_writes.latest();
+        match (queued, pending) {
+            (Some((queued_ts, queued_snapshot)), Some((pending_ts, pending_snapshot))) => {
+                if queued_ts >= pending_ts {
+                    queued_snapshot
+                } else {
+                    pending_snapshot
+                }
+            },
+            (Some((_, queued_snapshot)), None) => queued_snapshot,
+            (None, Some((_, pending_snapshot))) => pending_snapshot,
+            (None, None) => self.snapshot_manager.read().latest_snapshot(),
+        }
+    }
+
+    fn enqueue_snapshot(&mut self, commit_id: usize, ts: Timestamp, snapshot: Snapshot) {
+        if let Some((last_commit_id, last_ts, _)) = self.queued_snapshots.back() {
+            assert!(
+                *last_commit_id < commit_id,
+                "queued snapshots must be ordered by commit id"
+            );
+            assert!(*last_ts <= ts, "queued snapshots must be monotonic by timestamp");
+        }
+        self.queued_snapshots.push_back((commit_id, ts, snapshot));
+    }
+
+    fn dequeue_snapshot(&mut self, commit_id: usize) {
+        let (queued_commit_id, _, _) = self
+            .queued_snapshots
+            .pop_front()
+            .expect("missing queued snapshot for published write");
+        assert_eq!(
+            queued_commit_id, commit_id,
+            "published snapshot order diverged from queued write order"
+        );
+    }
+
     pub(crate) fn start(
         log: LogWriter,
         snapshot_manager: Writer<SnapshotManager>,
@@ -356,6 +476,7 @@ impl<RT: Runtime> Committer<RT> {
             partition_map,
             timestamp_oracle,
             prepared_transactions: std::collections::HashMap::new(),
+            queued_snapshots: VecDeque::new(),
             raft_state,
         };
         let handle = runtime.spawn("committer", async move {
@@ -380,6 +501,8 @@ impl<RT: Runtime> Committer<RT> {
 
     async fn go(mut self, mut rx: mpsc::Receiver<CommitterMessage>) -> anyhow::Result<()> {
         let mut last_bumped_repeatable_ts = self.runtime.monotonic_now();
+        let mut last_replication_frontier_heartbeat = self.runtime.monotonic_now();
+        let mut last_replication_frontier_heartbeat_ts = Timestamp::MIN;
         // Assume there were commits just before the backend restarted, so first do a
         // quick bump.
         // None means a bump is ongoing. Avoid parallel bumps in case they
@@ -406,6 +529,20 @@ impl<RT: Runtime> Committer<RT> {
             } else {
                 Either::Right(std::future::pending())
             };
+            let frontier_heartbeat_fut = if self
+                .partition_map
+                .as_ref()
+                .is_some_and(|partition_map| partition_map.num_partitions() > 1)
+            {
+                Either::Left(
+                    self.runtime.wait(
+                        REPLICATION_FRONTIER_HEARTBEAT_INTERVAL
+                            .saturating_sub(last_replication_frontier_heartbeat.elapsed()),
+                    ),
+                )
+            } else {
+                Either::Right(std::future::pending())
+            };
             select_biased! {
                 _ = bump_fut.fuse() => {
                     let committer_span = committer_span.get_or_insert_with(|| {
@@ -419,6 +556,12 @@ impl<RT: Runtime> Committer<RT> {
                     self.bump_max_repeatable_ts(tx, commit_id, committer_span);
                     commit_id += 1;
                     last_bumped_repeatable_ts = self.runtime.monotonic_now();
+                }
+                _ = frontier_heartbeat_fut.fuse() => {
+                    self.maybe_publish_idle_replication_frontier_heartbeat(
+                        &mut last_replication_frontier_heartbeat_ts,
+                    );
+                    last_replication_frontier_heartbeat = self.runtime.monotonic_now();
                 }
                 result = self.persistence_writes.select_next_some() => {
                     let pending_commit = result.context("Write failed. Unsure if transaction committed to disk.")?;
@@ -438,6 +581,7 @@ impl<RT: Runtime> Committer<RT> {
                             let publish_commit_span = committer_span.as_ref().map(|root| Span::enter_with_parents("publish_commit", [root, &parent_span])).unwrap_or_else(|| parent_span);
                             let _guard = publish_commit_span.set_local_parent();
                             let commit_ts = pending_write.must_commit_ts();
+                            self.dequeue_snapshot(pending_commit_id);
                             self.publish_commit(
                                 pending_write, write_bytes, document_writes, index_writes,
                             );
@@ -478,17 +622,51 @@ impl<RT: Runtime> Committer<RT> {
                         } => {
                             // Publish replica delta — same position in the
                             // pipeline as local commits (Raft pattern).
+                            self.dequeue_snapshot(pending_commit_id);
                             let writes = crate::write_log::index_keys_from_document_updates(
                                 &remapped_updates,
                                 &snapshot.index_registry,
                             );
-                            self.log.append(commit_ts, writes, write_source);
+                            if !writes.is_empty() {
+                                self.log.append(commit_ts, writes, write_source);
+                            }
                             let mut sm = self.snapshot_manager.write();
                             sm.push(commit_ts, snapshot, write_bytes);
                             if let Some(source_partition) = source_partition {
                                 sm.update_replication_frontier(source_partition, commit_ts)?;
                             }
                             let _ = result.send(Ok(commit_ts));
+                        },
+                        PersistenceWrite::ReplicationFrontierHeartbeat {
+                            commit_ts,
+                            source_partition,
+                            result,
+                            ..
+                        } => {
+                            self.publish_replication_frontier_progress(
+                                commit_ts,
+                                source_partition,
+                            )?;
+                            let _ = result.send(Ok(commit_ts));
+                        },
+                        PersistenceWrite::InstallSnapshot {
+                            snapshot_ts,
+                            snapshot,
+                            replication_frontiers,
+                            result,
+                            ..
+                        } => {
+                            self.pending_writes = PendingWrites::new();
+                            self.prepared_transactions.clear();
+                            self.queued_snapshots.clear();
+                            self.log.reset(snapshot_ts);
+                            self.last_assigned_ts = snapshot_ts;
+                            self.snapshot_manager.write().replace(
+                                snapshot_ts,
+                                snapshot,
+                                replication_frontiers,
+                            );
+                            let _ = result.send(Ok(snapshot_ts));
                         },
                     }
                     // Report the trace if it is longer than the threshold
@@ -544,14 +722,28 @@ impl<RT: Runtime> Committer<RT> {
                             }
                         },
                         Some(CommitterMessage::ApplyReplicaDelta { delta, result }) => {
-                            let apply_result = self.apply_replica_delta(delta);
-                            let _ = result.send(apply_result);
+                            if let Err(e) = self.apply_replica_delta(delta, result, commit_id) {
+                                tracing::error!("Failed to queue replica delta for apply: {e:#}");
+                            } else {
+                                commit_id += 1;
+                            }
+                        },
+                        Some(CommitterMessage::InstallSnapshot { checkpoint, result }) => {
+                            self.install_snapshot(checkpoint, result, commit_id)?;
+                            commit_id += 1;
                         },
                         #[cfg(any(test, feature = "testing"))]
                         Some(CommitterMessage::BumpMaxRepeatableTs { result }) => {
                             let span = Span::noop();
                             self.bump_max_repeatable_ts(result, commit_id, &span);
                             commit_id += 1;
+                        },
+                        #[cfg(any(test, feature = "testing"))]
+                        Some(CommitterMessage::TickIdleReplicationFrontierHeartbeat { result }) => {
+                            self.maybe_publish_idle_replication_frontier_heartbeat(
+                                &mut last_replication_frontier_heartbeat_ts,
+                            );
+                            let _ = result.send(());
                         },
                         Some(CommitterMessage::FinishTextAndVectorBootstrap {
                             bootstrapped_indexes,
@@ -895,6 +1087,47 @@ impl<RT: Runtime> Committer<RT> {
         Ok(())
     }
 
+    fn publish_replication_frontier_progress(
+        &mut self,
+        frontier_ts: Timestamp,
+        source_partition: crate::partition::PartitionId,
+    ) -> anyhow::Result<()> {
+        // Idle replica heartbeats advance the safe frontier for remote reads,
+        // but they do not publish a newer readable snapshot. Keep that
+        // follower-read frontier separate from the persisted repeatable
+        // snapshot timestamp so we do not advertise a snapshot that does not
+        // exist.
+        let mut snapshot_manager = self.snapshot_manager.write();
+        snapshot_manager.update_replication_frontier(source_partition, frontier_ts)?;
+        Ok(())
+    }
+
+    fn maybe_publish_idle_replication_frontier_heartbeat(
+        &mut self,
+        last_replication_frontier_heartbeat_ts: &mut Timestamp,
+    ) {
+        match self.idle_replication_frontier_heartbeat_ts() {
+            Ok(Some(frontier_ts)) => {
+                if frontier_ts > *last_replication_frontier_heartbeat_ts {
+                    self.publish_replication_frontier_heartbeat(frontier_ts);
+                    *last_replication_frontier_heartbeat_ts = frontier_ts;
+                }
+            },
+            Ok(None) => {},
+            Err(e) => {
+                let local_partition = self
+                    .partition_map
+                    .as_ref()
+                    .map(|partition_map| partition_map.local_partition());
+                tracing::warn!(
+                    ?local_partition,
+                    error = %format!("{e:#}"),
+                    "Skipping idle replication frontier heartbeat"
+                );
+            },
+        }
+    }
+
     fn publish_replication_frontier_heartbeat(&self, frontier_ts: Timestamp) {
         let Some(partition_map) = self.partition_map.as_ref() else {
             return;
@@ -931,6 +1164,24 @@ impl<RT: Runtime> Committer<RT> {
         });
     }
 
+    fn idle_replication_frontier_heartbeat_ts(&mut self) -> anyhow::Result<Option<Timestamp>> {
+        let Some(partition_map) = self.partition_map.as_ref() else {
+            return Ok(None);
+        };
+        if partition_map.num_partitions() <= 1 {
+            return Ok(None);
+        }
+        if self
+            .raft_state
+            .as_ref()
+            .is_some_and(|raft_state| !raft_state.is_leader())
+        {
+            return Ok(None);
+        }
+
+        Ok(Some(self.next_max_repeatable_ts()?))
+    }
+
     fn ensure_leader_for_writes(&self) -> anyhow::Result<()> {
         if let Some(ref raft) = self.raft_state {
             if !raft.is_leader() {
@@ -950,6 +1201,7 @@ impl<RT: Runtime> Committer<RT> {
         &self,
         writes: &[DocumentUpdateWithPrevTs],
         table_mapping: &TableMapping,
+        write_source: &WriteSource,
     ) -> anyhow::Result<()> {
         let Some(partition_map) = self.partition_map.as_ref() else {
             return Ok(());
@@ -960,11 +1212,12 @@ impl<RT: Runtime> Committer<RT> {
             let table_name = table_mapping
                 .tablet_name(tablet_id)
                 .with_context(|| format!("Missing table mapping for prepared write {tablet_id}"))?;
-            if table_name.is_system() {
-                continue;
-            }
-            if !partition_map.is_local(&table_name) {
-                let partition = partition_map.partition_for_table(&table_name);
+            if let Some(partition) = crate::partition::routed_partition_for_table(
+                &table_name,
+                partition_map,
+                write_source,
+            ) && partition != partition_map.local_partition()
+            {
                 anyhow::bail!(
                     "Write to table '{}' rejected during prepare: owned by {}, not this node \
                      ({}). Coordinator routed this transaction to the wrong participant.",
@@ -996,6 +1249,7 @@ impl<RT: Runtime> Committer<RT> {
                 reads,
                 table_mapping,
                 partition_map,
+                write_source,
             )
         };
         if stale.is_empty() {
@@ -1026,7 +1280,7 @@ impl<RT: Runtime> Committer<RT> {
         explicit_commit_ts: Option<Timestamp>,
     ) -> anyhow::Result<crate::two_phase::PrepareResult> {
         self.ensure_leader_for_writes()?;
-        self.ensure_prepare_ownership(&writes, table_mapping)?;
+        self.ensure_prepare_ownership(&writes, table_mapping, &write_source)?;
         self.validate_remote_read_frontiers(begin_ts, reads, table_mapping, &write_source)?;
 
         let local_commit_floor =
@@ -1143,20 +1397,19 @@ impl<RT: Runtime> Committer<RT> {
     ) -> anyhow::Result<ValidatedCommit> {
         self.ensure_leader_for_writes()?;
 
-        // Partition ownership check: if partitioning is enabled, verify
-        // that all writes to USER tables target tables owned by this node.
-        // System tables (starting with _) are exempt — every node writes
-        // to its own system tables during initialization and operation.
+        // Partition ownership check: verify that all authoritative writes for
+        // this operation target tables owned by this node. Deploy metadata
+        // operations route system tables to the metadata owner on partition 0.
         if let Some(ref partition_map) = self.partition_map {
             for write in transaction.writes.coalesced_writes() {
                 let tablet_id = write.id.tablet_id;
                 if let Ok(table_name) = transaction.table_mapping.tablet_name(tablet_id) {
-                    // Skip system tables — every node manages its own.
-                    if table_name.is_system() {
-                        continue;
-                    }
-                    if !partition_map.is_local(&table_name) {
-                        let partition = partition_map.partition_for_table(&table_name);
+                    if let Some(partition) = crate::partition::routed_partition_for_table(
+                        &table_name,
+                        partition_map,
+                        &write_source,
+                    ) && partition != partition_map.local_partition()
+                    {
                         anyhow::bail!(
                             "Write to table '{}' rejected: owned by {}, not this node ({}). Route \
                              this mutation to the correct partition owner.",
@@ -1247,10 +1500,7 @@ impl<RT: Runtime> Committer<RT> {
         // have the same tables and indexes as the base snapshot and the final
         // publishing snapshot. Therefore index writes can be computed from the
         // latest pending snapshot.
-        let mut latest_pending_snapshot = self
-            .pending_writes
-            .latest_snapshot()
-            .unwrap_or_else(|| self.snapshot_manager.read().latest_snapshot());
+        let mut latest_pending_snapshot = self.base_snapshot_for_new_writes();
         for &document_update in ordered_updates.iter() {
             let (updates, vector_index_write_size, text_index_write_size) =
                 latest_pending_snapshot.update(document_update, commit_ts)?;
@@ -1326,6 +1576,24 @@ impl<RT: Runtime> Committer<RT> {
     ) {
         let apply_timer = metrics::commit_apply_timer();
         let commit_ts = pending_write.must_commit_ts();
+
+        if let Some(ref tso) = self.timestamp_oracle {
+            let tso = tso.clone();
+            if let Err(err) = block_in_place(|| {
+                let rt = tokio::runtime::Handle::current();
+                if rt.runtime_flavor() == tokio::runtime::RuntimeFlavor::CurrentThread {
+                    futures::executor::block_on(tso.advance_committed_ts(commit_ts))
+                } else {
+                    rt.block_on(tso.advance_committed_ts(commit_ts))
+                }
+            }) {
+                tracing::warn!(
+                    "Failed to advance global max_committed to {} before publishing commit: \
+                     {err:#}",
+                    u64::from(commit_ts),
+                );
+            }
+        }
 
         let (ordered_updates, write_source, new_snapshot) =
             match self.pending_writes.pop_first(pending_write) {
@@ -1433,6 +1701,140 @@ impl<RT: Runtime> Committer<RT> {
         apply_timer.finish();
     }
 
+    fn install_snapshot(
+        &mut self,
+        checkpoint: CheckpointData,
+        result: oneshot::Sender<anyhow::Result<Timestamp>>,
+        commit_id: usize,
+    ) -> anyhow::Result<()> {
+        let persistence = self.persistence.clone();
+        let runtime = self.runtime.clone();
+        let virtual_system_mapping = self.virtual_system_mapping.clone();
+        let partition_map = self.partition_map.clone();
+        let persistence_version = persistence.reader().version();
+
+        self.persistence_writes.push_back(
+            async move {
+                let checkpoint_ts = checkpoint.timestamp;
+                let compacted_documents = compact_checkpoint_documents(&checkpoint);
+                let checkpoint_persistence = Arc::new(CheckpointPersistence::from_checkpoint(
+                    CheckpointData {
+                        timestamp: checkpoint.timestamp,
+                        documents: compacted_documents.clone(),
+                        globals: checkpoint.globals.clone(),
+                    },
+                    persistence_version,
+                ));
+                let repeatable_ts = RepeatableTimestamp::new_validated(
+                    checkpoint_ts,
+                    RepeatableReason::SnapshotManagerLatest,
+                );
+                let retention_validator = Arc::new(NoopRetentionValidator);
+                let mut db_snapshot = DatabaseSnapshot::load(
+                    runtime,
+                    checkpoint_persistence,
+                    repeatable_ts,
+                    retention_validator,
+                    virtual_system_mapping,
+                )
+                .await?;
+
+                if let Some(value) = checkpoint
+                    .globals
+                    .get(&String::from(PersistenceGlobalKey::TableSummary))
+                {
+                    let summary_snapshot = TableSummarySnapshot::try_from(value.clone())?;
+                    let table_summaries = TableSummaries::new(
+                        summary_snapshot,
+                        db_snapshot.table_registry().table_mapping(),
+                        &db_snapshot.snapshot.virtual_system_mapping,
+                    )?;
+                    db_snapshot.snapshot.table_summaries = Some(table_summaries);
+                }
+
+                let index_entries = checkpoint_index_entries(
+                    &db_snapshot.snapshot,
+                    &compacted_documents,
+                    checkpoint_ts,
+                );
+
+                let mut existing_documents = Vec::new();
+                let persistence_reader = persistence.reader();
+                let mut document_stream = persistence_reader.load_documents(
+                    TimestampRange::all(),
+                    Order::Asc,
+                    1024,
+                    Arc::new(NoopRetentionValidator),
+                );
+                while let Some(entry) = document_stream.try_next().await? {
+                    existing_documents.push((entry.ts, entry.id));
+                }
+                if !existing_documents.is_empty() {
+                    persistence.delete(existing_documents).await?;
+                }
+
+                let mut cursor = None;
+                loop {
+                    let chunk = persistence.load_index_chunk(cursor.clone(), 1024).await?;
+                    if chunk.is_empty() {
+                        break;
+                    }
+                    cursor = chunk.last().cloned();
+                    persistence.delete_index_entries(chunk).await?;
+                }
+
+                for chunk in compacted_documents.chunks(1024) {
+                    persistence
+                        .write(chunk, &[], ConflictStrategy::Overwrite)
+                        .await?;
+                }
+                for chunk in index_entries.chunks(1024) {
+                    persistence
+                        .write(&[], chunk, ConflictStrategy::Overwrite)
+                        .await?;
+                }
+                for key in PersistenceGlobalKey::all_keys() {
+                    if let Some(value) = checkpoint.globals.get(&String::from(key)) {
+                        persistence
+                            .write_persistence_global(key, value.clone())
+                            .await?;
+                    }
+                }
+
+                let replication_frontiers = checkpoint
+                    .globals
+                    .get(&String::from(PersistenceGlobalKey::ReplicationFrontiers))
+                    .map(|value| {
+                        crate::snapshot_manager::replication_frontiers_from_json(value.clone())
+                    })
+                    .transpose()?
+                    .unwrap_or_else(|| {
+                        partition_map
+                            .as_ref()
+                            .map(|map| {
+                                map.all_partitions()
+                                    .into_iter()
+                                    .filter(|partition| *partition != map.local_partition())
+                                    .map(|partition| (partition, Timestamp::MIN))
+                                    .collect()
+                            })
+                            .unwrap_or_default()
+                    });
+
+                Ok(PersistenceWrite::InstallSnapshot {
+                    snapshot_ts: checkpoint_ts,
+                    snapshot: db_snapshot.snapshot,
+                    replication_frontiers,
+                    result,
+                    commit_id,
+                })
+            }
+            .boxed(),
+        );
+
+        Ok(())
+    }
+
     /// Apply a replicated delta from the Primary to this Replica's state.
     ///
     /// This is the Replica's apply path — equivalent to the Primary's
@@ -1445,7 +1847,12 @@ impl<RT: Runtime> Committer<RT> {
     /// 3. Apply remaining document updates with remapped IDs
     /// 4. Write to Replica's persistence (so function runner can read modules)
     /// 5. Update SnapshotManager and WriteLog
-    fn apply_replica_delta(&mut self, delta: CommitDelta) -> anyhow::Result<Timestamp> {
+    fn apply_replica_delta(
+        &mut self,
+        delta: CommitDelta,
+        result: oneshot::Sender<anyhow::Result<Timestamp>>,
+        commit_id: usize,
+    ) -> anyhow::Result<()> {
         use std::collections::BTreeMap;
 
         use common::{
@@ -1458,24 +1865,17 @@ impl<RT: Runtime> Committer<RT> {
         };
         use value::ResolvedDocumentId;
 
-        // Assign a locally-valid timestamp for the replica delta WITHOUT
-        // consuming TSO batch entries and WITHOUT using the system clock.
-        //
-        // Why no TSO: the TSO batch is reserved for local commits (writes
-        // that originate on this node). TiDB's followers apply with the
-        // leader's commitTS, not a new TSO value.
-        //
-        // Why no system clock: the system clock may have advanced far beyond
-        // the TSO batch range. Including it would poison last_assigned_ts to
-        // a value above the TSO range, causing all subsequent next_commit_ts()
-        // calls to skip the TSO value and use last_assigned_ts + 1 instead,
-        // eventually colliding with max_repeatable_ts bumps.
-        //
-        // The correct approach (CockroachDB pattern): use only the monotonic
-        // counters that stay in the same domain as next_commit_ts().
+        // Apply replica deltas in the same timestamp domain as the leader's
+        // commit. Followers should never "forget" a higher remote commit
+        // timestamp and then hand out a lower local one for a future 2PC
+        // prepare. We therefore use the remote commit timestamp as a floor and
+        // only bump above it when local monotonicity requires it.
         let remote_ts = delta.ts;
         let latest_ts = self.snapshot_manager.read().latest_ts();
-        let commit_ts = cmp::max(latest_ts.succ()?, self.last_assigned_ts.succ()?);
+        let commit_ts = cmp::max(
+            remote_ts,
+            cmp::max(latest_ts.succ()?, self.last_assigned_ts.succ()?),
+        );
         self.last_assigned_ts = commit_ts;
         tracing::info!(
             "Applying replica delta: remote_ts={}, local_ts={}, {} document updates, {} tablet \
@@ -1624,7 +2024,54 @@ impl<RT: Runtime> Committer<RT> {
             );
         }
 
-        let mut snapshot = self.snapshot_manager.read().latest_snapshot();
+        let is_frontier_only = tables_updates.is_empty() && other_updates.is_empty();
+        if is_frontier_only {
+            let Some(source_partition) = delta.source_partition else {
+                tracing::debug!(
+                    "Skipping no-op replica delta at ts {} with no source partition",
+                    u64::from(commit_ts),
+                );
+                let _ = result.send(Ok(commit_ts));
+                return Ok(());
+            };
+            let updated_replication_frontiers = {
+                let mut frontiers = self.snapshot_manager.read().replication_frontiers();
+                let should_update = frontiers
+                    .get(&source_partition)
+                    .is_none_or(|current| *current < commit_ts);
+                if should_update {
+                    frontiers.insert(source_partition, commit_ts);
+                }
+                frontiers
+            };
+            let persistence = self.persistence.clone();
+            self.persistence_writes.push_back(
+                async move {
+                    persistence
+                        .write_persistence_global(
+                            PersistenceGlobalKey::ReplicationFrontiers,
+                            replication_frontiers_to_json(&updated_replication_frontiers),
+                        )
+                        .await?;
+                    Ok(PersistenceWrite::ReplicationFrontierHeartbeat {
+                        commit_ts,
+                        source_partition,
+                        result,
+                        commit_id,
+                    })
+                }
+                .boxed(),
+            );
+
+            tracing::info!(
+                "Queued replication frontier heartbeat: ts={}, partition={}",
+                u64::from(commit_ts),
+                source_partition.0,
+            );
+            return Ok(());
+        }
+
+        let mut snapshot = self.base_snapshot_for_new_writes();
         let mut all_remapped_updates = Vec::new();
         let mut all_index_updates = Vec::new();
 
@@ -1635,10 +2082,10 @@ impl<RT: Runtime> Committer<RT> {
         // When replicating a _tables entry from another node, the remote
         // table number may collide with a different local table. We reassign
         // the table number to a locally-unique value, preserving only the
-        // table name and TabletId (derived from developer_id) for remapping.
+        // table name and TabletId (derived from document_id) for remapping.
         if !tables_updates.is_empty() {
             use value::{
-                ConvexObject,
+                DocumentObject,
                 TableNumber,
             };
 
@@ -1670,7 +2117,7 @@ impl<RT: Runtime> Committer<RT> {
                         let remapped = DocumentUpdate {
                             id: ResolvedDocumentId {
                                 tablet_id: local_tablet,
-                                developer_id: update.id.developer_id,
+                                document_id: update.id.document_id,
                             },
                             old_document: update
                                 .old_document
@@ -1711,7 +2158,7 @@ impl<RT: Runtime> Committer<RT> {
                     local_number,
                     metadata.state,
                 );
-                let local_value: ConvexObject = local_metadata.try_into()?;
+                let local_value: DocumentObject = local_metadata.try_into()?;
 
                 tracing::info!(
                     "Creating replicated table '{}' with local number {} (remote was {})",
@@ -1724,7 +2171,7 @@ impl<RT: Runtime> Committer<RT> {
                 // the locally-assigned table number.
                 let remapped_id = ResolvedDocumentId {
                     tablet_id: local_tablet,
-                    developer_id: update.id.developer_id,
+                    document_id: update.id.document_id,
                 };
                 let remapped_doc =
                     ResolvedDocument::new(remapped_id, new_doc.creation_time(), local_value)?;
@@ -1762,7 +2209,7 @@ impl<RT: Runtime> Committer<RT> {
             let remapped = DocumentUpdate {
                 id: ResolvedDocumentId {
                     tablet_id: local_tablet,
-                    developer_id: update.id.developer_id,
+                    document_id: update.id.document_id,
                 },
                 old_document: update
                     .old_document
@@ -1820,8 +2267,7 @@ impl<RT: Runtime> Committer<RT> {
         });
 
         let persistence = self.persistence.clone();
-        let (tx, _rx) = oneshot::channel();
-        let commit_id_val = 0usize; // Replica deltas don't participate in tracing.
+        self.enqueue_snapshot(commit_id, commit_ts, snapshot.clone());
 
         self.persistence_writes.push_back({
             let doc_writes = document_writes.clone();
@@ -1858,8 +2304,8 @@ impl<RT: Runtime> Committer<RT> {
                     write_source: delta.write_source,
                     write_bytes: delta.write_bytes,
                     source_partition,
-                    result: tx,
-                    commit_id: commit_id_val,
+                    result,
+                    commit_id,
                 })
             }
             .boxed()
@@ -1874,7 +2320,7 @@ impl<RT: Runtime> Committer<RT> {
             num_doc_writes,
         );
 
-        Ok(commit_ts)
+        Ok(())
     }
 
     // ========== 2PC Handlers (Vitess prepare/commit/rollback pattern) ==========
@@ -2057,6 +2503,11 @@ impl<RT: Runtime> Committer<RT> {
                 return None;
             },
         };
+        let queued_snapshot = self
+            .pending_writes
+            .latest_snapshot()
+            .expect("validated commit should stage a pending snapshot");
+        self.enqueue_snapshot(commit_id, pending_write.must_commit_ts(), queued_snapshot);
 
         // necessary because this value is moved
         let parent_trace_copy = parent_trace.clone();
@@ -2386,6 +2837,20 @@ impl CommitterClient {
         rx.await.map_err(|_| metrics::shutdown_error())?
     }
 
+    #[cfg(any(test, feature = "testing"))]
+    pub async fn tick_idle_replication_frontier_heartbeat_for_test(
+        &self,
+    ) -> anyhow::Result<()> {
+        let (tx, rx) = oneshot::channel();
+        let message = CommitterMessage::TickIdleReplicationFrontierHeartbeat { result: tx };
+        self.sender.try_send(message).map_err(|e| match e {
+            TrySendError::Full(..) => metrics::committer_full_error().into(),
+            TrySendError::Closed(..) => metrics::shutdown_error(),
+        })?;
+        rx.await.map_err(|_| metrics::shutdown_error())?;
+        Ok(())
+    }
+
     // Tell the committer to load all indexes for the given tables into memory.
     pub async fn load_indexes_into_memory(
         &self,
@@ -2413,6 +2878,7 @@ impl CommitterClient {
         &self,
         begin_ts: Timestamp,
         reads: &ReadSet,
+        write_source: &WriteSource,
     ) -> anyhow::Result<()> {
         let Some(partition_map) = self.partition_map.as_ref() else {
             return Ok(());
@@ -2424,6 +2890,7 @@ impl CommitterClient {
                 reads,
                 snapshot_reader.latest_snapshot().table_mapping(),
                 partition_map,
+                write_source,
             )
         };
         if required.is_empty() {
@@ -2477,17 +2944,12 @@ impl CommitterClient {
 
         // Finish reading everything from persistence.
         let transaction = transaction.finalize()?;
-        if !self
-            .partition_map
-            .as_ref()
-            .is_some_and(|partition_map| has_nonlocal_user_writes(&transaction, partition_map))
-        {
-            self.wait_for_remote_read_frontiers(
-                *transaction.begin_timestamp,
-                transaction.reads.read_set(),
-            )
-            .await?;
-        }
+        self.wait_for_remote_read_frontiers(
+            *transaction.begin_timestamp,
+            transaction.reads.read_set(),
+            &write_source,
+        )
+        .await?;
 
         // Note that we do a best effort validation for memory index sizes. We
         // use the latest snapshot instead of the transaction base snapshot. This
@@ -2498,20 +2960,34 @@ impl CommitterClient {
         // Classify: single-partition (fast path) vs cross-partition (2PC).
         // TiDB 1PC optimization: skip 2PC when all writes target one partition.
         if let Some(ref partition_map) = self.partition_map {
-            let classification =
-                crate::two_phase_coordinator::classify_transaction(&transaction, partition_map);
-            if let crate::two_phase_coordinator::TransactionClassification::CrossPartition {
-                ..
-            } = classification
-            {
-                tracing::info!("Cross-partition transaction detected, using 2PC coordinator");
-                return crate::two_phase_coordinator::coordinate_two_phase_commit(
-                    self,
-                    transaction,
-                    write_source,
-                    partition_map,
-                )
-                .await;
+            match crate::two_phase_coordinator::classify_transaction(
+                &transaction,
+                partition_map,
+                &write_source,
+            ) {
+                crate::two_phase_coordinator::TransactionClassification::SinglePartition => {},
+                crate::two_phase_coordinator::TransactionClassification::RemoteSinglePartition {
+                    owner,
+                } => {
+                    anyhow::bail!(
+                        "Write rejected: this transaction targets only {}, not this node ({}). \
+                         Route this mutation to the correct partition owner.",
+                        owner,
+                        partition_map.local_partition(),
+                    );
+                },
+                crate::two_phase_coordinator::TransactionClassification::CrossPartition {
+                    ..
+                } => {
+                    tracing::info!("Cross-partition transaction detected, using 2PC coordinator");
+                    return crate::two_phase_coordinator::coordinate_two_phase_commit(
+                        self,
+                        transaction,
+                        write_source,
+                        partition_map,
+                    )
+                    .await;
+                },
             }
         }
 
@@ -2553,6 +3029,7 @@ impl CommitterClient {
         self.wait_for_remote_read_frontiers(
             *transaction.begin_timestamp,
             transaction.reads.read_set(),
+            &write_source,
         )
         .await?;
         let (tx, rx) = oneshot::channel();
@@ -2586,8 +3063,12 @@ impl CommitterClient {
         write_source: WriteSource,
         prepare_ts: Timestamp,
     ) -> anyhow::Result<crate::two_phase::PrepareResult> {
-        self.wait_for_remote_read_frontiers(*transaction.begin_timestamp, &transaction.reads)
-            .await?;
+        self.wait_for_remote_read_frontiers(
+            *transaction.begin_timestamp,
+            &transaction.reads,
+            &write_source,
+        )
+        .await?;
         let (tx, rx) = oneshot::channel();
         let message = CommitterMessage::PrepareRemote {
             transaction_id,
@@ -2628,6 +3109,19 @@ impl CommitterClient {
         let (tx, rx) = oneshot::channel();
         let message = CommitterMessage::RollbackPrepared {
             transaction_id,
+            result: tx,
+        };
+        self.sender.try_send(message).map_err(|e| match e {
+            TrySendError::Full(..) => metrics::committer_full_error().into(),
+            TrySendError::Closed(..) => metrics::shutdown_error(),
+        })?;
+        rx.await.map_err(|_| metrics::shutdown_error())?
+    }
+
+    pub async fn install_snapshot(&self, checkpoint: CheckpointData) -> anyhow::Result<Timestamp> {
+        let (tx, rx) = oneshot::channel();
+        let message = CommitterMessage::InstallSnapshot {
+            checkpoint,
             result: tx,
         };
         self.sender.try_send(message).map_err(|e| match e {
@@ -2681,7 +3175,7 @@ impl CommitterClient {
                 let display_id = generated_ids
                     .iter()
                     .find(|id| InternalDocumentId::from(**id) == document_id)
-                    .map(|id| DeveloperDocumentId::from(*id).encode())
+                    .map(|id| PublicDocumentId::from(*id).encode())
                     .unwrap_or(document_id.to_string());
                 if maybe_doc.is_none() {
                     anyhow::bail!(ErrorMetadata::bad_request(
@@ -2692,6 +3186,20 @@ impl CommitterClient {
                         ),
                     ));
                 } else {
+                    let table_mapping = transaction.metadata.table_mapping();
+                    if transaction
+                        .metadata
+                        .table_mapping()
+                        .is_system_tablet(document_id.table())
+                        && let Ok(table_name) = table_mapping.tablet_name(document_id.table())
+                        && is_retryable_system_generated_id_conflict(&table_name, true)
+                    {
+                        let metadata = ErrorMetadata::system_occ(None, None);
+                        return Err(anyhow::anyhow!(metadata).context(format!(
+                            "System metadata row with _id {display_id} in table {table_name} \
+                             already exists; retrying against a fresher metadata view"
+                        )));
+                    }
                     anyhow::bail!(ErrorMetadata::bad_request(
                         "DocumentExists",
                         format!(
@@ -2722,8 +3230,14 @@ enum CommitterMessage {
         delta: CommitDelta,
         result: oneshot::Sender<anyhow::Result<Timestamp>>,
     },
+    InstallSnapshot {
+        checkpoint: CheckpointData,
+        result: oneshot::Sender<anyhow::Result<Timestamp>>,
+    },
     #[cfg(any(test, feature = "testing"))]
     BumpMaxRepeatableTs { result: oneshot::Sender<Timestamp> },
+    #[cfg(any(test, feature = "testing"))]
+    TickIdleReplicationFrontierHeartbeat { result: oneshot::Sender<()> },
     LoadIndexesIntoMemory {
         tables: BTreeSet<TableName>,
         result: oneshot::Sender<anyhow::Result<()>>,
@@ -2767,6 +3281,41 @@ enum CommitterMessage {
         transaction_id: crate::two_phase::TwoPhaseTransactionId,
         result: oneshot::Sender<anyhow::Result<()>>,
     },
+}
+
+fn is_retryable_system_generated_id_conflict(
+    table_name: &TableName,
+    document_exists: bool,
+) -> bool {
+    document_exists && &**table_name == "_udf_config"
+}
+
+#[cfg(test)]
+mod tests {
+    use std::str::FromStr;
+
+    use value::TableName;
+
+    use super::is_retryable_system_generated_id_conflict;
+
+    #[test]
+    fn retryable_system_generated_id_conflict_matches_udf_config_table() {
+        let table_name = TableName::from_str("_udf_config").unwrap();
+        assert!(is_retryable_system_generated_id_conflict(&table_name, true));
+    }
+
+    #[test]
+    fn retryable_system_generated_id_conflict_rejects_other_tables() {
+        let table_name = TableName::from_str("_components").unwrap();
+        assert!(!is_retryable_system_generated_id_conflict(
+            &table_name,
+            true
+        ));
+        let udf_table = TableName::from_str("_udf_config").unwrap();
+        assert!(!is_retryable_system_generated_id_conflict(
+            &udf_table, false
+        ));
+    }
 }
 
 // Within a single transaction that writes multiple documents, this is the order

--- a/crates/database/src/component_registry.rs
+++ b/crates/database/src/component_registry.rs
@@ -29,7 +29,7 @@ use imbl::OrdMap;
 use value::{
     val,
     values_to_bytes,
-    DeveloperDocumentId,
+    PublicDocumentId,
     TableMapping,
     TableNamespace,
     TabletId,
@@ -51,7 +51,7 @@ use crate::{
 #[derive(Debug, Clone, PartialEq)]
 pub struct ComponentRegistry {
     components_tablet: TabletId,
-    components: OrdMap<DeveloperDocumentId, ParsedDocument<ComponentMetadata>>,
+    components: OrdMap<PublicDocumentId, ParsedDocument<ComponentMetadata>>,
 }
 
 impl ComponentRegistry {
@@ -66,7 +66,7 @@ impl ComponentRegistry {
             .tablet_id;
         let components: OrdMap<_, _> = component_docs
             .into_iter()
-            .map(|component| (component.developer_id(), component))
+            .map(|component| (component.document_id(), component))
             .collect();
         Ok(Self {
             components_tablet,
@@ -102,7 +102,7 @@ impl ComponentRegistry {
                 None => None,
                 Some(old_doc) => Some(old_doc.parse()?),
             };
-            anyhow::ensure!(self.components.get(&id.developer_id) == old_component.as_ref());
+            anyhow::ensure!(self.components.get(&id.document_id) == old_component.as_ref());
             let new_component = match new_doc {
                 None => None,
                 Some(new_doc) => Some(new_doc.parse()?),
@@ -232,7 +232,7 @@ impl ComponentRegistry {
 
     pub fn component_children(
         &self,
-        parent_id: DeveloperDocumentId,
+        parent_id: PublicDocumentId,
         reads: &mut TransactionReadSet,
     ) -> anyhow::Result<Vec<ParsedDocument<ComponentMetadata>>> {
         let interval =
@@ -262,7 +262,7 @@ impl ComponentRegistry {
 
     pub fn component_in_parent(
         &self,
-        parent_and_name: Option<(DeveloperDocumentId, ComponentName)>,
+        parent_and_name: Option<(PublicDocumentId, ComponentName)>,
         reads: &mut TransactionReadSet,
     ) -> anyhow::Result<Option<ParsedDocument<ComponentMetadata>>> {
         let interval = Interval::prefix(
@@ -300,7 +300,7 @@ impl ComponentRegistry {
 
     fn get_component(
         &self,
-        id: DeveloperDocumentId,
+        id: PublicDocumentId,
         reads: &mut TransactionReadSet,
     ) -> Option<&ParsedDocument<ComponentMetadata>> {
         let index_key = IndexKey::new(vec![], id).to_bytes().into();
@@ -328,10 +328,10 @@ impl Update<'_> {
         if let Some(update) = self.update {
             let components = &mut self.registry.components;
             if let Some(old_component) = update.old_component {
-                components.remove(&old_component.developer_id());
+                components.remove(&old_component.document_id());
             }
             if let Some(new_component) = update.new_component {
-                components.insert(new_component.developer_id(), new_component);
+                components.insert(new_component.document_id(), new_component);
             }
         }
     }

--- a/crates/database/src/database.rs
+++ b/crates/database/src/database.rs
@@ -101,7 +101,7 @@ use common::{
         Timestamp,
     },
     value::{
-        ConvexObject,
+        DocumentObject,
         ResolvedDocumentId,
         TableMapping,
         TabletId,
@@ -153,7 +153,7 @@ use usage_tracking::{
     FunctionUsageTracker,
 };
 use value::{
-    id_v6::DeveloperDocumentId,
+    id_v6::PublicDocumentId,
     Size,
     TableNamespace,
     TableNumber,
@@ -169,6 +169,7 @@ use crate::{
         NUM_RESERVED_LEGACY_TABLE_NUMBERS,
         NUM_RESERVED_SYSTEM_TABLE_NUMBERS,
     },
+    checkpoint::CheckpointData,
     committer::{
         Committer,
         CommitterClient,
@@ -189,8 +190,10 @@ use crate::{
     },
     schema_registry::SchemaRegistry,
     search_index_bootstrap::SearchIndexBootstrapWorker,
+    snapshot_checkpointer::checkpoint_to_bytes,
     snapshot_manager::{
         replication_frontiers_from_json,
+        replication_frontiers_to_json,
         Snapshot,
         SnapshotManager,
         TableSummaries,
@@ -340,7 +343,7 @@ pub struct DocumentDeltas {
     /// because streaming export always uses string IDs
     pub deltas: Vec<(
         Timestamp,
-        DeveloperDocumentId,
+        PublicDocumentId,
         ComponentPath,
         TableName,
         Option<StreamingExportDocument>,
@@ -384,7 +387,7 @@ impl<RT: Runtime> DatabaseSnapshot<RT> {
 
     #[fastrace::trace]
     async fn load_raw_and_parsed_table_documents<
-        D: TryFrom<ConvexObject, Error = anyhow::Error>,
+        D: TryFrom<DocumentObject, Error = anyhow::Error>,
     >(
         persistence_snapshot: &PersistenceSnapshot,
         index_id: IndexId,
@@ -1161,6 +1164,11 @@ impl<RT: Runtime> Database<RT> {
         self.snapshot_manager.lock().replication_frontier(partition)
     }
 
+    #[cfg(any(test, feature = "testing"))]
+    pub(crate) fn persisted_max_repeatable_ts_for_test(&self) -> RepeatableTimestamp {
+        self.snapshot_manager.lock().persisted_max_repeatable_ts()
+    }
+
     #[cfg(test)]
     pub fn new_search_and_vector_bootstrap_worker_for_testing(
         &self,
@@ -1465,7 +1473,7 @@ impl<RT: Runtime> Database<RT> {
                 .id(table_name)?;
             let document_id = ResolvedDocumentId::new(
                 tables_table_id.tablet_id,
-                DeveloperDocumentId::new(tables_table_id.table_number, table_id.tablet_id.0),
+                PublicDocumentId::new(tables_table_id.table_number, table_id.tablet_id.0),
             );
             let metadata = TableMetadata::new(
                 TableNamespace::Global,
@@ -1959,6 +1967,73 @@ impl<RT: Runtime> Database<RT> {
         })
     }
 
+    pub async fn build_raft_snapshot_checkpoint(&self) -> anyhow::Result<CheckpointData> {
+        let db_snapshot = self.latest_database_snapshot()?;
+        let ts = *db_snapshot.timestamp();
+        let mut documents = Vec::new();
+
+        for (tablet_id, index_id) in db_snapshot.index_registry().by_id_indexes() {
+            let mut stream = db_snapshot.persistence_snapshot.index_scan(
+                index_id,
+                tablet_id,
+                &Interval::all(),
+                Order::Asc,
+                usize::MAX,
+            );
+            while let Some((_, latest_document)) = stream.try_next().await? {
+                documents.push(DocumentLogEntry {
+                    ts,
+                    id: value::InternalDocumentId::new(
+                        latest_document.value.id().tablet_id,
+                        latest_document.value.id().internal_id(),
+                    ),
+                    value: Some(latest_document.value),
+                    prev_ts: latest_document.prev_ts,
+                });
+            }
+        }
+
+        let mut globals = BTreeMap::new();
+        for key in PersistenceGlobalKey::all_keys() {
+            if let Some(value) = self.reader.get_persistence_global(key).await? {
+                globals.insert(String::from(key), value);
+            }
+        }
+        globals.insert(
+            String::from(PersistenceGlobalKey::MaxRepeatableTimestamp),
+            serde_json::Value::from(u64::from(ts)),
+        );
+        globals.insert(
+            String::from(PersistenceGlobalKey::ReplicationFrontiers),
+            replication_frontiers_to_json(&self.snapshot_manager.lock().replication_frontiers()),
+        );
+        if let Some(table_summaries) = db_snapshot.table_summaries() {
+            let table_summary_snapshot = crate::table_summary::TableSummarySnapshot {
+                tables: table_summaries
+                    .tables
+                    .iter()
+                    .map(|(k, v)| (*k, v.clone()))
+                    .collect(),
+                ts,
+            };
+            globals.insert(
+                String::from(PersistenceGlobalKey::TableSummary),
+                serde_json::Value::from(&table_summary_snapshot),
+            );
+        }
+
+        Ok(CheckpointData {
+            timestamp: ts,
+            documents,
+            globals,
+        })
+    }
+
+    pub async fn build_raft_snapshot_bytes(&self) -> anyhow::Result<Vec<u8>> {
+        let checkpoint = self.build_raft_snapshot_checkpoint().await?;
+        checkpoint_to_bytes(&checkpoint)
+    }
+
     pub fn check_write_throughput_limit(&self) -> anyhow::Result<()> {
         self.snapshot_manager.lock().check_write_throughput_limit()
     }
@@ -2152,7 +2227,7 @@ impl<RT: Runtime> Database<RT> {
                     .get(&component_id)
                     .cloned()
                     .unwrap_or_else(ComponentPath::root);
-                let id = DeveloperDocumentId::new(table_number, id.internal_id());
+                let id = PublicDocumentId::new(table_number, id.internal_id());
                 let column_filter = filter
                     .selection
                     .column_filter(&component_path, &table_name)?;
@@ -2397,7 +2472,7 @@ impl<RT: Runtime> Database<RT> {
             ),
             PageResult::TableDone(table_iterator) => match tablet_ids.get(1) {
                 Some(&next_tablet_id) => {
-                    // TODO(lee) just use DeveloperDocumentId::min() once we no longer
+                    // TODO(lee) just use PublicDocumentId::min() once we no longer
                     // need to be rollback-safe.
                     let next_table_number = table_mapping.tablet_number(next_tablet_id)?;
                     let next_by_id = *by_id_indexes.get(&next_tablet_id).ok_or_else(|| {
@@ -2405,7 +2480,7 @@ impl<RT: Runtime> Database<RT> {
                     })?;
                     let next_cursor = ResolvedDocumentId::new(
                         next_tablet_id,
-                        DeveloperDocumentId::new(next_table_number, InternalId::MIN),
+                        PublicDocumentId::new(next_table_number, InternalId::MIN),
                     );
                     let next_document_stream = table_iterator
                         .into_stream_documents_in_table(
@@ -2696,7 +2771,7 @@ impl ConflictingReadWithWriteSource {
         if !table_name.is_system() {
             let metadata = ErrorMetadata::user_occ(
                 Some(table_name.into()),
-                Some(self.read.id.developer_id.encode()),
+                Some(self.read.id.document_id.encode()),
                 write_source,
                 occ_msg,
                 write_ts_val,

--- a/crates/database/src/database_index_workers/mod.rs
+++ b/crates/database/src/database_index_workers/mod.rs
@@ -62,7 +62,7 @@ use usage_tracking::{
     UsageCounter,
 };
 use value::{
-    DeveloperDocumentId,
+    PublicDocumentId,
     ResolvedDocumentId,
     TableNamespace,
     TabletId,
@@ -258,7 +258,7 @@ impl<RT: Runtime> IndexWorker<RT> {
                 && matches!(on_disk_state, DatabaseIndexState::Backfilling(_))
             {
                 let backfill_metadata = model
-                    .existing_backfill_metadata(index_metadata.id().developer_id)
+                    .existing_backfill_metadata(index_metadata.id().document_id)
                     .await?;
                 let backfill_cursor =
                     backfill_metadata.and_then(|metadata| metadata.cursor.clone());
@@ -340,12 +340,12 @@ impl<RT: Runtime> IndexWorker<RT> {
                 let mut model = IndexBackfillModel::new(&mut tx);
                 let cursor = ResolvedDocumentId::new(
                     tablet_id,
-                    DeveloperDocumentId::new(table_number, cursor.internal_id())
+                    PublicDocumentId::new(table_number, cursor.internal_id())
                 );
                 tracing::info!(
                     "IndexWorker got progress update for {} indexes in tablet {tablet_id} at cursor {}",
                     index_ids.len(),
-                    cursor.developer_id,
+                    cursor.document_id,
                 );
                 for index_id in index_ids {
                     model
@@ -571,7 +571,7 @@ impl<RT: Runtime> IndexWorker<RT> {
         let index_doc = tx
             .get(ResolvedDocumentId::new(
                 index_table_id.tablet_id,
-                DeveloperDocumentId::new(index_table_id.table_number, index_id),
+                PublicDocumentId::new(index_table_id.table_number, index_id),
             ))
             .await?
             .ok_or_else(|| anyhow::anyhow!("Index {index_id:?} no longer exists"))?;
@@ -609,7 +609,7 @@ impl<RT: Runtime> IndexWorker<RT> {
         let index_doc = tx
             .get(ResolvedDocumentId::new(
                 index_table_id.tablet_id,
-                DeveloperDocumentId::new(index_table_id.table_number, index_id),
+                PublicDocumentId::new(index_table_id.table_number, index_id),
             ))
             .await?
             .ok_or_else(|| anyhow::anyhow!("Index {index_id:?} no longer exists"))?;
@@ -658,7 +658,7 @@ impl<RT: Runtime> IndexWorker<RT> {
         let index_table_id = tx.bootstrap_tables().index_id;
         let full_index_id = ResolvedDocumentId::new(
             index_table_id.tablet_id,
-            DeveloperDocumentId::new(index_table_id.table_number, index_id),
+            PublicDocumentId::new(index_table_id.table_number, index_id),
         );
         let index_doc = tx
             .get(full_index_id)

--- a/crates/database/src/database_index_workers/tests.rs
+++ b/crates/database/src/database_index_workers/tests.rs
@@ -109,7 +109,7 @@ async fn test_db_index_backfill_progress(
     let mut tx = db.begin_system().await?;
     let mut model = IndexBackfillModel::new(&mut tx);
     let backfill_progress = model
-        .existing_backfill_metadata(index_id.developer_id)
+        .existing_backfill_metadata(index_id.document_id)
         .await?
         .unwrap();
     assert_eq!(backfill_progress.num_docs_indexed, 10);
@@ -166,7 +166,7 @@ async fn test_db_index_multi_index_backfill_progress_multiple_indexes_same_table
 
     for index in [index_id1, index_id2] {
         let progress = model
-            .existing_backfill_metadata(index.developer_id)
+            .existing_backfill_metadata(index.document_id)
             .await?
             .unwrap();
         // With CHUNK_SIZE=10 and 2 indexes, expecting 5 docs
@@ -266,7 +266,7 @@ async fn test_db_index_backfill_resumable(
     let mut tx = db.begin_system().await?;
     let mut model = IndexBackfillModel::new(&mut tx);
     let backfill_progress = model
-        .existing_backfill_metadata(index_id.developer_id)
+        .existing_backfill_metadata(index_id.document_id)
         .await?
         .unwrap();
     assert_eq!(backfill_progress.num_docs_indexed, 10);
@@ -293,7 +293,7 @@ async fn test_db_index_backfill_resumable(
     let mut tx = db.begin_system().await?;
     let mut model = IndexBackfillModel::new(&mut tx);
     let backfill_progress = model
-        .existing_backfill_metadata(index_id.developer_id)
+        .existing_backfill_metadata(index_id.document_id)
         .await?
         .unwrap();
     // Check that backfill is complete

--- a/crates/database/src/partition.rs
+++ b/crates/database/src/partition.rs
@@ -29,6 +29,8 @@ use std::{
 
 use value::TableName;
 
+use crate::write_log::WriteSource;
+
 /// Identifies a partition (node) in the cluster.
 /// Partition 0 is the default and owns all system tables.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -152,9 +154,34 @@ impl PartitionMap {
     }
 }
 
+pub fn uses_metadata_owner(write_source: &WriteSource) -> bool {
+    matches!(write_source.as_str(), Some("start_push" | "finish_push"))
+}
+
+/// Returns the authoritative partition for tables that should be coordinated
+/// cluster-wide for the current operation.
+///
+/// - User tables always have a single partition owner.
+/// - Deploy metadata operations (`start_push`, `finish_push`) route system
+///   tables to the metadata owner on partition 0 (TiDB DDL owner pattern).
+/// - Other system-table writes are node-local operational state and therefore
+///   return `None`.
+pub fn routed_partition_for_table(
+    table: &TableName,
+    partition_map: &PartitionMap,
+    write_source: &WriteSource,
+) -> Option<PartitionId> {
+    if !table.is_system() || uses_metadata_owner(write_source) {
+        Some(partition_map.partition_for_table(table))
+    } else {
+        None
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::write_log::WriteSource;
 
     #[test]
     fn test_single_partition() {
@@ -238,5 +265,31 @@ mod tests {
         let map = PartitionMap::from_config("a=1,b=2", PartitionId(0), 3);
         let all = map.all_partitions();
         assert_eq!(all, vec![PartitionId(0), PartitionId(1), PartitionId(2)]);
+    }
+
+    #[test]
+    fn test_routed_partition_for_table_keeps_non_deploy_system_tables_local() {
+        let map = PartitionMap::from_config("messages=1", PartitionId(1), 2);
+        assert_eq!(
+            routed_partition_for_table(
+                &"_modules".parse().unwrap(),
+                &map,
+                &WriteSource::new("cron_tick"),
+            ),
+            None
+        );
+    }
+
+    #[test]
+    fn test_routed_partition_for_table_routes_deploy_system_tables_to_owner() {
+        let map = PartitionMap::from_config("messages=1", PartitionId(1), 2);
+        assert_eq!(
+            routed_partition_for_table(
+                &"_modules".parse().unwrap(),
+                &map,
+                &WriteSource::new("finish_push"),
+            ),
+            Some(PartitionId::DEFAULT)
+        );
     }
 }

--- a/crates/database/src/patch.rs
+++ b/crates/database/src/patch.rs
@@ -3,7 +3,7 @@ use std::collections::BTreeMap;
 use common::{
     types::MaybeValue,
     value::{
-        ConvexObject,
+        DocumentObject,
         FieldName,
     },
 };
@@ -17,7 +17,7 @@ pub struct PatchValue {
 }
 
 impl PatchValue {
-    pub fn apply(self, original: ConvexObject) -> anyhow::Result<ConvexObject> {
+    pub fn apply(self, original: DocumentObject) -> anyhow::Result<DocumentObject> {
         let mut original_fields: BTreeMap<_, _> = original.into();
 
         for (field, maybe_value) in self.fields {
@@ -59,8 +59,8 @@ impl TryFrom<JsonValue> for PatchValue {
     }
 }
 
-impl From<ConvexObject> for PatchValue {
-    fn from(obj: ConvexObject) -> Self {
+impl From<DocumentObject> for PatchValue {
+    fn from(obj: DocumentObject) -> Self {
         let mut fields = BTreeMap::new();
         for (field, value) in obj.into_iter() {
             fields.insert(field, MaybeValue::from(value));
@@ -94,13 +94,13 @@ mod tests {
     use common::assert_obj;
     use value::{
         assert_val,
-        ConvexObject,
+        DocumentObject,
     };
 
     #[test]
     fn test_apply() -> anyhow::Result<()> {
         // Overwrite duplicate fields instead of merging sub-fields.
-        let original: ConvexObject = assert_obj!(
+        let original: DocumentObject = assert_obj!(
             "name" => {
                 "first" => "Mr",
                 "last" => "Fantastik",

--- a/crates/database/src/query/search_query.rs
+++ b/crates/database/src/query/search_query.rs
@@ -28,7 +28,7 @@ use search::{
 };
 use tokio::task;
 use value::{
-    DeveloperDocumentId,
+    PublicDocumentId,
     TableNamespace,
     TableNumber,
 };
@@ -248,7 +248,7 @@ impl SearchResultIterator {
 
         self.next_index += 1;
 
-        let id = DeveloperDocumentId::new(self.table_number, candidate.id);
+        let id = PublicDocumentId::new(self.table_number, candidate.id);
         let (document, existing_doc_ts) = UserFacingModel::new(tx, self.namespace)
             .get_with_ts(id, self.version.clone())
             .await?

--- a/crates/database/src/raft_node.rs
+++ b/crates/database/src/raft_node.rs
@@ -25,6 +25,7 @@ use std::{
 use raft::{
     prelude::*,
     raw_node::RawNode,
+    SnapshotStatus,
     StateRole,
 };
 use slog::o;
@@ -140,12 +141,14 @@ impl RaftNode {
         engine: Arc<raft_engine::Engine>,
         mailbox: mpsc::UnboundedReceiver<RaftMessage>,
         peer_senders: HashMap<u64, mpsc::UnboundedSender<Message>>,
+        snapshot_provider: Option<Arc<dyn crate::raft_storage::RaftSnapshotProvider>>,
     ) -> anyhow::Result<Self> {
         let storage = ConvexRaftStorage::new(
             config.partition_id,
             engine,
             config.node_id,
             config.peers.clone(),
+            snapshot_provider,
         )?;
 
         // On restart, pick up where we left off (applied index from
@@ -185,7 +188,11 @@ impl RaftNode {
 
     /// Run the Raft loop. This is the main event loop following TiKV's pattern:
     /// tick → receive messages → propose → process ready → advance.
-    pub async fn run(&mut self, mut on_committed: impl FnMut(&[u8]) -> anyhow::Result<()>) {
+    pub async fn run(
+        &mut self,
+        mut on_committed: impl FnMut(&[u8]) -> anyhow::Result<()>,
+        mut on_snapshot: impl FnMut(&[u8]) -> anyhow::Result<()>,
+    ) {
         let tick_interval = Duration::from_millis(100);
         let mut last_tick = Instant::now();
 
@@ -269,15 +276,27 @@ impl RaftNode {
                 // 1. Send messages to peers.
                 for msg in ready.take_messages() {
                     let to = msg.to;
+                    let is_snapshot = msg.get_msg_type() == MessageType::MsgSnapshot;
                     if let Some(sender) = self.peer_senders.get(&to) {
                         if sender.send(msg).is_err() {
                             tracing::warn!("Failed to send Raft message to node {to}");
+                            if is_snapshot {
+                                self.raw_node.report_snapshot(to, SnapshotStatus::Failure);
+                            }
+                        } else if is_snapshot {
+                            self.raw_node.report_snapshot(to, SnapshotStatus::Finish);
                         }
                     }
                 }
 
-                // 2. Snapshot transfer not yet implemented.
-                // Nodes that fall too far behind must re-bootstrap.
+                // 2. Persist and apply any incoming snapshot before appending entries.
+                if !ready.snapshot().is_empty() {
+                    if let Err(e) = self.storage.apply_snapshot(ready.snapshot()) {
+                        tracing::error!("Failed to persist snapshot: {e}");
+                    } else if let Err(e) = on_snapshot(ready.snapshot().get_data()) {
+                        tracing::error!("Failed to apply snapshot to state machine: {e}");
+                    }
+                }
 
                 // 3+4. Persist log entries + hard state atomically.
                 // TiKV WriteBatch pattern: entries and hard state go in one
@@ -296,8 +315,15 @@ impl RaftNode {
                 // 5. Send persisted messages.
                 for msg in ready.take_persisted_messages() {
                     let to = msg.to;
+                    let is_snapshot = msg.get_msg_type() == MessageType::MsgSnapshot;
                     if let Some(sender) = self.peer_senders.get(&to) {
-                        let _ = sender.send(msg);
+                        if sender.send(msg).is_err() {
+                            if is_snapshot {
+                                self.raw_node.report_snapshot(to, SnapshotStatus::Failure);
+                            }
+                        } else if is_snapshot {
+                            self.raw_node.report_snapshot(to, SnapshotStatus::Finish);
+                        }
                     }
                 }
 
@@ -421,6 +447,9 @@ impl RaftNode {
             }
         }
 
+        if !ready.snapshot().is_empty() {
+            self.storage.apply_snapshot(ready.snapshot()).unwrap();
+        }
         self.storage.append_entries(ready.entries()).unwrap();
         if let Some(hs) = ready.hs() {
             self.storage.set_hardstate(hs).unwrap();
@@ -465,7 +494,7 @@ mod tests {
 
         let engine = test_engine();
         let (_tx, rx) = mpsc::unbounded_channel();
-        let mut node = RaftNode::new(config, engine, rx, HashMap::new()).unwrap();
+        let mut node = RaftNode::new(config, engine, rx, HashMap::new(), None).unwrap();
 
         // Tick enough times to trigger election.
         for _ in 0..20 {
@@ -488,7 +517,7 @@ mod tests {
 
         let engine = test_engine();
         let (_tx, rx) = mpsc::unbounded_channel();
-        let mut node = RaftNode::new(config, engine, rx, HashMap::new()).unwrap();
+        let mut node = RaftNode::new(config, engine, rx, HashMap::new(), None).unwrap();
 
         // Become leader first.
         for _ in 0..20 {
@@ -531,7 +560,7 @@ mod tests {
 
         let engine = test_engine();
         let (_tx, rx) = mpsc::unbounded_channel();
-        let mut node = RaftNode::new(config, engine, rx, HashMap::new()).unwrap();
+        let mut node = RaftNode::new(config, engine, rx, HashMap::new(), None).unwrap();
 
         let observed_leader_id = std::sync::Arc::new(std::sync::atomic::AtomicU64::new(0));
         let observed_leader_id_clone = observed_leader_id.clone();

--- a/crates/database/src/raft_partition.rs
+++ b/crates/database/src/raft_partition.rs
@@ -116,10 +116,17 @@ impl RaftPartitionManager {
         config: RaftNodeConfig,
         engine: Arc<raft_engine::Engine>,
         peer_senders: HashMap<u64, mpsc::UnboundedSender<Message>>,
+        snapshot_provider: Option<Arc<dyn crate::raft_storage::RaftSnapshotProvider>>,
     ) -> anyhow::Result<Self> {
         let (mailbox_tx, mailbox_rx) = mpsc::unbounded_channel();
 
-        let mut node = RaftNode::new(config.clone(), engine, mailbox_rx, peer_senders)?;
+        let mut node = RaftNode::new(
+            config.clone(),
+            engine,
+            mailbox_rx,
+            peer_senders,
+            snapshot_provider,
+        )?;
 
         let is_leader = Arc::new(AtomicBool::new(false));
         let leader_id = Arc::new(AtomicU64::new(0));
@@ -215,7 +222,8 @@ mod tests {
             ..Default::default()
         };
 
-        let manager = RaftPartitionManager::new(config, test_engine(), HashMap::new()).unwrap();
+        let manager =
+            RaftPartitionManager::new(config, test_engine(), HashMap::new(), None).unwrap();
         let state = manager.state();
 
         assert!(!state.is_leader());
@@ -233,7 +241,8 @@ mod tests {
             heartbeat_tick: 3,
         };
 
-        let mut manager = RaftPartitionManager::new(config, test_engine(), HashMap::new()).unwrap();
+        let mut manager =
+            RaftPartitionManager::new(config, test_engine(), HashMap::new(), None).unwrap();
         let state = manager.state();
 
         assert!(!state.is_leader());
@@ -248,7 +257,11 @@ mod tests {
         // The shared state should now reflect leadership.
         assert!(state.is_leader());
         assert_eq!(state.leader_id(), 1);
-        assert_eq!(state.leader_id(), 1, "Shared state should expose the elected leader ID");
+        assert_eq!(
+            state.leader_id(),
+            1,
+            "Shared state should expose the elected leader ID"
+        );
     }
 
     #[test]
@@ -260,7 +273,8 @@ mod tests {
             ..Default::default()
         };
 
-        let manager = RaftPartitionManager::new(config, test_engine(), HashMap::new()).unwrap();
+        let manager =
+            RaftPartitionManager::new(config, test_engine(), HashMap::new(), None).unwrap();
         let state = manager.state();
 
         // Should be able to send without error (node exists).

--- a/crates/database/src/raft_storage.rs
+++ b/crates/database/src/raft_storage.rs
@@ -39,6 +39,22 @@ use crate::partition::PartitionId;
 const HARD_STATE_KEY: &[u8] = b"hard_state";
 /// Key for storing ConfState in raft-engine's KV space.
 const CONF_STATE_KEY: &[u8] = b"conf_state";
+/// Key for storing the latest installed/generated snapshot in raft-engine's KV
+/// space.
+const SNAPSHOT_KEY: &[u8] = b"snapshot";
+
+pub trait RaftSnapshotProvider: Send + Sync {
+    fn snapshot_bytes(&self) -> anyhow::Result<Vec<u8>>;
+}
+
+impl<F> RaftSnapshotProvider for F
+where
+    F: Fn() -> anyhow::Result<Vec<u8>> + Send + Sync,
+{
+    fn snapshot_bytes(&self) -> anyhow::Result<Vec<u8>> {
+        self()
+    }
+}
 
 /// Bridge between raft-rs Entry type and raft-engine's MessageExt trait.
 /// Tells raft-engine how to extract the log index from an Entry.
@@ -66,6 +82,8 @@ pub struct ConvexRaftStorage {
     /// Cached ConfState for the Storage trait (raft-engine doesn't track this
     /// separately from entries, so we cache it in memory and persist to KV).
     conf_state: ConfState,
+    /// Hook for generating state-machine snapshots on demand.
+    snapshot_provider: Option<Arc<dyn RaftSnapshotProvider>>,
 }
 
 impl ConvexRaftStorage {
@@ -93,6 +111,7 @@ impl ConvexRaftStorage {
         engine: Arc<Engine>,
         _node_id: u64,
         peers: Vec<u64>,
+        snapshot_provider: Option<Arc<dyn RaftSnapshotProvider>>,
     ) -> anyhow::Result<Self> {
         let region_id = partition_id.0 as u64;
 
@@ -127,6 +146,7 @@ impl ConvexRaftStorage {
             partition_id,
             engine,
             conf_state,
+            snapshot_provider,
         })
     }
 
@@ -200,6 +220,33 @@ impl ConvexRaftStorage {
         Ok(())
     }
 
+    fn persisted_snapshot(&self) -> anyhow::Result<Option<Snapshot>> {
+        self.engine
+            .get_message(self.region_id(), SNAPSHOT_KEY)
+            .context("Failed to read Snapshot from raft-engine")
+    }
+
+    pub fn apply_snapshot(&mut self, snapshot: &Snapshot) -> anyhow::Result<()> {
+        let metadata = snapshot.get_metadata();
+        let mut batch = LogBatch::default();
+        batch.add_command(self.region_id(), raft_engine::Command::Clean);
+        batch
+            .put_message(self.region_id(), SNAPSHOT_KEY.to_vec(), snapshot)
+            .context("Failed to add Snapshot to LogBatch")?;
+        batch
+            .put_message(
+                self.region_id(),
+                CONF_STATE_KEY.to_vec(),
+                metadata.get_conf_state(),
+            )
+            .context("Failed to add snapshot ConfState to LogBatch")?;
+        self.engine
+            .write(&mut batch, true)
+            .context("Failed to write snapshot to raft-engine")?;
+        self.conf_state = metadata.get_conf_state().clone();
+        Ok(())
+    }
+
     /// Get the current hard state.
     pub fn hard_state(&self) -> anyhow::Result<HardState> {
         let hs: Option<HardState> = self
@@ -230,6 +277,12 @@ impl ConvexRaftStorage {
     pub fn partition_id(&self) -> PartitionId {
         self.partition_id
     }
+
+    fn snapshot_metadata(&self) -> anyhow::Result<Option<SnapshotMetadata>> {
+        Ok(self
+            .persisted_snapshot()?
+            .map(|snapshot| snapshot.metadata.unwrap_or_default()))
+    }
 }
 
 /// Implement raft-rs Storage trait backed by raft-engine.
@@ -259,6 +312,10 @@ impl Storage for ConvexRaftStorage {
         max_size: impl Into<Option<u64>>,
         _context: GetEntriesContext,
     ) -> RaftResult<Vec<Entry>> {
+        let first = self.first_index()?;
+        if low < first {
+            return Err(raft::Error::Store(StorageError::Compacted));
+        }
         let max = max_size.into().map(|s| s as usize);
         let mut entries = Vec::new();
         self.engine
@@ -272,6 +329,18 @@ impl Storage for ConvexRaftStorage {
     }
 
     fn term(&self, idx: u64) -> RaftResult<u64> {
+        if let Some(snapshot_metadata) = self.snapshot_metadata().map_err(|e| {
+            raft::Error::Store(StorageError::Other(Box::new(std::io::Error::other(
+                e.to_string(),
+            ))))
+        })? {
+            if idx == snapshot_metadata.index {
+                return Ok(snapshot_metadata.term);
+            }
+            if idx < snapshot_metadata.index {
+                return Err(raft::Error::Store(StorageError::Compacted));
+            }
+        }
         let entry: Option<Entry> = self
             .engine
             .get_entry::<RaftMessageExt>(self.region_id(), idx)
@@ -293,19 +362,71 @@ impl Storage for ConvexRaftStorage {
     }
 
     fn first_index(&self) -> RaftResult<u64> {
-        Ok(self.engine.first_index(self.region_id()).unwrap_or(1))
+        let engine_first = self.engine.first_index(self.region_id());
+        let snapshot_first = self
+            .snapshot_metadata()
+            .map_err(|e| {
+                raft::Error::Store(StorageError::Other(Box::new(std::io::Error::other(
+                    e.to_string(),
+                ))))
+            })?
+            .map(|metadata| metadata.index.saturating_add(1));
+        Ok(match (engine_first, snapshot_first) {
+            (Some(engine_first), Some(snapshot_first)) => engine_first.max(snapshot_first),
+            (Some(engine_first), None) => engine_first,
+            (None, Some(snapshot_first)) => snapshot_first,
+            (None, None) => 1,
+        })
     }
 
     fn last_index(&self) -> RaftResult<u64> {
-        Ok(self.engine.last_index(self.region_id()).unwrap_or(0))
+        let engine_last = self.engine.last_index(self.region_id()).unwrap_or(0);
+        let snapshot_last = self
+            .snapshot_metadata()
+            .map_err(|e| {
+                raft::Error::Store(StorageError::Other(Box::new(std::io::Error::other(
+                    e.to_string(),
+                ))))
+            })?
+            .map(|metadata| metadata.index)
+            .unwrap_or(0);
+        Ok(engine_last.max(snapshot_last))
     }
 
     fn snapshot(&self, _request_index: u64, _to: u64) -> RaftResult<Snapshot> {
-        // Snapshot transfer not yet implemented.
-        // For now, nodes that fall too far behind must re-bootstrap.
-        Err(raft::Error::Store(
-            StorageError::SnapshotTemporarilyUnavailable,
-        ))
+        let Some(snapshot_provider) = &self.snapshot_provider else {
+            return Err(raft::Error::Store(
+                StorageError::SnapshotTemporarilyUnavailable,
+            ));
+        };
+
+        let hard_state = self.hard_state().map_err(|e| {
+            raft::Error::Store(StorageError::Other(Box::new(std::io::Error::other(
+                e.to_string(),
+            ))))
+        })?;
+        let snapshot_index = hard_state.commit;
+        if snapshot_index == 0 {
+            return Err(raft::Error::Store(
+                StorageError::SnapshotTemporarilyUnavailable,
+            ));
+        }
+        let snapshot_term = self.term(snapshot_index)?;
+        let snapshot_data = snapshot_provider.snapshot_bytes().map_err(|e| {
+            raft::Error::Store(StorageError::Other(Box::new(std::io::Error::other(
+                e.to_string(),
+            ))))
+        })?;
+
+        let mut metadata = SnapshotMetadata::default();
+        metadata.index = snapshot_index;
+        metadata.term = snapshot_term;
+        metadata.set_conf_state(self.conf_state.clone());
+
+        let mut snapshot = Snapshot::default();
+        snapshot.set_metadata(metadata);
+        snapshot.set_data(snapshot_data.into());
+        Ok(snapshot)
     }
 }
 
@@ -321,7 +442,8 @@ mod tests {
     #[test]
     fn test_create_storage() {
         let engine = test_engine();
-        let storage = ConvexRaftStorage::new(PartitionId(0), engine, 1, vec![1, 2, 3]).unwrap();
+        let storage =
+            ConvexRaftStorage::new(PartitionId(0), engine, 1, vec![1, 2, 3], None).unwrap();
         assert_eq!(storage.partition_id(), PartitionId(0));
         assert!(storage.first_index().is_ok());
         assert!(storage.last_index().is_ok());
@@ -330,7 +452,7 @@ mod tests {
     #[test]
     fn test_append_and_read_entries() {
         let engine = test_engine();
-        let storage = ConvexRaftStorage::new(PartitionId(0), engine, 1, vec![1]).unwrap();
+        let storage = ConvexRaftStorage::new(PartitionId(0), engine, 1, vec![1], None).unwrap();
 
         let mut entry = Entry::default();
         entry.set_index(1);
@@ -348,7 +470,7 @@ mod tests {
     #[test]
     fn test_hardstate_persistence() {
         let engine = test_engine();
-        let storage = ConvexRaftStorage::new(PartitionId(0), engine, 1, vec![1]).unwrap();
+        let storage = ConvexRaftStorage::new(PartitionId(0), engine, 1, vec![1], None).unwrap();
 
         let mut hs = HardState::default();
         hs.set_term(5);
@@ -365,7 +487,8 @@ mod tests {
     #[test]
     fn test_initial_state_with_peers() {
         let engine = test_engine();
-        let storage = ConvexRaftStorage::new(PartitionId(1), engine, 2, vec![1, 2, 3]).unwrap();
+        let storage =
+            ConvexRaftStorage::new(PartitionId(1), engine, 2, vec![1, 2, 3], None).unwrap();
         let state = storage.initial_state().unwrap();
         let voters = state.conf_state.get_voters().to_vec();
         assert_eq!(voters, vec![1, 2, 3]);
@@ -379,7 +502,8 @@ mod tests {
         // First boot: write entries and hard state.
         {
             let engine = ConvexRaftStorage::open_engine(path).unwrap();
-            let storage = ConvexRaftStorage::new(PartitionId(0), engine, 1, vec![1, 2, 3]).unwrap();
+            let storage =
+                ConvexRaftStorage::new(PartitionId(0), engine, 1, vec![1, 2, 3], None).unwrap();
 
             let mut entry = Entry::default();
             entry.set_index(1);
@@ -398,7 +522,8 @@ mod tests {
         // Reopen: verify state survived.
         {
             let engine = ConvexRaftStorage::open_engine(path).unwrap();
-            let storage = ConvexRaftStorage::new(PartitionId(0), engine, 1, vec![1, 2, 3]).unwrap();
+            let storage =
+                ConvexRaftStorage::new(PartitionId(0), engine, 1, vec![1, 2, 3], None).unwrap();
 
             // Hard state persisted.
             let state = storage.initial_state().unwrap();
@@ -413,6 +538,53 @@ mod tests {
                 .unwrap();
             assert_eq!(entries.len(), 1);
             assert_eq!(&entries[0].get_data()[..], b"persisted");
+        }
+    }
+
+    #[test]
+    fn test_snapshot_persists_and_reloads() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().to_str().unwrap();
+
+        {
+            let engine = ConvexRaftStorage::open_engine(path).unwrap();
+            let provider: Arc<dyn RaftSnapshotProvider> = Arc::new(|| Ok(b"checkpoint".to_vec()));
+            let mut storage =
+                ConvexRaftStorage::new(PartitionId(0), engine, 1, vec![1, 2, 3], Some(provider))
+                    .unwrap();
+
+            let mut entries = Vec::new();
+            for index in 1..=5 {
+                let mut entry = Entry::default();
+                entry.set_index(index);
+                entry.set_term(2);
+                entries.push(entry);
+            }
+            storage.append_entries(&entries).unwrap();
+
+            let mut hs = HardState::default();
+            hs.set_term(2);
+            hs.set_commit(5);
+            storage.set_hardstate(&hs).unwrap();
+
+            let snapshot = storage.snapshot(5, 2).unwrap();
+            assert_eq!(snapshot.get_metadata().index, 5);
+            assert_eq!(snapshot.get_metadata().term, 2);
+            assert_eq!(snapshot.get_data(), b"checkpoint");
+
+            storage.apply_snapshot(&snapshot).unwrap();
+            assert_eq!(storage.first_index().unwrap(), 6);
+            assert_eq!(storage.last_index().unwrap(), 5);
+            assert_eq!(storage.term(5).unwrap(), 2);
+        }
+
+        {
+            let engine = ConvexRaftStorage::open_engine(path).unwrap();
+            let storage =
+                ConvexRaftStorage::new(PartitionId(0), engine, 1, vec![1, 2, 3], None).unwrap();
+            assert_eq!(storage.first_index().unwrap(), 6);
+            assert_eq!(storage.last_index().unwrap(), 5);
+            assert_eq!(storage.term(5).unwrap(), 2);
         }
     }
 }

--- a/crates/database/src/search_index_bootstrap.rs
+++ b/crates/database/src/search_index_bootstrap.rs
@@ -585,9 +585,9 @@ mod tests {
     use value::{
         assert_obj,
         ConvexValue,
-        DeveloperDocumentId,
         FieldPath,
         InternalId,
+        PublicDocumentId,
         ResolvedDocumentId,
         TableName,
         TableNamespace,
@@ -650,7 +650,7 @@ mod tests {
 
     fn assert_expected_vector(
         vectors: Vec<PublicVectorSearchQueryResult>,
-        expected: DeveloperDocumentId,
+        expected: PublicDocumentId,
     ) {
         assert_eq!(
             vectors
@@ -911,7 +911,7 @@ mod tests {
         db: &Database<TestRuntime>,
         index_metadata: &IndexMetadata<TableName>,
         vector: [f32; 2],
-    ) -> anyhow::Result<DeveloperDocumentId> {
+    ) -> anyhow::Result<PublicDocumentId> {
         add_vector_by_table(db, index_metadata.name.table().clone(), vector).await
     }
 
@@ -919,7 +919,7 @@ mod tests {
         db: &Database<TestRuntime>,
         table_name: TableName,
         vector: [f32; 2],
-    ) -> anyhow::Result<DeveloperDocumentId> {
+    ) -> anyhow::Result<PublicDocumentId> {
         let mut tx = db.begin_system().await?;
         let values: ConvexValue = vector
             .into_iter()

--- a/crates/database/src/search_index_workers/index_meta.rs
+++ b/crates/database/src/search_index_workers/index_meta.rs
@@ -40,7 +40,7 @@ use search::{
 use storage::Storage;
 use sync_types::Timestamp;
 use value::{
-    ConvexObject,
+    DocumentObject,
     TableNumber,
     TabletId,
 };
@@ -264,7 +264,7 @@ impl<T: SearchIndex> SearchOnDiskState<T> {
 pub enum SnapshotData<T> {
     /// An unrecognized snapshot, probably from a newer version of backend than
     /// this one that we subsequently rolled back.
-    Unknown(ConvexObject),
+    Unknown(DocumentObject),
     MultiSegment(Vec<T>),
 }
 

--- a/crates/database/src/search_index_workers/search_flusher.rs
+++ b/crates/database/src/search_index_workers/search_flusher.rs
@@ -788,7 +788,7 @@ pub(crate) async fn incremental_table_scan<T: SearchIndex>(
 
         let page_len = page.len();
         for (i, (index_key, latest_doc)) in page.into_iter().enumerate() {
-            let developer_doc_id = latest_doc.value.id().developer_id;
+            let developer_doc_id = latest_doc.value.id().document_id;
             let size = T::estimate_document_size(schema, &latest_doc.value);
             total_size += size;
 

--- a/crates/database/src/snapshot_checkpointer.rs
+++ b/crates/database/src/snapshot_checkpointer.rs
@@ -245,6 +245,10 @@ fn checkpoint_to_proto(data: &CheckpointData) -> anyhow::Result<checkpoint_proto
     })
 }
 
+pub fn checkpoint_to_bytes(data: &CheckpointData) -> anyhow::Result<Vec<u8>> {
+    Ok(checkpoint_to_proto(data)?.encode_to_vec())
+}
+
 pub fn checkpoint_from_proto(
     proto: checkpoint_proto::CheckpointData,
 ) -> anyhow::Result<CheckpointData> {
@@ -307,4 +311,9 @@ pub fn checkpoint_from_proto(
         documents,
         globals,
     })
+}
+
+pub fn checkpoint_from_bytes(bytes: &[u8]) -> anyhow::Result<CheckpointData> {
+    let proto = checkpoint_proto::CheckpointData::decode(bytes)?;
+    checkpoint_from_proto(proto)
 }

--- a/crates/database/src/snapshot_manager.rs
+++ b/crates/database/src/snapshot_manager.rs
@@ -187,12 +187,39 @@ impl TableSummaries {
                 anyhow::anyhow!("Updating non-existent table {}", document_id.tablet_id)
             })?
             .clone();
+        let is_system_table = table_mapping.is_system_tablet(document_id.tablet_id);
+        let mut used_lossy_summary_update = false;
         if let Some(old_value) = old {
-            table_summary = table_summary
-                .remove(&old_value.value().0)
-                .with_context(|| format!("removing from table {}", document_id.tablet_id))?;
+            match table_summary.remove(&old_value.value().0) {
+                Ok(updated_summary) => {
+                    table_summary = updated_summary;
+                },
+                Err(error) if is_system_table => {
+                    tracing::warn!(
+                        tablet_id = ?document_id.tablet_id,
+                        error = ?error,
+                        "System table summary drift detected; degrading summary to unknown"
+                    );
+                    table_summary = table_summary
+                        .lossy_update(
+                            old.map(|document| &document.value().0),
+                            new.map(|document| &document.value().0),
+                        )
+                        .with_context(|| {
+                            format!(
+                                "lossy system table summary update failed for table {}",
+                                document_id.tablet_id
+                            )
+                        })?;
+                    used_lossy_summary_update = true;
+                },
+                Err(error) => {
+                    return Err(error)
+                        .with_context(|| format!("removing from table {}", document_id.tablet_id));
+                },
+            }
         }
-        if let Some(new_value) = new {
+        if !used_lossy_summary_update && let Some(new_value) = new {
             table_summary = table_summary.insert(&new_value.value().0);
         }
         if let Some(TableUpdate {
@@ -226,7 +253,6 @@ impl TableSummaries {
         let new_info_total_size = table_summary.total_size();
         match self.tables.insert(document_id.tablet_id, table_summary) {
             Some(old_summary) => {
-                let is_system_table = table_mapping.is_system_tablet(document_id.tablet_id);
                 if !is_system_table {
                     self.num_user_documents =
                         self.num_user_documents + new_info_num_values - old_summary.num_values();
@@ -853,6 +879,23 @@ impl SnapshotManager {
         self.write_throughput_limiter.record_write(ts, write_bytes);
     }
 
+    pub fn replace(
+        &mut self,
+        ts: Timestamp,
+        snapshot: Snapshot,
+        replication_frontiers: BTreeMap<PartitionId, Timestamp>,
+    ) {
+        self.versions.clear();
+        self.versions.push_back((ts, snapshot));
+        self.persisted_max_repeatable_ts = ts;
+        self.replication_frontiers = replication_frontiers;
+        self.notify_waiters();
+        let partitions: Vec<_> = self.replication_frontiers.keys().copied().collect();
+        for partition in partitions {
+            self.notify_replication_waiters(partition);
+        }
+    }
+
     pub fn check_write_throughput_limit(&self) -> anyhow::Result<()> {
         if !self.write_throughput_limiter.check_limit() {
             anyhow::bail!(ErrorMetadata::rate_limited(
@@ -884,6 +927,7 @@ impl SnapshotManager {
             Ok(false)
         }
     }
+
 }
 
 pub fn replication_frontiers_to_json(frontiers: &BTreeMap<PartitionId, Timestamp>) -> JsonValue {

--- a/crates/database/src/streaming_export_selection.rs
+++ b/crates/database/src/streaming_export_selection.rs
@@ -19,7 +19,7 @@
 //! # use sync_types::Timestamp;
 //! # use value::{
 //! #     assert_obj,
-//! #     DeveloperDocumentId,
+//! #     PublicDocumentId,
 //! #     TableNumber,
 //! # };
 //! # use database::streaming_export_selection::{
@@ -57,7 +57,7 @@
 //! assert!(!selection.is_table_included(&"other_component".parse()?, &"users".parse()?));
 //!
 //! // This can also be used to filter documents
-//! let doc_id = DeveloperDocumentId::new(TableNumber::try_from(1)?, InternalId::MIN);
+//! let doc_id = PublicDocumentId::new(TableNumber::try_from(1)?, InternalId::MIN);
 //! let doc = DeveloperDocument::new(
 //!     doc_id.clone(),
 //!     CreationTime::try_from(Timestamp::MIN)?,
@@ -99,9 +99,9 @@ use proptest_derive::Arbitrary;
 use serde_json::Value as JsonValue;
 use value::{
     export::ValueFormat,
-    ConvexObject,
-    DeveloperDocumentId,
+    DocumentObject,
     FieldName,
+    PublicDocumentId,
     Size,
     TableName,
 };
@@ -324,12 +324,12 @@ impl StreamingExportColumnSelection {
 #[derive(Eq, PartialEq, Debug)]
 #[cfg_attr(test, derive(Clone))]
 pub struct StreamingExportDocument {
-    id: DeveloperDocumentId,
-    value: PII<ConvexObject>,
+    id: PublicDocumentId,
+    value: PII<DocumentObject>,
 }
 
 impl StreamingExportDocument {
-    pub fn new(id: DeveloperDocumentId, value: PII<ConvexObject>) -> anyhow::Result<Self> {
+    pub fn new(id: PublicDocumentId, value: PII<DocumentObject>) -> anyhow::Result<Self> {
         // Verify that `value` contains `_id`
         anyhow::ensure!(
             value.0.get(&FieldName::from(ID_FIELD.clone()))
@@ -377,7 +377,7 @@ impl StreamingExportDocument {
         }
     }
 
-    pub fn id(&self) -> DeveloperDocumentId {
+    pub fn id(&self) -> PublicDocumentId {
         self.id
     }
 }
@@ -653,7 +653,7 @@ mod tests_column_filtering {
 
     #[test]
     fn test_filter_document_with_creation_time() -> anyhow::Result<()> {
-        let id = DeveloperDocumentId::new(TableNumber::try_from(1)?, InternalId::MIN);
+        let id = PublicDocumentId::new(TableNumber::try_from(1)?, InternalId::MIN);
         let creation_time = CreationTime::try_from(Timestamp::MIN)?;
         let value = assert_obj!(
             "_id" => id.encode(),
@@ -690,7 +690,7 @@ mod tests_column_filtering {
 
     #[test]
     fn test_filter_document_without_creation_time() -> anyhow::Result<()> {
-        let id = DeveloperDocumentId::new(TableNumber::try_from(1)?, InternalId::MIN);
+        let id = PublicDocumentId::new(TableNumber::try_from(1)?, InternalId::MIN);
         let creation_time = CreationTime::try_from(Timestamp::MIN)?;
         let value = assert_obj!(
             "_id" => id.encode(),
@@ -836,7 +836,7 @@ mod tests_export_fields {
     fn test_export_fields_convex_encoded_json() -> anyhow::Result<()> {
         let mut id_generator = TestIdGenerator::new();
         let posts_table_name: TableName = "posts".parse()?;
-        let id = id_generator.user_generate(&posts_table_name).developer_id;
+        let id = id_generator.user_generate(&posts_table_name).document_id;
 
         let big_value: i64 = 1234567890123456789;
         let doc = StreamingExportDocument::new(
@@ -865,7 +865,7 @@ mod tests_export_fields {
     fn test_export_fields_convex_clean_json() -> anyhow::Result<()> {
         let mut id_generator = TestIdGenerator::new();
         let posts_table_name: TableName = "posts".parse()?;
-        let id = id_generator.user_generate(&posts_table_name).developer_id;
+        let id = id_generator.user_generate(&posts_table_name).document_id;
 
         let big_value: i64 = 1234567890123456789;
         let doc = StreamingExportDocument::new(

--- a/crates/database/src/subscription.rs
+++ b/crates/database/src/subscription.rs
@@ -830,12 +830,12 @@ mod tests {
     use sync_types::Timestamp;
     use tokio::sync::mpsc;
     use value::{
-        ConvexObject,
         ConvexString,
         ConvexValue,
-        DeveloperDocumentId,
+        DocumentObject,
         FieldName,
         FieldPath,
+        PublicDocumentId,
         ResolvedDocumentId,
         TableNumber,
         TabletId,
@@ -979,7 +979,7 @@ mod tests {
                 let internal_id = id_generator.generate_internal();
                 let id = ResolvedDocumentId::new(
                     *index_name.table(),
-                    DeveloperDocumentId::new(TableNumber::try_from(1).unwrap(), internal_id),
+                    PublicDocumentId::new(TableNumber::try_from(1).unwrap(), internal_id),
                 );
                 assert_eq!(*index_name.table(), id.tablet_id);
 
@@ -1013,19 +1013,19 @@ mod tests {
         ResolvedDocument::new(id, time, object).unwrap()
     }
 
-    fn create_object(field_path: FieldPath, field_value: String) -> ConvexObject {
+    fn create_object(field_path: FieldPath, field_value: String) -> DocumentObject {
         let mut map: BTreeMap<FieldName, ConvexValue> = BTreeMap::new();
         let name = field_path.fields().last().unwrap();
         map.insert(
             FieldName::from(name.clone()),
             ConvexValue::String(ConvexString::try_from(field_value).unwrap()),
         );
-        let mut object = ConvexObject::try_from(map).unwrap();
+        let mut object = DocumentObject::try_from(map).unwrap();
 
         for field in field_path.fields().iter().rev().skip(1) {
             let mut new_map = BTreeMap::new();
             new_map.insert(FieldName::from(field.clone()), ConvexValue::Object(object));
-            object = ConvexObject::try_from(new_map).unwrap();
+            object = DocumentObject::try_from(new_map).unwrap();
         }
         object
     }

--- a/crates/database/src/system_query.rs
+++ b/crates/database/src/system_query.rs
@@ -35,7 +35,7 @@ use value::{
     serde::ConvexSerializable,
     sorting::write_sort_key,
     walk::ConvexValueWalker,
-    DeveloperDocumentId,
+    PublicDocumentId,
     TableNamespace,
     TabletId,
 };
@@ -327,7 +327,7 @@ impl<RT: Runtime> Transaction<RT> {
     pub async fn get_system<T: SystemTable>(
         &mut self,
         namespace: TableNamespace,
-        id: DeveloperDocumentId,
+        id: PublicDocumentId,
     ) -> anyhow::Result<Option<Arc<ParsedDocument<T::Metadata>>>>
     where
         T::Metadata: ConvexSerializable,
@@ -476,7 +476,7 @@ mod tests {
         codegen_convex_serialization,
         values_to_bytes,
         ConvexValue,
-        DeveloperDocumentId,
+        PublicDocumentId,
         ResolvedDocumentId,
         TableName,
         TableNamespace,
@@ -613,7 +613,7 @@ mod tests {
                 BinaryKey::min(),
                 End::after_prefix(&k::<ConvexValue, 2>([
                     doc1.creation_time().into(),
-                    doc1.developer_id().encode().try_into().unwrap()
+                    doc1.document_id().encode().try_into().unwrap()
                 ]))
             )])
         );
@@ -627,7 +627,7 @@ mod tests {
                 BinaryKey::min(),
                 End::after_prefix(&k::<ConvexValue, 2>([
                     doc2.creation_time().into(),
-                    doc2.developer_id().encode().try_into().unwrap()
+                    doc2.document_id().encode().try_into().unwrap()
                 ]))
             )])
         );
@@ -828,19 +828,19 @@ mod tests {
         db.commit(tx).await?;
         let mut tx = db.begin_system().await?;
         assert_eq!(
-            tx.get_system::<TestTable>(namespace, doc.developer_id())
+            tx.get_system::<TestTable>(namespace, doc.document_id())
                 .await?
                 .unwrap()
                 .id(),
             doc.id()
         );
         assert_eq!(
-            tx.get_system::<TestTable>(namespace, DeveloperDocumentId::MIN)
+            tx.get_system::<TestTable>(namespace, PublicDocumentId::MIN)
                 .await?,
             None
         );
-        let doc_key = k([doc.developer_id().encode()]);
-        let missing_key = k([DeveloperDocumentId::MIN.encode()]);
+        let doc_key = k([doc.document_id().encode()]);
+        let missing_key = k([PublicDocumentId::MIN.encode()]);
         assert_eq!(
             index_reads(&tx, &SystemIndex::<TestTable>::by_id(), namespace),
             intervals([

--- a/crates/database/src/table_iteration.rs
+++ b/crates/database/src/table_iteration.rs
@@ -851,7 +851,7 @@ mod tests {
             IndexName,
         },
         value::{
-            ConvexObject,
+            DocumentObject,
             FieldName,
             FieldPath,
             TableName,
@@ -890,7 +890,7 @@ mod tests {
         UserFacingModel,
     };
 
-    fn small_user_object() -> impl Strategy<Value = ConvexObject> {
+    fn small_user_object() -> impl Strategy<Value = DocumentObject> {
         let values = resolved_value_strategy(
             FieldName::user_strategy,
             ValueBranching::small(),
@@ -903,12 +903,12 @@ mod tests {
     enum Update {
         Insert {
             #[proptest(strategy = "small_user_object()")]
-            object: ConvexObject,
+            object: DocumentObject,
         },
         Replace {
             index: usize,
             #[proptest(strategy = "small_user_object()")]
-            object: ConvexObject,
+            object: DocumentObject,
         },
         Delete {
             index: usize,
@@ -919,7 +919,7 @@ mod tests {
         prop_vec(prop_vec(any::<Update>(), 0..4), 0..4)
     }
 
-    fn small_user_objects() -> impl Strategy<Value = Vec<ConvexObject>> {
+    fn small_user_objects() -> impl Strategy<Value = Vec<DocumentObject>> {
         prop_vec(small_user_object(), 1..8)
     }
 
@@ -934,7 +934,7 @@ mod tests {
         Ok(by_id_metadata.id().internal_id())
     }
 
-    fn iterator_includes_all_documents_test(table_name: TableName, objects: Vec<ConvexObject>) {
+    fn iterator_includes_all_documents_test(table_name: TableName, objects: Vec<DocumentObject>) {
         let td = TestDriver::new();
         let runtime = td.rt();
         let test = async {
@@ -968,7 +968,7 @@ mod tests {
     async fn racing_commits_test(
         runtime: TestRuntime,
         table_name: TableName,
-        initial: Vec<ConvexObject>,
+        initial: Vec<DocumentObject>,
         update_batches: Vec<Vec<Update>>,
         pause: PauseController,
     ) -> anyhow::Result<()> {

--- a/crates/database/src/table_registry.rs
+++ b/crates/database/src/table_registry.rs
@@ -14,7 +14,7 @@ use common::{
         TableName,
     },
     value::{
-        ConvexObject,
+        DocumentObject,
         ResolvedDocumentId,
         TableMapping,
         TabletId,
@@ -67,8 +67,8 @@ impl TableRegistry {
         &mut self,
         index_registry: &IndexRegistry,
         id: ResolvedDocumentId,
-        old_value: Option<&ConvexObject>,
-        new_value: Option<&ConvexObject>,
+        old_value: Option<&DocumentObject>,
+        new_value: Option<&DocumentObject>,
     ) -> anyhow::Result<Option<TableUpdate>> {
         let maybe_table_update = self
             .begin_update(index_registry, id, old_value, new_value)?
@@ -80,8 +80,8 @@ impl TableRegistry {
         &'a mut self,
         index_registry: &IndexRegistry,
         id: ResolvedDocumentId,
-        old_value: Option<&ConvexObject>,
-        new_value: Option<&ConvexObject>,
+        old_value: Option<&DocumentObject>,
+        new_value: Option<&DocumentObject>,
     ) -> anyhow::Result<Update<'a>> {
         let table_update = if self
             .table_mapping

--- a/crates/database/src/table_summary.rs
+++ b/crates/database/src/table_summary.rs
@@ -39,7 +39,7 @@ use common::{
         Timestamp,
     },
     value::{
-        ConvexObject,
+        DocumentObject,
         JsonInteger,
         Size,
         TableMapping,
@@ -118,7 +118,7 @@ impl TableSummary {
         &self.inferred_type
     }
 
-    pub fn insert(&self, object: &ConvexObject) -> Self {
+    pub fn insert(&self, object: &DocumentObject) -> Self {
         let total_size = self.total_size + object.size() as u64;
         Self {
             inferred_type: self.inferred_type.insert(object),
@@ -126,7 +126,7 @@ impl TableSummary {
         }
     }
 
-    pub fn remove(&self, object: &ConvexObject) -> anyhow::Result<Self> {
+    pub fn remove(&self, object: &DocumentObject) -> anyhow::Result<Self> {
         let size = object.size() as u64;
         Ok(Self {
             inferred_type: self.inferred_type.remove(object)?,
@@ -134,6 +134,37 @@ impl TableSummary {
                 .total_size
                 .checked_sub(size)
                 .context("total_size went negative?")?,
+        })
+    }
+
+    pub fn lossy_update(
+        &self,
+        old: Option<&DocumentObject>,
+        new: Option<&DocumentObject>,
+    ) -> anyhow::Result<Self> {
+        let old_count = u64::from(old.is_some());
+        let new_count = u64::from(new.is_some());
+        let old_size = old.map(|object| object.size() as u64).unwrap_or(0);
+        let new_size = new.map(|object| object.size() as u64).unwrap_or(0);
+
+        let num_values = self
+            .num_values()
+            .saturating_sub(old_count)
+            .checked_add(new_count)
+            .context("num_values overflowed?")?;
+        let total_size = self
+            .total_size
+            .saturating_sub(old_size)
+            .checked_add(new_size)
+            .context("total_size overflowed?")?;
+
+        if num_values == 0 {
+            return Ok(Self::empty());
+        }
+
+        Ok(Self {
+            inferred_type: CountedShape::new(ShapeEnum::Unknown, num_values),
+            total_size,
         })
     }
 
@@ -187,7 +218,7 @@ impl Arbitrary for TableSummary {
     type Strategy = impl Strategy<Value = TableSummary>;
 
     fn arbitrary_with((): Self::Parameters) -> Self::Strategy {
-        let values = prop::collection::vec((any::<bool>(), any::<ConvexObject>()), 0..10);
+        let values = prop::collection::vec((any::<bool>(), any::<DocumentObject>()), 0..10);
         values.prop_map(|values| {
             let mut summary = TableSummary::empty();
             for (_, value) in values.iter() {
@@ -603,7 +634,7 @@ mod tests {
             FieldName,
             TableName,
         },
-        value::ConvexObject,
+        value::DocumentObject,
     };
     use keybroker::Identity;
     use prop::collection::vec as prop_vec;
@@ -613,6 +644,7 @@ mod tests {
         TestRuntime,
     };
     use serde_json::Value as JsonValue;
+    use shape_inference::ShapeEnum;
     use value::{
         assert_obj,
         proptest::{
@@ -621,6 +653,7 @@ mod tests {
         },
         resolved_object_strategy,
         resolved_value_strategy,
+        Size,
         TableNamespace,
     };
 
@@ -773,7 +806,7 @@ mod tests {
         }
     }
 
-    fn small_user_object() -> impl Strategy<Value = ConvexObject> {
+    fn small_user_object() -> impl Strategy<Value = DocumentObject> {
         let values = resolved_value_strategy(
             FieldName::user_strategy,
             ValueBranching::small(),
@@ -782,11 +815,11 @@ mod tests {
         resolved_object_strategy(FieldName::user_strategy(), values, 0..4)
     }
 
-    fn small_user_objects() -> impl Strategy<Value = Vec<ConvexObject>> {
+    fn small_user_objects() -> impl Strategy<Value = Vec<DocumentObject>> {
         prop_vec(small_user_object(), 0..8)
     }
 
-    fn backfill_matches_test(table_name: TableName, vs: Vec<ConvexObject>) {
+    fn backfill_matches_test(table_name: TableName, vs: Vec<DocumentObject>) {
         let td = TestDriver::new();
         let runtime = td.rt();
         let test = async {
@@ -828,7 +861,7 @@ mod tests {
         td.run_until(test).unwrap();
     }
 
-    fn multiple_tables_test(values: BTreeMap<TableName, Vec<ConvexObject>>) {
+    fn multiple_tables_test(values: BTreeMap<TableName, Vec<DocumentObject>>) {
         let td = TestDriver::new();
         let runtime = td.rt();
         let test = async {
@@ -902,5 +935,45 @@ mod tests {
         ) {
             multiple_tables_test(values);
         }
+    }
+
+    #[test]
+    fn test_lossy_update_degrades_summary_shape_but_preserves_counts() {
+        let old_value = assert_obj!("field" => 1);
+        let new_value = assert_obj!("field" => true);
+
+        let summary = TableSummary::empty().insert(&old_value);
+        let degraded = summary
+            .lossy_update(Some(&old_value), Some(&new_value))
+            .expect("lossy update should succeed");
+
+        assert_eq!(degraded.num_values(), 1);
+        assert_eq!(degraded.total_size(), new_value.size() as u64);
+        assert!(matches!(
+            degraded.inferred_type().variant(),
+            ShapeEnum::Unknown
+        ));
+
+        let emptied = degraded
+            .remove(&new_value)
+            .expect("unknown summaries should remain removable");
+        assert!(emptied.is_empty());
+    }
+
+    #[test]
+    fn test_lossy_update_recovers_from_empty_summary_replacement() {
+        let old_value = assert_obj!("field" => 1);
+        let new_value = assert_obj!("field" => true);
+
+        let degraded = TableSummary::empty()
+            .lossy_update(Some(&old_value), Some(&new_value))
+            .expect("lossy update should recover from empty summaries");
+
+        assert_eq!(degraded.num_values(), 1);
+        assert_eq!(degraded.total_size(), new_value.size() as u64);
+        assert!(matches!(
+            degraded.inferred_type().variant(),
+            ShapeEnum::Unknown
+        ));
     }
 }

--- a/crates/database/src/tests/mod.rs
+++ b/crates/database/src/tests/mod.rs
@@ -67,8 +67,8 @@ use common::{
         WriteTimestamp,
     },
     value::{
-        ConvexObject,
         ConvexValue,
+        DocumentObject,
     },
     virtual_system_mapping::{
         all_tables_name_to_number,
@@ -91,7 +91,7 @@ use sync_types::backoff::Backoff;
 use value::{
     array,
     assert_val,
-    id_v6::DeveloperDocumentId,
+    id_v6::PublicDocumentId,
     val,
     FieldPath,
     ResolvedDocumentId,
@@ -409,14 +409,14 @@ async fn test_delete_conflict(rt: TestRuntime) -> anyhow::Result<()> {
     let database = new_test_database(rt).await;
     let mut tx = database.begin(Identity::system()).await?;
     let id = TestFacingModel::new(&mut tx)
-        .insert(&"key".parse()?, ConvexObject::empty())
+        .insert(&"key".parse()?, DocumentObject::empty())
         .await?;
     database.commit(tx).await?;
 
     let mut tx1 = database.begin(Identity::system()).await?;
     assert!(tx1.get(id).await?.is_some());
     TestFacingModel::new(&mut tx1)
-        .insert(&"key2".parse()?, ConvexObject::empty())
+        .insert(&"key2".parse()?, DocumentObject::empty())
         .await?;
 
     let mut tx2 = database.begin(Identity::system()).await?;
@@ -450,7 +450,7 @@ async fn test_creation_time_success(rt: TestRuntime) -> anyhow::Result<()> {
     let database = new_test_database(rt.clone()).await;
     let mut tx = database.begin(Identity::system()).await?;
     TestFacingModel::new(&mut tx)
-        .insert(&"table".parse()?, ConvexObject::empty())
+        .insert(&"table".parse()?, DocumentObject::empty())
         .await?;
     database.commit(tx).await?;
 
@@ -461,10 +461,10 @@ async fn test_creation_time_success(rt: TestRuntime) -> anyhow::Result<()> {
     assert!(tx1.next_creation_time < tx2.next_creation_time);
 
     TestFacingModel::new(&mut tx1)
-        .insert(&"table".parse()?, ConvexObject::empty())
+        .insert(&"table".parse()?, DocumentObject::empty())
         .await?;
     TestFacingModel::new(&mut tx2)
-        .insert(&"table".parse()?, ConvexObject::empty())
+        .insert(&"table".parse()?, DocumentObject::empty())
         .await?;
 
     database.commit(tx1).await?;
@@ -487,13 +487,13 @@ async fn test_id_reuse_across_transactions(rt: TestRuntime) -> anyhow::Result<()
     let mut tx = database.begin(Identity::system()).await?;
     // Pretend we create another document with the same ID as the first. We can't do
     // this through the normal Transaction interface so we pretend it's an import.
-    let id_v6 = DeveloperDocumentId::from(document.id()).encode();
+    let id_v6 = PublicDocumentId::from(document.id()).encode();
     let table_mapping_for_schema = tx.table_mapping().clone();
     ImportFacingModel::new(&mut tx)
         .insert(
             TabletIdAndTableNumber {
                 tablet_id: document.id().tablet_id,
-                table_number: document.id().developer_id.table(),
+                table_number: document.id().document_id.table(),
             },
             &"table".parse()?,
             assert_obj!("_id" => id_v6),
@@ -513,16 +513,16 @@ async fn test_id_reuse_within_a_transactions(rt: TestRuntime) -> anyhow::Result<
     let database = new_test_database(rt).await;
     let mut tx = database.begin(Identity::system()).await?;
     let document_id = TestFacingModel::new(&mut tx)
-        .insert(&"table".parse()?, ConvexObject::empty())
+        .insert(&"table".parse()?, DocumentObject::empty())
         .await?;
     let table_mapping = tx.table_mapping().clone();
     let table_id = table_mapping
         .namespace(TableNamespace::test_user())
         .name_to_id()("table".parse()?)?;
 
-    // Do another insert using the same DocumentId.
+    // Do another insert using the same PublicDocumentId.
     let value = assert_obj!(
-        "_id" => DeveloperDocumentId::from(document_id).encode(),
+        "_id" => PublicDocumentId::from(document_id).encode(),
     );
     let err = ImportFacingModel::new(&mut tx)
         .insert(table_id, &"table".parse()?, value, &table_mapping)
@@ -647,10 +647,10 @@ async fn test_full_table_scan_order(rt: TestRuntime) -> anyhow::Result<()> {
     let namespace = TableNamespace::test_user();
     let mut tx = database.begin(Identity::system()).await?;
     let doc1 = TestFacingModel::new(&mut tx)
-        .insert_and_get("messages".parse()?, ConvexObject::empty())
+        .insert_and_get("messages".parse()?, DocumentObject::empty())
         .await?;
     let doc2 = TestFacingModel::new(&mut tx)
-        .insert_and_get("messages".parse()?, ConvexObject::empty())
+        .insert_and_get("messages".parse()?, DocumentObject::empty())
         .await?;
     database.commit(tx).await?;
 
@@ -1078,7 +1078,7 @@ async fn test_insert_new_table_for_import(rt: TestRuntime) -> anyhow::Result<()>
         .await?;
     let doc1_id = ResolvedDocumentId::new(
         table_id.tablet_id,
-        DeveloperDocumentId::new(table_id.table_number, doc1_id.internal_id()),
+        PublicDocumentId::new(table_id.table_number, doc1_id.internal_id()),
     );
     let doc2_id = ImportFacingModel::new(&mut tx)
         .insert(
@@ -1090,7 +1090,7 @@ async fn test_insert_new_table_for_import(rt: TestRuntime) -> anyhow::Result<()>
         .await?;
     let doc2_id = ResolvedDocumentId::new(
         table_id.tablet_id,
-        DeveloperDocumentId::new(table_id.table_number, doc2_id.internal_id()),
+        PublicDocumentId::new(table_id.table_number, doc2_id.internal_id()),
     );
 
     database.commit(tx).await?;
@@ -1231,7 +1231,7 @@ async fn test_importing_foreign_reference_schema_validated(rt: TestRuntime) -> a
         )
         .await?;
     let foreign_doc_id =
-        DeveloperDocumentId::new(foreign_table_id.table_number, foreign_doc.internal_id());
+        PublicDocumentId::new(foreign_table_id.table_number, foreign_doc.internal_id());
     ImportFacingModel::new(&mut tx)
         .insert(
             table_id,
@@ -1327,7 +1327,7 @@ async fn test_import_overwrite_foreign_reference_schema_validated(
     let active_foreign_doc = UserFacingModel::new_root_for_test(&mut tx)
         .insert(foreign_table_name.clone(), assert_obj!())
         .await?;
-    let active_foreign_doc_id = DeveloperDocumentId::new(
+    let active_foreign_doc_id = PublicDocumentId::new(
         active_foreign_table_number,
         active_foreign_doc.internal_id(),
     );
@@ -1353,7 +1353,7 @@ async fn test_import_overwrite_foreign_reference_schema_validated(
         )
         .await?;
     let foreign_doc_id =
-        DeveloperDocumentId::new(foreign_table_id.table_number, foreign_doc.internal_id());
+        PublicDocumentId::new(foreign_table_id.table_number, foreign_doc.internal_id());
     ImportFacingModel::new(&mut tx)
         .insert(
             table_id,
@@ -1403,7 +1403,7 @@ async fn test_overwrite_for_import(rt: TestRuntime) -> anyhow::Result<()> {
         .insert(table_name.clone(), object.clone())
         .await?;
     let doc0_id = tx.resolve_developer_id(&doc_id_user_facing, TableNamespace::test_user())?;
-    let doc0_id_str: String = DeveloperDocumentId::from(doc0_id).encode();
+    let doc0_id_str: String = PublicDocumentId::from(doc0_id).encode();
     database.commit(tx).await?;
     let object_with_id = assert_obj!("_id" => &*doc0_id_str, "value" => 2);
 
@@ -1413,7 +1413,7 @@ async fn test_overwrite_for_import(rt: TestRuntime) -> anyhow::Result<()> {
         .insert_table_for_import(
             TableNamespace::test_user(),
             &table_name,
-            Some(doc0_id.developer_id.table()),
+            Some(doc0_id.document_id.table()),
         )
         .await?;
     let mut table_mapping_for_schema = tx.table_mapping().clone();
@@ -1433,11 +1433,11 @@ async fn test_overwrite_for_import(rt: TestRuntime) -> anyhow::Result<()> {
         .await?;
     let doc1_id = ResolvedDocumentId::new(
         table_id.tablet_id,
-        DeveloperDocumentId::new(table_id.table_number, doc1_id.internal_id()),
+        PublicDocumentId::new(table_id.table_number, doc1_id.internal_id()),
     );
     database.commit(tx).await?;
     assert_eq!(doc1_id.internal_id(), doc0_id.internal_id());
-    assert_eq!(doc1_id.developer_id.table(), doc0_id.developer_id.table());
+    assert_eq!(doc1_id.document_id.table(), doc0_id.document_id.table());
     assert!(doc1_id.tablet_id != doc0_id.tablet_id);
 
     let mut tx = database.begin(Identity::system()).await?;
@@ -1512,7 +1512,7 @@ async fn test_interrupted_import_then_delete_table(rt: TestRuntime) -> anyhow::R
         .await?;
     let doc1_id_inner = ResolvedDocumentId::new(
         table_id.tablet_id,
-        DeveloperDocumentId::new(table_id.table_number, doc1_id.internal_id()),
+        PublicDocumentId::new(table_id.table_number, doc1_id.internal_id()),
     );
     database.commit(tx).await?;
     // Now the import fails. The hidden table never gets activated.

--- a/crates/database/src/tests/raft_failover_tests.rs
+++ b/crates/database/src/tests/raft_failover_tests.rs
@@ -14,7 +14,11 @@ use std::{
     sync::Arc,
 };
 
-use raft::StateRole;
+use raft::{
+    SnapshotStatus,
+    StateRole,
+    Storage,
+};
 use tokio::sync::mpsc;
 
 use crate::{
@@ -36,6 +40,8 @@ fn test_engine() -> Arc<raft_engine::Engine> {
 fn create_three_node_group() -> Vec<RaftNode> {
     let peer_ids = vec![1u64, 2, 3];
     let mut nodes = Vec::new();
+    let snapshot_provider: Arc<dyn crate::raft_storage::RaftSnapshotProvider> =
+        Arc::new(|| Ok(Vec::new()));
 
     for &id in &peer_ids {
         let engine = test_engine();
@@ -47,7 +53,14 @@ fn create_three_node_group() -> Vec<RaftNode> {
             election_tick: 10,
             heartbeat_tick: 3,
         };
-        let node = RaftNode::new(config, engine, rx, HashMap::new()).unwrap();
+        let node = RaftNode::new(
+            config,
+            engine,
+            rx,
+            HashMap::new(),
+            Some(snapshot_provider.clone()),
+        )
+        .unwrap();
         nodes.push(node);
     }
 
@@ -66,7 +79,7 @@ fn tick_cycle(nodes: &mut [RaftNode], active: &[bool]) -> Vec<Vec<u8>> {
     }
 
     // Collect all messages from ready states.
-    let mut all_messages: Vec<(u64, raft::prelude::Message)> = Vec::new();
+    let mut all_messages: Vec<(u64, u64, raft::prelude::Message)> = Vec::new();
 
     for (i, node) in nodes.iter_mut().enumerate() {
         if !active[i] {
@@ -76,9 +89,12 @@ fn tick_cycle(nodes: &mut [RaftNode], active: &[bool]) -> Vec<Vec<u8>> {
             let mut ready = node.raw_node.ready();
 
             for msg in ready.take_messages() {
-                all_messages.push((msg.to, msg));
+                all_messages.push((node.node_id(), msg.to, msg));
             }
 
+            if !ready.snapshot().is_empty() {
+                node.storage.apply_snapshot(ready.snapshot()).unwrap();
+            }
             node.storage.append_entries(ready.entries()).unwrap();
             if let Some(hs) = ready.hs() {
                 node.storage.set_hardstate(hs).unwrap();
@@ -93,7 +109,7 @@ fn tick_cycle(nodes: &mut [RaftNode], active: &[bool]) -> Vec<Vec<u8>> {
             }
 
             for msg in ready.take_persisted_messages() {
-                all_messages.push((msg.to, msg));
+                all_messages.push((node.node_id(), msg.to, msg));
             }
 
             let mut light_rd = node.raw_node.advance(ready);
@@ -109,12 +125,25 @@ fn tick_cycle(nodes: &mut [RaftNode], active: &[bool]) -> Vec<Vec<u8>> {
     }
 
     // Route messages to target nodes (only active ones).
-    for (to, msg) in all_messages {
+    for (from, to, msg) in all_messages {
+        let is_snapshot = msg.get_msg_type() == raft::prelude::MessageType::MsgSnapshot;
+        let mut delivered = false;
         for (i, node) in nodes.iter_mut().enumerate() {
             if active[i] && node.node_id() == to {
                 let _ = node.raw_node.step(msg.clone());
+                delivered = true;
                 break;
             }
+        }
+        if is_snapshot && let Some(source) = nodes.iter_mut().find(|node| node.node_id() == from) {
+            source.raw_node.report_snapshot(
+                to,
+                if delivered {
+                    SnapshotStatus::Finish
+                } else {
+                    SnapshotStatus::Failure
+                },
+            );
         }
     }
 
@@ -428,5 +457,63 @@ async fn test_raft_log_consistency() {
         commit_indices[0] >= 5,
         "Commit index too low: {}",
         commit_indices[0]
+    );
+}
+
+// ============================================================
+// Test 8: Lagging follower catches up via snapshot
+// ============================================================
+
+#[tokio::test]
+async fn test_lagging_follower_catches_up_via_snapshot() {
+    let mut nodes = create_three_node_group();
+    let leader_id = elect_leader(&mut nodes);
+    let leader_idx = node_idx(&nodes, leader_id);
+    let lagging_idx = (0..3).find(|&i| i != leader_idx).unwrap();
+
+    let mut active = vec![true; 3];
+    active[lagging_idx] = false;
+
+    for i in 0..12 {
+        nodes[leader_idx]
+            .raw_node
+            .propose(vec![], format!("snapshot-entry-{i}").into_bytes())
+            .unwrap();
+        for _ in 0..5 {
+            tick_cycle(&mut nodes, &active);
+        }
+    }
+
+    let compact_index = nodes[leader_idx].raw_node.raft.raft_log.committed;
+    assert!(
+        compact_index > 1,
+        "expected committed work before compaction"
+    );
+    nodes[leader_idx].storage.compact(compact_index).unwrap();
+
+    active[lagging_idx] = true;
+    nodes[leader_idx]
+        .raw_node
+        .propose(vec![], b"post-snapshot".to_vec())
+        .unwrap();
+
+    for _ in 0..80 {
+        tick_cycle(&mut nodes, &active);
+        if nodes[lagging_idx].storage.last_index().unwrap()
+            == nodes[leader_idx].storage.last_index().unwrap()
+            && nodes[lagging_idx].storage.first_index().unwrap() > 1
+        {
+            break;
+        }
+    }
+
+    assert_eq!(
+        nodes[lagging_idx].storage.last_index().unwrap(),
+        nodes[leader_idx].storage.last_index().unwrap(),
+        "lagging follower should catch up to leader's last index",
+    );
+    assert!(
+        nodes[lagging_idx].storage.first_index().unwrap() > 1,
+        "lagging follower should have installed a snapshot instead of replaying from index 1",
     );
 }

--- a/crates/database/src/tests/search_index_backfill_tests.rs
+++ b/crates/database/src/tests/search_index_backfill_tests.rs
@@ -3,7 +3,7 @@
 /// `SearchIndexTestHarness` so they run for both text and vector indexes.
 use async_trait::async_trait;
 use runtime::testing::TestRuntime;
-use value::DeveloperDocumentId;
+use value::PublicDocumentId;
 
 /// Simplified view of a segment's document counts, common to both index
 /// types.
@@ -31,13 +31,13 @@ pub trait SearchIndexTestHarness: Sized + Send {
     async fn create_backfilling_index(&self) -> anyhow::Result<()>;
 
     /// Insert `count` documents and return their IDs.
-    async fn add_documents(&self, count: u32) -> anyhow::Result<Vec<DeveloperDocumentId>>;
+    async fn add_documents(&self, count: u32) -> anyhow::Result<Vec<PublicDocumentId>>;
 
     /// Delete a document by ID.
-    async fn delete_document(&self, id: DeveloperDocumentId) -> anyhow::Result<()>;
+    async fn delete_document(&self, id: PublicDocumentId) -> anyhow::Result<()>;
 
     /// Replace a document's content (new random content).
-    async fn replace_document(&self, id: DeveloperDocumentId) -> anyhow::Result<()>;
+    async fn replace_document(&self, id: PublicDocumentId) -> anyhow::Result<()>;
 
     /// Create a backfill flusher whose incremental threshold yields roughly
     /// `docs_per_segment` documents per segment, and step it once.
@@ -55,7 +55,7 @@ pub trait SearchIndexTestHarness: Sized + Send {
     /// Assert that exactly `expected_ids` are returned by a broad search.
     async fn assert_documents_searchable(
         &self,
-        expected_ids: &[DeveloperDocumentId],
+        expected_ids: &[PublicDocumentId],
     ) -> anyhow::Result<()>;
 }
 
@@ -280,7 +280,7 @@ mod text {
     };
     use runtime::testing::TestRuntime;
     use value::{
-        DeveloperDocumentId,
+        PublicDocumentId,
         TableNamespace,
     };
 
@@ -307,19 +307,19 @@ mod text {
             Ok(())
         }
 
-        async fn add_documents(&self, count: u32) -> anyhow::Result<Vec<DeveloperDocumentId>> {
+        async fn add_documents(&self, count: u32) -> anyhow::Result<Vec<PublicDocumentId>> {
             let mut ids = Vec::new();
             for i in 0..count {
                 let resolved_id = self
                     .fixtures
                     .add_document(&format!("searchable_text_{i}"))
                     .await?;
-                ids.push(resolved_id.developer_id);
+                ids.push(resolved_id.document_id);
             }
             Ok(ids)
         }
 
-        async fn delete_document(&self, id: DeveloperDocumentId) -> anyhow::Result<()> {
+        async fn delete_document(&self, id: PublicDocumentId) -> anyhow::Result<()> {
             let mut tx = self.fixtures.db.begin_system().await?;
             let resolved = tx.resolve_developer_id(&id, TableNamespace::test_user())?;
             tx.delete_inner(resolved).await?;
@@ -327,7 +327,7 @@ mod text {
             Ok(())
         }
 
-        async fn replace_document(&self, id: DeveloperDocumentId) -> anyhow::Result<()> {
+        async fn replace_document(&self, id: PublicDocumentId) -> anyhow::Result<()> {
             let resolved = {
                 let mut tx = self.fixtures.db.begin_system().await?;
                 tx.resolve_developer_id(&id, TableNamespace::test_user())?
@@ -396,12 +396,12 @@ mod text {
 
         async fn assert_documents_searchable(
             &self,
-            expected_ids: &[DeveloperDocumentId],
+            expected_ids: &[PublicDocumentId],
         ) -> anyhow::Result<()> {
             let index_name = "table.search_index".parse()?;
             // Search for a term that all added documents contain.
             let results = self.fixtures.search(index_name, "searchable_text").await?;
-            let mut result_ids: Vec<_> = results.iter().map(|r| r.id().developer_id).collect();
+            let mut result_ids: Vec<_> = results.iter().map(|r| r.id().document_id).collect();
             result_ids.sort();
             let mut expected: Vec<_> = expected_ids.to_vec();
             expected.sort();
@@ -477,7 +477,7 @@ mod vector {
     use value::{
         assert_obj,
         ConvexValue,
-        DeveloperDocumentId,
+        PublicDocumentId,
         TableName,
         TableNamespace,
     };
@@ -563,7 +563,7 @@ mod vector {
             Ok(())
         }
 
-        async fn add_documents(&self, count: u32) -> anyhow::Result<Vec<DeveloperDocumentId>> {
+        async fn add_documents(&self, count: u32) -> anyhow::Result<Vec<PublicDocumentId>> {
             let mut ids = Vec::new();
             for _ in 0..count {
                 let mut tx = self.database.begin(Identity::system()).await?;
@@ -581,7 +581,7 @@ mod vector {
             Ok(ids)
         }
 
-        async fn delete_document(&self, id: DeveloperDocumentId) -> anyhow::Result<()> {
+        async fn delete_document(&self, id: PublicDocumentId) -> anyhow::Result<()> {
             let mut tx = self.database.begin_system().await?;
             let mut model = UserFacingModel::new(&mut tx, TableNamespace::test_user());
             model.delete(id).await?;
@@ -589,7 +589,7 @@ mod vector {
             Ok(())
         }
 
-        async fn replace_document(&self, id: DeveloperDocumentId) -> anyhow::Result<()> {
+        async fn replace_document(&self, id: PublicDocumentId) -> anyhow::Result<()> {
             let mut tx = self.database.begin_system().await?;
             let random_vector = random_vector_value(&mut self.rt.rng());
             let obj = assert_obj!(
@@ -694,7 +694,7 @@ mod vector {
 
         async fn assert_documents_searchable(
             &self,
-            expected_ids: &[DeveloperDocumentId],
+            expected_ids: &[PublicDocumentId],
         ) -> anyhow::Result<()> {
             use common::components::ComponentId;
             use maplit::btreeset;
@@ -713,8 +713,7 @@ mod vector {
                     },
                 )
                 .await?;
-            let mut result_ids: Vec<DeveloperDocumentId> =
-                results.into_iter().map(|r| r.id).collect();
+            let mut result_ids: Vec<PublicDocumentId> = results.into_iter().map(|r| r.id).collect();
             result_ids.sort();
             let mut expected: Vec<_> = expected_ids.to_vec();
             expected.sort();

--- a/crates/database/src/tests/streaming_export_tests.rs
+++ b/crates/database/src/tests/streaming_export_tests.rs
@@ -80,21 +80,21 @@ async fn test_document_deltas(rt: TestRuntime) -> anyhow::Result<()> {
         vec![
             (
                 ts1,
-                doc1sort.developer_id(),
+                doc1sort.document_id(),
                 ComponentPath::root(),
                 table_mapping.tablet_name(doc1sort.id().tablet_id)?,
                 Some(StreamingExportDocument::with_all_fields(doc1sort.clone()))
             ),
             (
                 ts1,
-                doc2sort.developer_id(),
+                doc2sort.document_id(),
                 ComponentPath::root(),
                 table_mapping.tablet_name(doc2sort.id().tablet_id)?,
                 Some(StreamingExportDocument::with_all_fields(doc2sort.clone()))
             ),
             (
                 ts2,
-                doc3.developer_id(),
+                doc3.document_id(),
                 ComponentPath::root(),
                 table_mapping.tablet_name(doc3.id().tablet_id)?,
                 Some(StreamingExportDocument::with_all_fields(doc3.clone()))
@@ -117,7 +117,7 @@ async fn test_document_deltas(rt: TestRuntime) -> anyhow::Result<()> {
         deltas_cursor.deltas,
         vec![(
             ts2,
-            doc3.developer_id(),
+            doc3.document_id(),
             ComponentPath::root(),
             table_mapping.tablet_name(doc3.id().tablet_id)?,
             Some(StreamingExportDocument::with_all_fields(doc3.clone()))
@@ -145,7 +145,7 @@ async fn test_document_deltas(rt: TestRuntime) -> anyhow::Result<()> {
         deltas_table_filter.deltas,
         vec![(
             ts1,
-            doc1.developer_id(),
+            doc1.document_id(),
             ComponentPath::root(),
             table_mapping.tablet_name(doc1.id().tablet_id)?,
             Some(StreamingExportDocument::with_all_fields(doc1.clone()))
@@ -170,14 +170,14 @@ async fn test_document_deltas(rt: TestRuntime) -> anyhow::Result<()> {
         vec![
             (
                 ts1,
-                doc1sort.developer_id(),
+                doc1sort.document_id(),
                 ComponentPath::root(),
                 table_mapping.tablet_name(doc1sort.id().tablet_id)?,
                 Some(StreamingExportDocument::with_all_fields(doc1sort.clone()))
             ),
             (
                 ts1,
-                doc2sort.developer_id(),
+                doc2sort.document_id(),
                 ComponentPath::root(),
                 table_mapping.tablet_name(doc2sort.id().tablet_id)?,
                 Some(StreamingExportDocument::with_all_fields(doc2sort.clone()))
@@ -276,7 +276,7 @@ async fn document_deltas_should_not_ignore_rows_from_tables_that_were_not_delete
         deltas.deltas,
         vec![(
             ts_insert,
-            remaining_doc.developer_id(),
+            remaining_doc.document_id(),
             ComponentPath::root(),
             table_mapping.tablet_name(remaining_doc.id().tablet_id)?,
             Some(StreamingExportDocument::with_all_fields(
@@ -315,7 +315,7 @@ async fn test_snapshot_list(
         .insert_and_get("table3".parse()?, assert_obj!("f" => 3))
         .await?;
     let doc4 = UserFacingModel::new_root_for_test(&mut tx)
-        .patch(doc2.developer_id(), assert_obj!("f" => 4).into())
+        .patch(doc2.document_id(), assert_obj!("f" => 4).into())
         .await?;
     let tablet_id = tx
         .table_mapping()

--- a/crates/database/src/tests/text_test_utils.rs
+++ b/crates/database/src/tests/text_test_utils.rs
@@ -51,8 +51,8 @@ use sync_types::Timestamp;
 use usage_tracking::UsageCounter;
 use value::{
     assert_obj,
-    DeveloperDocumentId,
     FieldPath,
+    PublicDocumentId,
     ResolvedDocumentId,
     TableName,
     TableNamespace,
@@ -233,7 +233,7 @@ impl TextFixtures {
 
     pub async fn index_backfill_progress(
         &self,
-        index_id: DeveloperDocumentId,
+        index_id: PublicDocumentId,
     ) -> anyhow::Result<Option<Arc<ParsedDocument<IndexBackfillMetadata>>>> {
         let mut tx = self.db.begin_system().await?;
         IndexBackfillModel::new(&mut tx)

--- a/crates/database/src/tests/usage_tracking.rs
+++ b/crates/database/src/tests/usage_tracking.rs
@@ -574,7 +574,7 @@ async fn test_usage_tracking_basic_insert_and_get(rt: TestRuntime) -> anyhow::Re
         .begin_with_usage(Identity::Unknown(None), tx_usage.clone())
         .await?;
     UserFacingModel::new_root_for_test(&mut tx)
-        .get_with_ts(doc_id.developer_id, None)
+        .get_with_ts(doc_id.document_id, None)
         .await?;
     db.commit(tx).await?;
     usage_counter

--- a/crates/database/src/tests/vector_test_utils.rs
+++ b/crates/database/src/tests/vector_test_utils.rs
@@ -66,8 +66,8 @@ use usage_tracking::UsageCounter;
 use value::{
     assert_obj,
     ConvexValue,
-    DeveloperDocumentId,
     FieldPath,
+    PublicDocumentId,
     ResolvedDocumentId,
     TableName,
     TableNamespace,
@@ -244,7 +244,7 @@ impl VectorFixtures {
 
     pub async fn index_backfill_progress(
         &self,
-        index_id: DeveloperDocumentId,
+        index_id: PublicDocumentId,
     ) -> anyhow::Result<Option<Arc<ParsedDocument<IndexBackfillMetadata>>>> {
         let mut tx = self.db.begin_system().await?;
         IndexBackfillModel::new(&mut tx)

--- a/crates/database/src/tests/vector_tests.rs
+++ b/crates/database/src/tests/vector_tests.rs
@@ -55,9 +55,9 @@ use search::searcher::{
 use storage::Storage;
 use value::{
     assert_obj,
-    ConvexObject,
     ConvexValue,
-    DeveloperDocumentId,
+    DocumentObject,
+    PublicDocumentId,
     TableName,
     TableNamespace,
 };
@@ -202,7 +202,7 @@ impl<RT: Runtime> Scenario<RT> {
     async fn seed_table_with_vector_data(
         &self,
         num_docs: u32,
-    ) -> anyhow::Result<Vec<DeveloperDocumentId>> {
+    ) -> anyhow::Result<Vec<PublicDocumentId>> {
         let mut ids = vec![];
         for _ in 0..num_docs {
             let mut tx = self.database.begin(Identity::system()).await?;
@@ -359,7 +359,7 @@ enum TestAction {
 
 struct RandomizedTest<RT: Runtime> {
     scenario: Scenario<RT>,
-    model: BTreeMap<TestKey, (DeveloperDocumentId, TestUpdate)>,
+    model: BTreeMap<TestKey, (PublicDocumentId, TestUpdate)>,
 }
 
 impl<RT: Runtime> RandomizedTest<RT> {
@@ -386,7 +386,7 @@ impl<RT: Runtime> RandomizedTest<RT> {
                         ConvexValue::String(format!("{value:?}").try_into()?),
                     );
                 }
-                let new_obj = ConvexObject::try_from(new_obj)?;
+                let new_obj = DocumentObject::try_from(new_obj)?;
                 let id = if let Some((document_id, _)) = self.model.remove(&update.key) {
                     UserFacingModel::new_root_for_test(&mut tx)
                         .replace(document_id, new_obj)
@@ -920,7 +920,7 @@ async fn test_recall_multi_segment(rt: TestRuntime) -> anyhow::Result<()> {
     let mut expected: Vec<_> = by_id
         .iter()
         .map(|(id, vector)| PublicVectorSearchQueryResult {
-            id: DeveloperDocumentId::new(table_number, *id),
+            id: PublicDocumentId::new(table_number, *id),
             score: cosine_similarity(&query, vector),
         })
         .collect();

--- a/crates/database/src/tests/write_scaling_tests.rs
+++ b/crates/database/src/tests/write_scaling_tests.rs
@@ -10,10 +10,16 @@ use std::{
     time::Duration,
 };
 
+use async_trait::async_trait;
 use common::{
     assert_obj,
     bootstrap_model::index::database_index::IndexedFields,
     interval::Interval,
+    pause::PauseController,
+    query::{
+        Order,
+        Query,
+    },
     runtime::{
         new_unlimited_rate_limiter,
         testing::{
@@ -23,7 +29,10 @@ use common::{
     },
     shutdown::ShutdownSignal,
     testing::TestPersistence,
-    types::TabletIndexName,
+    types::{
+        TabletIndexName,
+        Timestamp,
+    },
 };
 use keybroker::Identity;
 use pb::replication::{
@@ -62,7 +71,10 @@ use crate::{
         testing::InMemoryDistributedLog,
         CommitDelta,
     },
-    committer::CommitterClient,
+    committer::{
+        CommitterClient,
+        AFTER_PENDING_WRITE_SNAPSHOT,
+    },
     partition::{
         PartitionId,
         PartitionMap,
@@ -77,6 +89,7 @@ use crate::{
         TwoPhaseCommitGrpcClient,
         TwoPhaseTransactionId,
     },
+    tests::run_query,
     Database,
     TestFacingModel,
     UserFacingModel,
@@ -146,10 +159,14 @@ fn partitioned_map(local_partition: PartitionId) -> PartitionMap {
     PartitionMap::from_config("messages=0,projects=1", local_partition, 2)
 }
 
+fn partitioned_map_with_tasks(local_partition: PartitionId) -> PartitionMap {
+    PartitionMap::from_config("messages=0,projects=1,tasks=1", local_partition, 2)
+}
+
 async fn insert_doc_get_id(
     db: &Database<TestRuntime>,
     table: &str,
-    fields: common::value::ConvexObject,
+    fields: common::value::DocumentObject,
 ) -> anyhow::Result<ResolvedDocumentId> {
     let table_name: TableName = table.parse()?;
     let mut tx = db.begin(Identity::system()).await?;
@@ -163,7 +180,7 @@ async fn insert_doc_get_id(
 async fn insert_doc(
     db: &Database<TestRuntime>,
     table: &str,
-    fields: common::value::ConvexObject,
+    fields: common::value::DocumentObject,
 ) -> anyhow::Result<common::types::Timestamp> {
     let table_name: TableName = table.parse()?;
     let mut tx = db.begin(Identity::system()).await?;
@@ -268,6 +285,23 @@ impl TwoPhaseCommitService for FailingPrepareGrpcService {
         Err(Status::failed_precondition(
             "rollback_prepared should not be called after a failed prepare",
         ))
+    }
+}
+
+struct FailingTimestampOracle;
+
+#[async_trait]
+impl TimestampOracle for FailingTimestampOracle {
+    async fn next_ts(&self) -> anyhow::Result<Timestamp> {
+        anyhow::bail!("TSO unavailable during idle heartbeat test");
+    }
+
+    async fn max_committed_ts(&self) -> anyhow::Result<Timestamp> {
+        anyhow::bail!("TSO unavailable during idle heartbeat test");
+    }
+
+    async fn advance_committed_ts(&self, _ts: Timestamp) -> anyhow::Result<()> {
+        anyhow::bail!("TSO unavailable during idle heartbeat test");
     }
 }
 
@@ -834,6 +868,220 @@ async fn test_replication_frontier_persists_across_restart(rt: TestRuntime) -> a
     Ok(())
 }
 
+#[convex_macro::test_runtime]
+async fn test_replication_frontier_heartbeat_does_not_advance_snapshot_ts(
+    rt: TestRuntime,
+) -> anyhow::Result<()> {
+    let log = Arc::new(InMemoryDistributedLog::new());
+    let node_a = create_node(&rt, log.clone(), Some(partitioned_map(PartitionId(0)))).await?;
+    let node_b = create_node(&rt, log.clone(), Some(partitioned_map(PartitionId(1)))).await?;
+
+    insert_doc(&node_b, "projects", assert_obj!("name" => "seed")).await?;
+    let initial_delta = log
+        .deltas()
+        .into_iter()
+        .last()
+        .expect("seed project should publish a delta");
+    node_a
+        .committer_for_test()
+        .apply_replica_delta(initial_delta)
+        .await?;
+
+    let snapshot_ts_before = *node_a.now_ts_for_reads();
+    let persisted_repeatable_before = *node_a.persisted_max_repeatable_ts_for_test();
+    let projects = run_query(
+        node_a.clone(),
+        TableNamespace::root_component(),
+        Query::full_table_scan("projects".parse()?, Order::Asc),
+    )
+    .await?;
+    assert_eq!(projects.len(), 1, "replica should expose the seeded project");
+
+    let heartbeat_ts = node_b.bump_max_repeatable_ts().await?;
+    node_a
+        .committer_for_test()
+        .apply_replica_delta(CommitDelta {
+            ts: heartbeat_ts,
+            document_writes: Arc::new(Vec::new()),
+            document_updates: Vec::new(),
+            index_writes: Arc::new(Vec::new()),
+            write_source: WriteSource::new("replication_frontier_snapshot_ts_test"),
+            write_bytes: 0,
+            tablet_id_to_table_name: Default::default(),
+            source_partition: Some(PartitionId(1)),
+        })
+        .await?;
+
+    assert_eq!(
+        *node_a.now_ts_for_reads(),
+        snapshot_ts_before,
+        "frontier-only heartbeats should not publish a cloned snapshot",
+    );
+    assert_eq!(
+        *node_a.persisted_max_repeatable_ts_for_test(),
+        persisted_repeatable_before,
+        "frontier-only heartbeats should not advertise a newer persisted snapshot",
+    );
+    assert_eq!(
+        node_a.replication_frontier_for_test(PartitionId(1)),
+        Some(heartbeat_ts),
+        "heartbeat should still advance the remote replication frontier",
+    );
+
+    let projects_after = run_query(
+        node_a,
+        TableNamespace::root_component(),
+        Query::full_table_scan("projects".parse()?, Order::Asc),
+    )
+    .await?;
+    assert_eq!(
+        projects_after.len(),
+        1,
+        "heartbeat should not erase replica-queryable state",
+    );
+
+    Ok(())
+}
+
+#[convex_macro::test_runtime]
+async fn test_replica_table_number_allocation_waits_for_prior_publish(
+    rt: TestRuntime,
+) -> anyhow::Result<()> {
+    let log = Arc::new(InMemoryDistributedLog::new());
+    let node_a = create_node(
+        &rt,
+        log.clone(),
+        Some(partitioned_map_with_tasks(PartitionId(0))),
+    )
+    .await?;
+    let node_b = create_node(
+        &rt,
+        log.clone(),
+        Some(partitioned_map_with_tasks(PartitionId(1))),
+    )
+    .await?;
+
+    insert_doc(&node_b, "projects", assert_obj!("name" => "seed-project")).await?;
+    let project_delta = log
+        .deltas()
+        .into_iter()
+        .last()
+        .expect("project seed should publish a delta");
+    node_a
+        .committer_for_test()
+        .apply_replica_delta(project_delta)
+        .await?;
+
+    insert_doc(
+        &node_b,
+        "tasks",
+        assert_obj!("title" => "seed-task", "project" => "seed-project"),
+    )
+    .await?;
+    let task_delta = log
+        .deltas()
+        .into_iter()
+        .last()
+        .expect("task seed should publish a delta");
+    node_a
+        .committer_for_test()
+        .apply_replica_delta(task_delta)
+        .await?;
+
+    let mut tx = node_a.begin(Identity::system()).await?;
+    let mapping = tx.table_mapping().namespace(TableNamespace::Global);
+    let projects = mapping.id(&"projects".parse()?)?;
+    let tasks = mapping.id(&"tasks".parse()?)?;
+
+    assert_ne!(
+        projects.table_number, tasks.table_number,
+        "replica-applied tables must allocate distinct local table numbers",
+    );
+
+    Ok(())
+}
+
+#[convex_macro::test_runtime]
+async fn test_replica_delta_does_not_erase_pending_local_table_creation(
+    rt: TestRuntime,
+    pause: PauseController,
+) -> anyhow::Result<()> {
+    let log = Arc::new(InMemoryDistributedLog::new());
+    let node_a = create_node(
+        &rt,
+        log.clone(),
+        Some(partitioned_map_with_tasks(PartitionId(0))),
+    )
+    .await?;
+    let node_b = create_node(
+        &rt,
+        log.clone(),
+        Some(partitioned_map_with_tasks(PartitionId(1))),
+    )
+    .await?;
+
+    let hold_guard = pause.hold(AFTER_PENDING_WRITE_SNAPSHOT);
+    let node_b_for_commit = node_b.clone();
+    let first_task_fut = async move {
+        insert_doc_get_id(
+            &node_b_for_commit,
+            "tasks",
+            assert_obj!("title" => "task-1", "project" => "alpha"),
+        )
+        .await
+    };
+
+    let node_a_for_delta = node_a.clone();
+    let node_b_for_delta = node_b.clone();
+    let log_for_delta = log.clone();
+    let orchestrate = async move {
+        let pause_guard = hold_guard.wait_for_blocked().await;
+
+        insert_doc(
+            &node_a_for_delta,
+            "messages",
+            assert_obj!("text" => "remote-message"),
+        )
+        .await?;
+        let delta = log_for_delta
+            .deltas()
+            .into_iter()
+            .last()
+            .expect("remote message should publish a delta");
+
+        let committer = node_b_for_delta.committer_for_test();
+        let apply_fut = committer.apply_replica_delta(delta);
+        if let Some(guard) = pause_guard {
+            guard.unpause();
+        }
+        apply_fut.await?;
+        anyhow::Ok(())
+    };
+
+    let (first_task_id, ..) = futures::try_join!(first_task_fut, orchestrate)?;
+
+    let second_task_id = insert_doc_get_id(
+        &node_b,
+        "tasks",
+        assert_obj!("title" => "task-2", "project" => "alpha"),
+    )
+    .await?;
+
+    let mut tx = node_b.begin(Identity::system()).await?;
+    assert_eq!(
+        tx.get(first_task_id).await?.is_some(),
+        true,
+        "the first locally created task must remain readable after replica apply",
+    );
+    assert_eq!(
+        tx.get(second_task_id).await?.is_some(),
+        true,
+        "the second locally created task must remain readable after replica apply",
+    );
+
+    Ok(())
+}
+
 #[test]
 fn test_remote_prepare_over_grpc_is_idempotent() -> anyhow::Result<()> {
     let td = TestDriver::new_with_io();
@@ -868,8 +1116,15 @@ fn test_remote_prepare_over_grpc_is_idempotent() -> anyhow::Result<()> {
             .enumerate()
             .map(|(index, _)| index)
             .collect();
-        let participant_tx =
-            ParticipantTransaction::from_final_transaction(&final_tx, &write_indexes)?;
+        let write_source = WriteSource::new("remote_prepare_idempotent_test");
+        let partition_map = partitioned_map(PartitionId(1));
+        let participant_tx = ParticipantTransaction::from_final_transaction(
+            &final_tx,
+            PartitionId(1),
+            &write_indexes,
+            &partition_map,
+            &write_source,
+        )?;
 
         let txn_id = TwoPhaseTransactionId::new();
         let prepare_ts = node_b.committer_for_test().allocate_commit_ts().await?;
@@ -878,17 +1133,12 @@ fn test_remote_prepare_over_grpc_is_idempotent() -> anyhow::Result<()> {
             .prepare(
                 &txn_id,
                 participant_tx.clone(),
-                WriteSource::new("remote_prepare_idempotent_test"),
+                write_source.clone(),
                 prepare_ts,
             )
             .await?;
         let second = client
-            .prepare(
-                &txn_id,
-                participant_tx,
-                WriteSource::new("remote_prepare_idempotent_test"),
-                prepare_ts,
-            )
+            .prepare(&txn_id, participant_tx, write_source, prepare_ts)
             .await?;
 
         assert_eq!(first.prepare_ts, prepare_ts);
@@ -1033,7 +1283,7 @@ fn test_failed_remote_prepare_rolls_back_local_participant() -> anyhow::Result<(
 
         let message_id =
             insert_doc_get_id(&node_a, "messages", assert_obj!("text" => "seed")).await?;
-        let message_id = value::DeveloperDocumentId::from(message_id);
+        let message_id = value::PublicDocumentId::from(message_id);
 
         let mut tx = node_a.begin(Identity::system()).await?;
         let mut model = TestFacingModel::new(&mut tx);
@@ -1063,6 +1313,34 @@ fn test_failed_remote_prepare_rolls_back_local_participant() -> anyhow::Result<(
         node_a.commit(retry_tx).await?;
 
         failing_server.shutdown().await?;
+        Ok(())
+    })
+}
+
+#[test]
+fn test_idle_replication_frontier_heartbeat_tso_failure_is_nonfatal() -> anyhow::Result<()> {
+    let td = TestDriver::new_with_io();
+    let rt = td.rt();
+    td.run_until(async move {
+        let log = Arc::new(InMemoryDistributedLog::new());
+        let tso: Arc<dyn TimestampOracle> = Arc::new(FailingTimestampOracle);
+        let node = create_node_with_options(
+            &rt,
+            log,
+            Some(partitioned_map(PartitionId(0))),
+            None,
+            Some(tso),
+        )
+        .await?;
+
+        let committer = node.committer_for_test();
+        committer
+            .tick_idle_replication_frontier_heartbeat_for_test()
+            .await?;
+        committer
+            .tick_idle_replication_frontier_heartbeat_for_test()
+            .await?;
+
         Ok(())
     })
 }

--- a/crates/database/src/text_index_worker/text_meta.rs
+++ b/crates/database/src/text_index_worker/text_meta.rs
@@ -75,7 +75,7 @@ use search::{
 use storage::Storage;
 use sync_types::Timestamp;
 use value::{
-    DeveloperDocumentId,
+    PublicDocumentId,
     TableNumber,
     TabletId,
 };
@@ -259,7 +259,7 @@ impl SearchIndex for TextSearchIndex {
             .try_filter(move |revision_pair| {
                 let doc_id_index_key = IndexKey::new(
                     vec![],
-                    DeveloperDocumentId::new(table_number, revision_pair.id.internal_id()),
+                    PublicDocumentId::new(table_number, revision_pair.id.internal_id()),
                 );
                 futures::future::ready(filter_id_range.contains(&doc_id_index_key.to_bytes()))
             })

--- a/crates/database/src/timestamp_oracle.rs
+++ b/crates/database/src/timestamp_oracle.rs
@@ -79,7 +79,10 @@ impl<RT: Runtime> TimestampOracle for LocalTimestampOracle<RT> {
     async fn next_ts(&self) -> anyhow::Result<Timestamp> {
         let mut state = self.state.lock();
         let system_ts = self.runtime.generate_timestamp()?;
-        let next = std::cmp::max(system_ts, state.last_assigned.succ()?);
+        let next = std::cmp::max(
+            system_ts,
+            std::cmp::max(state.last_assigned.succ()?, state.max_committed.succ()?),
+        );
         state.last_assigned = next;
         Ok(next)
     }
@@ -128,6 +131,19 @@ struct BatchState {
 const TSO_COUNTER_KEY: &str = "tso_counter";
 const TSO_MAX_COMMITTED_KEY: &str = "tso_max_committed";
 const DEFAULT_BATCH_SIZE: u64 = 1000;
+
+fn next_ts_from_reserved_batch(
+    current: u64,
+    upper_bound: u64,
+    min_next: u64,
+) -> Option<(u64, u64)> {
+    let candidate = std::cmp::max(current, min_next);
+    (candidate < upper_bound).then_some((candidate, candidate + 1))
+}
+
+fn batch_lower_bound(counter_value: u64, min_next: u64) -> u64 {
+    std::cmp::max(counter_value, min_next)
+}
 
 impl BatchTimestampOracle {
     /// Connect to NATS and initialize the KV bucket for timestamp allocation.
@@ -186,7 +202,7 @@ impl BatchTimestampOracle {
     /// Reserve a new batch of timestamps from the central counter.
     /// Uses NATS KV atomic update (CAS) to ensure no two nodes get
     /// overlapping ranges.
-    async fn reserve_batch(&self) -> anyhow::Result<(u64, u64)> {
+    async fn reserve_batch_at_or_above(&self, min_next: u64) -> anyhow::Result<(u64, u64)> {
         let jetstream = async_nats::jetstream::new(self.nats_client.clone());
         let kv = jetstream
             .get_key_value(&self.kv_bucket)
@@ -209,8 +225,8 @@ impl BatchTimestampOracle {
                     .context("TSO: Invalid counter value")?,
             );
 
-            let new_lower = current_value;
-            let new_upper = current_value + self.batch_size;
+            let new_lower = batch_lower_bound(current_value, min_next);
+            let new_upper = new_lower + self.batch_size;
             let new_value = new_upper.to_be_bytes().to_vec();
 
             // Atomic compare-and-swap: only succeeds if no other node
@@ -240,24 +256,35 @@ impl BatchTimestampOracle {
 #[async_trait]
 impl TimestampOracle for BatchTimestampOracle {
     async fn next_ts(&self) -> anyhow::Result<Timestamp> {
-        // Fast path: check if we have a timestamp available in the current batch.
-        {
-            let mut state = self.state.lock();
-            if state.current < state.upper_bound {
-                let ts = state.current;
-                state.current += 1;
+        let committed_floor = self.max_committed_ts().await?;
+        let min_next = u64::from(committed_floor.succ()?);
+
+        loop {
+            let candidate = {
+                let mut state = self.state.lock();
+                if committed_floor > state.max_committed {
+                    state.max_committed = committed_floor;
+                }
+
+                if let Some((ts, next_current)) =
+                    next_ts_from_reserved_batch(state.current, state.upper_bound, min_next)
+                {
+                    state.current = next_current;
+                    Some(ts)
+                } else {
+                    None
+                }
+            };
+
+            if let Some(ts) = candidate {
                 return Timestamp::try_from(ts);
             }
+
+            let (lower, upper) = self.reserve_batch_at_or_above(min_next).await?;
+            let mut state = self.state.lock();
+            state.current = lower;
+            state.upper_bound = upper;
         }
-
-        // Slow path: reserve a new batch from NATS KV.
-        let (lower, upper) = self.reserve_batch().await?;
-
-        let mut state = self.state.lock();
-        state.current = lower + 1; // We'll return `lower`, advance to lower+1.
-        state.upper_bound = upper;
-
-        Timestamp::try_from(lower)
     }
 
     async fn max_committed_ts(&self) -> anyhow::Result<Timestamp> {
@@ -294,7 +321,6 @@ impl TimestampOracle for BatchTimestampOracle {
             }
         }
 
-        // Update NATS KV (best-effort, non-blocking for the commit path).
         let jetstream = async_nats::jetstream::new(self.nats_client.clone());
         let kv = jetstream
             .get_key_value(&self.kv_bucket)
@@ -302,9 +328,47 @@ impl TimestampOracle for BatchTimestampOracle {
             .context("TSO: Failed to get KV bucket")?;
 
         let value = ts_u64.to_be_bytes().to_vec();
-        let _ = kv.put(TSO_MAX_COMMITTED_KEY, value.into()).await;
+        for attempt in 0..10 {
+            match kv.entry(TSO_MAX_COMMITTED_KEY).await? {
+                Some(entry) => {
+                    let current = u64::from_be_bytes(
+                        entry
+                            .value
+                            .as_ref()
+                            .try_into()
+                            .context("TSO: Invalid max_committed value")?,
+                    );
+                    if current >= ts_u64 {
+                        return Ok(());
+                    }
 
-        Ok(())
+                    match kv
+                        .update(TSO_MAX_COMMITTED_KEY, value.clone().into(), entry.revision)
+                        .await
+                    {
+                        Ok(_) => return Ok(()),
+                        Err(_) => {
+                            tracing::debug!(
+                                "TSO: max_committed CAS conflict on attempt {attempt}, retrying"
+                            );
+                            tokio::time::sleep(std::time::Duration::from_millis(1 << attempt))
+                                .await;
+                        },
+                    }
+                },
+                None => match kv.create(TSO_MAX_COMMITTED_KEY, value.clone().into()).await {
+                    Ok(_) => return Ok(()),
+                    Err(_) => {
+                        tracing::debug!(
+                            "TSO: max_committed create conflict on attempt {attempt}, retrying"
+                        );
+                        tokio::time::sleep(std::time::Duration::from_millis(1 << attempt)).await;
+                    },
+                },
+            }
+        }
+
+        anyhow::bail!("TSO: Failed to advance max_committed after 10 attempts")
     }
 }
 
@@ -336,7 +400,7 @@ pub mod testing {
     impl TimestampOracle for InMemoryTimestampOracle {
         async fn next_ts(&self) -> anyhow::Result<Timestamp> {
             let mut state = self.state.lock();
-            let next = state.last_assigned.succ()?;
+            let next = std::cmp::max(state.last_assigned.succ()?, state.max_committed.succ()?);
             state.last_assigned = next;
             Ok(next)
         }
@@ -352,5 +416,42 @@ pub mod testing {
             }
             Ok(())
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        batch_lower_bound,
+        next_ts_from_reserved_batch,
+    };
+
+    #[test]
+    fn reserved_batch_uses_current_when_already_above_floor() {
+        let (ts, next_current) =
+            next_ts_from_reserved_batch(100, 200, 90).expect("candidate within batch");
+        assert_eq!(ts, 100);
+        assert_eq!(next_current, 101);
+    }
+
+    #[test]
+    fn reserved_batch_fast_forwards_to_committed_floor() {
+        let (ts, next_current) =
+            next_ts_from_reserved_batch(100, 200, 150).expect("candidate within batch");
+        assert_eq!(ts, 150);
+        assert_eq!(next_current, 151);
+    }
+
+    #[test]
+    fn reserved_batch_exhausts_when_floor_is_beyond_range() {
+        assert!(next_ts_from_reserved_batch(100, 200, 200).is_none());
+        assert!(next_ts_from_reserved_batch(100, 200, 250).is_none());
+    }
+
+    #[test]
+    fn reserve_batch_starts_above_committed_floor_when_counter_lags() {
+        assert_eq!(batch_lower_bound(1000, 1001), 1001);
+        assert_eq!(batch_lower_bound(1000, 1500), 1500);
+        assert_eq!(batch_lower_bound(2000, 1500), 2000);
     }
 }

--- a/crates/database/src/transaction.rs
+++ b/crates/database/src/transaction.rs
@@ -66,8 +66,8 @@ use common::{
         WriteTimestamp,
     },
     value::{
-        id_v6::DeveloperDocumentId,
-        ConvexObject,
+        id_v6::PublicDocumentId,
+        DocumentObject,
         ResolvedDocumentId,
         Size,
         TableMapping,
@@ -257,7 +257,7 @@ impl<RT: Runtime> Transaction<RT> {
 
     pub fn resolve_developer_id(
         &mut self,
-        id: &DeveloperDocumentId,
+        id: &PublicDocumentId,
         namespace: TableNamespace,
     ) -> anyhow::Result<ResolvedDocumentId> {
         id.to_resolved(self.table_mapping().namespace(namespace).number_to_tablet())
@@ -301,7 +301,7 @@ impl<RT: Runtime> Transaction<RT> {
 
     pub fn resolve_idv6(
         &mut self,
-        id: DeveloperDocumentId,
+        id: PublicDocumentId,
         namespace: TableNamespace,
         table_filter: TableFilter,
     ) -> anyhow::Result<TableName> {
@@ -599,7 +599,7 @@ impl<RT: Runtime> Transaction<RT> {
     pub(crate) async fn replace_inner(
         &mut self,
         id: ResolvedDocumentId,
-        value: ConvexObject,
+        value: DocumentObject,
     ) -> anyhow::Result<ResolvedDocument> {
         task::consume_budget().await;
 

--- a/crates/database/src/transaction_id_generator.rs
+++ b/crates/database/src/transaction_id_generator.rs
@@ -11,7 +11,7 @@ use rand::{
 };
 use rand_chacha::ChaCha12Rng;
 use value::{
-    DeveloperDocumentId,
+    PublicDocumentId,
     ResolvedDocumentId,
     TableNumber,
     TabletIdAndTableNumber,
@@ -55,8 +55,8 @@ impl TransactionIdGenerator {
         InternalId(id_bytes)
     }
 
-    pub fn generate(&mut self, table_number: TableNumber) -> DeveloperDocumentId {
-        DeveloperDocumentId::new(table_number, self.generate_internal())
+    pub fn generate(&mut self, table_number: TableNumber) -> PublicDocumentId {
+        PublicDocumentId::new(table_number, self.generate_internal())
     }
 
     pub fn generate_resolved(
@@ -65,7 +65,7 @@ impl TransactionIdGenerator {
     ) -> ResolvedDocumentId {
         ResolvedDocumentId::new(
             tablet_id_and_number.tablet_id,
-            DeveloperDocumentId::new(tablet_id_and_number.table_number, self.generate_internal()),
+            PublicDocumentId::new(tablet_id_and_number.table_number, self.generate_internal()),
         )
     }
 }

--- a/crates/database/src/transaction_index.rs
+++ b/crates/database/src/transaction_index.rs
@@ -67,8 +67,8 @@ use search::{
 use storage::Storage;
 use tokio::task;
 use value::{
-    DeveloperDocumentId,
     FieldPath,
+    PublicDocumentId,
 };
 
 use crate::{
@@ -635,7 +635,7 @@ impl TransactionIndex {
             // name->index mapping to depend only on index id, we rely
             // on index name being immutable.
             Some(index) => {
-                let full_index_id = DeveloperDocumentId::new(index_table_number, index.id());
+                let full_index_id = PublicDocumentId::new(index_table_number, index.id());
                 let index_key = IndexKey::new(vec![], full_index_id);
                 Interval::prefix(index_key.to_bytes().into())
             },

--- a/crates/database/src/two_phase.rs
+++ b/crates/database/src/two_phase.rs
@@ -15,10 +15,7 @@
 //!   - TiDB 1PC: https://pingcap.github.io/tidb-dev-guide/understand-tidb/1pc.html
 //!   - CockroachDB: https://www.cockroachlabs.com/blog/parallel-commits/
 
-use std::collections::{
-    BTreeMap,
-    BTreeSet,
-};
+use std::collections::BTreeMap;
 
 use anyhow::Context;
 use common::{
@@ -76,7 +73,11 @@ use value::{
 };
 
 use crate::{
-    partition::PartitionId,
+    partition::{
+        routed_partition_for_table,
+        PartitionId,
+        PartitionMap,
+    },
     reads::{
         IndexReads,
         ReadSet,
@@ -186,6 +187,7 @@ impl NodeAddresses {
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct ParticipantTabletMetadata {
     pub tablet_id: TabletId,
+    pub namespace: TableNamespace,
     pub table_number: TableNumber,
     pub table_name: TableName,
 }
@@ -202,7 +204,10 @@ pub struct ParticipantTransaction {
 impl ParticipantTransaction {
     pub fn from_final_transaction(
         transaction: &FinalTransaction,
+        participant: PartitionId,
         write_indexes: &[usize],
+        partition_map: &PartitionMap,
+        write_source: &WriteSource,
     ) -> anyhow::Result<Self> {
         let selected_writes: Vec<_> = transaction
             .writes
@@ -211,22 +216,29 @@ impl ParticipantTransaction {
             .filter(|(index, _)| write_indexes.contains(index))
             .map(|(_, write)| write.clone())
             .collect();
-        let relevant_tablets: BTreeSet<_> = selected_writes
-            .iter()
-            .map(|write| write.id.tablet_id)
-            .collect();
+
+        let belongs_to_participant = |tablet_id: TabletId| -> bool {
+            let Ok(table_name) = transaction.table_mapping.tablet_name(tablet_id) else {
+                return false;
+            };
+            match routed_partition_for_table(&table_name, partition_map, write_source) {
+                Some(owner) => owner == participant,
+                None => participant == partition_map.local_partition(),
+            }
+        };
+
         let indexed_reads = transaction
             .reads
             .read_set()
             .iter_indexed()
-            .filter(|(index_name, _)| relevant_tablets.contains(index_name.table()))
+            .filter(|(index_name, _)| belongs_to_participant(*index_name.table()))
             .map(|(index_name, reads)| (index_name.clone(), reads.clone()))
             .collect();
         let search_reads = transaction
             .reads
             .read_set()
             .iter_search()
-            .filter(|(index_name, _)| relevant_tablets.contains(index_name.table()))
+            .filter(|(index_name, _)| belongs_to_participant(*index_name.table()))
             .map(|(index_name, reads)| (index_name.clone(), reads.clone()))
             .collect();
         let reads = ReadSet::new(indexed_reads, search_reads);
@@ -238,10 +250,12 @@ impl ParticipantTransaction {
             }
             let table_name = transaction.table_mapping.tablet_name(tablet_id)?;
             let table_number = transaction.table_mapping.tablet_number(tablet_id)?;
+            let namespace = transaction.table_mapping.tablet_namespace(tablet_id)?;
             tablet_metadata.insert(
                 tablet_id,
                 ParticipantTabletMetadata {
                     tablet_id,
+                    namespace,
                     table_number,
                     table_name,
                 },
@@ -277,7 +291,7 @@ impl ParticipantTransaction {
             }
             table_mapping.insert_tablet(
                 metadata.tablet_id,
-                TableNamespace::Global,
+                metadata.namespace,
                 metadata.table_number,
                 metadata.table_name.clone(),
             );
@@ -320,16 +334,22 @@ impl TryFrom<TwoPcParticipantTransactionProto> for ParticipantTransaction {
             .map(
                 |TwoPcTabletMetadata {
                      tablet_id,
+                     component_id,
                      table_number,
                      table_name,
                  }| {
                     let tablet_id = tablet_id_from_bytes(tablet_id)?;
+                    let namespace = match component_id {
+                        Some(component_id) => TableNamespace::ByComponent(component_id.parse()?),
+                        None => TableNamespace::Global,
+                    };
                     let table_number = table_number.try_into()?;
                     let table_name = table_name.parse::<TableName>()?;
                     Ok((
                         tablet_id,
                         ParticipantTabletMetadata {
                             tablet_id,
+                            namespace,
                             table_number,
                             table_name,
                         },
@@ -491,6 +511,10 @@ impl TryFrom<ParticipantTransaction> for TwoPcParticipantTransactionProto {
                 .into_values()
                 .map(|metadata| TwoPcTabletMetadata {
                     tablet_id: tablet_id_to_bytes(metadata.tablet_id),
+                    component_id: match metadata.namespace {
+                        TableNamespace::Global => None,
+                        TableNamespace::ByComponent(component_id) => Some(component_id.encode()),
+                    },
                     table_number: u32::from(metadata.table_number),
                     table_name: metadata.table_name.to_string(),
                 })

--- a/crates/database/src/two_phase_coordinator.rs
+++ b/crates/database/src/two_phase_coordinator.rs
@@ -18,6 +18,7 @@ use common::types::Timestamp;
 use crate::{
     committer::CommitterClient,
     partition::{
+        routed_partition_for_table,
         PartitionId,
         PartitionMap,
     },
@@ -38,6 +39,9 @@ pub enum TransactionClassification {
     /// All writes target a single partition — use the normal fast path (TiDB
     /// 1PC).
     SinglePartition,
+    /// All writes target a single remote partition. This should be rejected by
+    /// the receiving node instead of running 2PC locally.
+    RemoteSinglePartition { owner: PartitionId },
     /// Writes span multiple partitions — use 2PC.
     CrossPartition {
         /// Writes grouped by owning partition.
@@ -49,23 +53,33 @@ pub enum TransactionClassification {
 pub fn classify_transaction(
     transaction: &FinalTransaction,
     partition_map: &PartitionMap,
+    write_source: &WriteSource,
 ) -> TransactionClassification {
     let mut partitions: BTreeMap<PartitionId, Vec<usize>> = BTreeMap::new();
 
     for (i, write) in transaction.writes.coalesced_writes().enumerate() {
         let tablet_id = write.id.tablet_id;
         if let Ok(table_name) = transaction.table_mapping.tablet_name(tablet_id) {
-            // System tables stay on the coordinator path.
-            if table_name.is_system() {
-                continue;
+            if let Some(partition) =
+                routed_partition_for_table(&table_name, partition_map, write_source)
+            {
+                partitions.entry(partition).or_default().push(i);
             }
-            let partition = partition_map.partition_for_table(&table_name);
-            partitions.entry(partition).or_default().push(i);
         }
     }
 
-    if partitions.len() <= 1 {
+    if partitions.is_empty() {
         TransactionClassification::SinglePartition
+    } else if partitions.len() == 1 {
+        let owner = *partitions
+            .keys()
+            .next()
+            .expect("single-partition classification should have one owner");
+        if owner == partition_map.local_partition() {
+            TransactionClassification::SinglePartition
+        } else {
+            TransactionClassification::RemoteSinglePartition { owner }
+        }
     } else {
         TransactionClassification::CrossPartition { partitions }
     }
@@ -74,22 +88,21 @@ pub fn classify_transaction(
 fn participant_write_indexes(
     transaction: &FinalTransaction,
     partition_map: &PartitionMap,
-    user_partitions: &BTreeMap<PartitionId, Vec<usize>>,
+    write_source: &WriteSource,
 ) -> BTreeMap<PartitionId, Vec<usize>> {
-    let mut participant_indexes = user_partitions.clone();
+    let mut participant_indexes: BTreeMap<PartitionId, Vec<usize>> = BTreeMap::new();
     let local_partition = partition_map.local_partition();
 
     for (index, write) in transaction.writes.coalesced_writes().enumerate() {
-        if transaction
-            .table_mapping
-            .tablet_name(write.id.tablet_id)
-            .is_ok_and(|table_name| table_name.is_system())
-        {
-            participant_indexes
-                .entry(local_partition)
-                .or_default()
-                .push(index);
-        }
+        let Ok(table_name) = transaction.table_mapping.tablet_name(write.id.tablet_id) else {
+            continue;
+        };
+        let participant = routed_partition_for_table(&table_name, partition_map, write_source)
+            .unwrap_or(local_partition);
+        participant_indexes
+            .entry(participant)
+            .or_default()
+            .push(index);
     }
 
     participant_indexes.retain(|_, indexes| !indexes.is_empty());
@@ -116,9 +129,12 @@ async fn prepare_participant(
             )
             .await?
     } else {
-        let node_addresses = node_addresses.context(
-            "NODE_ADDRESSES is required for cross-partition transactions with remote participants",
-        )?;
+        let node_addresses = node_addresses.with_context(|| {
+            format!(
+                "NODE_ADDRESSES is required to route this transaction to the authoritative owner \
+                 {participant}"
+            )
+        })?;
         let addr = node_addresses
             .address_for(participant)
             .with_context(|| format!("Missing NODE_ADDRESSES entry for {participant}"))?;
@@ -155,9 +171,12 @@ async fn rollback_participant(
             .rollback_prepared(transaction_id.clone())
             .await
     } else {
-        let node_addresses = node_addresses.context(
-            "NODE_ADDRESSES is required for cross-partition transactions with remote participants",
-        )?;
+        let node_addresses = node_addresses.with_context(|| {
+            format!(
+                "NODE_ADDRESSES is required to route rollback to the authoritative owner \
+                 {participant}"
+            )
+        })?;
         let addr = node_addresses
             .address_for(participant)
             .with_context(|| format!("Missing NODE_ADDRESSES entry for {participant}"))?;
@@ -178,9 +197,12 @@ async fn commit_participant(
             .commit_prepared(transaction_id.clone())
             .await
     } else {
-        let node_addresses = node_addresses.context(
-            "NODE_ADDRESSES is required for cross-partition transactions with remote participants",
-        )?;
+        let node_addresses = node_addresses.with_context(|| {
+            format!(
+                "NODE_ADDRESSES is required to route commit to the authoritative owner \
+                 {participant}"
+            )
+        })?;
         let addr = node_addresses
             .address_for(participant)
             .with_context(|| format!("Missing NODE_ADDRESSES entry for {participant}"))?;
@@ -190,7 +212,8 @@ async fn commit_participant(
 }
 
 fn is_retryable_prepare_ts_error(err: &anyhow::Error) -> bool {
-    err.to_string().contains("2PC Prepare assigned ts=")
+    err.chain()
+        .any(|cause| cause.to_string().contains("2PC Prepare assigned ts="))
 }
 
 /// Execute the 2PC protocol for a cross-partition transaction.
@@ -200,13 +223,13 @@ pub async fn coordinate_two_phase_commit(
     write_source: WriteSource,
     partition_map: &PartitionMap,
 ) -> anyhow::Result<Timestamp> {
-    let TransactionClassification::CrossPartition { partitions } =
-        classify_transaction(&transaction, partition_map)
+    let TransactionClassification::CrossPartition { partitions: _ } =
+        classify_transaction(&transaction, partition_map, &write_source)
     else {
         anyhow::bail!("2PC coordinator called for a single-partition transaction");
     };
 
-    let participant_indexes = participant_write_indexes(&transaction, partition_map, &partitions);
+    let participant_indexes = participant_write_indexes(&transaction, partition_map, &write_source);
     let txn_id = TwoPhaseTransactionId::new();
     let node_addresses = local_committer.node_addresses();
     let participants: Vec<_> = participant_indexes
@@ -214,7 +237,13 @@ pub async fn coordinate_two_phase_commit(
         .map(|(participant, write_indexes)| -> anyhow::Result<_> {
             Ok((
                 *participant,
-                ParticipantTransaction::from_final_transaction(&transaction, write_indexes)?,
+                ParticipantTransaction::from_final_transaction(
+                    &transaction,
+                    *participant,
+                    write_indexes,
+                    partition_map,
+                    &write_source,
+                )?,
             ))
         })
         .collect::<anyhow::Result<_>>()?;
@@ -272,6 +301,13 @@ pub async fn coordinate_two_phase_commit(
                     }
 
                     if is_retryable_prepare_ts_error(&err) && attempt + 1 < MAX_PREPARE_TS_RETRIES {
+                        tracing::info!(
+                            "2PC Coordinator: retrying txn={} with a newer prepare timestamp \
+                             after participant {} rejected ts on attempt {}",
+                            txn_id,
+                            participant,
+                            attempt + 1,
+                        );
                         last_retryable_error = Some(err);
                         retry_prepare = true;
                         break;
@@ -322,4 +358,24 @@ pub async fn coordinate_two_phase_commit(
             txn_id
         )
     }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::is_retryable_prepare_ts_error;
+
+    #[test]
+    fn retryable_prepare_ts_error_detects_wrapped_grpc_status() {
+        let err = anyhow::anyhow!(
+            "Prepare failed: 2PC Prepare assigned ts=10 but this participant requires ts>=20"
+        )
+        .context("gRPC Prepare failed");
+        assert!(is_retryable_prepare_ts_error(&err));
+    }
+
+    #[test]
+    fn retryable_prepare_ts_error_rejects_unrelated_errors() {
+        let err = anyhow::anyhow!("gRPC Prepare failed");
+        assert!(!is_retryable_prepare_ts_error(&err));
+    }
 }

--- a/crates/database/src/vector_index_worker/flusher.rs
+++ b/crates/database/src/vector_index_worker/flusher.rs
@@ -350,7 +350,7 @@ mod tests {
         assert_eq!(segment.total_point_count(), 1);
         // Should have written backfill progress, and it is halfway done.
         let progress = fixtures
-            .index_backfill_progress(index_id.developer_id)
+            .index_backfill_progress(index_id.document_id)
             .await?
             .unwrap();
         assert_eq!(progress.num_docs_indexed, 1);
@@ -377,7 +377,7 @@ mod tests {
         assert_eq!(segment.total_point_count(), 1);
         // Should have written backfill progress, and it is halfway done.
         let progress = fixtures
-            .index_backfill_progress(index_id.developer_id)
+            .index_backfill_progress(index_id.document_id)
             .await?
             .unwrap();
         assert_eq!(progress.num_docs_indexed, 1);

--- a/crates/database/src/vector_index_worker/vector_meta.rs
+++ b/crates/database/src/vector_index_worker/vector_meta.rs
@@ -61,7 +61,7 @@ use search::{
 use storage::Storage;
 use sync_types::Timestamp;
 use value::{
-    DeveloperDocumentId,
+    PublicDocumentId,
     TableNumber,
     TabletId,
 };
@@ -249,7 +249,7 @@ impl SearchIndex for VectorSearchIndex {
             .try_filter(move |entry| {
                 let doc_id_index_key = IndexKey::new(
                     vec![],
-                    DeveloperDocumentId::new(table_number, entry.id.internal_id()),
+                    PublicDocumentId::new(table_number, entry.id.internal_id()),
                 );
                 let in_range = filter_id_range.contains(&doc_id_index_key.to_bytes());
                 let duplicate = documents_seen.contains(&entry.id);

--- a/crates/database/src/virtual_tables/mod.rs
+++ b/crates/database/src/virtual_tables/mod.rs
@@ -12,7 +12,7 @@ use common::{
 };
 use errors::ErrorMetadata;
 use value::{
-    DeveloperDocumentId,
+    PublicDocumentId,
     ResolvedDocumentId,
     TableNamespace,
 };
@@ -42,7 +42,7 @@ impl<'a, RT: Runtime> VirtualTable<'a, RT> {
     pub async fn get(
         &mut self,
         namespace: TableNamespace,
-        id: DeveloperDocumentId,
+        id: PublicDocumentId,
         version: Option<Version>,
     ) -> anyhow::Result<Option<(DeveloperDocument, WriteTimestamp)>> {
         let tablet_id = self

--- a/crates/database/src/write_limits.rs
+++ b/crates/database/src/write_limits.rs
@@ -1,7 +1,7 @@
-use value::DeveloperDocumentId;
+use value::PublicDocumentId;
 
 /// Metrics related to document writes
 pub struct BiggestDocumentWrites {
-    pub max_size: (DeveloperDocumentId, usize),
-    pub max_nesting: (DeveloperDocumentId, usize),
+    pub max_size: (PublicDocumentId, usize),
+    pub max_nesting: (PublicDocumentId, usize),
 }

--- a/crates/database/src/write_log.rs
+++ b/crates/database/src/write_log.rs
@@ -317,6 +317,11 @@ impl WriteLogManager {
             self.log.by_ts.pop_front();
         }
     }
+
+    fn reset(&mut self, ts: Timestamp) {
+        self.log = WriteLog::new(ts);
+        self.notify_waiters();
+    }
 }
 
 /// WriteLog holds recent commits that have been written to persistence and
@@ -622,6 +627,10 @@ impl LogWriter {
     pub fn max_ts(&self) -> Timestamp {
         self.inner.lock().log.max_ts()
     }
+
+    pub fn reset(&mut self, ts: Timestamp) {
+        block_in_place(|| self.inner.lock().reset(ts));
+    }
 }
 
 /// Pending writes are used by the committer to detect conflicts between a new
@@ -660,6 +669,13 @@ impl PendingWrites {
             .iter()
             .next_back()
             .map(|(_, (_, _, snapshot))| snapshot.clone())
+    }
+
+    pub fn latest(&self) -> Option<(Timestamp, Snapshot)> {
+        self.by_ts
+            .iter()
+            .next_back()
+            .map(|(ts, (_, _, snapshot))| (*ts, snapshot.clone()))
     }
 
     /// Recomputes the snapshot associated with each pending write, rebasing the
@@ -1090,7 +1106,7 @@ mod tests {
 
         fn make_doc(
             &mut self,
-            obj: common::value::ConvexObject,
+            obj: common::value::DocumentObject,
         ) -> anyhow::Result<(ResolvedDocumentId, IndexKey, PackedDocument)> {
             let id = self.id_generator.user_generate(&"users".parse()?);
             let doc = ResolvedDocument::new(id, CreationTime::ONE, obj)?;

--- a/crates/database/src/writes.rs
+++ b/crates/database/src/writes.rs
@@ -45,7 +45,7 @@ use errors::ErrorMetadata;
 use imbl::OrdSet;
 use value::{
     values_to_bytes,
-    DeveloperDocumentId,
+    PublicDocumentId,
     TabletId,
 };
 
@@ -218,7 +218,7 @@ pub struct TransactionWriteSize {
     // Total number of writes (i.e. calls to `mutate`)
     pub num_writes: usize,
 
-    // Total size of mutations. Writing to the same DocumentId twice will still count twice.
+    // Total size of mutations. Writing to the same PublicDocumentId twice will still count twice.
     pub size: usize,
 }
 
@@ -376,7 +376,7 @@ impl Writes {
             // Writes to a table require the table still exists.
             let table_id_bytes = IndexKey::new(
                 vec![],
-                DeveloperDocumentId::new(table_mapping.tables_id.table_number, tablet_id.0),
+                PublicDocumentId::new(table_mapping.tables_id.table_number, tablet_id.0),
             )
             .to_bytes();
             reads.record_indexed_derived(
@@ -408,7 +408,7 @@ impl Writes {
         Ok(())
     }
 
-    /// Register a newly allocated DocumentId.
+    /// Register a newly allocated PublicDocumentId.
     /// This enables us to check for reuse on commit.
     pub(crate) fn register_new_id(
         &mut self,
@@ -438,7 +438,8 @@ impl Writes {
         &self.system_tx_size
     }
 
-    /// Iterate over the coalesced writes (so no `DocumentId` appears twice).
+    /// Iterate over the coalesced writes (so no `PublicDocumentId` appears
+    /// twice).
     pub fn coalesced_writes(&self) -> impl Iterator<Item = &DocumentUpdateWithPrevTs> {
         self.updates.iter().map(|x| &**x)
     }

--- a/crates/exports/src/export_storage.rs
+++ b/crates/exports/src/export_storage.rs
@@ -96,7 +96,7 @@ pub(crate) async fn write_storage_table<'a, 'b: 'a, RT: Runtime>(
         let log_interval = Duration::from_secs(60 * 60);
         while let Some(LatestDocument { value: doc, .. }) = stream.try_next().await? {
             let file_storage_entry = ParseDocument::<FileStorageEntry>::parse(doc)?;
-            let virtual_storage_id = file_storage_entry.id().developer_id;
+            let virtual_storage_id = file_storage_entry.id().document_id;
             let creation_time = f64::from(file_storage_entry.creation_time());
             table_upload
                 .write_json_line(json!(FileStorageZipMetadata {
@@ -127,7 +127,7 @@ pub(crate) async fn write_storage_table<'a, 'b: 'a, RT: Runtime>(
         .stream_documents_in_table(*tablet_id, *by_id, None)
         .map_ok(|LatestDocument { value: doc, .. }| async {
             let file_storage_entry = ParseDocument::<FileStorageEntry>::parse(doc)?;
-            let virtual_storage_id = file_storage_entry.id().developer_id;
+            let virtual_storage_id = file_storage_entry.id().document_id;
             // Add an extension, which isn't necessary for anything and might be incorrect,
             // but allows the file to be viewed at a glance in most cases.
             let extension_guess = file_storage_entry
@@ -148,7 +148,7 @@ pub(crate) async fn write_storage_table<'a, 'b: 'a, RT: Runtime>(
                 .with_context(|| {
                     format!(
                         "file missing from storage: {} with key {:?}",
-                        file_storage_entry.developer_id().encode(),
+                        file_storage_entry.document_id().encode(),
                         file_storage_entry.storage_key,
                     )
                 })?;

--- a/crates/exports/src/tests.rs
+++ b/crates/exports/src/tests.rs
@@ -16,7 +16,7 @@ use common::{
         ConvexOrigin,
         TableName,
     },
-    value::ConvexObject,
+    value::DocumentObject,
 };
 use database::{
     test_helpers::DbFixtures,
@@ -52,7 +52,7 @@ use usage_tracking::FunctionUsageTracker;
 use value::{
     assert_obj,
     export::ValueFormat,
-    DeveloperDocumentId,
+    PublicDocumentId,
     ResolvedDocumentId,
     TableNamespace,
 };
@@ -223,7 +223,7 @@ async fn test_export_storage(rt: TestRuntime) -> anyhow::Result<()> {
     let file1: ParsedDocument<FileStorageEntry> = tx
         .get(ResolvedDocumentId::new(
             storage_table_id.tablet_id,
-            DeveloperDocumentId::new(storage_table_id.table_number, file1_id.internal_id()),
+            PublicDocumentId::new(storage_table_id.table_number, file1_id.internal_id()),
         ))
         .await?
         .unwrap()
@@ -347,12 +347,12 @@ async fn test_export_with_table_delete(rt: TestRuntime) -> anyhow::Result<()> {
     // Write to two tables and delete one.
     let mut tx = db.begin(Identity::system()).await?;
     UserFacingModel::new_root_for_test(&mut tx)
-        .insert("table_0".parse()?, ConvexObject::empty())
+        .insert("table_0".parse()?, DocumentObject::empty())
         .await?;
     db.commit(tx).await?;
     let mut tx = db.begin(Identity::system()).await?;
     UserFacingModel::new_root_for_test(&mut tx)
-        .insert("table_1".parse()?, ConvexObject::empty())
+        .insert("table_1".parse()?, DocumentObject::empty())
         .await?;
     db.commit(tx).await?;
     let mut tx = db.begin(Identity::system()).await?;

--- a/crates/file_storage/src/core.rs
+++ b/crates/file_storage/src/core.rs
@@ -67,7 +67,7 @@ use usage_tracking::{
     StorageUsageTracker,
 };
 use value::{
-    id_v6::DeveloperDocumentId,
+    id_v6::PublicDocumentId,
     TableNamespace,
 };
 
@@ -431,7 +431,7 @@ impl<RT: Runtime> TransactionalFileStorage<RT> {
         tx: &mut Transaction<RT>,
         namespace: TableNamespace,
         entry: FileStorageEntry,
-    ) -> anyhow::Result<DeveloperDocumentId> {
+    ) -> anyhow::Result<PublicDocumentId> {
         let system_doc_id = FileStorageModel::new(tx, namespace)
             .store_file(entry)
             .await?;
@@ -452,7 +452,7 @@ impl<RT: Runtime> FileStorage<RT> {
         file: impl Stream<Item = anyhow::Result<impl Into<Bytes>>> + Send,
         expected_sha256: Option<Sha256Digest>,
         usage_tracker: &dyn StorageUsageTracker,
-    ) -> anyhow::Result<DeveloperDocumentId> {
+    ) -> anyhow::Result<PublicDocumentId> {
         let entry = self
             .transactional_file_storage
             .upload_file(content_length, content_type, file, expected_sha256)
@@ -467,7 +467,7 @@ impl<RT: Runtime> FileStorage<RT> {
         namespace: TableNamespace,
         entry: FileStorageEntry,
         usage_tracker: &dyn StorageUsageTracker,
-    ) -> anyhow::Result<DeveloperDocumentId> {
+    ) -> anyhow::Result<PublicDocumentId> {
         let storage_id = entry.storage_id.clone();
         let size = entry.size;
         let content_type = entry

--- a/crates/fivetran_destination/src/api_types.rs
+++ b/crates/fivetran_destination/src/api_types.rs
@@ -10,7 +10,7 @@ use chrono::{
 use common::{
     schemas::json::TableDefinitionJson,
     value::{
-        ConvexObject,
+        DocumentObject,
         FieldPath,
         IdentifierFieldName,
     },
@@ -128,7 +128,7 @@ pub struct BatchWriteRow {
     pub table: String,
     pub operation: BatchWriteOperation,
     #[serde(with = "common::value::json_object")]
-    pub row: ConvexObject,
+    pub row: DocumentObject,
 }
 
 #[derive(Serialize, Deserialize, Clone, Copy, PartialEq, Eq)]

--- a/crates/fivetran_destination/src/application.rs
+++ b/crates/fivetran_destination/src/application.rs
@@ -10,7 +10,7 @@ use chrono::{
 use common::{
     try_chunks::TryChunksExt,
     value::{
-        ConvexObject,
+        DocumentObject,
         TableName,
     },
 };
@@ -242,7 +242,7 @@ async fn row_stream<'a>(
     let mut reader = read_rows(&mut deserializer, reader_params, schema);
 
     while let Some(row) = reader.next().await {
-        let row: ConvexObject = row
+        let row: DocumentObject = row
             .map_err(|err| DestinationError::FileReadError(file.clone(), err))?
             .try_into()
             .map_err(DestinationError::InvalidRow)?;

--- a/crates/fivetran_destination/src/convert.rs
+++ b/crates/fivetran_destination/src/convert.rs
@@ -9,8 +9,8 @@ use anyhow::{
 };
 use chrono::DateTime;
 use common::value::{
-    ConvexObject,
     ConvexValue,
+    DocumentObject,
     FieldName,
 };
 use fivetran_common::fivetran_sdk::value_type::Inner as FivetranValue;
@@ -180,10 +180,10 @@ fn timestamp_to_ms(ts: Timestamp) -> f64 {
 ///   }
 /// }
 /// ```
-impl TryInto<ConvexObject> for FileRow {
+impl TryInto<DocumentObject> for FileRow {
     type Error = anyhow::Error;
 
-    fn try_into(self) -> Result<ConvexObject, Self::Error> {
+    fn try_into(self) -> Result<DocumentObject, Self::Error> {
         let mut row: BTreeMap<FieldName, ConvexValue> = BTreeMap::new();
         let mut metadata: BTreeMap<FieldName, ConvexValue> = BTreeMap::new();
         let mut underscore_columns: BTreeMap<FieldName, ConvexValue> = BTreeMap::new();
@@ -228,15 +228,15 @@ impl TryInto<ConvexObject> for FileRow {
         if !underscore_columns.is_empty() {
             metadata.insert(
                 UNDERSCORED_COLUMNS_CONVEX_FIELD_NAME.clone().into(),
-                ConvexValue::Object(ConvexObject::try_from(underscore_columns)?),
+                ConvexValue::Object(DocumentObject::try_from(underscore_columns)?),
             );
         }
 
         row.insert(
             METADATA_CONVEX_FIELD_NAME.clone().into(),
-            ConvexValue::Object(ConvexObject::try_from(metadata)?),
+            ConvexValue::Object(DocumentObject::try_from(metadata)?),
         );
-        ConvexObject::try_from(row)
+        DocumentObject::try_from(row)
     }
 }
 
@@ -349,8 +349,8 @@ mod tests {
     use common::{
         assert_obj,
         value::{
-            ConvexObject,
             ConvexValue,
+            DocumentObject,
         },
     };
     use fivetran_common::fivetran_sdk::value_type::Inner as FivetranValue;
@@ -374,7 +374,7 @@ mod tests {
 
     #[test]
     fn convert_file_row_into_convex_object() -> anyhow::Result<()> {
-        let actual: ConvexObject = FileRow(btreemap! {
+        let actual: DocumentObject = FileRow(btreemap! {
             FivetranFieldName::from_str("name")? => FivetranFileValue::Value(FivetranValue::String("Nicolas".to_string())),
             FivetranFieldName::from_str("null_attribute")? => FivetranFileValue::Value(FivetranValue::Null(true)),
             FivetranFieldName::from_str("unmodified_attribute")? => FivetranFileValue::Unmodified,
@@ -398,7 +398,7 @@ mod tests {
 
     #[test]
     fn convert_file_row_with_all_metadata_fields() -> anyhow::Result<()> {
-        let actual: ConvexObject = FileRow(btreemap! {
+        let actual: DocumentObject = FileRow(btreemap! {
             FivetranFieldName::from_str("name")? => FivetranFileValue::Value(FivetranValue::String("Nicolas".to_string())),
             FivetranFieldName::from_str("_fivetran_id")? => FivetranFileValue::Value(FivetranValue::Int(42)),
             FivetranFieldName::from_str("_fivetran_deleted")? => FivetranFileValue::Value(FivetranValue::Bool(false)),
@@ -422,7 +422,7 @@ mod tests {
 
     #[test]
     fn convert_file_row_with_column_names_starting_with_underscore() -> anyhow::Result<()> {
-        let actual: ConvexObject = FileRow(btreemap! {
+        let actual: DocumentObject = FileRow(btreemap! {
             FivetranFieldName::from_str("_name")? => FivetranFileValue::Value(FivetranValue::String("Nicolas".to_string())),
             FivetranFieldName::from_str("_fivetran_synced")? => FivetranFileValue::Value(FivetranValue::UtcDatetime(Timestamp {
                 seconds: 1715700652,

--- a/crates/indexing/src/backend_in_memory_indexes.rs
+++ b/crates/indexing/src/backend_in_memory_indexes.rs
@@ -231,7 +231,7 @@ impl BackendInMemoryIndexes {
             .context("Missing meta index")?;
         let mut meta_index_map = DatabaseIndexMap::new_at(ts);
         for (ts, index_doc) in index_documents {
-            let index_key = IndexKey::new(vec![], index_doc.developer_id());
+            let index_key = IndexKey::new(vec![], index_doc.document_id());
             meta_index_map.insert(index_key.to_bytes(), ts, index_doc);
         }
 
@@ -1300,7 +1300,7 @@ mod cache_tests {
         assert_obj,
         val,
         values_to_bytes,
-        ConvexObject,
+        DocumentObject,
     };
 
     use super::DatabaseIndexSnapshotCache;
@@ -1326,7 +1326,7 @@ mod cache_tests {
         fn make_doc(
             &mut self,
             fields: &[FieldPath],
-            obj: ConvexObject,
+            obj: DocumentObject,
         ) -> anyhow::Result<(IndexKeyBytes, PackedDocument)> {
             let id = self.id_generator.user_generate(&"users".parse()?);
             let doc = ResolvedDocument::new(id, CreationTime::ONE, obj)?;
@@ -1344,7 +1344,7 @@ mod cache_tests {
             index_id: IndexId,
             is_by_id: bool,
             fields: &[FieldPath],
-            obj: ConvexObject,
+            obj: DocumentObject,
             ts: Timestamp,
         ) -> anyhow::Result<(IndexKeyBytes, PackedDocument)> {
             let (key, doc) = self.make_doc(fields, obj)?;

--- a/crates/isolate/src/client.rs
+++ b/crates/isolate/src/client.rs
@@ -149,7 +149,7 @@ use udf::{
 };
 use usage_tracking::FunctionUsageStats;
 use value::{
-    id_v6::DeveloperDocumentId,
+    id_v6::PublicDocumentId,
     identifier::Identifier,
 };
 use vector::PublicVectorSearchQueryResult;
@@ -283,7 +283,7 @@ pub trait ActionCallbacks: Send + Sync {
         identity: Identity,
         component: ComponentId,
         entry: FileStorageEntry,
-    ) -> anyhow::Result<(ComponentPath, DeveloperDocumentId)>;
+    ) -> anyhow::Result<(ComponentPath, PublicDocumentId)>;
 
     // Scheduler
     async fn schedule_job(
@@ -294,12 +294,12 @@ pub trait ActionCallbacks: Send + Sync {
         udf_args: SerializedArgs,
         scheduled_ts: UnixTimestamp,
         context: ExecutionContext,
-    ) -> anyhow::Result<DeveloperDocumentId>;
+    ) -> anyhow::Result<PublicDocumentId>;
 
     async fn cancel_job(
         &self,
         identity: Identity,
-        virtual_id: DeveloperDocumentId,
+        virtual_id: PublicDocumentId,
     ) -> anyhow::Result<()>;
 
     // Vector Search

--- a/crates/isolate/src/environment/action/async_syscall.rs
+++ b/crates/isolate/src/environment/action/async_syscall.rs
@@ -30,7 +30,7 @@ use serde_json::{
     Value as JsonValue,
 };
 use value::{
-    id_v6::DeveloperDocumentId,
+    id_v6::PublicDocumentId,
     JsonPackedValue,
 };
 use vector::{
@@ -316,7 +316,7 @@ impl<RT: Runtime> TaskExecutor<RT> {
         }
         let virtual_id_v6 = with_argument_error("db.cancel_job", || {
             let args: CancelJobArgs = serde_json::from_value(args)?;
-            let id = DeveloperDocumentId::decode(&args.id).context(ArgName("id"))?;
+            let id = PublicDocumentId::decode(&args.id).context(ArgName("id"))?;
             Ok(id)
         })?;
 

--- a/crates/isolate/src/environment/action/storage.rs
+++ b/crates/isolate/src/environment/action/storage.rs
@@ -21,7 +21,7 @@ use headers::{
 };
 use model::file_storage::FileStorageId;
 use usage_tracking::StorageUsageTracker;
-use value::id_v6::DeveloperDocumentId;
+use value::id_v6::PublicDocumentId;
 
 use super::task_executor::TaskExecutor;
 use crate::environment::{
@@ -45,7 +45,7 @@ impl<RT: Runtime> TaskExecutor<RT> {
         content_type: Option<String>,
         content_length: Option<String>,
         digest: Option<String>,
-    ) -> anyhow::Result<DeveloperDocumentId> {
+    ) -> anyhow::Result<PublicDocumentId> {
         let content_length = content_length
             .map(|c| -> anyhow::Result<headers::ContentLength> {
                 Ok(headers::ContentLength(c.parse()?))

--- a/crates/isolate/src/environment/action/task.rs
+++ b/crates/isolate/src/environment/action/task.rs
@@ -12,7 +12,7 @@ use deno_core::{
 };
 use serde::Serialize;
 use serde_json::Value as JsonValue;
-use value::id_v6::DeveloperDocumentId;
+use value::id_v6::PublicDocumentId;
 
 use crate::{
     environment::{
@@ -128,7 +128,7 @@ pub enum TaskResponseEnum {
     Fetch(HttpResponseV8),
     ParseMultiPart(Vec<FormPart>),
     Sleep(UnixTimestamp),
-    StorageStore(DeveloperDocumentId),
+    StorageStore(PublicDocumentId),
     StorageGet(Option<FileResponse>),
 }
 

--- a/crates/isolate/src/environment/component_definitions.rs
+++ b/crates/isolate/src/environment/component_definitions.rs
@@ -57,7 +57,7 @@ use udf::EvaluateAppDefinitionsResult;
 use value::{
     base64,
     identifier::Identifier,
-    ConvexObject,
+    DocumentObject,
     FieldName,
     NamespacedTableMapping,
 };
@@ -434,7 +434,7 @@ impl ComponentInitializerEvaluator {
                 };
                 args_obj.insert(FieldName::from_str(&arg_name)?, value);
             }
-            let args_obj = ConvexObject::try_from(args_obj)?;
+            let args_obj = DocumentObject::try_from(args_obj)?;
             let args_str = args_obj.json_serialize()?;
             let args_v8_str =
                 v8::String::new(&scope, &args_str).context("Failed to create string for args")?;
@@ -451,7 +451,7 @@ impl ComponentInitializerEvaluator {
                 })?;
             let result_str = helpers::to_rust_string(&scope, &v8_result)?;
             let result_json: JsonValue = serde_json::from_str(&result_str)?;
-            let result_obj = ConvexObject::try_from(result_json)?;
+            let result_obj = DocumentObject::try_from(result_json)?;
 
             let mut result = BTreeMap::new();
             for (arg_name, value) in BTreeMap::from(result_obj) {

--- a/crates/isolate/src/environment/helpers/module_loader.rs
+++ b/crates/isolate/src/environment/helpers/module_loader.rs
@@ -67,7 +67,7 @@ async fn download_module_source_from_package(
         source_package.sha256.clone(),
     )
     .await?;
-    let source_package_id: SourcePackageId = source_package.developer_id().into();
+    let source_package_id: SourcePackageId = source_package.document_id().into();
     for (module_path, module_config) in package {
         result.insert(
             (module_path, source_package_id),

--- a/crates/isolate/src/environment/udf/async_syscall.rs
+++ b/crates/isolate/src/environment/udf/async_syscall.rs
@@ -101,10 +101,10 @@ use udf::{
 };
 use value::{
     heap_size::HeapSize,
-    id_v6::DeveloperDocumentId,
+    id_v6::PublicDocumentId,
     serialized_args_ext::SerializedArgsExt,
     ConvexArray,
-    ConvexObject,
+    DocumentObject,
     TableName,
 };
 
@@ -328,7 +328,7 @@ pub trait AsyncSyscallProvider<RT: Runtime> {
         &mut self,
         udf_type: UdfType,
         path: ResolvedComponentFunctionPath,
-        args: ConvexObject,
+        args: DocumentObject,
     ) -> anyhow::Result<ConvexValue>;
 
     async fn create_function_handle(
@@ -486,7 +486,7 @@ impl<RT: Runtime> AsyncSyscallProvider<RT> for DatabaseUdfEnvironment<RT> {
         &mut self,
         udf_type: UdfType,
         path: ResolvedComponentFunctionPath,
-        args: ConvexObject,
+        args: DocumentObject,
     ) -> anyhow::Result<ConvexValue> {
         match (self.udf_type, udf_type) {
             // Queries can call other queries.
@@ -1012,7 +1012,7 @@ impl<RT: Runtime, P: AsyncSyscallProvider<RT>> DatabaseSyscallsV1<RT, P> {
 
         let virtual_id_v6 = with_argument_error("db.cancel_job", || {
             let args: CancelJobArgs = serde_json::from_value(args)?;
-            let id = DeveloperDocumentId::decode(&args.id).context(ArgName("id"))?;
+            let id = PublicDocumentId::decode(&args.id).context(ArgName("id"))?;
             Ok(id)
         })?;
 
@@ -1070,7 +1070,7 @@ impl<RT: Runtime, P: AsyncSyscallProvider<RT>> DatabaseSyscallsV1<RT, P> {
         let (id, value, table_name) = with_argument_error("db.patch", || {
             let args: UpdateArgs = serde_json::from_value(args)?;
 
-            let id = DeveloperDocumentId::decode(&args.id).context(ArgName("id"))?;
+            let id = PublicDocumentId::decode(&args.id).context(ArgName("id"))?;
             let actual_table_name = tx
                 .resolve_idv6(id, component.into(), table_filter)
                 .context(ArgName("id"))?;
@@ -1105,7 +1105,7 @@ impl<RT: Runtime, P: AsyncSyscallProvider<RT>> DatabaseSyscallsV1<RT, P> {
         let (id, value, table_name) = with_argument_error("db.replace", || {
             let args: ReplaceArgs = serde_json::from_value(args)?;
 
-            let id = DeveloperDocumentId::decode(&args.id).context(ArgName("id"))?;
+            let id = PublicDocumentId::decode(&args.id).context(ArgName("id"))?;
             let actual_table_name = tx
                 .resolve_idv6(id, component.into(), table_filter)
                 .context(ArgName("id"))?;
@@ -1198,8 +1198,7 @@ impl<RT: Runtime, P: AsyncSyscallProvider<RT>> DatabaseSyscallsV1<RT, P> {
                         };
 
                         let (id, is_system, version) = with_argument_error(method_name, || {
-                            let id =
-                                DeveloperDocumentId::decode(&args.id).context(ArgName("id"))?;
+                            let id = PublicDocumentId::decode(&args.id).context(ArgName("id"))?;
                             let version = parse_version(args.version)?;
                             Ok((id, args.is_system, version))
                         })?;
@@ -1329,7 +1328,7 @@ impl<RT: Runtime, P: AsyncSyscallProvider<RT>> DatabaseSyscallsV1<RT, P> {
         let tx = provider.tx()?;
         let (id, table_name) = with_argument_error("db.delete", || {
             let args: RemoveArgs = serde_json::from_value(args)?;
-            let id = DeveloperDocumentId::decode(&args.id).context(ArgName("id"))?;
+            let id = PublicDocumentId::decode(&args.id).context(ArgName("id"))?;
             let actual_table_name = tx
                 .resolve_idv6(id, component.into(), table_filter)
                 .context(ArgName("id"))?;
@@ -1365,7 +1364,7 @@ impl<RT: Runtime, P: AsyncSyscallProvider<RT>> DatabaseSyscallsV1<RT, P> {
         } = with_argument_error("runUdf", || Ok(serde_json::from_value(args)?))?;
         let (udf_type, args) = with_argument_error("runUdf", || {
             let udf_type: UdfType = udf_type.parse().context(ArgName("udfType"))?;
-            let args: ConvexObject = ConvexValue::try_from(args)
+            let args: DocumentObject = ConvexValue::try_from(args)
                 .context(ArgName("args"))?
                 .try_into()
                 .context(ArgName("args"))?;

--- a/crates/isolate/src/environment/udf/syscall.rs
+++ b/crates/isolate/src/environment/udf/syscall.rs
@@ -24,7 +24,7 @@ use serde_json::{
     Value as JsonValue,
 };
 use value::{
-    id_v6::DeveloperDocumentId,
+    id_v6::PublicDocumentId,
     identifier::Identifier,
     ConvexValue,
     InternalId,
@@ -171,12 +171,12 @@ fn syscall_normalize_id<RT: Runtime, P: SyscallProvider<RT>>(
     };
     let normalized_id = match table_number {
         Some(table_number) => {
-            if let Ok(id_v6) = DeveloperDocumentId::decode(&id_string)
+            if let Ok(id_v6) = PublicDocumentId::decode(&id_string)
                 && id_v6.table() == table_number
             {
                 Some(id_v6)
             } else if let Ok(internal_id) = InternalId::from_developer_str(&id_string) {
-                let id_v6 = DeveloperDocumentId::new(table_number, internal_id);
+                let id_v6 = PublicDocumentId::new(table_number, internal_id);
                 Some(id_v6)
             } else {
                 None

--- a/crates/isolate/src/test_helpers.rs
+++ b/crates/isolate/src/test_helpers.rs
@@ -153,9 +153,9 @@ use udf::{
 };
 use usage_tracking::FunctionUsageStats;
 use value::{
-    id_v6::DeveloperDocumentId,
+    id_v6::PublicDocumentId,
     serialized_args_ext::SerializedArgsExt,
-    ConvexObject,
+    DocumentObject,
     TableName,
     TableNamespace,
 };
@@ -464,7 +464,7 @@ impl<RT: Runtime, P: Persistence> UdfTest<RT, P> {
     pub async fn mutation(
         &self,
         udf_path: &str,
-        args: ConvexObject,
+        args: DocumentObject,
     ) -> anyhow::Result<ConvexValue> {
         self.mutation_with_identity(udf_path, args, Identity::system())
             .await
@@ -473,7 +473,7 @@ impl<RT: Runtime, P: Persistence> UdfTest<RT, P> {
     pub async fn mutation_js_error(
         &self,
         udf_path: &str,
-        args: ConvexObject,
+        args: DocumentObject,
     ) -> anyhow::Result<JsError> {
         let outcome: UdfOutcome = self
             .raw_mutation(
@@ -488,7 +488,7 @@ impl<RT: Runtime, P: Persistence> UdfTest<RT, P> {
     pub async fn mutation_log_lines(
         &self,
         udf_path: &str,
-        args: ConvexObject,
+        args: DocumentObject,
     ) -> anyhow::Result<LogLines> {
         let (_, outcome) = self
             .mutation_outcome(udf_path, args, Identity::system())
@@ -499,7 +499,7 @@ impl<RT: Runtime, P: Persistence> UdfTest<RT, P> {
     pub async fn mutation_with_identity(
         &self,
         udf_path: &str,
-        args: ConvexObject,
+        args: DocumentObject,
         identity: Identity,
     ) -> anyhow::Result<ConvexValue> {
         let (v, _) = self.mutation_outcome(udf_path, args, identity).await?;
@@ -509,7 +509,7 @@ impl<RT: Runtime, P: Persistence> UdfTest<RT, P> {
     pub async fn mutation_outcome(
         &self,
         udf_path: &str,
-        args: ConvexObject,
+        args: DocumentObject,
         identity: Identity,
     ) -> anyhow::Result<(ConvexValue, UdfOutcome)> {
         let outcome = self
@@ -599,7 +599,7 @@ impl<RT: Runtime, P: Persistence> UdfTest<RT, P> {
         Ok(outcome)
     }
 
-    pub async fn query(&self, udf_path: &str, args: ConvexObject) -> anyhow::Result<ConvexValue> {
+    pub async fn query(&self, udf_path: &str, args: DocumentObject) -> anyhow::Result<ConvexValue> {
         self.query_with_identity(udf_path, args, Identity::system())
             .await
     }
@@ -607,7 +607,7 @@ impl<RT: Runtime, P: Persistence> UdfTest<RT, P> {
     pub async fn query_js_error(
         &self,
         udf_path: &str,
-        args: ConvexObject,
+        args: DocumentObject,
     ) -> anyhow::Result<JsError> {
         let (outcome, _) = self
             .raw_query(
@@ -623,7 +623,7 @@ impl<RT: Runtime, P: Persistence> UdfTest<RT, P> {
     pub async fn query_log_lines(
         &self,
         udf_path: &str,
-        args: ConvexObject,
+        args: DocumentObject,
     ) -> anyhow::Result<LogLines> {
         let (_, outcome) = self
             .query_outcome(udf_path, args, Identity::system())
@@ -634,7 +634,7 @@ impl<RT: Runtime, P: Persistence> UdfTest<RT, P> {
     pub async fn query_with_identity(
         &self,
         udf_path: &str,
-        args: ConvexObject,
+        args: DocumentObject,
         identity: Identity,
     ) -> anyhow::Result<ConvexValue> {
         let (v, _) = self.query_outcome(udf_path, args, identity).await?;
@@ -645,7 +645,7 @@ impl<RT: Runtime, P: Persistence> UdfTest<RT, P> {
     pub async fn query_outcome(
         &self,
         udf_path: &str,
-        args: ConvexObject,
+        args: DocumentObject,
         identity: Identity,
     ) -> anyhow::Result<(ConvexValue, UdfOutcome)> {
         let (outcome, _) = self
@@ -736,7 +736,7 @@ impl<RT: Runtime, P: Persistence> UdfTest<RT, P> {
     pub async fn query_js_error_no_validation(
         &self,
         udf_path: &str,
-        args: ConvexObject,
+        args: DocumentObject,
     ) -> anyhow::Result<JsError> {
         let mut tx = self.database.begin(Identity::system()).await?;
         let udf_config = UdfConfigModel::new(&mut tx, TableNamespace::test_user())
@@ -971,7 +971,11 @@ impl<RT: Runtime, P: Persistence> UdfTest<RT, P> {
         Ok((outcome.result, log_lines.into()))
     }
 
-    pub async fn action(&self, udf_path: &str, args: ConvexObject) -> anyhow::Result<ConvexValue> {
+    pub async fn action(
+        &self,
+        udf_path: &str,
+        args: DocumentObject,
+    ) -> anyhow::Result<ConvexValue> {
         self.action_with_identity(udf_path, args, Identity::system())
             .await
     }
@@ -979,7 +983,7 @@ impl<RT: Runtime, P: Persistence> UdfTest<RT, P> {
     pub async fn action_js_error(
         &self,
         udf_path: &str,
-        args: ConvexObject,
+        args: DocumentObject,
     ) -> anyhow::Result<JsError> {
         let (outcome, _log_lines) = self
             .raw_action(
@@ -994,7 +998,7 @@ impl<RT: Runtime, P: Persistence> UdfTest<RT, P> {
     pub async fn action_log_lines(
         &self,
         udf_path: &str,
-        args: ConvexObject,
+        args: DocumentObject,
     ) -> anyhow::Result<LogLines> {
         let (_value, _outcome, log_lines) = self
             .action_outcome_and_log_lines(udf_path, args, Identity::system())
@@ -1005,7 +1009,7 @@ impl<RT: Runtime, P: Persistence> UdfTest<RT, P> {
     pub async fn action_with_identity(
         &self,
         udf_path: &str,
-        args: ConvexObject,
+        args: DocumentObject,
         identity: Identity,
     ) -> anyhow::Result<ConvexValue> {
         let (v, _) = self.action_outcome(udf_path, args, identity).await?;
@@ -1015,7 +1019,7 @@ impl<RT: Runtime, P: Persistence> UdfTest<RT, P> {
     pub async fn action_outcome(
         &self,
         udf_path: &str,
-        args: ConvexObject,
+        args: DocumentObject,
         identity: Identity,
     ) -> anyhow::Result<(ConvexValue, ActionOutcome)> {
         let (value, outcome, _) = self
@@ -1027,7 +1031,7 @@ impl<RT: Runtime, P: Persistence> UdfTest<RT, P> {
     pub async fn action_outcome_and_log_lines(
         &self,
         udf_path: &str,
-        args: ConvexObject,
+        args: DocumentObject,
         identity: Identity,
     ) -> anyhow::Result<(ConvexValue, ActionOutcome, LogLines)> {
         let (outcome, log_lines) = self
@@ -1298,7 +1302,7 @@ impl<RT: Runtime, P: Persistence> ActionCallbacks for UdfTest<RT, P> {
         identity: Identity,
         component: ComponentId,
         entry: FileStorageEntry,
-    ) -> anyhow::Result<(ComponentPath, DeveloperDocumentId)> {
+    ) -> anyhow::Result<(ComponentPath, PublicDocumentId)> {
         let mut tx = self.database.begin(identity).await?;
         let id = self
             .file_storage
@@ -1330,7 +1334,7 @@ impl<RT: Runtime, P: Persistence> ActionCallbacks for UdfTest<RT, P> {
         udf_args: SerializedArgs,
         scheduled_ts: UnixTimestamp,
         context: ExecutionContext,
-    ) -> anyhow::Result<DeveloperDocumentId> {
+    ) -> anyhow::Result<PublicDocumentId> {
         let mut tx: database::Transaction<RT> = self.database.begin(identity).await?;
         let (scheduled_path, udf_args) = validate_schedule_args(
             scheduled_path,
@@ -1354,7 +1358,7 @@ impl<RT: Runtime, P: Persistence> ActionCallbacks for UdfTest<RT, P> {
     async fn cancel_job(
         &self,
         identity: Identity,
-        virtual_id: DeveloperDocumentId,
+        virtual_id: PublicDocumentId,
     ) -> anyhow::Result<()> {
         let mut tx = self.database.begin(identity).await?;
         VirtualSchedulerModel::new(&mut tx, ComponentId::test_user().into())

--- a/crates/isolate/src/tests/basic.rs
+++ b/crates/isolate/src/tests/basic.rs
@@ -6,8 +6,8 @@ use common::{
     testing::assert_contains,
     types::FieldName,
     value::{
-        ConvexObject,
         ConvexValue,
+        DocumentObject,
     },
 };
 use keybroker::Identity;
@@ -92,7 +92,7 @@ async fn test_references(rt: TestRuntime) -> anyhow::Result<()> {
         let field_name: FieldName = "field".parse()?;
         must_let!(let ConvexValue::Object(obj) = t.mutation(
                 "basic:insertObject",
-                ConvexObject::for_value(field_name, ConvexValue::Null)?,
+                DocumentObject::for_value(field_name, ConvexValue::Null)?,
             ).await?);
         must_let!(let Some(ConvexValue::String(..)) = obj.get("_id"));
         Ok(())

--- a/crates/isolate/src/tests/headroom.rs
+++ b/crates/isolate/src/tests/headroom.rs
@@ -12,8 +12,8 @@ use common::{
     },
     testing::assert_contains,
     value::{
-        ConvexObject,
         ConvexValue,
+        DocumentObject,
     },
 };
 use must_let::must_let;
@@ -24,12 +24,12 @@ use crate::test_helpers::{
     UdfTestType,
 };
 
-fn get_f64(obj: &ConvexObject, key: &str) -> f64 {
+fn get_f64(obj: &DocumentObject, key: &str) -> f64 {
     must_let!(let Some(ConvexValue::Float64(v)) = obj.get(key));
     *v
 }
 
-fn get_obj<'a>(o: &'a ConvexObject, key: &str) -> &'a ConvexObject {
+fn get_obj<'a>(o: &'a DocumentObject, key: &str) -> &'a DocumentObject {
     must_let!(let Some(ConvexValue::Object(v)) = o.get(key));
     v
 }
@@ -45,7 +45,7 @@ impl ExpectedMetric {
         Self { used, remaining }
     }
 
-    fn assert_eq(&self, obj: &ConvexObject, field: &str) {
+    fn assert_eq(&self, obj: &DocumentObject, field: &str) {
         let v = get_obj(obj, field);
         assert_eq!(get_f64(v, "used"), self.used, "{field}.used");
         assert_eq!(get_f64(v, "remaining"), self.remaining, "{field}.remaining");
@@ -114,7 +114,7 @@ impl ExpectedHeadroom {
     }
 }
 
-fn assert_headroom(h: &ConvexObject, expected: &ExpectedHeadroom) {
+fn assert_headroom(h: &DocumentObject, expected: &ExpectedHeadroom) {
     expected.bytes_read.assert_eq(h, "bytesRead");
     expected.bytes_written.assert_eq(h, "bytesWritten");
     expected.documents_read.assert_eq(h, "documentsRead");

--- a/crates/isolate/src/tests/id_encoding.rs
+++ b/crates/isolate/src/tests/id_encoding.rs
@@ -9,12 +9,12 @@ use proptest::prelude::*;
 use runtime::testing::TestDriver;
 use value::{
     base32,
-    id_v6::DeveloperDocumentId,
+    id_v6::PublicDocumentId,
 };
 
 use crate::test_helpers::UdfTest;
 
-async fn test_idv6_js_decode(rt: TestRuntime, id: DeveloperDocumentId) -> anyhow::Result<()> {
+async fn test_idv6_js_decode(rt: TestRuntime, id: PublicDocumentId) -> anyhow::Result<()> {
     let t = UdfTest::default(rt).await?;
     must_let!(let ConvexValue::Object(obj) = t.query("idEncoding:decode", assert_obj!("id" => id.encode())).await?);
     must_let!(let Some(ConvexValue::Float64(table_number)) = obj.get("tableNumber"));
@@ -28,7 +28,7 @@ async fn test_idv6_js_is_id(rt: TestRuntime, id: String) -> anyhow::Result<()> {
     let t = UdfTest::default(rt).await?;
     must_let!(let ConvexValue::Object(obj) = t.query("idEncoding:isId", assert_obj!("id" => id.clone())).await?);
     must_let!(let Some(ConvexValue::Boolean(is_id)) = obj.get("result"));
-    assert_eq!(&DeveloperDocumentId::decode(&id).is_ok(), is_id);
+    assert_eq!(&PublicDocumentId::decode(&id).is_ok(), is_id);
     Ok(())
 }
 
@@ -36,7 +36,7 @@ proptest! {
     #![proptest_config(ProptestConfig { cases: 32 * env_config("CONVEX_PROPTEST_MULTIPLIER", 1), failure_persistence: None, .. ProptestConfig::default() })]
 
     #[test]
-    fn proptest_idv6_js_decode(id in any::<DeveloperDocumentId>()) {
+    fn proptest_idv6_js_decode(id in any::<PublicDocumentId>()) {
         let td = TestDriver::new();
         let rt = td.rt();
         td.run_until(test_idv6_js_decode(rt, id)).unwrap();

--- a/crates/isolate/src/tests/id_strings.rs
+++ b/crates/isolate/src/tests/id_strings.rs
@@ -19,7 +19,7 @@ use runtime::testing::{
 };
 use value::{
     assert_obj,
-    id_v6::DeveloperDocumentId,
+    id_v6::PublicDocumentId,
     ConvexValue,
     FieldName,
     InternalId,
@@ -39,7 +39,7 @@ async fn test_table_mapping_from_system_udf(rt: TestRuntime) -> anyhow::Result<(
         let document = TestFacingModel::new(&mut tx)
             .insert_and_get("table".parse()?, assert_obj!())
             .await?;
-        let table_number = document.id().developer_id.table();
+        let table_number = document.id().document_id.table();
         let table_number_field: FieldName = FieldName::from_str(table_number.to_string().as_ref())?;
         t.database.commit(tx).await?;
 
@@ -83,7 +83,7 @@ async fn test_system_normalize_id(rt: TestRuntime) -> anyhow::Result<()> {
             .await?;
         t.database.commit(tx).await?;
 
-        let id_v6 = DeveloperDocumentId::new(storage_table_number, internal_id);
+        let id_v6 = PublicDocumentId::new(storage_table_number, internal_id);
 
         // Correct virtual table name and number.
         must_let!(let ConvexValue::String(normalized_id) = t.query("idStrings:normalizeSystemId", assert_obj!(
@@ -113,13 +113,13 @@ async fn test_system_normalize_id(rt: TestRuntime) -> anyhow::Result<()> {
 
         // Physical table name and physical table number doesn't work.
         must_let!(let ConvexValue::Null = t.query("idStrings:normalizeSystemId", assert_obj!(
-            "id" => DeveloperDocumentId::new(storage_table_number, internal_id).encode(),
+            "id" => PublicDocumentId::new(storage_table_number, internal_id).encode(),
             "table" => "_file_storage",
         )).await?);
 
         // System table that doesn't even have a virtual table doesn't work.
         must_let!(let ConvexValue::Null = t.query("idStrings:normalizeSystemId", assert_obj!(
-            "id" => DeveloperDocumentId::new(indexes_table_number, internal_id).encode(),
+            "id" => PublicDocumentId::new(indexes_table_number, internal_id).encode(),
             "table" => "_index",
         )).await?);
 
@@ -137,7 +137,7 @@ async fn test_system_normalize_id(rt: TestRuntime) -> anyhow::Result<()> {
         t.query_js_error(
             "idStrings:normalizeSystemId",
             assert_obj!(
-                "id" => DeveloperDocumentId::new(user_table_number, internal_id).encode(),
+                "id" => PublicDocumentId::new(user_table_number, internal_id).encode(),
                 "table" => user_table_name.to_string(),
             ),
         )
@@ -188,7 +188,7 @@ async fn test_normalize_id(rt: TestRuntime, internal_id: InternalId) -> anyhow::
         .await?;
     t.database.commit(tx).await?;
 
-    let id_v6 = DeveloperDocumentId::new(table_number, internal_id);
+    let id_v6 = PublicDocumentId::new(table_number, internal_id);
 
     // Test IDv6 and correct table name
     must_let!(let ConvexValue::Object(obj) = t.query("idStrings:normalizeId", assert_obj!(

--- a/crates/isolate/src/tests/query.rs
+++ b/crates/isolate/src/tests/query.rs
@@ -28,8 +28,8 @@ use runtime::testing::TestRuntime;
 use udf::UdfOutcome;
 use value::{
     assert_val,
-    id_v6::DeveloperDocumentId,
-    ConvexObject,
+    id_v6::PublicDocumentId,
+    DocumentObject,
 };
 
 use crate::test_helpers::{
@@ -413,7 +413,7 @@ async fn test_index_range_errors(rt: TestRuntime) -> anyhow::Result<()> {
     .await
 }
 
-fn pagination_opts(cursor: ConvexValue) -> ConvexObject {
+fn pagination_opts(cursor: ConvexValue) -> DocumentObject {
     assert_obj!("paginationOpts" => ConvexValue::Object(assert_obj!(
         "cursor" => cursor,
         "numItems" => 1.0,
@@ -500,17 +500,17 @@ async fn test_pagination_max_bytes_read(rt: TestRuntime) -> anyhow::Result<()> {
         must_let!(let ConvexValue::String(id5) = t.mutation("query:insert", object.clone()).await?);
 
         let expected = vec![
-            DeveloperDocumentId::decode(&id1)?,
-            DeveloperDocumentId::decode(&id2)?,
-            DeveloperDocumentId::decode(&id3)?,
-            DeveloperDocumentId::decode(&id4)?,
-            DeveloperDocumentId::decode(&id5)?,
+            PublicDocumentId::decode(&id1)?,
+            PublicDocumentId::decode(&id2)?,
+            PublicDocumentId::decode(&id3)?,
+            PublicDocumentId::decode(&id4)?,
+            PublicDocumentId::decode(&id5)?,
         ];
 
         async fn read_to_end(
             t: &UdfTest<TestRuntime, TestPersistence>,
             max_bytes_read: usize,
-        ) -> anyhow::Result<(Vec<DeveloperDocumentId>, usize)> {
+        ) -> anyhow::Result<(Vec<PublicDocumentId>, usize)> {
             let mut results = Vec::new();
             let mut num_pages = 0;
             let mut cursor = ConvexValue::Null;
@@ -532,7 +532,7 @@ async fn test_pagination_max_bytes_read(rt: TestRuntime) -> anyhow::Result<()> {
                 for value in page.into_iter() {
                     must_let!(let ConvexValue::Object(object) = value);
                     must_let!(let Some(ConvexValue::String(id)) = object.get("_id"));
-                    results.push(DeveloperDocumentId::decode(id)?);
+                    results.push(PublicDocumentId::decode(id)?);
                 }
             }
             Ok((results, num_pages))
@@ -610,8 +610,8 @@ async fn test_multiple_paginated_queries_error(rt: TestRuntime) -> anyhow::Resul
 pub async fn assert_paginated_query_journal_is_correct(
     t: &UdfTest<TestRuntime, TestPersistence>,
     udf_path: &str,
-    args: ConvexObject,
-    middle_objects: Vec<(&'static str, ConvexObject, bool)>,
+    args: DocumentObject,
+    middle_objects: Vec<(&'static str, DocumentObject, bool)>,
 ) -> anyhow::Result<(ConvexArray, bool)> {
     let (outcome1, _) = t
         .raw_query(

--- a/crates/isolate/src/tests/shapes.rs
+++ b/crates/isolate/src/tests/shapes.rs
@@ -16,7 +16,7 @@ use shape_inference::{
 };
 use value::{
     assert_val,
-    id_v6::DeveloperDocumentId,
+    id_v6::PublicDocumentId,
     val,
     ResolvedDocumentId,
     TableNamespace,
@@ -35,12 +35,12 @@ async fn test_shape_inference_js(rt: TestRuntime) -> anyhow::Result<()> {
         (
             ConvexValue::from(ResolvedDocumentId::new(
                 table_id.tablet_id,
-                DeveloperDocumentId::new(table_id.table_number, InternalId::MIN),
+                PublicDocumentId::new(table_id.table_number, InternalId::MIN),
             )),
             r#"Id<"test">"#,
         ),
         (
-            ConvexValue::from(DeveloperDocumentId::new(table_number, InternalId::MIN)),
+            ConvexValue::from(PublicDocumentId::new(table_number, InternalId::MIN)),
             r#"Id<"test2">"#,
         ),
         (val!(null), "null"),

--- a/crates/isolate/src/tests/storage.rs
+++ b/crates/isolate/src/tests/storage.rs
@@ -41,7 +41,7 @@ async fn check_storage_url(
     must_let!(let Some(internal_id) = url_str.strip_prefix("http://127.0.0.1:8000/api/storage/"));
     must_let!(
         let Some((_, storage_entry)) = t.storage_get_file_entry(
-            Identity::system(), ComponentId::test_user(), FileStorageId::DocumentId(id_str.parse()?)
+            Identity::system(), ComponentId::test_user(), FileStorageId::PublicDocumentId(id_str.parse()?)
         ).await?
     );
     assert_eq!(storage_entry.storage_id, internal_id.parse()?);

--- a/crates/isolate/src/tests/system_udfs.rs
+++ b/crates/isolate/src/tests/system_udfs.rs
@@ -9,7 +9,7 @@ use keybroker::Identity;
 use model::environment_variables::EnvironmentVariablesModel;
 use must_let::must_let;
 use runtime::testing::TestRuntime;
-use value::ConvexObject;
+use value::DocumentObject;
 
 use crate::test_helpers::UdfTest;
 
@@ -36,9 +36,9 @@ async fn test_system_udf(rt: TestRuntime) -> anyhow::Result<()> {
         assert_obj!("name" => "A".to_string()),
     )
     .await?);
-    must_let!(let Some(ConvexValue::String(name)) = ConvexObject::get(&obj, "name"));
+    must_let!(let Some(ConvexValue::String(name)) = DocumentObject::get(&obj, "name"));
     assert_eq!(name.to_string(), "A");
-    must_let!(let Some(ConvexValue::String(value)) = ConvexObject::get(&obj, "value"));
+    must_let!(let Some(ConvexValue::String(value)) = DocumentObject::get(&obj, "value"));
     assert_eq!(value.to_string(), "B");
 
     // query a system environment variable
@@ -47,9 +47,9 @@ async fn test_system_udf(rt: TestRuntime) -> anyhow::Result<()> {
         assert_obj!("name" => "CONVEX_CLOUD_URL".to_string()),
     )
     .await?);
-    must_let!(let Some(ConvexValue::String(name)) = ConvexObject::get(&obj, "name"));
+    must_let!(let Some(ConvexValue::String(name)) = DocumentObject::get(&obj, "name"));
     assert_eq!(name.to_string(), "CONVEX_CLOUD_URL");
-    must_let!(let Some(ConvexValue::String(value)) = ConvexObject::get(&obj, "value"));
+    must_let!(let Some(ConvexValue::String(value)) = DocumentObject::get(&obj, "value"));
     assert_eq!(value.to_string(), "https://carnitas.convex.cloud");
 
     // calling with empty argument fails

--- a/crates/isolate/src/tests/user_error.rs
+++ b/crates/isolate/src/tests/user_error.rs
@@ -20,7 +20,7 @@ use model::{
 use must_let::must_let;
 use runtime::testing::TestRuntime;
 use value::{
-    id_v6::DeveloperDocumentId,
+    id_v6::PublicDocumentId,
     InternalId,
     TableName,
     TableNamespace,
@@ -152,7 +152,7 @@ async fn test_nonexistent_table(rt: TestRuntime) -> anyhow::Result<()> {
         let table_number = TableModel::new(&mut tx)
             .next_user_table_number(TableNamespace::test_user())
             .await?;
-        let nonexistent_id = DeveloperDocumentId::new(table_number, InternalId::MIN);
+        let nonexistent_id = PublicDocumentId::new(table_number, InternalId::MIN);
         t.mutation(
             "userError:nonexistentTable",
             assert_obj!("nonexistentId" => nonexistent_id),
@@ -187,19 +187,19 @@ async fn test_nonexistent_id(rt: TestRuntime) -> anyhow::Result<()> {
                 Some(table_number),
             ).await?
         );
-        let nonexistent_system_table_id = DeveloperDocumentId::new(table_number, InternalId::MIN);
+        let nonexistent_system_table_id = PublicDocumentId::new(table_number, InternalId::MIN);
 
         let virtual_table_number = tx
             .table_mapping()
             .namespace(TableNamespace::test_user())
             .name_to_id_user_input()(FILE_STORAGE_TABLE.clone())?.table_number;
-        let nonexistent_virtual_table_id = DeveloperDocumentId::new(
+        let nonexistent_virtual_table_id = PublicDocumentId::new(
             virtual_table_number, InternalId::MIN);
         let user_document = TestFacingModel::new(&mut tx)
             .insert_and_get("table".parse()?, assert_obj!())
             .await?;
-        let user_table_number = user_document.id().developer_id.table();
-        let nonexistent_user_table_id = DeveloperDocumentId::new(
+        let user_table_number = user_document.id().document_id.table();
+        let nonexistent_user_table_id = PublicDocumentId::new(
             user_table_number, InternalId::MIN);
         t.database.commit(tx).await?;
         t.mutation(

--- a/crates/keybroker/src/broker.rs
+++ b/crates/keybroker/src/broker.rs
@@ -1253,7 +1253,7 @@ mod tests {
             PersistenceVersion,
             TableName,
         },
-        value::DeveloperDocumentId,
+        value::PublicDocumentId,
     };
     use pb::convex_keys::{
         admin_key::Identity as AdminIdentityProto,
@@ -1394,7 +1394,7 @@ mod tests {
         let mut journal_with_cursor = QueryJournal::new();
         journal_with_cursor.end_cursor = Some(Cursor {
             position: CursorPosition::After(
-                IndexKey::new(vec![100.into()], DeveloperDocumentId::MIN).to_bytes(),
+                IndexKey::new(vec![100.into()], PublicDocumentId::MIN).to_bytes(),
             ),
             query_fingerprint: query.fingerprint(&IndexedFields::creation_time())?,
         });

--- a/crates/local_backend/src/deploy_config.rs
+++ b/crates/local_backend/src/deploy_config.rs
@@ -46,7 +46,7 @@ use serde::{
 };
 use serde_json::Value as JsonValue;
 use value::{
-    ConvexObject,
+    DocumentObject,
     TableNamespace,
 };
 
@@ -201,7 +201,7 @@ pub async fn get_config(
     let (config, modules, udf_config) = ConfigModel::new(&mut tx, component)
         .get_with_module_source(st.application.modules_cache())
         .await?;
-    let config = ConvexObject::try_from(config)?.to_internal_json();
+    let config = DocumentObject::try_from(config)?.to_internal_json();
 
     let modules = modules.into_iter().map(|m| m.into()).collect();
     let udf_server_version = udf_config.map(|config| format!("{}", config.server_version));
@@ -238,7 +238,7 @@ pub async fn get_config_hashes(
             environment: Some(m.environment.to_string()),
         })
         .collect();
-    let config = ConvexObject::try_from(config)?;
+    let config = DocumentObject::try_from(config)?;
     let config: JsonValue = config.to_internal_json();
 
     let node_version = SourcePackageModel::new(&mut tx, TableNamespace::Global)

--- a/crates/local_backend/src/deploy_config2.rs
+++ b/crates/local_backend/src/deploy_config2.rs
@@ -3,6 +3,7 @@ use std::{
     time::Duration,
 };
 
+use anyhow::Context;
 use application::deploy_config::{
     EvaluatePushResponse,
     FinishPushDiff,
@@ -28,7 +29,9 @@ use common::{
         },
         HttpResponseError,
     },
+    types::Timestamp,
 };
+use database::partition::PartitionId;
 use errors::{
     ErrorMetadata,
     ErrorMetadataAnyhowExt,
@@ -40,6 +43,11 @@ use fastrace::{
         SpanRecord,
         TraceId,
     },
+};
+use keybroker::{
+    AdminIdentityPrincipal,
+    Identity,
+    KeyBroker,
 };
 use model::{
     auth::types::AuthDiff,
@@ -57,14 +65,16 @@ use model::{
     source_packages::types::SourcePackage,
 };
 use serde::{
+    de::DeserializeOwned,
     Deserialize,
     Serialize,
 };
 use serde_json::Value as JsonValue;
+use url::Url;
 use value::{
     base64,
-    ConvexObject,
-    DeveloperDocumentId,
+    DocumentObject,
+    PublicDocumentId,
 };
 
 use crate::{
@@ -74,6 +84,146 @@ use crate::{
     },
     LocalAppState,
 };
+
+const INTERNAL_BACKEND_HTTP_PORT: u16 = 3210;
+
+fn metadata_owner_origin(st: &LocalAppState) -> anyhow::Result<Option<String>> {
+    let Some(local_partition) = st.partition_id else {
+        return Ok(None);
+    };
+    if local_partition == PartitionId::DEFAULT {
+        return Ok(None);
+    }
+    let node_addresses = st
+        .node_addresses
+        .as_ref()
+        .context("NODE_ADDRESSES is required to forward deploy metadata operations to the owner")?;
+    let owner_addr = node_addresses
+        .address_for(PartitionId::DEFAULT)
+        .context("Missing NODE_ADDRESSES entry for deploy metadata owner partition-0")?;
+    Ok(Some(http_origin_from_peer_addr(owner_addr)?))
+}
+
+fn http_origin_from_peer_addr(addr: &str) -> anyhow::Result<String> {
+    let normalized = if addr.contains("://") {
+        addr.to_string()
+    } else {
+        format!("http://{addr}")
+    };
+    let mut url = Url::parse(&normalized)?;
+    url.set_path("");
+    url.set_query(None);
+    url.set_fragment(None);
+    url.set_port(Some(INTERNAL_BACKEND_HTTP_PORT))
+        .map_err(|_| anyhow::anyhow!("Failed to map peer address {addr} to backend HTTP port"))?;
+    Ok(url.to_string().trim_end_matches('/').to_string())
+}
+
+trait AdminKeyCarrier {
+    fn admin_key(&self) -> &str;
+    fn set_admin_key(&mut self, admin_key: String);
+}
+
+async fn metadata_owner_instance_name(owner_origin: &str) -> anyhow::Result<String> {
+    let url = format!("{owner_origin}/instance_name");
+    let response = reqwest::Client::new().get(&url).send().await?;
+    let status = response.status();
+    let body = response.text().await?;
+    anyhow::ensure!(
+        status.is_success(),
+        "Metadata owner instance-name request to {url} failed with HTTP {status}: {body}"
+    );
+    let instance_name = body.trim();
+    anyhow::ensure!(
+        !instance_name.is_empty(),
+        "Metadata owner at {owner_origin} returned an empty instance name"
+    );
+    Ok(instance_name.to_owned())
+}
+
+fn issue_owner_admin_key(
+    st: &LocalAppState,
+    owner_instance_name: &str,
+    identity: &Identity,
+) -> anyhow::Result<String> {
+    let (principal, is_read_only) = match identity {
+        Identity::InstanceAdmin(admin_identity) | Identity::ActingUser(admin_identity, _) => (
+            admin_identity.principal().clone(),
+            admin_identity.is_read_only(),
+        ),
+        _ => anyhow::bail!("Deploy metadata forwarding requires an authenticated admin identity"),
+    };
+    let owner_key_broker = KeyBroker::new(owner_instance_name, st.instance_secret)?;
+    let owner_admin_key = match principal {
+        AdminIdentityPrincipal::Member(member_id) => {
+            if is_read_only {
+                owner_key_broker.issue_read_only_admin_key(member_id)
+            } else {
+                owner_key_broker.issue_admin_key(member_id)
+            }
+        },
+        AdminIdentityPrincipal::Team(_) => anyhow::bail!(
+            "Deploy metadata forwarding does not yet support team-scoped admin identities"
+        ),
+    };
+    Ok(owner_admin_key.as_string())
+}
+
+async fn maybe_forward_deploy_request<Req, Resp>(
+    st: &LocalAppState,
+    path: &str,
+    req: &mut Req,
+    needs_write_access: bool,
+) -> anyhow::Result<Option<Resp>>
+where
+    Req: Serialize + AdminKeyCarrier,
+    Resp: DeserializeOwned,
+{
+    let Some(owner_origin) = metadata_owner_origin(st)? else {
+        return Ok(None);
+    };
+    let identity = if needs_write_access {
+        must_be_admin_from_key_with_write_access(
+            st.application.app_auth(),
+            st.instance_name.clone(),
+            req.admin_key().to_owned(),
+        )
+        .await?
+    } else {
+        must_be_admin_from_key(
+            st.application.app_auth(),
+            st.instance_name.clone(),
+            req.admin_key().to_owned(),
+        )
+        .await?
+    };
+    let owner_instance_name = metadata_owner_instance_name(&owner_origin).await?;
+    let owner_admin_key = issue_owner_admin_key(st, &owner_instance_name, &identity)?;
+    req.set_admin_key(owner_admin_key);
+    Ok(Some(
+        forward_deploy_request(&owner_origin, path, req).await?,
+    ))
+}
+
+async fn forward_deploy_request<Req, Resp>(
+    owner_origin: &str,
+    path: &str,
+    req: &Req,
+) -> anyhow::Result<Resp>
+where
+    Req: Serialize + ?Sized,
+    Resp: DeserializeOwned,
+{
+    let url = format!("{owner_origin}{path}");
+    let response = reqwest::Client::new().post(&url).json(req).send().await?;
+    let status = response.status();
+    let body = response.text().await?;
+    anyhow::ensure!(
+        status.is_success(),
+        "Metadata owner request to {url} failed with HTTP {status}: {body}"
+    );
+    Ok(serde_json::from_str(&body)?)
+}
 
 impl TryFrom<StartPushResponse> for SerializedStartPushResponse {
     type Error = anyhow::Error;
@@ -87,11 +237,16 @@ impl TryFrom<StartPushResponse> for SerializedStartPushResponse {
                 .collect::<anyhow::Result<_>>()?,
             external_deps_id: value
                 .external_deps_id
-                .map(|id| String::from(DeveloperDocumentId::from(id))),
+                .map(|id| String::from(PublicDocumentId::from(id))),
             component_definition_packages: value
                 .component_definition_packages
                 .into_iter()
-                .map(|(k, v)| Ok((String::from(k), JsonValue::from(ConvexObject::try_from(v)?))))
+                .map(|(k, v)| {
+                    Ok((
+                        String::from(k),
+                        JsonValue::from(DocumentObject::try_from(v)?),
+                    ))
+                })
                 .collect::<anyhow::Result<_>>()?,
             app_auth: value
                 .app_auth
@@ -121,11 +276,7 @@ impl TryFrom<SerializedStartPushResponse> for StartPushResponse {
                 .collect::<anyhow::Result<_>>()?,
             external_deps_id: value
                 .external_deps_id
-                .map(|id| {
-                    anyhow::Ok(ExternalDepsPackageId::from(
-                        id.parse::<DeveloperDocumentId>()?,
-                    ))
-                })
+                .map(|id| anyhow::Ok(ExternalDepsPackageId::from(id.parse::<PublicDocumentId>()?)))
                 .transpose()?,
             component_definition_packages: value
                 .component_definition_packages
@@ -133,7 +284,7 @@ impl TryFrom<SerializedStartPushResponse> for StartPushResponse {
                 .map(|(k, v)| {
                     Ok((
                         k.parse()?,
-                        SourcePackage::try_from(ConvexObject::try_from(v)?)?,
+                        SourcePackage::try_from(DocumentObject::try_from(v)?)?,
                     ))
                 })
                 .collect::<anyhow::Result<_>>()?,
@@ -150,6 +301,16 @@ impl TryFrom<SerializedStartPushResponse> for StartPushResponse {
             app: value.app.try_into()?,
             schema_change: value.schema_change.try_into()?,
         })
+    }
+}
+
+impl AdminKeyCarrier for StartPushRequest {
+    fn admin_key(&self) -> &str {
+        &self.admin_key
+    }
+
+    fn set_admin_key(&mut self, admin_key: String) {
+        self.admin_key = admin_key;
     }
 }
 
@@ -200,8 +361,14 @@ pub struct AnalyzedComponent {
 #[debug_handler]
 pub async fn start_push(
     State(st): State<LocalAppState>,
-    Json(req): Json<StartPushRequest>,
+    Json(mut req): Json<StartPushRequest>,
 ) -> Result<impl IntoResponse, HttpResponseError> {
+    if let Some(forwarded) =
+        maybe_forward_deploy_request(&st, "/api/deploy2/start_push", &mut req, true).await?
+    {
+        return Ok(Json(forwarded));
+    }
+
     let _identity = must_be_admin_from_key_with_write_access(
         st.application.app_auth(),
         st.instance_name.clone(),
@@ -226,8 +393,14 @@ pub async fn start_push(
 // a long time on large instances.
 pub async fn evaluate_push(
     MtState(st): MtState<LocalAppState>,
-    Json(req): Json<StartPushRequest>,
+    Json(mut req): Json<StartPushRequest>,
 ) -> Result<impl IntoResponse, HttpResponseError> {
+    if let Some(forwarded) =
+        maybe_forward_deploy_request(&st, "/api/deploy2/evaluate_push", &mut req, true).await?
+    {
+        return Ok(Json(forwarded));
+    }
+
     let _identity = must_be_admin_from_key_with_write_access(
         st.application.app_auth(),
         st.instance_name.clone(),
@@ -247,7 +420,7 @@ pub async fn evaluate_push(
 
 const DEFAULT_SCHEMA_TIMEOUT_MS: u32 = 10_000;
 
-#[derive(Deserialize)]
+#[derive(Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct WaitForSchemaRequest {
     admin_key: String,
@@ -255,10 +428,26 @@ pub struct WaitForSchemaRequest {
     timeout_ms: Option<u32>,
 }
 
+impl AdminKeyCarrier for WaitForSchemaRequest {
+    fn admin_key(&self) -> &str {
+        &self.admin_key
+    }
+
+    fn set_admin_key(&mut self, admin_key: String) {
+        self.admin_key = admin_key;
+    }
+}
+
 pub async fn wait_for_schema(
     MtState(st): MtState<LocalAppState>,
-    Json(req): Json<WaitForSchemaRequest>,
+    Json(mut req): Json<WaitForSchemaRequest>,
 ) -> Result<impl IntoResponse, HttpResponseError> {
+    if let Some(forwarded) =
+        maybe_forward_deploy_request(&st, "/api/deploy2/wait_for_schema", &mut req, false).await?
+    {
+        return Ok(Json(forwarded));
+    }
+
     let identity = must_be_admin_from_key(
         st.application.app_auth(),
         st.instance_name.clone(),
@@ -277,12 +466,22 @@ pub async fn wait_for_schema(
     Ok(Json(SchemaStatusJson::from(resp)))
 }
 
-#[derive(Deserialize)]
+#[derive(Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct FinishPushRequest {
     pub admin_key: String,
     start_push: SerializedStartPushResponse,
     pub dry_run: bool,
+}
+
+impl AdminKeyCarrier for FinishPushRequest {
+    fn admin_key(&self) -> &str {
+        &self.admin_key
+    }
+
+    fn set_admin_key(&mut self, admin_key: String) {
+        self.admin_key = admin_key;
+    }
 }
 
 /// Internal version that returns the commit timestamp for use by conductor
@@ -315,12 +514,38 @@ pub async fn finish_push_internal(
     Ok((SerializedFinishPushDiff::try_from(resp)?, Some(ts)))
 }
 
+#[derive(Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SerializedFinishPushResponse {
+    #[serde(flatten)]
+    diff: SerializedFinishPushDiff,
+    commit_ts: Option<u64>,
+}
+
 pub async fn finish_push(
     MtState(st): MtState<LocalAppState>,
-    Json(req): Json<FinishPushRequest>,
+    Json(mut req): Json<FinishPushRequest>,
 ) -> Result<impl IntoResponse, HttpResponseError> {
-    let (diff, _ts) = finish_push_internal(&st, req).await?;
-    Ok(Json(diff))
+    if let Some(forwarded) = maybe_forward_deploy_request::<
+        FinishPushRequest,
+        SerializedFinishPushResponse,
+    >(&st, "/api/deploy2/finish_push", &mut req, true)
+    .await?
+    {
+        if let Some(commit_ts) = forwarded.commit_ts {
+            st.application
+                .database()
+                .wait_for_write_ts(Timestamp::try_from(commit_ts)?)
+                .await;
+        }
+        return Ok(Json(forwarded));
+    }
+
+    let (diff, commit_ts) = finish_push_internal(&st, req).await?;
+    Ok(Json(SerializedFinishPushResponse {
+        diff,
+        commit_ts: commit_ts.map(u64::from),
+    }))
 }
 
 #[derive(Deserialize)]
@@ -358,7 +583,7 @@ pub async fn report_push_completed_handler(
     Ok(Json(()))
 }
 
-#[derive(Serialize)]
+#[derive(Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct SerializedFinishPushDiff {
     auth_diff: AuthDiff,
@@ -467,5 +692,28 @@ impl TryFrom<SerializedEventRecord> for EventRecord {
             timestamp_unix_ns,
             properties,
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::http_origin_from_peer_addr;
+
+    #[test]
+    fn peer_addr_to_http_origin_supports_host_port_pairs() -> anyhow::Result<()> {
+        assert_eq!(
+            http_origin_from_peer_addr("node-p0a:50051")?,
+            "http://node-p0a:3210"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn peer_addr_to_http_origin_supports_urls() -> anyhow::Result<()> {
+        assert_eq!(
+            http_origin_from_peer_addr("http://node-p1a:50051")?,
+            "http://node-p1a:3210"
+        );
+        Ok(())
     }
 }

--- a/crates/local_backend/src/lib.rs
+++ b/crates/local_backend/src/lib.rs
@@ -65,6 +65,7 @@ use function_runner::{
 use governor::Quota;
 use http_client::CachedHttpClient;
 use indexing::index_cache::SharedIndexCache;
+use keybroker::InstanceSecret;
 use model::{
     initialize_application_system_tables,
     virtual_system_mapping,
@@ -126,8 +127,11 @@ pub struct LocalAppState {
     pub site_origin: ConvexSite,
     // Name of the instance. (e.g. crazy-giraffe-123)
     pub instance_name: String,
+    pub instance_secret: InstanceSecret,
     pub application: Application<ProdRuntime>,
     pub zombify_rx: async_broadcast::Receiver<()>,
+    pub partition_id: Option<database::partition::PartitionId>,
+    pub node_addresses: Option<database::two_phase::NodeAddresses>,
     /// Raft partition mailbox for receiving Raft messages from peers.
     /// None if Raft is not enabled.
     pub raft_mailbox_tx:
@@ -354,6 +358,12 @@ pub async fn make_app(
 
     let origin = config.convex_origin_url()?;
     let instance_name = config.name();
+    let instance_secret = config.secret()?;
+    let partition_id = config.partition_id.map(database::partition::PartitionId);
+    let node_addresses = config
+        .node_addresses
+        .as_deref()
+        .map(database::two_phase::NodeAddresses::from_config);
 
     if !config.disable_beacon {
         let beacon_future = beacon::start_beacon(
@@ -505,7 +515,21 @@ pub async fn make_app(
         let (peer_senders, transport_clients) =
             raft_transport::create_transport(&peer_addresses, raft_node_id);
 
-        let mut manager = RaftPartitionManager::new(raft_config, raft_engine, peer_senders)?;
+        let snapshot_provider = {
+            let database = database.clone();
+            Arc::new(move || {
+                common::runtime::block_in_place(|| {
+                    let rt = tokio::runtime::Handle::current();
+                    rt.block_on(async { database.build_raft_snapshot_bytes().await })
+                })
+            }) as Arc<dyn database::raft_storage::RaftSnapshotProvider>
+        };
+        let mut manager = RaftPartitionManager::new(
+            raft_config,
+            raft_engine,
+            peer_senders,
+            Some(snapshot_provider),
+        )?;
         let raft_state = manager.state();
         let mb_tx = manager.mailbox_tx();
         raft_mailbox_tx = Some(mb_tx);
@@ -519,36 +543,50 @@ pub async fn make_app(
             let committer = database.committer_client();
             let raft_state_for_apply = raft_state.clone();
             runtime.spawn_background("raft_node", async move {
-                node.run(|data| {
-                    // Deserialize the CommitDelta from the Raft entry.
-                    let envelope: database::nats_distributed_log::DeltaEnvelope =
-                        serde_json::from_slice(data).map_err(|e| {
-                            anyhow::anyhow!("Failed to deserialize Raft entry: {e}")
-                        })?;
-                    let delta = envelope.to_delta()?;
+                node.run(
+                    |data| {
+                        // Deserialize the CommitDelta from the Raft entry.
+                        let envelope: database::nats_distributed_log::DeltaEnvelope =
+                            serde_json::from_slice(data).map_err(|e| {
+                                anyhow::anyhow!("Failed to deserialize Raft entry: {e}")
+                            })?;
+                        let delta = envelope.to_delta()?;
 
-                    // Leader already applied locally — skip.
-                    // Followers apply via the Committer (same path as NATS).
-                    if !raft_state_for_apply.is_leader() {
-                        tracing::info!(
-                            "Raft follower applying committed delta: ts={}",
-                            u64::from(delta.ts),
-                        );
-                        // apply_replica_delta is async — use block_in_place
-                        // since we're in the Raft loop's sync callback.
+                        // Leader already applied locally — skip.
+                        // Followers apply via the Committer (same path as NATS).
+                        if !raft_state_for_apply.is_leader() {
+                            tracing::info!(
+                                "Raft follower applying committed delta: ts={}",
+                                u64::from(delta.ts),
+                            );
+                            // apply_replica_delta is async — use block_in_place
+                            // since we're in the Raft loop's sync callback.
+                            let committer = committer.clone();
+                            common::runtime::block_in_place(|| {
+                                let rt = tokio::runtime::Handle::current();
+                                rt.block_on(async {
+                                    if let Err(e) = committer.apply_replica_delta(delta).await {
+                                        tracing::error!("Raft follower apply failed: {e:#}");
+                                    }
+                                })
+                            });
+                        }
+
+                        Ok(())
+                    },
+                    |snapshot_bytes| {
+                        let checkpoint =
+                            database::snapshot_checkpointer::checkpoint_from_bytes(snapshot_bytes)?;
                         let committer = committer.clone();
                         common::runtime::block_in_place(|| {
                             let rt = tokio::runtime::Handle::current();
                             rt.block_on(async {
-                                if let Err(e) = committer.apply_replica_delta(delta).await {
-                                    tracing::error!("Raft follower apply failed: {e:#}");
-                                }
+                                committer.install_snapshot(checkpoint).await?;
+                                Ok::<_, anyhow::Error>(())
                             })
-                        });
-                    }
-
-                    Ok(())
-                })
+                        })
+                    },
+                )
                 .await;
             });
         }
@@ -572,8 +610,11 @@ pub async fn make_app(
         origin,
         site_origin: config.convex_site_url()?,
         instance_name,
+        instance_secret,
         application,
         zombify_rx,
+        partition_id,
+        node_addresses,
         raft_mailbox_tx,
     };
 

--- a/crates/local_backend/src/node_action_callbacks.rs
+++ b/crates/local_backend/src/node_action_callbacks.rs
@@ -63,7 +63,7 @@ use sync_types::{
 use usage_tracking::FunctionUsageTracker;
 use value::{
     export::ValueFormat,
-    id_v6::DeveloperDocumentId,
+    id_v6::PublicDocumentId,
 };
 use vector::{
     VectorSearch,
@@ -334,7 +334,7 @@ pub async fn cancel_developer_job(
     }: ExtractActionIdentity,
     Json(CancelDeveloperJobRequest { id }): Json<CancelDeveloperJobRequest>,
 ) -> Result<impl IntoResponse, HttpResponseError> {
-    let virtual_doc_id = DeveloperDocumentId::from_str(&id).context(ErrorMetadata::bad_request(
+    let virtual_doc_id = PublicDocumentId::from_str(&id).context(ErrorMetadata::bad_request(
         "InvalidArgument",
         "Invalid scheduled function ID",
     ))?;

--- a/crates/local_backend/src/parse.rs
+++ b/crates/local_backend/src/parse.rs
@@ -2,7 +2,7 @@ use common::components::ExportPath;
 use errors::ErrorMetadata;
 use sync_types::CanonicalizedUdfPath;
 use value::{
-    id_v6::DeveloperDocumentId,
+    id_v6::PublicDocumentId,
     NamespacedTableMapping,
     ResolvedDocumentId,
     TableName,
@@ -38,7 +38,7 @@ pub fn parse_document_id(
     table_mapping: &NamespacedTableMapping,
     table_name: &TableName,
 ) -> anyhow::Result<ResolvedDocumentId> {
-    let id = DeveloperDocumentId::decode(id)?.to_resolved(table_mapping.number_to_tablet())?;
+    let id = PublicDocumentId::decode(id)?.to_resolved(table_mapping.number_to_tablet())?;
     anyhow::ensure!(
         table_mapping.tablet_matches_name(id.tablet_id, table_name),
         invalid_id_error(table_name)
@@ -51,7 +51,7 @@ mod tests {
     use common::testing::TestIdGenerator;
     use model::environment_variables::ENVIRONMENT_VARIABLES_TABLE;
     use value::{
-        id_v6::DeveloperDocumentId,
+        id_v6::PublicDocumentId,
         TableNamespace,
     };
 
@@ -62,7 +62,7 @@ mod tests {
         let mut id_generator = TestIdGenerator::new();
 
         let id_v5 = id_generator.system_generate(&ENVIRONMENT_VARIABLES_TABLE);
-        let id_v6: DeveloperDocumentId = id_v5.into();
+        let id_v6: PublicDocumentId = id_v5.into();
 
         let table_mapping = id_generator.namespace(TableNamespace::Global);
         let id_v6_string = id_v6.encode();

--- a/crates/local_backend/src/snapshot_export.rs
+++ b/crates/local_backend/src/snapshot_export.rs
@@ -38,7 +38,7 @@ use model::exports::{
 use serde::Deserialize;
 use storage::StorageGetStream;
 use sync_types::Timestamp;
-use value::DeveloperDocumentId;
+use value::PublicDocumentId;
 
 use crate::{
     admin::must_be_admin_with_write_access,
@@ -93,7 +93,7 @@ pub async fn get_zip_export(
     Path(ZipExportRequest { id }): Path<ZipExportRequest>,
 ) -> Result<impl IntoResponse, HttpResponseError> {
     must_be_admin_with_write_access(&identity)?;
-    let id: Either<DeveloperDocumentId, Timestamp> = match id.parse() {
+    let id: Either<PublicDocumentId, Timestamp> = match id.parse() {
         Ok(id) => Either::Left(id),
         Err(_) => Either::Right(id.parse().context(ErrorMetadata::bad_request(
             "BadSnapshotId",
@@ -140,8 +140,8 @@ pub async fn set_export_expiration(
             "Must have system or admin identity to set export expiration"
         )))?;
     }
-    let snapshot_id: DeveloperDocumentId = snapshot_id
-        .parse::<DeveloperDocumentId>()
+    let snapshot_id: PublicDocumentId = snapshot_id
+        .parse::<PublicDocumentId>()
         .map_err(|e| anyhow::anyhow!(e))?;
     let mut tx = st.application.begin(identity).await?;
     ExportsModel::new(&mut tx)
@@ -164,8 +164,8 @@ pub async fn cancel_export(
             "Must have system or admin identity to cancel cloud export"
         )))?;
     }
-    let snapshot_id: DeveloperDocumentId = snapshot_id
-        .parse::<DeveloperDocumentId>()
+    let snapshot_id: PublicDocumentId = snapshot_id
+        .parse::<PublicDocumentId>()
         .map_err(|e| anyhow::anyhow!(e))?;
     let mut tx = st.application.begin(identity).await?;
     ExportsModel::new(&mut tx).cancel(snapshot_id).await?;

--- a/crates/local_backend/src/snapshot_import.rs
+++ b/crates/local_backend/src/snapshot_import.rs
@@ -38,7 +38,7 @@ use storage::{
     ClientDrivenUploadToken,
 };
 use value::{
-    id_v6::DeveloperDocumentId,
+    id_v6::PublicDocumentId,
     TableName,
 };
 
@@ -261,7 +261,7 @@ pub async fn perform_import(
     Json(PerformImportArgs { import_id }): Json<PerformImportArgs>,
 ) -> Result<impl IntoResponse, HttpResponseError> {
     must_be_admin_with_write_access(&identity)?;
-    let import_id = DeveloperDocumentId::decode(&import_id).context(ErrorMetadata::bad_request(
+    let import_id = PublicDocumentId::decode(&import_id).context(ErrorMetadata::bad_request(
         "InvalidImport",
         format!("invalid import id {import_id}"),
     ))?;
@@ -280,7 +280,7 @@ pub async fn cancel_import(
     ExtractIdentity(identity): ExtractIdentity,
     Json(CancelImportArgs { import_id }): Json<CancelImportArgs>,
 ) -> Result<impl IntoResponse, HttpResponseError> {
-    let import_id = DeveloperDocumentId::decode(&import_id).context(ErrorMetadata::bad_request(
+    let import_id = PublicDocumentId::decode(&import_id).context(ErrorMetadata::bad_request(
         "InvalidImport",
         format!("invalid import id {import_id}"),
     ))?;

--- a/crates/local_backend/src/streaming_export.rs
+++ b/crates/local_backend/src/streaming_export.rs
@@ -231,7 +231,7 @@ async fn _list_snapshot(
             let list_snapshot_cursor = serde_json::from_str::<ListSnapshotCursor>(&cursor)?;
             Ok(ResolvedDocumentId {
                 tablet_id: list_snapshot_cursor.tablet.parse()?,
-                developer_id: list_snapshot_cursor
+                document_id: list_snapshot_cursor
                     .id
                     .parse()
                     .map_err(anyhow::Error::new)?,
@@ -282,7 +282,7 @@ async fn _list_snapshot(
             .map(|new_cursor| -> anyhow::Result<String> {
                 serde_json::to_string(&ListSnapshotCursor {
                     tablet: new_cursor.tablet_id.to_string(),
-                    id: new_cursor.developer_id.encode(),
+                    id: new_cursor.document_id.encode(),
                 })
                 .context("Failed to serialize cursor")
             })

--- a/crates/migrations_model/src/migr_119/cron_jobs/mod.rs
+++ b/crates/migrations_model/src/migr_119/cron_jobs/mod.rs
@@ -27,8 +27,8 @@ use database::{
 };
 use value::{
     ConvexValue,
-    DeveloperDocumentId,
     FieldPath,
+    PublicDocumentId,
     TableName,
 };
 
@@ -168,7 +168,7 @@ impl<'a, RT: Runtime> CronModel<'a, RT> {
 
     pub async fn next_run(
         &mut self,
-        cron_job_id: DeveloperDocumentId,
+        cron_job_id: PublicDocumentId,
     ) -> anyhow::Result<Option<ParsedDocument<CronNextRun>>> {
         let query = Query::index_range(IndexRange {
             index_name: CRON_NEXT_RUN_INDEX_BY_CRON_JOB_ID.name(),

--- a/crates/migrations_model/src/migr_119/cron_jobs/types.rs
+++ b/crates/migrations_model/src/migr_119/cron_jobs/types.rs
@@ -27,12 +27,12 @@ use sync_types::{
 use value::{
     codegen_convex_serialization,
     heap_size::HeapSize,
-    id_v6::DeveloperDocumentId,
+    id_v6::PublicDocumentId,
     json_deserialize,
     obj,
     ConvexArray,
-    ConvexObject,
     ConvexValue,
+    DocumentObject,
 };
 
 #[derive(thiserror::Error, Debug, Clone)]
@@ -731,7 +731,7 @@ pub struct CronJobLog {
     pub execution_time: f64,
 }
 
-impl TryFrom<CronJobLog> for ConvexObject {
+impl TryFrom<CronJobLog> for DocumentObject {
     type Error = anyhow::Error;
 
     fn try_from(log: CronJobLog) -> anyhow::Result<Self, Self::Error> {
@@ -751,10 +751,10 @@ impl TryFrom<CronJobLog> for ConvexObject {
     }
 }
 
-impl TryFrom<ConvexObject> for CronJobLog {
+impl TryFrom<DocumentObject> for CronJobLog {
     type Error = anyhow::Error;
 
-    fn try_from(value: ConvexObject) -> anyhow::Result<Self, Self::Error> {
+    fn try_from(value: DocumentObject) -> anyhow::Result<Self, Self::Error> {
         let mut fields: BTreeMap<_, _> = value.into();
 
         let name = match fields.remove("name") {
@@ -830,7 +830,7 @@ pub enum CronJobStatus {
     Canceled { num_canceled: i64 },
 }
 
-impl TryFrom<CronJobStatus> for ConvexObject {
+impl TryFrom<CronJobStatus> for DocumentObject {
     type Error = anyhow::Error;
 
     fn try_from(status: CronJobStatus) -> anyhow::Result<Self, Self::Error> {
@@ -851,10 +851,10 @@ impl TryFrom<CronJobStatus> for ConvexObject {
     }
 }
 
-impl TryFrom<ConvexObject> for CronJobStatus {
+impl TryFrom<DocumentObject> for CronJobStatus {
     type Error = anyhow::Error;
 
-    fn try_from(value: ConvexObject) -> anyhow::Result<Self, Self::Error> {
+    fn try_from(value: DocumentObject) -> anyhow::Result<Self, Self::Error> {
         let mut fields: BTreeMap<_, _> = value.into();
         let status_t = match fields.remove("type") {
             Some(ConvexValue::String(s)) => s,
@@ -907,7 +907,7 @@ pub enum CronJobResult {
     Truncated(String),
 }
 
-impl TryFrom<CronJobResult> for ConvexObject {
+impl TryFrom<CronJobResult> for DocumentObject {
     type Error = anyhow::Error;
 
     fn try_from(result: CronJobResult) -> anyhow::Result<Self, Self::Error> {
@@ -925,10 +925,10 @@ impl TryFrom<CronJobResult> for ConvexObject {
     }
 }
 
-impl TryFrom<ConvexObject> for CronJobResult {
+impl TryFrom<DocumentObject> for CronJobResult {
     type Error = anyhow::Error;
 
-    fn try_from(value: ConvexObject) -> anyhow::Result<Self, Self::Error> {
+    fn try_from(value: DocumentObject) -> anyhow::Result<Self, Self::Error> {
         let mut fields: BTreeMap<_, _> = value.into();
         let result_t = match fields.remove("type") {
             Some(ConvexValue::String(s)) => s,
@@ -971,7 +971,7 @@ pub struct CronJobLogLines {
     pub is_truncated: bool,
 }
 
-impl TryFrom<CronJobLogLines> for ConvexObject {
+impl TryFrom<CronJobLogLines> for DocumentObject {
     type Error = anyhow::Error;
 
     fn try_from(cron_log: CronJobLogLines) -> anyhow::Result<Self, Self::Error> {
@@ -987,10 +987,10 @@ impl TryFrom<CronJobLogLines> for ConvexObject {
     }
 }
 
-impl TryFrom<ConvexObject> for CronJobLogLines {
+impl TryFrom<DocumentObject> for CronJobLogLines {
     type Error = anyhow::Error;
 
-    fn try_from(value: ConvexObject) -> anyhow::Result<Self, Self::Error> {
+    fn try_from(value: DocumentObject) -> anyhow::Result<Self, Self::Error> {
         let mut fields: BTreeMap<_, _> = value.into();
         let log_lines: RawLogLines = match fields.remove("logLines") {
             Some(ConvexValue::Array(a)) => a
@@ -1023,8 +1023,8 @@ mod tests {
     use sync_types::testing::assert_roundtrips;
     use value::{
         assert_obj,
-        ConvexObject,
         ConvexValue,
+        DocumentObject,
     };
 
     use crate::migr_119::cron_jobs::types::{
@@ -1041,22 +1041,22 @@ mod tests {
         )]
         #[test]
         fn test_cron_job_log_roundtrips(v in any::<CronJobLog>()) {
-            assert_roundtrips::<CronJobLog, ConvexObject>(v);
+            assert_roundtrips::<CronJobLog, DocumentObject>(v);
         }
 
         #[test]
         fn test_cron_job_status_roundtrips(v in any::<CronJobStatus>()) {
-            assert_roundtrips::<CronJobStatus, ConvexObject>(v);
+            assert_roundtrips::<CronJobStatus, DocumentObject>(v);
         }
 
         #[test]
         fn test_cron_job_result_roundtrips(v in any::<CronJobResult>()) {
-            assert_roundtrips::<CronJobResult, ConvexObject>(v);
+            assert_roundtrips::<CronJobResult, DocumentObject>(v);
         }
 
         #[test]
         fn test_cron_job_log_lines_roundtrips(v in any::<CronJobLogLines>()) {
-            assert_roundtrips::<CronJobLogLines, ConvexObject>(v);
+            assert_roundtrips::<CronJobLogLines, DocumentObject>(v);
         }
     }
 
@@ -1084,7 +1084,7 @@ mod tests {
 #[cfg_attr(any(test, feature = "testing"), derive(proptest_derive::Arbitrary))]
 pub struct CronNextRun {
     // Internally tracked metadata to execute the current run of the cron
-    pub cron_job_id: DeveloperDocumentId,
+    pub cron_job_id: PublicDocumentId,
     pub state: CronJobState,
     pub prev_ts: Option<Timestamp>,
     pub next_ts: Timestamp,
@@ -1115,7 +1115,7 @@ impl TryFrom<SerializedCronNextRun> for CronNextRun {
 
     fn try_from(value: SerializedCronNextRun) -> anyhow::Result<Self, Self::Error> {
         Ok(Self {
-            cron_job_id: DeveloperDocumentId::decode(&value.cron_job_id)?,
+            cron_job_id: PublicDocumentId::decode(&value.cron_job_id)?,
             state: value.state,
             prev_ts: value.prev_ts.map(|ts| ts.try_into()).transpose()?,
             next_ts: value.next_ts.try_into()?,

--- a/crates/migrations_model/src/migr_119/mod.rs
+++ b/crates/migrations_model/src/migr_119/mod.rs
@@ -29,13 +29,13 @@ pub async fn run_migration<RT: Runtime>(tx: &mut Transaction<RT>) -> anyhow::Res
         let crons = CronModel::new(tx, namespace.into()).list().await?;
         for cron in crons.values() {
             let next_run = CronNextRun {
-                cron_job_id: cron.id().developer_id,
+                cron_job_id: cron.id().document_id,
                 state: cron.state,
                 prev_ts: cron.prev_ts,
                 next_ts: cron.next_ts,
             };
             if let Some(existing_next_run) = CronModel::new(tx, namespace.into())
-                .next_run(cron.id().developer_id)
+                .next_run(cron.id().document_id)
                 .await?
                 .map(|next_run| next_run.into_value())
             {

--- a/crates/migrations_model/src/migr_121/log_sinks/types/mock_sink.rs
+++ b/crates/migrations_model/src/migr_121/log_sinks/types/mock_sink.rs
@@ -1,21 +1,21 @@
 use value::{
     obj,
-    ConvexObject,
+    DocumentObject,
 };
 
 #[derive(Debug, Clone, PartialEq)]
 #[cfg_attr(any(test, feature = "testing"), derive(proptest_derive::Arbitrary))]
 pub struct MockSinkConfig {}
 
-impl TryFrom<ConvexObject> for MockSinkConfig {
+impl TryFrom<DocumentObject> for MockSinkConfig {
     type Error = anyhow::Error;
 
-    fn try_from(_value: ConvexObject) -> Result<Self, Self::Error> {
+    fn try_from(_value: DocumentObject) -> Result<Self, Self::Error> {
         Ok(MockSinkConfig {})
     }
 }
 
-impl TryFrom<MockSinkConfig> for ConvexObject {
+impl TryFrom<MockSinkConfig> for DocumentObject {
     type Error = anyhow::Error;
 
     fn try_from(_value: MockSinkConfig) -> Result<Self, Self::Error> {

--- a/crates/migrations_model/src/migr_124/log_sinks/types/mock_sink.rs
+++ b/crates/migrations_model/src/migr_124/log_sinks/types/mock_sink.rs
@@ -1,21 +1,21 @@
 use value::{
     obj,
-    ConvexObject,
+    DocumentObject,
 };
 
 #[derive(Debug, Clone, PartialEq)]
 #[cfg_attr(any(test, feature = "testing"), derive(proptest_derive::Arbitrary))]
 pub struct MockSinkConfig {}
 
-impl TryFrom<ConvexObject> for MockSinkConfig {
+impl TryFrom<DocumentObject> for MockSinkConfig {
     type Error = anyhow::Error;
 
-    fn try_from(_value: ConvexObject) -> Result<Self, Self::Error> {
+    fn try_from(_value: DocumentObject) -> Result<Self, Self::Error> {
         Ok(MockSinkConfig {})
     }
 }
 
-impl TryFrom<MockSinkConfig> for ConvexObject {
+impl TryFrom<MockSinkConfig> for DocumentObject {
     type Error = anyhow::Error;
 
     fn try_from(_value: MockSinkConfig) -> Result<Self, Self::Error> {

--- a/crates/model/src/auth/types.rs
+++ b/crates/model/src/auth/types.rs
@@ -11,20 +11,20 @@ use serde::{
 };
 use value::{
     obj,
-    ConvexObject,
     ConvexValue,
+    DocumentObject,
 };
 
-/// Persisted version of AuthInfo that impls try_from to ConvexObject
+/// Persisted version of AuthInfo that impls try_from to DocumentObject
 /// Ideally this remains local to this crate (has to be pub for db-info)
 #[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd)]
 #[cfg_attr(any(test, feature = "testing"), derive(proptest_derive::Arbitrary))]
 pub struct AuthInfoPersisted(pub AuthInfo);
 
-impl TryFrom<ConvexObject> for AuthInfoPersisted {
+impl TryFrom<DocumentObject> for AuthInfoPersisted {
     type Error = anyhow::Error;
 
-    fn try_from(o: ConvexObject) -> Result<Self, Self::Error> {
+    fn try_from(o: DocumentObject) -> Result<Self, Self::Error> {
         let mut fields: BTreeMap<_, _> = o.into();
 
         let is_oidc = match fields.remove("type") {
@@ -76,7 +76,7 @@ impl TryFrom<ConvexObject> for AuthInfoPersisted {
     }
 }
 
-impl TryFrom<AuthInfoPersisted> for ConvexObject {
+impl TryFrom<AuthInfoPersisted> for DocumentObject {
     type Error = anyhow::Error;
 
     fn try_from(info: AuthInfoPersisted) -> Result<Self, Self::Error> {
@@ -120,7 +120,7 @@ impl AuthDiff {
         let added_strings = added
             .into_iter()
             .map(|auth_info| {
-                let auth_info_obj = ConvexObject::try_from(AuthInfoPersisted(auth_info))?;
+                let auth_info_obj = DocumentObject::try_from(AuthInfoPersisted(auth_info))?;
                 let auth_info_json = auth_info_obj.json_serialize()?;
                 anyhow::Ok(auth_info_json)
             })
@@ -129,7 +129,7 @@ impl AuthDiff {
         let removed_strings = removed
             .into_iter()
             .map(|auth_info| {
-                let auth_info_obj = ConvexObject::try_from(AuthInfoPersisted(auth_info))?;
+                let auth_info_obj = DocumentObject::try_from(AuthInfoPersisted(auth_info))?;
                 let auth_info_json = auth_info_obj.json_serialize()?;
                 anyhow::Ok(auth_info_json)
             })

--- a/crates/model/src/aws_lambda_versions/types.rs
+++ b/crates/model/src/aws_lambda_versions/types.rs
@@ -5,11 +5,11 @@ use std::{
 
 use common::document::ParsedDocument;
 use value::{
-    id_v6::DeveloperDocumentId,
+    id_v6::PublicDocumentId,
     obj,
     sha256::Sha256Digest,
-    ConvexObject,
     ConvexValue,
+    DocumentObject,
     FieldName,
 };
 
@@ -74,7 +74,7 @@ impl AwsLambdaType {
         match self {
             Self::Static => {
                 let source_package_id = deployed_code
-                    .map(|source_package| DeveloperDocumentId::from(source_package.id()).into());
+                    .map(|source_package| PublicDocumentId::from(source_package.id()).into());
                 Ok(AwsLambdaPackageDesc::Static { source_package_id })
             },
             Self::Dynamic => {
@@ -116,7 +116,7 @@ impl AwsLambdaPackageDesc {
     }
 }
 
-impl TryFrom<AwsLambdaPackageDesc> for ConvexObject {
+impl TryFrom<AwsLambdaPackageDesc> for DocumentObject {
     type Error = anyhow::Error;
 
     fn try_from(value: AwsLambdaPackageDesc) -> Result<Self, Self::Error> {
@@ -145,10 +145,10 @@ impl TryFrom<AwsLambdaPackageDesc> for ConvexObject {
     }
 }
 
-impl TryFrom<ConvexObject> for AwsLambdaPackageDesc {
+impl TryFrom<DocumentObject> for AwsLambdaPackageDesc {
     type Error = anyhow::Error;
 
-    fn try_from(obj: ConvexObject) -> Result<Self, Self::Error> {
+    fn try_from(obj: DocumentObject) -> Result<Self, Self::Error> {
         let mut fields = BTreeMap::from(obj);
 
         let lambda_type: String = match fields.remove("type") {
@@ -182,7 +182,7 @@ impl TryFrom<ConvexObject> for AwsLambdaPackageDesc {
     }
 }
 
-impl TryFrom<AwsLambdaConfig> for ConvexObject {
+impl TryFrom<AwsLambdaConfig> for DocumentObject {
     type Error = anyhow::Error;
 
     fn try_from(
@@ -224,7 +224,7 @@ impl TryFrom<AwsLambdaConfig> for ConvexObject {
     }
 }
 
-impl TryFrom<AwsLambdaVersion> for ConvexObject {
+impl TryFrom<AwsLambdaVersion> for DocumentObject {
     type Error = anyhow::Error;
 
     fn try_from(
@@ -253,10 +253,10 @@ impl TryFrom<AwsLambdaVersion> for ConvexObject {
     }
 }
 
-impl TryFrom<ConvexObject> for AwsLambdaConfig {
+impl TryFrom<DocumentObject> for AwsLambdaConfig {
     type Error = anyhow::Error;
 
-    fn try_from(value: ConvexObject) -> Result<Self, Self::Error> {
+    fn try_from(value: DocumentObject) -> Result<Self, Self::Error> {
         let mut object_fields: BTreeMap<_, _> = value.into();
         let env: anyhow::Result<_> = match object_fields.remove("env") {
             Some(ConvexValue::Object(env)) => env
@@ -322,10 +322,10 @@ impl TryFrom<ConvexObject> for AwsLambdaConfig {
     }
 }
 
-impl TryFrom<ConvexObject> for AwsLambdaVersion {
+impl TryFrom<DocumentObject> for AwsLambdaVersion {
     type Error = anyhow::Error;
 
-    fn try_from(value: ConvexObject) -> Result<Self, Self::Error> {
+    fn try_from(value: DocumentObject) -> Result<Self, Self::Error> {
         let mut object_fields: BTreeMap<_, _> = value.into();
         let lambda_name = match object_fields.remove("lambdaName") {
             Some(ConvexValue::String(key)) => key.into(),
@@ -373,7 +373,7 @@ mod tests {
     use cmd_util::env::env_config;
     use common::testing::assert_roundtrips;
     use proptest::prelude::*;
-    use value::ConvexObject;
+    use value::DocumentObject;
 
     use super::{
         AwsLambdaConfig,
@@ -387,12 +387,12 @@ mod tests {
 
         #[test]
         fn test_actions_version_roundtrip(v in any::<AwsLambdaVersion>()) {
-            assert_roundtrips::<AwsLambdaVersion, ConvexObject>(v);
+            assert_roundtrips::<AwsLambdaVersion, DocumentObject>(v);
         }
 
         #[test]
         fn test_lambda_config_roundtrip(v in any::<AwsLambdaConfig>()) {
-            assert_roundtrips::<AwsLambdaConfig, ConvexObject>(v);
+            assert_roundtrips::<AwsLambdaConfig, DocumentObject>(v);
         }
     }
 }

--- a/crates/model/src/components/config.rs
+++ b/crates/model/src/components/config.rs
@@ -49,8 +49,8 @@ use serde::{
 use strum::AsRefStr;
 use sync_types::CanonicalizedModulePath;
 use value::{
-    DeveloperDocumentId,
     InternalDocumentId,
+    PublicDocumentId,
     ResolvedDocumentId,
     TableNamespace,
 };
@@ -109,8 +109,8 @@ impl<'a, RT: Runtime> ComponentDefinitionConfigModel<'a, RT> {
         >,
     ) -> anyhow::Result<(
         BTreeMap<ComponentDefinitionPath, ComponentDefinitionDiff>,
-        BTreeMap<DeveloperDocumentId, NewModules>,
-        BTreeMap<DeveloperDocumentId, UdfConfig>,
+        BTreeMap<PublicDocumentId, NewModules>,
+        BTreeMap<PublicDocumentId, UdfConfig>,
     )> {
         let mut definition_diffs = BTreeMap::new();
 
@@ -196,7 +196,7 @@ impl<'a, RT: Runtime> ComponentDefinitionConfigModel<'a, RT> {
     pub async fn create_component_definition(
         &mut self,
         definition: ComponentDefinitionMetadata,
-    ) -> anyhow::Result<(DeveloperDocumentId, ComponentDefinitionDiff)> {
+    ) -> anyhow::Result<(PublicDocumentId, ComponentDefinitionDiff)> {
         let id = SystemMetadataModel::new_global(self.tx)
             .insert(&COMPONENT_DEFINITIONS_TABLE, definition.clone().try_into()?)
             .await?;
@@ -234,7 +234,7 @@ impl<'a, RT: Runtime> ComponentDefinitionConfigModel<'a, RT> {
 #[derive(Debug)]
 pub struct ComponentDefinitionDiff {}
 
-#[derive(Serialize)]
+#[derive(Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct SerializedComponentDefinitionDiff {}
 
@@ -352,14 +352,14 @@ impl<'a, RT: Runtime> ComponentConfigModel<'a, RT> {
     pub async fn initialize_component_namespace(
         &mut self,
         is_root: bool,
-    ) -> anyhow::Result<DeveloperDocumentId> {
+    ) -> anyhow::Result<PublicDocumentId> {
         let internal_id = SystemMetadataModel::new_global(self.tx).allocate_internal_id()?;
         let table_id = self
             .tx
             .table_mapping()
             .namespace(TableNamespace::Global)
             .name_to_id()(COMPONENTS_TABLE.clone())?;
-        let id = DeveloperDocumentId::new(table_id.table_number, internal_id);
+        let id = PublicDocumentId::new(table_id.table_number, internal_id);
         let component_id = ComponentId::new(is_root, id);
 
         if matches!(component_id, ComponentId::Root) {
@@ -408,7 +408,7 @@ impl<'a, RT: Runtime> ComponentConfigModel<'a, RT> {
                 let table_number = self.tx.table_mapping().tablet_number(id.table())?;
                 anyhow::Ok(ResolvedDocumentId::new(
                     id.table(),
-                    DeveloperDocumentId::new(table_number, id.internal_id()),
+                    PublicDocumentId::new(table_number, id.internal_id()),
                 ))
             })
             .transpose()
@@ -418,9 +418,9 @@ impl<'a, RT: Runtime> ComponentConfigModel<'a, RT> {
     pub async fn apply_component_tree_diff(
         &mut self,
         app: &CheckedComponent,
-        udf_config_by_definition: BTreeMap<DeveloperDocumentId, UdfConfig>,
+        udf_config_by_definition: BTreeMap<PublicDocumentId, UdfConfig>,
         schema_change: &SchemaChange,
-        modules_by_definition: BTreeMap<DeveloperDocumentId, NewModules>,
+        modules_by_definition: BTreeMap<PublicDocumentId, NewModules>,
     ) -> anyhow::Result<BTreeMap<ComponentPath, ComponentDiff>> {
         let definition_id_by_path = BootstrapComponentsModel::new(self.tx)
             .load_all_definitions()
@@ -522,12 +522,12 @@ impl<'a, RT: Runtime> ComponentConfigModel<'a, RT> {
     #[fastrace::trace]
     pub async fn create_component(
         &mut self,
-        id: DeveloperDocumentId,
+        id: PublicDocumentId,
         metadata: ComponentMetadata,
-        modules_by_definition: &BTreeMap<DeveloperDocumentId, NewModules>,
-        udf_config_by_definition: &BTreeMap<DeveloperDocumentId, UdfConfig>,
+        modules_by_definition: &BTreeMap<PublicDocumentId, NewModules>,
+        udf_config_by_definition: &BTreeMap<PublicDocumentId, UdfConfig>,
         schema_id: Option<ResolvedDocumentId>,
-    ) -> anyhow::Result<(DeveloperDocumentId, ComponentDiff)> {
+    ) -> anyhow::Result<(PublicDocumentId, ComponentDiff)> {
         let modules = modules_by_definition
             .get(&metadata.definition_id)
             .context("Missing modules for component definition")?;
@@ -538,7 +538,7 @@ impl<'a, RT: Runtime> ComponentConfigModel<'a, RT> {
         let document_id = SystemMetadataModel::new_global(self.tx)
             .insert_with_internal_id(&COMPONENTS_TABLE, id.internal_id(), metadata.try_into()?)
             .await?;
-        anyhow::ensure!(DeveloperDocumentId::from(document_id) == id);
+        anyhow::ensure!(PublicDocumentId::from(document_id) == id);
         let component_id = ComponentId::new(is_root, id);
         let udf_config_diff = UdfConfigModel::new(self.tx, component_id.into())
             .set(udf_config.clone())
@@ -590,10 +590,10 @@ impl<'a, RT: Runtime> ComponentConfigModel<'a, RT> {
         &mut self,
         existing: &ParsedDocument<ComponentMetadata>,
         new_metadata: ComponentMetadata,
-        modules_by_definition: &BTreeMap<DeveloperDocumentId, NewModules>,
-        udf_config_by_definition: &BTreeMap<DeveloperDocumentId, UdfConfig>,
+        modules_by_definition: &BTreeMap<PublicDocumentId, NewModules>,
+        udf_config_by_definition: &BTreeMap<PublicDocumentId, UdfConfig>,
         schema_id: Option<ResolvedDocumentId>,
-    ) -> anyhow::Result<(DeveloperDocumentId, ComponentDiff)> {
+    ) -> anyhow::Result<(PublicDocumentId, ComponentDiff)> {
         let component_id = if existing.parent_and_name().is_none() {
             ComponentId::Root
         } else {
@@ -662,7 +662,7 @@ impl<'a, RT: Runtime> ComponentConfigModel<'a, RT> {
     async fn unmount_component(
         &mut self,
         existing: &ParsedDocument<ComponentMetadata>,
-    ) -> anyhow::Result<(DeveloperDocumentId, ComponentDiff)> {
+    ) -> anyhow::Result<(PublicDocumentId, ComponentDiff)> {
         let component_id = if existing.parent_and_name().is_none() {
             ComponentId::Root
         } else {
@@ -797,11 +797,11 @@ impl<'a, RT: Runtime> ComponentConfigModel<'a, RT> {
 
 fn tree_diff_children<'a>(
     existing_components_by_parent: &'a BTreeMap<
-        Option<(DeveloperDocumentId, ComponentName)>,
+        Option<(PublicDocumentId, ComponentName)>,
         Arc<ParsedDocument<ComponentMetadata>>,
     >,
     new_node: Option<&'a CheckedComponent>,
-    internal_id: DeveloperDocumentId,
+    internal_id: PublicDocumentId,
 ) -> impl Iterator<Item = TreeDiffChild<'a>> {
     std::iter::from_coroutine(
         #[coroutine]
@@ -955,7 +955,7 @@ impl TryFrom<SerializedComponentDiff> for ComponentDiff {
 
 #[derive(Clone, Debug)]
 pub struct SchemaChange {
-    pub allocated_component_ids: BTreeMap<ComponentPath, DeveloperDocumentId>,
+    pub allocated_component_ids: BTreeMap<ComponentPath, PublicDocumentId>,
     pub schema_ids: BTreeMap<ComponentPath, Option<InternalDocumentId>>,
     pub index_diffs: BTreeMap<ComponentPath, AuditLogIndexDiff>,
 }

--- a/crates/model/src/components/handles.rs
+++ b/crates/model/src/components/handles.rs
@@ -41,8 +41,8 @@ use sync_types::{
 };
 use value::{
     ConvexValue,
-    DeveloperDocumentId,
     FieldPath,
+    PublicDocumentId,
     TableName,
     TableNamespace,
 };
@@ -98,7 +98,7 @@ impl<'a, RT: Runtime> FunctionHandlesModel<'a, RT> {
         &mut self,
         handle: FunctionHandle,
     ) -> anyhow::Result<CanonicalizedComponentFunctionPath> {
-        let id = DeveloperDocumentId::from(handle);
+        let id = PublicDocumentId::from(handle);
         let resolved_id = self.tx.resolve_developer_id(&id, TableNamespace::Global)?;
         let Some(document) = self.tx.get(resolved_id).await? else {
             anyhow::bail!(function_handle_not_found());
@@ -159,7 +159,7 @@ impl<'a, RT: Runtime> FunctionHandlesModel<'a, RT> {
         if document.deleted_ts.is_some() {
             anyhow::bail!(function_handle_not_found())
         }
-        Ok(FunctionHandle::new(document.developer_id()))
+        Ok(FunctionHandle::new(document.document_id()))
     }
 
     #[fastrace::trace]

--- a/crates/model/src/components/mod.rs
+++ b/crates/model/src/components/mod.rs
@@ -395,7 +395,7 @@ mod tests {
     };
     use keybroker::Identity;
     use runtime::testing::TestRuntime;
-    use value::DeveloperDocumentId;
+    use value::PublicDocumentId;
 
     use crate::{
         modules::{
@@ -411,7 +411,7 @@ mod tests {
 
         let mut tx = db.begin(Identity::system()).await?;
         let component_metadata = ComponentMetadata {
-            definition_id: DeveloperDocumentId::MIN,
+            definition_id: PublicDocumentId::MIN,
             component_type: ComponentType::App,
             state: ComponentState::Active,
         };

--- a/crates/model/src/components/types.rs
+++ b/crates/model/src/components/types.rs
@@ -22,7 +22,7 @@ use serde::{
 };
 use serde_json::Value as JsonValue;
 use sync_types::CanonicalizedModulePath;
-use value::ConvexObject;
+use value::DocumentObject;
 
 use crate::{
     config::types::{
@@ -155,7 +155,7 @@ impl TryFrom<EvaluatedComponentDefinition> for SerializedEvaluatedComponentDefin
                 .into_iter()
                 .map(|(k, v)| Ok((String::from(k), v.try_into()?)))
                 .collect::<anyhow::Result<_>>()?,
-            udf_config: ConvexObject::try_from(value.udf_config)?.into(),
+            udf_config: DocumentObject::try_from(value.udf_config)?.into(),
         })
     }
 }
@@ -172,7 +172,7 @@ impl TryFrom<SerializedEvaluatedComponentDefinition> for EvaluatedComponentDefin
                 .into_iter()
                 .map(|(k, v)| Ok((k.parse()?, v.try_into()?)))
                 .collect::<anyhow::Result<_>>()?,
-            udf_config: UdfConfig::try_from(ConvexObject::try_from(value.udf_config)?)?,
+            udf_config: UdfConfig::try_from(DocumentObject::try_from(value.udf_config)?)?,
         })
     }
 }

--- a/crates/model/src/config/types.rs
+++ b/crates/model/src/config/types.rs
@@ -40,8 +40,8 @@ use value::{
     remove_string,
     sha256::Sha256Digest,
     ConvexArray,
-    ConvexObject,
     ConvexValue,
+    DocumentObject,
 };
 
 use crate::{
@@ -163,7 +163,7 @@ pub struct ConfigFile {
     pub auth_info: Option<Vec<SerializedAuthInfo>>,
 }
 
-impl TryFrom<ConfigMetadata> for ConvexObject {
+impl TryFrom<ConfigMetadata> for DocumentObject {
     type Error = anyhow::Error;
 
     fn try_from(m: ConfigMetadata) -> anyhow::Result<Self> {
@@ -176,7 +176,7 @@ impl TryFrom<ConfigMetadata> for ConvexObject {
             let auth_info = m
                 .auth_info
                 .into_iter()
-                .map(|v| Ok(ConvexObject::try_from(AuthInfoPersisted(v))?.into()))
+                .map(|v| Ok(DocumentObject::try_from(AuthInfoPersisted(v))?.into()))
                 .collect::<anyhow::Result<Vec<ConvexValue>>>()?
                 .try_into()?;
             config.insert("authInfo".parse()?, auth_info);
@@ -189,14 +189,14 @@ impl TryFrom<ConfigMetadata> for ConvexValue {
     type Error = anyhow::Error;
 
     fn try_from(value: ConfigMetadata) -> Result<Self, Self::Error> {
-        Ok(ConvexObject::try_from(value)?.into())
+        Ok(DocumentObject::try_from(value)?.into())
     }
 }
 
-impl TryFrom<ConvexObject> for ConfigMetadata {
+impl TryFrom<DocumentObject> for ConfigMetadata {
     type Error = anyhow::Error;
 
-    fn try_from(o: ConvexObject) -> Result<Self, Self::Error> {
+    fn try_from(o: DocumentObject) -> Result<Self, Self::Error> {
         let mut fields: BTreeMap<_, _> = o.into();
         let functions = match fields.remove("functions") {
             Some(ConvexValue::String(s)) => s.into(),
@@ -209,7 +209,7 @@ impl TryFrom<ConvexObject> for ConfigMetadata {
             Some(v) => ConvexArray::try_from(v)?
                 .into_iter()
                 .map(|v| {
-                    let parsed: AuthInfoPersisted = ConvexObject::try_from(v)?.try_into()?;
+                    let parsed: AuthInfoPersisted = DocumentObject::try_from(v)?.try_into()?;
                     Ok(parsed.0)
                 })
                 .collect::<anyhow::Result<Vec<AuthInfo>>>()?,
@@ -329,7 +329,7 @@ pub struct UdfServerVersionDiff {
     pub previous_version: String,
     pub next_version: String,
 }
-impl TryFrom<UdfServerVersionDiff> for ConvexObject {
+impl TryFrom<UdfServerVersionDiff> for DocumentObject {
     type Error = anyhow::Error;
 
     fn try_from(value: UdfServerVersionDiff) -> Result<Self, Self::Error> {
@@ -337,10 +337,10 @@ impl TryFrom<UdfServerVersionDiff> for ConvexObject {
     }
 }
 
-impl TryFrom<ConvexObject> for UdfServerVersionDiff {
+impl TryFrom<DocumentObject> for UdfServerVersionDiff {
     type Error = anyhow::Error;
 
-    fn try_from(obj: ConvexObject) -> anyhow::Result<Self> {
+    fn try_from(obj: DocumentObject) -> anyhow::Result<Self> {
         let mut fields = BTreeMap::from(obj);
         Ok(Self {
             previous_version: remove_string(&mut fields, "previous_version")?,

--- a/crates/model/src/cron_jobs/mod.rs
+++ b/crates/model/src/cron_jobs/mod.rs
@@ -30,8 +30,8 @@ use types::CronJobMetadata;
 use value::{
     heap_size::WithHeapSize,
     ConvexValue,
-    DeveloperDocumentId,
     FieldPath,
+    PublicDocumentId,
     ResolvedDocumentId,
     TableName,
     TableNamespace,
@@ -229,7 +229,7 @@ impl<'a, RT: Runtime> CronModel<'a, RT> {
         let cron_job_id = SystemMetadataModel::new(self.tx, self.component.into())
             .insert(&CRON_JOBS_TABLE, cron.try_into()?)
             .await?
-            .developer_id;
+            .document_id;
 
         let next_run = CronNextRun {
             cron_job_id,
@@ -247,7 +247,7 @@ impl<'a, RT: Runtime> CronModel<'a, RT> {
 
     pub async fn next_run(
         &mut self,
-        cron_job_id: DeveloperDocumentId,
+        cron_job_id: PublicDocumentId,
     ) -> anyhow::Result<Option<ParsedDocument<CronNextRun>>> {
         let query = Query::index_range(IndexRange {
             index_name: CRON_NEXT_RUN_INDEX_BY_CRON_JOB_ID.name(),
@@ -282,7 +282,7 @@ impl<'a, RT: Runtime> CronModel<'a, RT> {
             if next_next_run.secs_since_f64(now) > 30.0 {
                 // Read in next-run to the readset and update it.
                 let mut next_run = self
-                    .next_run(cron_job.id().developer_id)
+                    .next_run(cron_job.id().document_id)
                     .await?
                     .context("No next run found")?
                     .into_value();
@@ -308,7 +308,7 @@ impl<'a, RT: Runtime> CronModel<'a, RT> {
             .delete(cron_job.id())
             .await?;
         let next_run = self
-            .next_run(cron_job.id().developer_id)
+            .next_run(cron_job.id().document_id)
             .await?
             .context("No next run found")?;
         SystemMetadataModel::new(self.tx, self.component.into())
@@ -366,7 +366,7 @@ impl<'a, RT: Runtime> CronModel<'a, RT> {
         };
         let cron: ParsedDocument<CronJobMetadata> = job.parse()?;
         let next_run = self
-            .next_run(id.developer_id)
+            .next_run(id.document_id)
             .await?
             .context("No next run found")?
             .into_value();
@@ -380,7 +380,7 @@ impl<'a, RT: Runtime> CronModel<'a, RT> {
         while let Some(job) = query_stream.next(self.tx, None).await? {
             let cron: ParsedDocument<CronJobMetadata> = job.parse()?;
             let next_run = self
-                .next_run(cron.id().developer_id)
+                .next_run(cron.id().document_id)
                 .await?
                 .context("No next run found")?
                 .into_value();

--- a/crates/model/src/cron_jobs/types.rs
+++ b/crates/model/src/cron_jobs/types.rs
@@ -35,12 +35,12 @@ use sync_types::{
 use value::{
     codegen_convex_serialization,
     heap_size::HeapSize,
-    id_v6::DeveloperDocumentId,
+    id_v6::PublicDocumentId,
     json_deserialize,
     obj,
     ConvexArray,
-    ConvexObject,
     ConvexValue,
+    DocumentObject,
     ResolvedDocumentId,
     Size,
 };
@@ -103,7 +103,7 @@ impl CronJob {
 
     pub fn cron_next_run(&self) -> CronNextRun {
         CronNextRun {
-            cron_job_id: self.id.developer_id,
+            cron_job_id: self.id.document_id,
             state: self.state.clone(),
             prev_ts: self.prev_ts,
             next_ts: self.next_ts,
@@ -802,7 +802,7 @@ pub struct CronJobLog {
     pub execution_time: f64,
 }
 
-impl TryFrom<CronJobLog> for ConvexObject {
+impl TryFrom<CronJobLog> for DocumentObject {
     type Error = anyhow::Error;
 
     fn try_from(log: CronJobLog) -> anyhow::Result<Self, Self::Error> {
@@ -822,10 +822,10 @@ impl TryFrom<CronJobLog> for ConvexObject {
     }
 }
 
-impl TryFrom<ConvexObject> for CronJobLog {
+impl TryFrom<DocumentObject> for CronJobLog {
     type Error = anyhow::Error;
 
-    fn try_from(value: ConvexObject) -> anyhow::Result<Self, Self::Error> {
+    fn try_from(value: DocumentObject) -> anyhow::Result<Self, Self::Error> {
         let mut fields: BTreeMap<_, _> = value.into();
 
         let name = match fields.remove("name") {
@@ -898,7 +898,7 @@ pub enum CronJobStatus {
     Canceled { num_canceled: i64 },
 }
 
-impl TryFrom<CronJobStatus> for ConvexObject {
+impl TryFrom<CronJobStatus> for DocumentObject {
     type Error = anyhow::Error;
 
     fn try_from(status: CronJobStatus) -> anyhow::Result<Self, Self::Error> {
@@ -919,10 +919,10 @@ impl TryFrom<CronJobStatus> for ConvexObject {
     }
 }
 
-impl TryFrom<ConvexObject> for CronJobStatus {
+impl TryFrom<DocumentObject> for CronJobStatus {
     type Error = anyhow::Error;
 
-    fn try_from(value: ConvexObject) -> anyhow::Result<Self, Self::Error> {
+    fn try_from(value: DocumentObject) -> anyhow::Result<Self, Self::Error> {
         let mut fields: BTreeMap<_, _> = value.into();
         let status_t = match fields.remove("type") {
             Some(ConvexValue::String(s)) => s,
@@ -975,7 +975,7 @@ pub enum CronJobResult {
     Truncated(String),
 }
 
-impl TryFrom<CronJobResult> for ConvexObject {
+impl TryFrom<CronJobResult> for DocumentObject {
     type Error = anyhow::Error;
 
     fn try_from(result: CronJobResult) -> anyhow::Result<Self, Self::Error> {
@@ -993,10 +993,10 @@ impl TryFrom<CronJobResult> for ConvexObject {
     }
 }
 
-impl TryFrom<ConvexObject> for CronJobResult {
+impl TryFrom<DocumentObject> for CronJobResult {
     type Error = anyhow::Error;
 
-    fn try_from(value: ConvexObject) -> anyhow::Result<Self, Self::Error> {
+    fn try_from(value: DocumentObject) -> anyhow::Result<Self, Self::Error> {
         let mut fields: BTreeMap<_, _> = value.into();
         let result_t = match fields.remove("type") {
             Some(ConvexValue::String(s)) => s,
@@ -1039,7 +1039,7 @@ pub struct CronJobLogLines {
     pub is_truncated: bool,
 }
 
-impl TryFrom<CronJobLogLines> for ConvexObject {
+impl TryFrom<CronJobLogLines> for DocumentObject {
     type Error = anyhow::Error;
 
     fn try_from(cron_log: CronJobLogLines) -> anyhow::Result<Self, Self::Error> {
@@ -1055,10 +1055,10 @@ impl TryFrom<CronJobLogLines> for ConvexObject {
     }
 }
 
-impl TryFrom<ConvexObject> for CronJobLogLines {
+impl TryFrom<DocumentObject> for CronJobLogLines {
     type Error = anyhow::Error;
 
-    fn try_from(value: ConvexObject) -> anyhow::Result<Self, Self::Error> {
+    fn try_from(value: DocumentObject) -> anyhow::Result<Self, Self::Error> {
         let mut fields: BTreeMap<_, _> = value.into();
         let log_lines: RawLogLines = match fields.remove("logLines") {
             Some(ConvexValue::Array(a)) => a
@@ -1091,8 +1091,8 @@ mod tests {
     use sync_types::testing::assert_roundtrips;
     use value::{
         assert_obj,
-        ConvexObject,
         ConvexValue,
+        DocumentObject,
     };
 
     use crate::cron_jobs::types::{
@@ -1109,22 +1109,22 @@ mod tests {
         )]
         #[test]
         fn test_cron_job_log_roundtrips(v in any::<CronJobLog>()) {
-            assert_roundtrips::<CronJobLog, ConvexObject>(v);
+            assert_roundtrips::<CronJobLog, DocumentObject>(v);
         }
 
         #[test]
         fn test_cron_job_status_roundtrips(v in any::<CronJobStatus>()) {
-            assert_roundtrips::<CronJobStatus, ConvexObject>(v);
+            assert_roundtrips::<CronJobStatus, DocumentObject>(v);
         }
 
         #[test]
         fn test_cron_job_result_roundtrips(v in any::<CronJobResult>()) {
-            assert_roundtrips::<CronJobResult, ConvexObject>(v);
+            assert_roundtrips::<CronJobResult, DocumentObject>(v);
         }
 
         #[test]
         fn test_cron_job_log_lines_roundtrips(v in any::<CronJobLogLines>()) {
-            assert_roundtrips::<CronJobLogLines, ConvexObject>(v);
+            assert_roundtrips::<CronJobLogLines, DocumentObject>(v);
         }
     }
 
@@ -1149,7 +1149,7 @@ mod tests {
 #[cfg_attr(any(test, feature = "testing"), derive(proptest_derive::Arbitrary))]
 pub struct CronNextRun {
     // Internally tracked metadata to execute the current run of the cron
-    pub cron_job_id: DeveloperDocumentId,
+    pub cron_job_id: PublicDocumentId,
     pub state: CronJobState,
     pub prev_ts: Option<Timestamp>,
     pub next_ts: Timestamp,
@@ -1180,7 +1180,7 @@ impl TryFrom<SerializedCronNextRun> for CronNextRun {
 
     fn try_from(value: SerializedCronNextRun) -> anyhow::Result<Self, Self::Error> {
         Ok(Self {
-            cron_job_id: DeveloperDocumentId::decode(&value.cron_job_id)?,
+            cron_job_id: PublicDocumentId::decode(&value.cron_job_id)?,
             state: value.state,
             prev_ts: value.prev_ts.map(|ts| ts.try_into()).transpose()?,
             next_ts: value.next_ts.try_into()?,

--- a/crates/model/src/deployment_audit_log/mod.rs
+++ b/crates/model/src/deployment_audit_log/mod.rs
@@ -11,7 +11,7 @@ use database::{
     Transaction,
 };
 use value::{
-    ConvexObject,
+    DocumentObject,
     FieldPath,
     ResolvedDocumentId,
     TableName,
@@ -85,7 +85,7 @@ impl<'a, RT: Runtime> DeploymentAuditLogModel<'a, RT> {
             .transpose()?;
         let mut deployment_audit_log_ids = vec![];
         for event in events {
-            let event_object: ConvexObject = event.try_into()?;
+            let event_object: DocumentObject = event.try_into()?;
             let event_object_with_member_id = match member_id_value {
                 Some(member_id) => event_object.shallow_merge(obj!("member_id" => member_id)?)?,
                 None => event_object.shallow_merge(obj!("member_id" => null)?)?,

--- a/crates/model/src/deployment_audit_log/types.rs
+++ b/crates/model/src/deployment_audit_log/types.rs
@@ -36,8 +36,8 @@ use value::{
     remove_vec,
     remove_vec_of_strings,
     val,
-    ConvexObject,
     ConvexValue,
+    DocumentObject,
     TableName,
 };
 
@@ -256,7 +256,7 @@ impl DeploymentAuditLogEvent {
         }
     }
 
-    fn metadata(self) -> anyhow::Result<ConvexObject> {
+    fn metadata(self) -> anyhow::Result<DocumentObject> {
         match self {
             DeploymentAuditLogEvent::CreateEnvironmentVariable { name }
             | DeploymentAuditLogEvent::UpdateEnvironmentVariable { name }
@@ -281,7 +281,7 @@ impl DeploymentAuditLogEvent {
                 obj!("request_destination" => request_destination.to_string())
             },
             DeploymentAuditLogEvent::PushConfig { config_diff } => {
-                ConvexObject::try_from(config_diff)
+                DocumentObject::try_from(config_diff)
             },
             DeploymentAuditLogEvent::PushConfigWithComponents { diffs } => diffs.try_into(),
             DeploymentAuditLogEvent::BuildIndexes {
@@ -374,8 +374,8 @@ impl DeploymentAuditLogEvent {
                     "table_names" => table_names,
                     "table_count" => table_count as i64,
                     "import_mode" => import_mode.to_string(),
-                    "import_format" => ConvexObject::try_from(import_format)?,
-                    "requestor" => ConvexObject::try_from(requestor)?,
+                    "import_format" => DocumentObject::try_from(import_format)?,
+                    "requestor" => DocumentObject::try_from(requestor)?,
                     "table_names_deleted" => table_names_deleted,
                     "table_count_deleted" => table_count_deleted as i64,
                 )
@@ -408,7 +408,7 @@ impl DeploymentAuditLogEvent {
     }
 }
 
-impl TryFrom<DeploymentAuditLogEvent> for ConvexObject {
+impl TryFrom<DeploymentAuditLogEvent> for DocumentObject {
     type Error = anyhow::Error;
 
     fn try_from(value: DeploymentAuditLogEvent) -> anyhow::Result<Self> {
@@ -419,21 +419,21 @@ impl TryFrom<DeploymentAuditLogEvent> for ConvexObject {
 fn value_to_index_metadata(
     value: ConvexValue,
 ) -> anyhow::Result<(IndexName, DeveloperIndexConfig)> {
-    let obj = ConvexObject::try_from(value)?;
+    let obj = DocumentObject::try_from(value)?;
     let mut fields = BTreeMap::from(obj);
     let name = remove_string(&mut fields, "name")?;
-    let obj = ConvexObject::try_from(fields)?;
+    let obj = DocumentObject::try_from(fields)?;
     let developer_index_config = obj.try_into()?;
     Ok((IndexName::from_str(&name)?, developer_index_config))
 }
 
-impl TryFrom<ConvexObject> for DeploymentAuditLogEvent {
+impl TryFrom<DocumentObject> for DeploymentAuditLogEvent {
     type Error = anyhow::Error;
 
-    fn try_from(obj: ConvexObject) -> anyhow::Result<Self> {
+    fn try_from(obj: DocumentObject) -> anyhow::Result<Self> {
         let mut fields = BTreeMap::from(obj);
         let action: String = remove_string(&mut fields, "action")?;
-        let metadata: ConvexObject = remove_object(&mut fields, "metadata")?;
+        let metadata: DocumentObject = remove_object(&mut fields, "metadata")?;
         let mut fields = BTreeMap::from(metadata);
         let event = match &*action {
             "create_environment_variable" => DeploymentAuditLogEvent::CreateEnvironmentVariable {
@@ -457,10 +457,10 @@ impl TryFrom<ConvexObject> for DeploymentAuditLogEvent {
                 request_destination: remove_string(&mut fields, "request_destination")?.parse()?,
             },
             "push_config" => DeploymentAuditLogEvent::PushConfig {
-                config_diff: ConvexObject::try_from(fields)?.try_into()?,
+                config_diff: DocumentObject::try_from(fields)?.try_into()?,
             },
             "push_config_with_components" => DeploymentAuditLogEvent::PushConfigWithComponents {
-                diffs: ConvexObject::try_from(fields)?.try_into()?,
+                diffs: DocumentObject::try_from(fields)?.try_into()?,
             },
             "build_indexes" => {
                 let added_indexes = remove_vec(&mut fields, "added_indexes")?
@@ -485,7 +485,7 @@ impl TryFrom<ConvexObject> for DeploymentAuditLogEvent {
                 let table_names: BTreeMap<_, _> = remove_vec(&mut fields, "table_names")?
                     .into_iter()
                     .map(|v| {
-                        let o: ConvexObject = v.try_into()?;
+                        let o: DocumentObject = v.try_into()?;
                         let mut fields = BTreeMap::from(o);
                         let component = ComponentPath::deserialize(
                             remove_nullable_string(&mut fields, "component")?.as_deref(),
@@ -502,7 +502,7 @@ impl TryFrom<ConvexObject> for DeploymentAuditLogEvent {
                     remove_vec(&mut fields, "table_names_deleted")?
                         .into_iter()
                         .map(|v| {
-                            let o: ConvexObject = v.try_into()?;
+                            let o: DocumentObject = v.try_into()?;
                             let mut fields = BTreeMap::from(o);
                             let component = ComponentPath::deserialize(
                                 remove_nullable_string(&mut fields, "component")?.as_deref(),
@@ -723,7 +723,7 @@ mod tests {
     };
     use proptest::prelude::*;
     use serde_json::json;
-    use value::ConvexObject;
+    use value::DocumentObject;
 
     use super::DeploymentAuditLogEvent;
 
@@ -733,7 +733,7 @@ mod tests {
         )]
         #[test]
         fn test_try_from(e in any::<DeploymentAuditLogEvent>()) {
-            ConvexObject::try_from(e).unwrap();
+            DocumentObject::try_from(e).unwrap();
         }
 
         #[test]
@@ -771,7 +771,7 @@ mod proptests {
     use proptest::prelude::*;
     use value::{
         testing::assert_roundtrips,
-        ConvexObject,
+        DocumentObject,
     };
 
     use crate::deployment_audit_log::types::DeploymentAuditLogEvent;
@@ -780,7 +780,7 @@ mod proptests {
         #![proptest_config(ProptestConfig { cases: 16 * env_config("CONVEX_PROPTEST_MULTIPLIER", 1), failure_persistence: None, .. ProptestConfig::default() })]
         #[test]
         fn test_deployment_audit_log_roundtrip(v in any::<DeploymentAuditLogEvent>()) {
-            assert_roundtrips::<DeploymentAuditLogEvent, ConvexObject>(v);
+            assert_roundtrips::<DeploymentAuditLogEvent, DocumentObject>(v);
         }
     }
 }

--- a/crates/model/src/environment_variables/types.rs
+++ b/crates/model/src/environment_variables/types.rs
@@ -7,30 +7,30 @@ pub use common::types::{
 };
 use value::{
     obj,
-    ConvexObject,
     ConvexValue,
+    DocumentObject,
 };
 
 #[derive(Debug, PartialEq, Clone)]
 #[cfg_attr(any(test, feature = "testing"), derive(proptest_derive::Arbitrary))]
 pub struct PersistedEnvironmentVariable(pub EnvironmentVariable);
 
-impl TryFrom<PersistedEnvironmentVariable> for ConvexObject {
+impl TryFrom<PersistedEnvironmentVariable> for DocumentObject {
     type Error = anyhow::Error;
 
     fn try_from(
         PersistedEnvironmentVariable(
             EnvironmentVariable { name, value }
         ): PersistedEnvironmentVariable,
-    ) -> anyhow::Result<ConvexObject> {
+    ) -> anyhow::Result<DocumentObject> {
         obj!("name" => String::from(name), "value" => String::from(value))
     }
 }
 
-impl TryFrom<ConvexObject> for PersistedEnvironmentVariable {
+impl TryFrom<DocumentObject> for PersistedEnvironmentVariable {
     type Error = anyhow::Error;
 
-    fn try_from(obj: ConvexObject) -> anyhow::Result<PersistedEnvironmentVariable> {
+    fn try_from(obj: DocumentObject) -> anyhow::Result<PersistedEnvironmentVariable> {
         let mut fields = BTreeMap::from(obj);
         let name: String = match fields.remove("name") {
             Some(ConvexValue::String(s)) => s.into(),
@@ -54,7 +54,7 @@ mod tests {
     use proptest::prelude::*;
     use value::{
         testing::assert_roundtrips,
-        ConvexObject,
+        DocumentObject,
     };
 
     use super::PersistedEnvironmentVariable;
@@ -65,7 +65,7 @@ mod tests {
         )]
         #[test]
         fn test_env_var_to_object_roundtrip(e in any::<PersistedEnvironmentVariable>()) {
-            assert_roundtrips::<PersistedEnvironmentVariable, ConvexObject>(e);
+            assert_roundtrips::<PersistedEnvironmentVariable, DocumentObject>(e);
         }
     }
 }

--- a/crates/model/src/exports/mod.rs
+++ b/crates/model/src/exports/mod.rs
@@ -34,8 +34,8 @@ use types::{
 };
 use value::{
     ConvexValue,
-    DeveloperDocumentId,
     FieldPath,
+    PublicDocumentId,
     ResolvedDocumentId,
     TableName,
     TableNamespace,
@@ -215,7 +215,7 @@ impl<'a, RT: Runtime> ExportsModel<'a, RT> {
 
     pub async fn get(
         &mut self,
-        snapshot_id: DeveloperDocumentId,
+        snapshot_id: PublicDocumentId,
     ) -> anyhow::Result<Option<ParsedDocument<Export>>> {
         let export = self
             .tx
@@ -227,7 +227,7 @@ impl<'a, RT: Runtime> ExportsModel<'a, RT> {
 
     pub async fn set_expiration(
         &mut self,
-        snapshot_id: DeveloperDocumentId,
+        snapshot_id: PublicDocumentId,
         expiration_ts_ns: u64,
     ) -> anyhow::Result<()> {
         let (id, mut export) = self
@@ -281,7 +281,7 @@ impl<'a, RT: Runtime> ExportsModel<'a, RT> {
         Ok(to_delete)
     }
 
-    pub async fn cancel(&mut self, snapshot_id: DeveloperDocumentId) -> anyhow::Result<()> {
+    pub async fn cancel(&mut self, snapshot_id: PublicDocumentId) -> anyhow::Result<()> {
         let (id, export) = self
             .get(snapshot_id)
             .await?
@@ -315,7 +315,7 @@ mod tests {
         TestRuntime,
     };
     use sync_types::Timestamp;
-    use value::ConvexObject;
+    use value::DocumentObject;
 
     use crate::{
         exports::{
@@ -333,7 +333,7 @@ mod tests {
     fn test_export_deserialization() -> anyhow::Result<()> {
         #[track_caller]
         fn check_roundtrip(export: &Export) {
-            let object: ConvexObject = export
+            let object: DocumentObject = export
                 .clone()
                 .try_into()
                 .expect("failed to serialize export");
@@ -439,7 +439,7 @@ mod tests {
         assert_eq!(exports_model.latest_in_progress().await?, None);
         assert_eq!(
             exports_model
-                .get(snapshot_id.developer_id)
+                .get(snapshot_id.document_id)
                 .await?
                 .unwrap()
                 .into_value(),
@@ -541,10 +541,10 @@ mod tests {
 
         let new_expiration = ts_u64 + 2000;
         exports_model
-            .set_expiration(id.developer_id, new_expiration)
+            .set_expiration(id.document_id, new_expiration)
             .await?;
         let export = exports_model
-            .get(id.developer_id)
+            .get(id.document_id)
             .await?
             .context("Not found")?
             .into_value();
@@ -625,10 +625,10 @@ mod tests {
             let mut tx = db.begin_system().await?;
             let mut exports_model = ExportsModel::new(&mut tx);
             let export_id = exports_model.insert_export(export).await?;
-            exports_model.cancel(export_id.developer_id).await?;
+            exports_model.cancel(export_id.document_id).await?;
             assert_matches!(
                 *exports_model
-                    .get(export_id.developer_id)
+                    .get(export_id.document_id)
                     .await?
                     .expect("Document must exist"),
                 Export::Canceled { .. }
@@ -652,7 +652,7 @@ mod tests {
             let mut exports_model = ExportsModel::new(&mut tx);
             let export_id = exports_model.insert_export(export).await?;
             exports_model
-                .cancel(export_id.developer_id)
+                .cancel(export_id.document_id)
                 .await
                 .unwrap_err();
             db.commit(tx).await?;

--- a/crates/model/src/external_packages/mod.rs
+++ b/crates/model/src/external_packages/mod.rs
@@ -26,7 +26,7 @@ use database::{
     Transaction,
 };
 use value::{
-    id_v6::DeveloperDocumentId,
+    id_v6::PublicDocumentId,
     TableName,
     TableNamespace,
 };
@@ -77,7 +77,7 @@ impl<'a, RT: Runtime> ExternalPackagesModel<'a, RT> {
         &mut self,
         external_deps_package_id: ExternalDepsPackageId,
     ) -> anyhow::Result<ParsedDocument<ExternalDepsPackage>> {
-        let id: DeveloperDocumentId = external_deps_package_id.into();
+        let id: PublicDocumentId = external_deps_package_id.into();
         let document_id = self.tx.resolve_developer_id(&id, TableNamespace::Global)?;
         self.tx
             .get(document_id)
@@ -93,7 +93,7 @@ impl<'a, RT: Runtime> ExternalPackagesModel<'a, RT> {
         let id = SystemMetadataModel::new_global(self.tx)
             .insert(&EXTERNAL_PACKAGES_TABLE, external_deps_package.try_into()?)
             .await?;
-        let doc_id: DeveloperDocumentId = id.into();
+        let doc_id: PublicDocumentId = id.into();
         Ok(doc_id.into())
     }
 
@@ -128,7 +128,7 @@ impl<'a, RT: Runtime> ExternalPackagesModel<'a, RT> {
                 .map(|dep| (dep.package, dep.version))
                 .collect();
             if pkg_deps_map.eq(&deps_map) {
-                return Ok(Some((DeveloperDocumentId::from(id).into(), pkg)));
+                return Ok(Some((PublicDocumentId::from(id).into(), pkg)));
             }
 
             cache_entries_checked += 1;

--- a/crates/model/src/external_packages/types.rs
+++ b/crates/model/src/external_packages/types.rs
@@ -5,11 +5,11 @@ use common::types::{
     ObjectKey,
 };
 use value::{
-    id_v6::DeveloperDocumentId,
+    id_v6::PublicDocumentId,
     obj,
     sha256::Sha256Digest,
-    ConvexObject,
     ConvexValue,
+    DocumentObject,
 };
 
 use crate::source_packages::types::PackageSize;
@@ -25,15 +25,15 @@ pub struct ExternalDepsPackage {
 
 #[cfg_attr(any(test, feature = "testing"), derive(proptest_derive::Arbitrary))]
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct ExternalDepsPackageId(DeveloperDocumentId);
+pub struct ExternalDepsPackageId(PublicDocumentId);
 
-impl From<DeveloperDocumentId> for ExternalDepsPackageId {
-    fn from(id: DeveloperDocumentId) -> Self {
+impl From<PublicDocumentId> for ExternalDepsPackageId {
+    fn from(id: PublicDocumentId) -> Self {
         Self(id)
     }
 }
 
-impl From<ExternalDepsPackageId> for DeveloperDocumentId {
+impl From<ExternalDepsPackageId> for PublicDocumentId {
     fn from(value: ExternalDepsPackageId) -> Self {
         value.0
     }
@@ -49,15 +49,15 @@ impl TryFrom<ConvexValue> for ExternalDepsPackageId {
     type Error = anyhow::Error;
 
     fn try_from(value: ConvexValue) -> Result<Self, Self::Error> {
-        let id: DeveloperDocumentId = value.try_into()?;
+        let id: PublicDocumentId = value.try_into()?;
         Ok(Self(id))
     }
 }
 
-impl TryFrom<ConvexObject> for ExternalDepsPackage {
+impl TryFrom<DocumentObject> for ExternalDepsPackage {
     type Error = anyhow::Error;
 
-    fn try_from(value: ConvexObject) -> Result<Self, Self::Error> {
+    fn try_from(value: DocumentObject) -> Result<Self, Self::Error> {
         let mut fields = BTreeMap::from(value);
 
         let storage_key = match fields.remove("storageKey") {
@@ -91,7 +91,7 @@ impl TryFrom<ConvexObject> for ExternalDepsPackage {
     }
 }
 
-impl TryFrom<ExternalDepsPackage> for ConvexObject {
+impl TryFrom<ExternalDepsPackage> for DocumentObject {
     type Error = anyhow::Error;
 
     fn try_from(value: ExternalDepsPackage) -> Result<Self, Self::Error> {
@@ -116,7 +116,7 @@ mod tests {
     use cmd_util::env::env_config;
     use common::testing::assert_roundtrips;
     use proptest::prelude::*;
-    use value::ConvexObject;
+    use value::DocumentObject;
 
     use super::ExternalDepsPackage;
 
@@ -126,7 +126,7 @@ mod tests {
         )]
         #[test]
         fn test_external_package_roundtrip(v in any::<ExternalDepsPackage>()) {
-            assert_roundtrips::<ExternalDepsPackage, ConvexObject>(v);
+            assert_roundtrips::<ExternalDepsPackage, DocumentObject>(v);
         }
     }
 }

--- a/crates/model/src/file_storage/mod.rs
+++ b/crates/model/src/file_storage/mod.rs
@@ -52,7 +52,7 @@ use pb::storage::{
 };
 use usage_tracking::FunctionUsageTracker;
 use value::{
-    id_v6::DeveloperDocumentId,
+    id_v6::PublicDocumentId,
     ConvexValue,
     FieldPath,
     ResolvedDocumentId,
@@ -128,16 +128,16 @@ impl SystemTable for FileStorageTable {
 #[cfg_attr(any(test, feature = "testing"), derive(proptest_derive::Arbitrary))]
 pub enum FileStorageId {
     LegacyStorageId(StorageUuid),
-    DocumentId(DeveloperDocumentId),
+    PublicDocumentId(PublicDocumentId),
 }
 
 impl FromStr for FileStorageId {
     type Err = anyhow::Error;
 
     fn from_str(storage_id: &str) -> Result<Self, Self::Err> {
-        let decoded_id = DeveloperDocumentId::decode(storage_id);
+        let decoded_id = PublicDocumentId::decode(storage_id);
         match decoded_id {
-            Ok(decoded_id) => Ok(FileStorageId::DocumentId(decoded_id)),
+            Ok(decoded_id) => Ok(FileStorageId::PublicDocumentId(decoded_id)),
             Err(_) => Ok(FileStorageId::LegacyStorageId(storage_id.parse().context(
                 ErrorMetadata::bad_request(
                     "InvalidStorageId",
@@ -160,7 +160,7 @@ impl TryFrom<FileStorageIdProto> for FileStorageId {
                 FileStorageId::LegacyStorageId(storage_id.parse()?)
             },
             Some(FileStorageIdTypeProto::DocumentId(storage_id)) => {
-                FileStorageId::DocumentId(DeveloperDocumentId::decode(storage_id.as_str())?)
+                FileStorageId::PublicDocumentId(PublicDocumentId::decode(storage_id.as_str())?)
             },
             None => anyhow::bail!("Missing `storage_id_type` field"),
         };
@@ -174,7 +174,7 @@ impl From<FileStorageId> for FileStorageIdProto {
             FileStorageId::LegacyStorageId(storage_id) => {
                 FileStorageIdTypeProto::LegacyStorageId(storage_id.to_string())
             },
-            FileStorageId::DocumentId(storage_id) => {
+            FileStorageId::PublicDocumentId(storage_id) => {
                 FileStorageIdTypeProto::DocumentId(storage_id.encode())
             },
         };
@@ -262,7 +262,7 @@ impl<'a, RT: Runtime> FileStorageModel<'a, RT> {
                 )],
                 order: Order::Asc,
             }),
-            FileStorageId::DocumentId(document_id) => {
+            FileStorageId::PublicDocumentId(document_id) => {
                 let table_name = self
                     .tx
                     .resolve_idv6(

--- a/crates/model/src/file_storage/types.rs
+++ b/crates/model/src/file_storage/types.rs
@@ -11,8 +11,8 @@ use common::{
 use pb::storage::FileStorageEntry as FileStorageEntryProto;
 use value::{
     sha256::Sha256Digest,
-    ConvexObject,
     ConvexValue,
+    DocumentObject,
 };
 
 #[cfg_attr(any(test, feature = "testing"), derive(proptest_derive::Arbitrary))]
@@ -26,7 +26,7 @@ pub struct FileStorageEntry {
     pub content_type: Option<String>, // Optional ContentType header saved with file
 }
 
-impl TryFrom<FileStorageEntry> for ConvexObject {
+impl TryFrom<FileStorageEntry> for DocumentObject {
     type Error = anyhow::Error;
 
     fn try_from(
@@ -52,10 +52,10 @@ impl TryFrom<FileStorageEntry> for ConvexObject {
     }
 }
 
-impl TryFrom<ConvexObject> for FileStorageEntry {
+impl TryFrom<DocumentObject> for FileStorageEntry {
     type Error = anyhow::Error;
 
-    fn try_from(value: ConvexObject) -> Result<Self, Self::Error> {
+    fn try_from(value: DocumentObject) -> Result<Self, Self::Error> {
         let mut object_fields: BTreeMap<_, _> = value.into();
         let storage_id = match object_fields.remove("storageId") {
             Some(v) => v.try_into()?,
@@ -130,7 +130,7 @@ mod tests {
     use common::testing::assert_roundtrips;
     use pb::storage::FileStorageEntry as FileStorageEntryProto;
     use proptest::prelude::*;
-    use value::ConvexObject;
+    use value::DocumentObject;
 
     use super::FileStorageEntry;
 
@@ -141,7 +141,7 @@ mod tests {
 
         #[test]
         fn test_storage_entry_roundtrip(v in any::<FileStorageEntry>()) {
-            assert_roundtrips::<FileStorageEntry, ConvexObject>(v);
+            assert_roundtrips::<FileStorageEntry, DocumentObject>(v);
         }
 
         #[test]

--- a/crates/model/src/file_storage/virtual_table.rs
+++ b/crates/model/src/file_storage/virtual_table.rs
@@ -22,8 +22,8 @@ use common::{
 use semver::Version;
 use value::{
     val,
-    ConvexObject,
     ConvexValue,
+    DocumentObject,
     FieldName,
     TableMapping,
 };
@@ -73,7 +73,7 @@ impl VirtualSystemDocMapper for FileStorageDocMapper {
             size: metadata.size as f64,
             content_type: metadata.content_type,
         };
-        let mut public_metadata_resolved: ConvexObject = public_metadata.try_into()?;
+        let mut public_metadata_resolved: DocumentObject = public_metadata.try_into()?;
 
         let virtual_developer_id =
             virtual_system_mapping.system_resolved_id_to_virtual_developer_id(doc.id())?;
@@ -103,7 +103,7 @@ struct PublicFileMetadata {
     content_type: Option<String>, // Optional ContentType header saved with file
 }
 
-impl TryFrom<PublicFileMetadata> for ConvexObject {
+impl TryFrom<PublicFileMetadata> for DocumentObject {
     type Error = anyhow::Error;
 
     fn try_from(
@@ -123,6 +123,6 @@ impl TryFrom<PublicFileMetadata> for ConvexObject {
                 Some(ct) => val!(ct),
             },
         );
-        ConvexObject::try_from(obj)
+        DocumentObject::try_from(obj)
     }
 }

--- a/crates/model/src/fivetran_import/mod.rs
+++ b/crates/model/src/fivetran_import/mod.rs
@@ -52,8 +52,8 @@ use fivetran_destination::{
     },
 };
 use value::{
-    ConvexObject,
     ConvexValue,
+    DocumentObject,
     FieldName,
     TableName,
     TableNamespace,
@@ -80,7 +80,7 @@ impl<'a, RT: Runtime> FivetranImportModel<'a, RT> {
             BatchWriteOperation::Upsert => {
                 if let Some(existing_document) = existing_document {
                     UserFacingModel::new(self.tx, TableNamespace::Global)
-                        .replace(existing_document.developer_id(), row.row)
+                        .replace(existing_document.document_id(), row.row)
                         .await?;
                 } else {
                     UserFacingModel::new(self.tx, TableNamespace::Global)
@@ -101,7 +101,7 @@ impl<'a, RT: Runtime> FivetranImportModel<'a, RT> {
 
                 UserFacingModel::new(self.tx, TableNamespace::Global)
                     .patch(
-                        existing_document.developer_id(),
+                        existing_document.document_id(),
                         fivetran_patch_value(existing_document.into_value().into_value(), row.row),
                     )
                     .await?;
@@ -109,7 +109,7 @@ impl<'a, RT: Runtime> FivetranImportModel<'a, RT> {
             BatchWriteOperation::HardDelete => {
                 if let Some(existing_document) = existing_document {
                     UserFacingModel::new(self.tx, TableNamespace::Global)
-                        .delete(existing_document.developer_id())
+                        .delete(existing_document.document_id())
                         .await?;
                 }
             },
@@ -126,15 +126,12 @@ impl<'a, RT: Runtime> FivetranImportModel<'a, RT> {
         match delete_type {
             DeleteType::HardDelete => {
                 UserFacingModel::new(self.tx, TableNamespace::Global)
-                    .delete(doc.developer_id())
+                    .delete(doc.document_id())
                     .await?;
             },
             DeleteType::SoftDelete => {
                 UserFacingModel::new(self.tx, TableNamespace::Global)
-                    .replace(
-                        doc.developer_id(),
-                        mark_as_soft_deleted(doc.into_value().0)?,
-                    )
+                    .replace(doc.document_id(), mark_as_soft_deleted(doc.into_value().0)?)
                     .await?;
             },
         }
@@ -144,7 +141,7 @@ impl<'a, RT: Runtime> FivetranImportModel<'a, RT> {
     async fn primary_key_query(
         &mut self,
         table_name: &TableName,
-        object: &ConvexObject,
+        object: &DocumentObject,
     ) -> anyhow::Result<ResolvedQuery<RT>> {
         let mut model = IndexModel::new(self.tx);
         let indexes = model
@@ -310,7 +307,7 @@ impl<'a, RT: Runtime> FivetranImportModel<'a, RT> {
 /// new value. But for Fivetran’s point of view, the metadata fields are all
 /// separate, which means we must make sure that we’re not overriding the entire
 /// `fivetran` field if it contains attributes that are not overridden.
-fn fivetran_patch_value(existing_document: ConvexObject, patch: ConvexObject) -> PatchValue {
+fn fivetran_patch_value(existing_document: DocumentObject, patch: DocumentObject) -> PatchValue {
     let metadata_field_name = FieldName::from(METADATA_CONVEX_FIELD_NAME.clone());
 
     let mut existing_document: BTreeMap<FieldName, ConvexValue> = existing_document.into();
@@ -329,7 +326,7 @@ fn fivetran_patch_value(existing_document: ConvexObject, patch: ConvexObject) ->
     PatchValue::from(
         patch
             .shallow_merge(
-                ConvexObject::for_value(
+                DocumentObject::for_value(
                     metadata_field_name,
                     ConvexValue::Object(existing_metadata.shallow_merge(new_metadata).expect(
                         "The number of metadata fields should always be under the field count \
@@ -345,18 +342,18 @@ fn fivetran_patch_value(existing_document: ConvexObject, patch: ConvexObject) ->
     )
 }
 
-fn mark_as_soft_deleted(object: ConvexObject) -> anyhow::Result<ConvexObject> {
+fn mark_as_soft_deleted(object: DocumentObject) -> anyhow::Result<DocumentObject> {
     let metadata_key = FieldName::from(METADATA_CONVEX_FIELD_NAME.clone());
 
     let mut new_value: BTreeMap<FieldName, ConvexValue> = object.into();
     let metadata_object = match new_value.remove(&metadata_key) {
         Some(ConvexValue::Object(object)) => object,
-        _ => ConvexObject::empty(),
+        _ => DocumentObject::empty(),
     };
 
     new_value.insert(
         metadata_key,
-        ConvexValue::Object(metadata_object.shallow_merge(ConvexObject::for_value(
+        ConvexValue::Object(metadata_object.shallow_merge(DocumentObject::for_value(
             FieldName::from(SOFT_DELETE_CONVEX_FIELD_NAME.clone()),
             ConvexValue::Boolean(true),
         )?)?),

--- a/crates/model/src/log_sinks/types/mock_sink.rs
+++ b/crates/model/src/log_sinks/types/mock_sink.rs
@@ -1,21 +1,21 @@
 use value::{
     obj,
-    ConvexObject,
+    DocumentObject,
 };
 
 #[derive(Debug, Clone, PartialEq)]
 #[cfg_attr(any(test, feature = "testing"), derive(proptest_derive::Arbitrary))]
 pub struct MockSinkConfig {}
 
-impl TryFrom<ConvexObject> for MockSinkConfig {
+impl TryFrom<DocumentObject> for MockSinkConfig {
     type Error = anyhow::Error;
 
-    fn try_from(_value: ConvexObject) -> Result<Self, Self::Error> {
+    fn try_from(_value: DocumentObject) -> Result<Self, Self::Error> {
         Ok(MockSinkConfig {})
     }
 }
 
-impl TryFrom<MockSinkConfig> for ConvexObject {
+impl TryFrom<MockSinkConfig> for DocumentObject {
     type Error = anyhow::Error;
 
     fn try_from(_value: MockSinkConfig) -> Result<Self, Self::Error> {

--- a/crates/model/src/modules/module_versions.rs
+++ b/crates/model/src/modules/module_versions.rs
@@ -609,7 +609,7 @@ impl TryFrom<AnalyzedModule> for SerializedMappedModule {
 mod tests {
     use value::{
         obj,
-        ConvexObject,
+        DocumentObject,
     };
 
     use super::AnalyzedFunction;
@@ -618,7 +618,7 @@ mod tests {
     #[test]
     fn test_analyzed_function_backwards_compatibility() -> anyhow::Result<()> {
         // Old metadata won't have `visibility` or `args`
-        let metadata: ConvexObject = obj!(
+        let metadata: DocumentObject = obj!(
             "name" =>  "myFunction",
             "lineno" => 1,
             "udfType" => "Query"

--- a/crates/model/src/modules/types.rs
+++ b/crates/model/src/modules/types.rs
@@ -10,7 +10,7 @@ use sync_types::{
 use value::{
     codegen_convex_serialization,
     sha256::Sha256Digest,
-    DeveloperDocumentId,
+    PublicDocumentId,
 };
 
 use super::module_versions::{
@@ -52,7 +52,7 @@ impl TryFrom<SerializedModuleMetadata> for ModuleMetadata {
                 let path: ModulePath = m.path.parse()?;
                 path.assume_canonicalized()?
             },
-            source_package_id: DeveloperDocumentId::decode(&m.source_package_id)?.into(),
+            source_package_id: PublicDocumentId::decode(&m.source_package_id)?.into(),
             environment: m.environment.parse()?,
             analyze_result: m.analyze_result.map(|s| s.try_into()).transpose()?,
             sha256: Sha256Digest::from_base64(&m.sha256)?,
@@ -66,7 +66,7 @@ impl TryFrom<ModuleMetadata> for SerializedModuleMetadata {
     fn try_from(m: ModuleMetadata) -> anyhow::Result<Self> {
         Ok(Self {
             path: String::from(m.path),
-            source_package_id: DeveloperDocumentId::from(m.source_package_id).to_string(),
+            source_package_id: PublicDocumentId::from(m.source_package_id).to_string(),
             environment: m.environment.to_string(),
             analyze_result: m.analyze_result.map(|s| s.try_into()).transpose()?,
             sha256: m.sha256.as_base64(),

--- a/crates/model/src/scheduled_jobs/mod.rs
+++ b/crates/model/src/scheduled_jobs/mod.rs
@@ -47,7 +47,7 @@ use errors::ErrorMetadata;
 use imbl::ordmap;
 use sync_types::Timestamp;
 use value::{
-    id_v6::DeveloperDocumentId,
+    id_v6::PublicDocumentId,
     ConvexArray,
     ConvexValue,
     FieldPath,
@@ -279,7 +279,7 @@ impl<'a, RT: Runtime> SchedulerModel<'a, RT> {
         };
         let scheduled_job = ScheduledJobMetadata::new(
             path.clone(),
-            args_id.developer_id,
+            args_id.document_id,
             ScheduledJobState::Pending,
             // Don't set next_ts in the past to avoid scheduler incorrectly logging
             // it is falling behind. We should keep `original_scheduled_ts` intact
@@ -321,7 +321,7 @@ impl<'a, RT: Runtime> SchedulerModel<'a, RT> {
                         let scheduled_ts = self.tx.begin_timestamp();
                         ScheduledJobMetadata::new(
                             path,
-                            args_id.developer_id,
+                            args_id.document_id,
                             ScheduledJobState::Canceled,
                             None,
                             Some(*scheduled_ts),
@@ -580,7 +580,7 @@ impl<'a, RT: Runtime> VirtualSchedulerModel<'a, RT> {
         args: ConvexArray,
         ts: UnixTimestamp,
         context: ExecutionContext,
-    ) -> anyhow::Result<DeveloperDocumentId> {
+    ) -> anyhow::Result<PublicDocumentId> {
         let system_id = SchedulerModel::new(self.tx, self.namespace)
             .schedule(path, args, ts, context)
             .await?;
@@ -589,7 +589,7 @@ impl<'a, RT: Runtime> VirtualSchedulerModel<'a, RT> {
             .system_resolved_id_to_virtual_developer_id(system_id)
     }
 
-    pub async fn cancel(&mut self, virtual_id: DeveloperDocumentId) -> anyhow::Result<()> {
+    pub async fn cancel(&mut self, virtual_id: PublicDocumentId) -> anyhow::Result<()> {
         let table_mapping = self.tx.table_mapping().clone();
         let system_id = self
             .tx

--- a/crates/model/src/scheduled_jobs/types.rs
+++ b/crates/model/src/scheduled_jobs/types.rs
@@ -19,7 +19,7 @@ use sync_types::types::SerializedArgs;
 use value::{
     codegen_convex_serialization,
     ConvexArray,
-    DeveloperDocumentId,
+    PublicDocumentId,
 };
 
 #[derive(Clone)]
@@ -89,7 +89,7 @@ pub struct ScheduledJobMetadata {
 
     /// ID for the document in the `_scheduled_jobs_args` table in the same
     /// namespace as this scheduled job that has the arguments for the job.
-    pub args_id: Option<DeveloperDocumentId>,
+    pub args_id: Option<PublicDocumentId>,
 
     pub state: ScheduledJobState,
 
@@ -121,7 +121,7 @@ pub fn args_to_bytes(args: ConvexArray) -> anyhow::Result<ByteBuf> {
 impl ScheduledJobMetadata {
     pub fn new(
         path: CanonicalizedComponentFunctionPath,
-        args_id: DeveloperDocumentId,
+        args_id: PublicDocumentId,
         state: ScheduledJobState,
         next_ts: Option<Timestamp>,
         completed_ts: Option<Timestamp>,

--- a/crates/model/src/scheduled_jobs/virtual_table.rs
+++ b/crates/model/src/scheduled_jobs/virtual_table.rs
@@ -26,8 +26,8 @@ use semver::Version;
 use sync_types::CanonicalizedUdfPath;
 use value::{
     ConvexArray,
-    ConvexObject,
     ConvexValue,
+    DocumentObject,
     FieldName,
     ResolvedDocumentId,
     TableMapping,
@@ -103,7 +103,7 @@ impl VirtualSystemDocMapper for ScheduledJobsDocMapper {
                 None => None,
             },
         };
-        let mut public_job_resolved: ConvexObject = public_job.try_into()?;
+        let mut public_job_resolved: DocumentObject = public_job.try_into()?;
 
         let virtual_developer_id =
             virtual_system_mapping.system_resolved_id_to_virtual_developer_id(doc.id())?;
@@ -135,7 +135,7 @@ pub struct PublicScheduledJob {
     pub completed_time: Option<f64>,
 }
 
-impl TryFrom<PublicScheduledJob> for ConvexObject {
+impl TryFrom<PublicScheduledJob> for DocumentObject {
     type Error = anyhow::Error;
 
     fn try_from(job: PublicScheduledJob) -> anyhow::Result<Self> {
@@ -147,7 +147,7 @@ impl TryFrom<PublicScheduledJob> for ConvexObject {
         obj.insert("args".parse()?, ConvexValue::Array(job.args));
 
         // Rename `type` -> `kind` in the scheduled job state
-        let system_state: ConvexObject = job.state.try_into()?;
+        let system_state: DocumentObject = job.state.try_into()?;
         let mut fields: BTreeMap<_, _> = system_state.into();
         match fields.remove("type") {
             Some(value) => fields.insert(FieldName::from_str("kind")?, value),
@@ -166,14 +166,14 @@ impl TryFrom<PublicScheduledJob> for ConvexObject {
                 ConvexValue::Float64(completed_time),
             );
         }
-        ConvexObject::try_from(obj)
+        DocumentObject::try_from(obj)
     }
 }
 
-impl TryFrom<ConvexObject> for PublicScheduledJob {
+impl TryFrom<DocumentObject> for PublicScheduledJob {
     type Error = anyhow::Error;
 
-    fn try_from(obj: ConvexObject) -> anyhow::Result<Self> {
+    fn try_from(obj: DocumentObject) -> anyhow::Result<Self> {
         let mut fields = BTreeMap::from(obj);
         let name = match fields.remove("name") {
             Some(ConvexValue::String(name)) => String::from(name).parse()?,
@@ -199,7 +199,7 @@ impl TryFrom<ConvexObject> for PublicScheduledJob {
             Some(value) => state_fields.insert(FieldName::from_str("type")?, value),
             None => anyhow::bail!("Missing `kind` field in ScheduledJobState"),
         };
-        let system_state = ConvexObject::try_from(state_fields)?;
+        let system_state = DocumentObject::try_from(state_fields)?;
         let state = system_state.try_into()?;
         let scheduled_time = match fields.remove("scheduledTime") {
             Some(ConvexValue::Float64(scheduled_time)) => scheduled_time,
@@ -231,7 +231,7 @@ mod tests {
     use proptest::prelude::*;
     use value::{
         testing::assert_roundtrips,
-        ConvexObject,
+        DocumentObject,
     };
 
     use crate::scheduled_jobs::virtual_table::PublicScheduledJob;
@@ -242,7 +242,7 @@ mod tests {
         )]
         #[test]
         fn test_public_scheduled_job_roundtrips(v in any::<PublicScheduledJob>()) {
-            assert_roundtrips::<PublicScheduledJob, ConvexObject>(v);
+            assert_roundtrips::<PublicScheduledJob, DocumentObject>(v);
         }
     }
 }

--- a/crates/model/src/session_requests/types.rs
+++ b/crates/model/src/session_requests/types.rs
@@ -15,7 +15,7 @@ use common::{
     value::ConvexValue,
 };
 use value::{
-    ConvexObject,
+    DocumentObject,
     JsonPackedValue,
 };
 
@@ -50,7 +50,7 @@ pub struct SessionRequestRecord {
     pub identity: InertIdentity,
 }
 
-impl TryFrom<SessionRequestRecord> for ConvexObject {
+impl TryFrom<SessionRequestRecord> for DocumentObject {
     type Error = anyhow::Error;
 
     fn try_from(request: SessionRequestRecord) -> anyhow::Result<Self> {
@@ -63,10 +63,10 @@ impl TryFrom<SessionRequestRecord> for ConvexObject {
     }
 }
 
-impl TryFrom<ConvexObject> for SessionRequestRecord {
+impl TryFrom<DocumentObject> for SessionRequestRecord {
     type Error = anyhow::Error;
 
-    fn try_from(object: ConvexObject) -> anyhow::Result<Self> {
+    fn try_from(object: DocumentObject) -> anyhow::Result<Self> {
         let mut fields: BTreeMap<_, _> = object.into();
 
         let session_id: SessionId = match fields.remove("sessionId") {
@@ -109,7 +109,7 @@ pub enum SessionRequestOutcome {
     },
 }
 
-impl TryFrom<SessionRequestOutcome> for ConvexObject {
+impl TryFrom<SessionRequestOutcome> for DocumentObject {
     type Error = anyhow::Error;
 
     fn try_from(outcome: SessionRequestOutcome) -> anyhow::Result<Self> {
@@ -131,10 +131,10 @@ impl TryFrom<SessionRequestOutcome> for ConvexObject {
     }
 }
 
-impl TryFrom<ConvexObject> for SessionRequestOutcome {
+impl TryFrom<DocumentObject> for SessionRequestOutcome {
     type Error = anyhow::Error;
 
-    fn try_from(object: ConvexObject) -> anyhow::Result<Self> {
+    fn try_from(object: DocumentObject) -> anyhow::Result<Self> {
         let mut fields: BTreeMap<_, _> = object.into();
 
         let udf_type = match fields.remove("type") {
@@ -182,7 +182,7 @@ mod tests {
     use cmd_util::env::env_config;
     use common::testing::assert_roundtrips;
     use proptest::prelude::*;
-    use value::ConvexObject;
+    use value::DocumentObject;
 
     use super::SessionRequestRecord;
 
@@ -192,7 +192,7 @@ mod tests {
         )]
         #[test]
         fn test_session_request_roundtrips(v in any::<SessionRequestRecord>()) {
-            assert_roundtrips::<SessionRequestRecord, ConvexObject>(v);
+            assert_roundtrips::<SessionRequestRecord, DocumentObject>(v);
         }
     }
 }

--- a/crates/model/src/snapshot_imports/mod.rs
+++ b/crates/model/src/snapshot_imports/mod.rs
@@ -26,8 +26,8 @@ use errors::ErrorMetadata;
 use sync_types::Timestamp;
 use types::ImportRequestor;
 use value::{
-    ConvexObject,
     ConvexValue,
+    DocumentObject,
     ResolvedDocumentId,
     TableName,
     TableNamespace,
@@ -392,7 +392,7 @@ impl<'a, RT: Runtime> SnapshotImportModel<'a, RT> {
         &mut self,
         import_state: ImportState,
     ) -> anyhow::Result<Option<ParsedDocument<SnapshotImport>>> {
-        let import_state_type = ConvexObject::try_from(import_state)?
+        let import_state_type = DocumentObject::try_from(import_state)?
             .get("state")
             .context("should have state field")?
             .clone();

--- a/crates/model/src/source_packages/mod.rs
+++ b/crates/model/src/source_packages/mod.rs
@@ -14,7 +14,7 @@ use database::{
     Transaction,
 };
 use value::{
-    id_v6::DeveloperDocumentId,
+    id_v6::PublicDocumentId,
     TableName,
     TableNamespace,
 };
@@ -66,7 +66,7 @@ impl<'a, RT: Runtime> SourcePackageModel<'a, RT> {
         let document_id = SystemMetadataModel::new(self.tx, self.namespace)
             .insert(&SOURCE_PACKAGES_TABLE, source_package.try_into()?)
             .await?;
-        let id: DeveloperDocumentId = document_id.into();
+        let id: PublicDocumentId = document_id.into();
         Ok(id.into())
     }
 
@@ -74,7 +74,7 @@ impl<'a, RT: Runtime> SourcePackageModel<'a, RT> {
         &mut self,
         source_package_id: SourcePackageId,
     ) -> anyhow::Result<ParsedDocument<SourcePackage>> {
-        let id: DeveloperDocumentId = source_package_id.into();
+        let id: PublicDocumentId = source_package_id.into();
         let document_id = self.tx.resolve_developer_id(&id, self.namespace)?;
         self.tx
             .get(document_id)

--- a/crates/model/src/source_packages/types.rs
+++ b/crates/model/src/source_packages/types.rs
@@ -17,7 +17,7 @@ use serde_bytes::ByteBuf;
 use value::{
     codegen_convex_serialization,
     heap_size::HeapSize,
-    id_v6::DeveloperDocumentId,
+    id_v6::PublicDocumentId,
     sha256::Sha256Digest,
     ConvexValue,
 };
@@ -175,7 +175,7 @@ codegen_convex_serialization!(PackageSize, SerializedPackageSize);
 
 #[cfg_attr(any(test, feature = "testing"), derive(proptest_derive::Arbitrary))]
 #[derive(Debug, Clone, PartialEq, Eq, Copy, PartialOrd, Ord, Hash)]
-pub struct SourcePackageId(DeveloperDocumentId);
+pub struct SourcePackageId(PublicDocumentId);
 
 impl HeapSize for SourcePackageId {
     fn heap_size(&self) -> usize {
@@ -183,15 +183,15 @@ impl HeapSize for SourcePackageId {
     }
 }
 
-impl From<DeveloperDocumentId> for SourcePackageId {
-    fn from(id: DeveloperDocumentId) -> Self {
+impl From<PublicDocumentId> for SourcePackageId {
+    fn from(id: PublicDocumentId) -> Self {
         Self(id)
     }
 }
 
 impl From<SourcePackageId> for ConvexValue {
     fn from(value: SourcePackageId) -> Self {
-        let id: DeveloperDocumentId = value.into();
+        let id: PublicDocumentId = value.into();
         id.into()
     }
 }
@@ -200,13 +200,13 @@ impl TryFrom<ConvexValue> for SourcePackageId {
     type Error = anyhow::Error;
 
     fn try_from(value: ConvexValue) -> Result<Self, Self::Error> {
-        let id: DeveloperDocumentId = value.try_into()?;
+        let id: PublicDocumentId = value.try_into()?;
         Ok(SourcePackageId(id))
     }
 }
 
-impl From<SourcePackageId> for DeveloperDocumentId {
-    fn from(id: SourcePackageId) -> DeveloperDocumentId {
+impl From<SourcePackageId> for PublicDocumentId {
+    fn from(id: SourcePackageId) -> PublicDocumentId {
         id.0
     }
 }
@@ -230,7 +230,7 @@ impl TryFrom<SourcePackage> for SerializedSourcePackage {
             sha256: ByteBuf::from(value.sha256.to_vec()),
             external_package_id: value
                 .external_deps_package_id
-                .map(|id| DeveloperDocumentId::from(id).encode()),
+                .map(|id| PublicDocumentId::from(id).encode()),
             package_size: Some(value.package_size.try_into()?),
             node_version: value.node_version.map(String::from),
         })
@@ -244,7 +244,7 @@ impl TryFrom<SerializedSourcePackage> for SourcePackage {
         let sha256 = value.sha256.into_vec().try_into()?;
         let external_package_id = match value.external_package_id {
             None => None,
-            Some(s) => Some(DeveloperDocumentId::decode(&s)?.into()),
+            Some(s) => Some(PublicDocumentId::decode(&s)?.into()),
         };
         let package_size: PackageSize = match value.package_size {
             Some(o) => o.try_into()?,
@@ -274,8 +274,8 @@ mod tests {
     use proptest::prelude::*;
     use value::{
         sha256::Sha256Digest,
-        ConvexObject,
-        DeveloperDocumentId,
+        DocumentObject,
+        PublicDocumentId,
     };
 
     use super::SourcePackage;
@@ -290,7 +290,7 @@ mod tests {
         )]
         #[test]
         fn test_source_package_roundtrip(v in any::<SourcePackage>()) {
-            assert_roundtrips::<SourcePackage, ConvexObject>(v);
+            assert_roundtrips::<SourcePackage, DocumentObject>(v);
         }
     }
 
@@ -310,7 +310,7 @@ mod tests {
                 sha256: Sha256Digest::from(*b"\xed\x65\x82\xb7\xa6\x39\xd8\xdf\xf1\x43\x67\xbb\x4e\x27\x5c\xe9\x93\xc0\xc7\xa2\x80\x52\x8b\x1a\xc5\x57\x15\x72\xae\x5d\x6d\x69"),
                 external_deps_package_id: Some(ExternalDepsPackageId::from(
                     "k423gp2tq6nsw6ngwhkw72c3z17fkb5t"
-                        .parse::<DeveloperDocumentId>()
+                        .parse::<PublicDocumentId>()
                         .unwrap()
                 )),
                 package_size: PackageSize {

--- a/crates/model/src/test_helpers/mod.rs
+++ b/crates/model/src/test_helpers/mod.rs
@@ -82,7 +82,7 @@ impl<RT: Runtime> DatabaseExt for Database<RT> {
         let parent_component_id = match parent {
             TableNamespace::Global => {
                 if let Some(component) = BootstrapComponentsModel::new(&mut tx).root_component()? {
-                    component.id().developer_id
+                    component.id().document_id
                 } else {
                     // Initialize the root component too
                     let root_definition_id = SystemMetadataModel::new_global(&mut tx)
@@ -102,14 +102,14 @@ impl<RT: Runtime> DatabaseExt for Database<RT> {
                         .insert(
                             &COMPONENTS_TABLE,
                             ComponentMetadata {
-                                definition_id: root_definition_id.developer_id,
+                                definition_id: root_definition_id.document_id,
                                 component_type: ComponentType::App,
                                 state: ComponentState::Active,
                             }
                             .try_into()?,
                         )
                         .await?;
-                    root_component.developer_id
+                    root_component.document_id
                 }
             },
             TableNamespace::ByComponent(id) => id,
@@ -139,7 +139,7 @@ impl<RT: Runtime> DatabaseExt for Database<RT> {
                 &COMPONENTS_TABLE,
                 component_id.internal_id(),
                 ComponentMetadata {
-                    definition_id: definition_id.developer_id,
+                    definition_id: definition_id.document_id,
                     component_type: ComponentType::ChildComponent {
                         parent: parent_component_id,
                         name: name.parse()?,

--- a/crates/model/src/udf_config/mod.rs
+++ b/crates/model/src/udf_config/mod.rs
@@ -3,8 +3,12 @@ use std::sync::{
     LazyLock,
 };
 
+use anyhow::Context;
 use common::{
-    document::ParsedDocument,
+    document::{
+        ParseDocument,
+        ParsedDocument,
+    },
     runtime::Runtime,
 };
 use database::{
@@ -12,10 +16,15 @@ use database::{
     SystemMetadataModel,
     Transaction,
 };
+use errors::ErrorMetadataAnyhowExt;
 
 pub mod types;
 use types::UdfConfig;
 use value::{
+    DocumentObject,
+    InternalId,
+    PublicDocumentId,
+    ResolvedDocumentId,
     TableName,
     TableNamespace,
 };
@@ -31,6 +40,15 @@ pub static UDF_CONFIG_TABLE: LazyLock<TableName> = LazyLock::new(|| {
         .parse()
         .expect("Invalid built-in UDF config table")
 });
+
+const GLOBAL_UDF_CONFIG_INTERNAL_ID: InternalId = InternalId(*b"udf_config_root!");
+
+fn fixed_internal_id(namespace: TableNamespace) -> InternalId {
+    match namespace {
+        TableNamespace::Global => GLOBAL_UDF_CONFIG_INTERNAL_ID,
+        TableNamespace::ByComponent(component_id) => component_id.internal_id(),
+    }
+}
 
 pub struct UdfConfigTable;
 impl SystemTable for UdfConfigTable {
@@ -55,13 +73,70 @@ impl<'a, RT: Runtime> UdfConfigModel<'a, RT> {
         Self { tx, namespace }
     }
 
-    pub async fn get(&mut self) -> anyhow::Result<Option<Arc<ParsedDocument<UdfConfig>>>> {
-        let config = self
-            .tx
+    async fn all_configs(&mut self) -> anyhow::Result<Vec<Arc<ParsedDocument<UdfConfig>>>> {
+        self.tx
             .query_system(self.namespace, &SystemIndex::<UdfConfigTable>::by_id())?
-            .unique()
+            .all()
+            .await
+    }
+
+    fn preferred_config(
+        configs: &[Arc<ParsedDocument<UdfConfig>>],
+        fixed_id: InternalId,
+    ) -> Option<Arc<ParsedDocument<UdfConfig>>> {
+        configs
+            .iter()
+            .find(|doc| doc.id().internal_id() == fixed_id)
+            .cloned()
+            .or_else(|| {
+                configs
+                    .iter()
+                    .max_by_key(|doc| (doc.creation_time(), doc.id()))
+                    .cloned()
+            })
+    }
+
+    fn fixed_doc_id(&mut self) -> anyhow::Result<ResolvedDocumentId> {
+        let table_id = self
+            .tx
+            .table_mapping()
+            .namespace(self.namespace)
+            .id(&UDF_CONFIG_TABLE)?;
+        Ok(ResolvedDocumentId::new(
+            table_id.tablet_id,
+            PublicDocumentId::new(table_id.table_number, fixed_internal_id(self.namespace)),
+        ))
+    }
+
+    async fn replace_fixed_config(
+        &mut self,
+        value: DocumentObject,
+    ) -> anyhow::Result<Arc<ParsedDocument<UdfConfig>>> {
+        let fixed_doc_id = self.fixed_doc_id()?;
+        let existing_doc = SystemMetadataModel::new(self.tx, self.namespace)
+            .get(fixed_doc_id)
+            .await?
+            .context("Fixed _udf_config row appeared but could not be loaded")?;
+        let parsed: ParsedDocument<UdfConfig> = existing_doc.parse()?;
+        SystemMetadataModel::new(self.tx, self.namespace)
+            .replace(fixed_doc_id, value)
             .await?;
-        Ok(config)
+        Ok(Arc::new(parsed))
+    }
+
+    pub async fn get(&mut self) -> anyhow::Result<Option<Arc<ParsedDocument<UdfConfig>>>> {
+        let configs = self.all_configs().await?;
+        if configs.len() > 1 {
+            tracing::warn!(
+                namespace = ?self.namespace,
+                count = configs.len(),
+                "Multiple _udf_config rows found; using fixed row"
+            );
+        }
+        Ok(Self::preferred_config(
+            &configs,
+            fixed_internal_id(self.namespace),
+        ))
     }
 
     #[fastrace::trace]
@@ -73,19 +148,47 @@ impl<'a, RT: Runtime> UdfConfigModel<'a, RT> {
             anyhow::bail!(unauthorized_error("set_udf_config"));
         }
         let new_server_version = new_config.server_version.clone();
-        let value = new_config.try_into()?;
-
-        let existing_doc = self.get().await?;
-        let opt_previous_version = if let Some(existing_doc) = existing_doc {
-            SystemMetadataModel::new(self.tx, self.namespace)
-                .replace(existing_doc.id(), value)
-                .await?;
+        let value: DocumentObject = new_config.try_into()?;
+        let fixed_id = fixed_internal_id(self.namespace);
+        let existing_docs = self.all_configs().await?;
+        let preferred_doc = Self::preferred_config(&existing_docs, fixed_id);
+        let opt_previous_version = if let Some(existing_doc) = preferred_doc {
+            if existing_doc.id().internal_id() == fixed_id {
+                SystemMetadataModel::new(self.tx, self.namespace)
+                    .replace(existing_doc.id(), value.clone())
+                    .await?;
+            } else {
+                match SystemMetadataModel::new(self.tx, self.namespace)
+                    .insert_with_internal_id(&UDF_CONFIG_TABLE, fixed_id, value.clone())
+                    .await
+                {
+                    Ok(_) => {},
+                    Err(err) if err.short_msg() == "DocumentExists" => {
+                        self.replace_fixed_config(value.clone()).await?;
+                    },
+                    Err(err) => return Err(err),
+                }
+            }
+            for stale_doc in existing_docs {
+                if stale_doc.id().internal_id() != fixed_id {
+                    SystemMetadataModel::new(self.tx, self.namespace)
+                        .delete(stale_doc.id())
+                        .await?;
+                }
+            }
             Some(existing_doc.server_version.clone())
         } else {
-            SystemMetadataModel::new(self.tx, self.namespace)
-                .insert(&UDF_CONFIG_TABLE, value)
-                .await?;
-            None
+            match SystemMetadataModel::new(self.tx, self.namespace)
+                .insert_with_internal_id(&UDF_CONFIG_TABLE, fixed_id, value.clone())
+                .await
+            {
+                Ok(_) => None,
+                Err(err) if err.short_msg() == "DocumentExists" => {
+                    let existing_doc = self.replace_fixed_config(value).await?;
+                    Some(existing_doc.server_version.clone())
+                },
+                Err(err) => return Err(err),
+            }
         };
 
         let version_diff = match opt_previous_version {
@@ -105,5 +208,57 @@ impl<'a, RT: Runtime> UdfConfigModel<'a, RT> {
             }),
         };
         Ok(version_diff)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use database::test_helpers::DbFixtures;
+    use keybroker::Identity;
+    use runtime::testing::TestRuntime;
+    use value::TableNamespace;
+
+    use super::*;
+    use crate::{
+        test_helpers::DbFixturesWithModel,
+        udf_config::types::UdfConfig,
+    };
+
+    #[convex_macro::test_runtime]
+    async fn test_set_converges_duplicate_udf_config_rows(rt: TestRuntime) -> anyhow::Result<()> {
+        let db = DbFixtures::new_with_model(&rt).await?.db;
+
+        let config_v1 = UdfConfig::new_for_test(&rt, "1000.0.0".parse()?);
+        let config_v2 = UdfConfig::new_for_test(&rt, "1001.0.0".parse()?);
+
+        let mut tx = db.begin(Identity::system()).await?;
+        SystemMetadataModel::new(&mut tx, TableNamespace::Global)
+            .insert(&UDF_CONFIG_TABLE, config_v1.clone().try_into()?)
+            .await?;
+        SystemMetadataModel::new(&mut tx, TableNamespace::Global)
+            .insert(&UDF_CONFIG_TABLE, config_v1.try_into()?)
+            .await?;
+        db.commit(tx).await?;
+
+        let mut tx = db.begin(Identity::system()).await?;
+        let diff = UdfConfigModel::new(&mut tx, TableNamespace::Global)
+            .set(config_v2.clone())
+            .await?;
+        assert!(diff.is_some());
+        db.commit(tx).await?;
+
+        let mut tx = db.begin_system().await?;
+        let docs = tx
+            .query_system(
+                TableNamespace::Global,
+                &SystemIndex::<UdfConfigTable>::by_id(),
+            )?
+            .all()
+            .await?;
+        assert_eq!(docs.len(), 1);
+        assert_eq!(docs[0].id().internal_id(), GLOBAL_UDF_CONFIG_INTERNAL_ID);
+        assert_eq!(**docs[0], config_v2);
+
+        Ok(())
     }
 }

--- a/crates/model/src/udf_config/types.rs
+++ b/crates/model/src/udf_config/types.rs
@@ -111,14 +111,14 @@ mod tests {
     use common::runtime::UnixTimestamp;
     use semver::Version;
     use serde_json::json;
-    use value::ConvexObject;
+    use value::DocumentObject;
 
     use crate::udf_config::types::UdfConfig;
 
     #[test]
     fn test_frozen_obj() {
         assert_eq!(
-            UdfConfig::try_from(ConvexObject::try_from(json!({
+            UdfConfig::try_from(DocumentObject::try_from(json!({
                 "importPhaseRngSeed": {"$bytes": "JycnJycnJycnJycnJycnJycnJycnJycnJycnJycnJyc="},
                 "importPhaseUnixTimestamp": {"$integer": "AADITmdtwRs="},
                 "serverVersion": "123.456.789",

--- a/crates/mysql/src/tests.rs
+++ b/crates/mysql/src/tests.rs
@@ -30,8 +30,8 @@ use common::{
         Timestamp,
     },
     value::{
-        ConvexObject,
         ConvexValue,
+        DocumentObject,
         Size,
     },
 };
@@ -257,7 +257,7 @@ async fn test_lease_preempt() -> anyhow::Result<()> {
     let doc_id = id_generator.user_generate(&table);
     id_generator.write_tables(p1.clone()).await?;
 
-    let doc = ResolvedDocument::new(doc_id, CreationTime::ONE, ConvexObject::empty())?;
+    let doc = ResolvedDocument::new(doc_id, CreationTime::ONE, DocumentObject::empty())?;
 
     // Holding lease -- can write.
     p1.write(

--- a/crates/node_executor/src/executor.rs
+++ b/crates/node_executor/src/executor.rs
@@ -97,8 +97,8 @@ use udf::{
 use value::{
     base64,
     heap_size::WithHeapSize,
-    ConvexObject,
     ConvexValue,
+    DocumentObject,
 };
 
 use crate::metrics::{
@@ -578,7 +578,7 @@ impl TryFrom<ExecutorRequest> for JsonValue {
                     .environment_variables
                     .into_iter()
                     .map(|(name, value)| {
-                        ConvexObject::try_from(PersistedEnvironmentVariable(
+                        DocumentObject::try_from(PersistedEnvironmentVariable(
                             EnvironmentVariable::new(name, value),
                         ))
                         .map(JsonValue::from)
@@ -614,7 +614,7 @@ impl TryFrom<ExecutorRequest> for JsonValue {
                     .environment_variables
                     .into_iter()
                     .map(|(name, value)| {
-                        ConvexObject::try_from(PersistedEnvironmentVariable(
+                        DocumentObject::try_from(PersistedEnvironmentVariable(
                             EnvironmentVariable::new(name, value),
                         ))
                         .map(JsonValue::from)

--- a/crates/node_executor/src/local.rs
+++ b/crates/node_executor/src/local.rs
@@ -396,9 +396,9 @@ mod tests {
     use udf::validation::ValidatedPathAndArgs;
     use value::{
         array,
-        id_v6::DeveloperDocumentId,
+        id_v6::PublicDocumentId,
         ConvexArray,
-        ConvexObject,
+        DocumentObject,
     };
 
     use super::LocalNodeExecutor;
@@ -440,7 +440,7 @@ mod tests {
         })
     }
 
-    fn create_args(args_object: ConvexObject) -> anyhow::Result<ConvexArray> {
+    fn create_args(args_object: DocumentObject) -> anyhow::Result<ConvexArray> {
         array![ConvexValue::Object(args_object)]
     }
 
@@ -451,7 +451,7 @@ mod tests {
         ExecuteRequest {
             path_and_args,
             source_package,
-            source_package_id: DeveloperDocumentId::MIN.into(),
+            source_package_id: PublicDocumentId::MIN.into(),
             user_identity: None,
             auth_header: None,
             environment_variables: btreemap! {},
@@ -570,7 +570,7 @@ mod tests {
                     VERSION.clone(),
                 ),
                 source_package,
-                source_package_id: DeveloperDocumentId::MIN.into(),
+                source_package_id: PublicDocumentId::MIN.into(),
                 user_identity: Some(identity.attributes.clone()),
                 auth_header: None,
                 environment_variables: btreemap! {},
@@ -878,7 +878,7 @@ mod tests {
                     VERSION.clone(),
                 ),
                 source_package,
-                source_package_id: DeveloperDocumentId::MIN.into(),
+                source_package_id: PublicDocumentId::MIN.into(),
                 user_identity: None,
                 auth_header: None,
                 environment_variables,

--- a/crates/packed_value/benches/packed_value.rs
+++ b/crates/packed_value/benches/packed_value.rs
@@ -22,7 +22,7 @@ use serde_json::Value as JsonValue;
 use value::{
     assert_obj,
     assert_val,
-    id_v6::DeveloperDocumentId,
+    id_v6::PublicDocumentId,
     val,
     ConvexValue,
     FieldName,
@@ -31,7 +31,7 @@ use value::{
 };
 
 fn benchmark_values() -> anyhow::Result<Vec<(&'static str, ConvexValue)>> {
-    let idv6 = DeveloperDocumentId::new(TableNumber::try_from(123)?, InternalId([0x16; 16]));
+    let idv6 = PublicDocumentId::new(TableNumber::try_from(123)?, InternalId([0x16; 16]));
 
     let string_short = "some text a person would insert in their document";
     let string_fr =

--- a/crates/packed_value/src/lib.rs
+++ b/crates/packed_value/src/lib.rs
@@ -19,8 +19,8 @@ use flexbuffers::{
 use value::{
     heap_size::HeapSize,
     serde::ConvexSerializable,
-    ConvexObject,
     ConvexValue,
+    DocumentObject,
     FieldPath,
 };
 
@@ -132,7 +132,7 @@ impl PackedValue<ByteBuffer> {
         }
     }
 
-    pub fn pack_object(value: &ConvexObject) -> Self {
+    pub fn pack_object(value: &DocumentObject) -> Self {
         let mut builder = Builder::default();
         Self::_pack_object(value, &mut builder);
         Self {
@@ -174,7 +174,7 @@ impl PackedValue<ByteBuffer> {
         }
     }
 
-    fn _pack_object(object: &ConvexObject, builder: &mut impl FlexBuilder) {
+    fn _pack_object(object: &DocumentObject, builder: &mut impl FlexBuilder) {
         let mut map = builder.start_map();
         for (field, value) in object.iter() {
             let mut builder = (&field[..], &mut map);

--- a/crates/pb/protos/common.proto
+++ b/crates/pb/protos/common.proto
@@ -34,7 +34,7 @@ message ResolvedDocumentId {
   optional bytes internal_id = 2;
 }
 
-message DeveloperDocumentId {
+message PublicDocumentId {
   optional uint32 table_number = 1;
   optional bytes internal_id = 2;
 }
@@ -142,12 +142,12 @@ message FunctionCaller {
 }
 
 message SchedulerFunctionCaller {
-  common.DeveloperDocumentId job_id = 1;
+  common.PublicDocumentId job_id = 1;
   optional string component_id = 2;
 }
 
 message ActionFunctionCaller {
-  common.DeveloperDocumentId parent_scheduled_job = 1;
+  common.PublicDocumentId parent_scheduled_job = 1;
   optional string component_id = 2;
   optional string parent_execution_id = 3;
 }

--- a/crates/pb/protos/replication.proto
+++ b/crates/pb/protos/replication.proto
@@ -105,6 +105,7 @@ message TwoPcTabletMetadata {
   bytes tablet_id = 1;
   uint32 table_number = 2;
   string table_name = 3;
+  optional string component_id = 4;
 }
 
 message TwoPcIndexedRead {

--- a/crates/pb/src/document_id.rs
+++ b/crates/pb/src/document_id.rs
@@ -1,19 +1,19 @@
 use anyhow::Context;
 use value::{
-    DeveloperDocumentId,
+    PublicDocumentId,
     ResolvedDocumentId,
     TabletId,
     TabletIdAndTableNumber,
 };
 
 use crate::common::{
-    DeveloperDocumentId as DeveloperDocumentIdProto,
+    PublicDocumentId as PublicDocumentIdProto,
     ResolvedDocumentId as ResolvedDocumentIdProto,
     TabletIdAndTableNumber as TabletIdAndTableNumberProto,
 };
 
-impl From<DeveloperDocumentId> for DeveloperDocumentIdProto {
-    fn from(value: DeveloperDocumentId) -> Self {
+impl From<PublicDocumentId> for PublicDocumentIdProto {
+    fn from(value: PublicDocumentId) -> Self {
         let (table_number, internal_id) = value.into_table_and_id();
         Self {
             table_number: Some(table_number.into()),
@@ -22,14 +22,14 @@ impl From<DeveloperDocumentId> for DeveloperDocumentIdProto {
     }
 }
 
-impl TryFrom<DeveloperDocumentIdProto> for DeveloperDocumentId {
+impl TryFrom<PublicDocumentIdProto> for PublicDocumentId {
     type Error = anyhow::Error;
 
     fn try_from(
-        DeveloperDocumentIdProto {
+        PublicDocumentIdProto {
             table_number,
             internal_id,
-        }: DeveloperDocumentIdProto,
+        }: PublicDocumentIdProto,
     ) -> anyhow::Result<Self> {
         let table_number = table_number
             .context("Missing `table_number` field")?
@@ -45,9 +45,9 @@ impl From<ResolvedDocumentId> for ResolvedDocumentIdProto {
     fn from(value: ResolvedDocumentId) -> Self {
         let tablet_id_and_number = TabletIdAndTableNumber {
             tablet_id: value.tablet_id,
-            table_number: value.developer_id.table(),
+            table_number: value.document_id.table(),
         };
-        let internal_id = value.developer_id.internal_id();
+        let internal_id = value.document_id.internal_id();
         Self {
             table: Some(tablet_id_and_number.into()),
             internal_id: Some(internal_id.0.to_vec()),
@@ -67,10 +67,10 @@ impl TryFrom<ResolvedDocumentIdProto> for ResolvedDocumentId {
         let internal_id = internal_id
             .ok_or_else(|| anyhow::anyhow!("Missing internal_id"))?
             .try_into()?;
-        let developer_id = DeveloperDocumentId::new(table.table_number, internal_id);
+        let document_id = PublicDocumentId::new(table.table_number, internal_id);
         Ok(Self {
             tablet_id: table.tablet_id,
-            developer_id,
+            document_id,
         })
     }
 }
@@ -118,11 +118,11 @@ mod tests {
     use value::testing::assert_roundtrips;
 
     use super::{
-        DeveloperDocumentId,
+        PublicDocumentId,
         ResolvedDocumentId,
     };
     use crate::common::{
-        DeveloperDocumentId as DeveloperDocumentIdProto,
+        PublicDocumentId as PublicDocumentIdProto,
         ResolvedDocumentId as ResolvedDocumentIdProto,
     };
 
@@ -137,8 +137,8 @@ mod tests {
         }
 
         #[test]
-        fn test_developer_document_id_roundtrips(left in any::<DeveloperDocumentId>()) {
-            assert_roundtrips::<DeveloperDocumentId, DeveloperDocumentIdProto>(left);
+        fn test_public_document_id_roundtrips(left in any::<PublicDocumentId>()) {
+            assert_roundtrips::<PublicDocumentId, PublicDocumentIdProto>(left);
         }
     }
 }

--- a/crates/postgres/src/tests.rs
+++ b/crates/postgres/src/tests.rs
@@ -30,8 +30,8 @@ use common::{
         Timestamp,
     },
     value::{
-        ConvexObject,
         ConvexValue,
+        DocumentObject,
         Size,
     },
 };
@@ -226,7 +226,7 @@ async fn test_lease_preempt() -> anyhow::Result<()> {
     let doc_id = id_generator.user_generate(&table);
     id_generator.write_tables(p1.clone()).await?;
 
-    let doc = ResolvedDocument::new(doc_id, CreationTime::ONE, ConvexObject::empty())?;
+    let doc = ResolvedDocument::new(doc_id, CreationTime::ONE, DocumentObject::empty())?;
 
     // Holding lease -- can write.
     p1.write(

--- a/crates/search/benches/memory_index.rs
+++ b/crates/search/benches/memory_index.rs
@@ -44,8 +44,8 @@ use search::{
 use serde::Deserialize;
 use value::{
     assert_obj,
-    DeveloperDocumentId,
     InternalId,
+    PublicDocumentId,
     ResolvedDocumentId,
     TableNumber,
     TabletId,
@@ -112,7 +112,7 @@ impl Dataset {
                 let internal_id = alloc_id();
                 let id = ResolvedDocumentId::new(
                     table_id.tablet_id,
-                    DeveloperDocumentId::new(table_id.table_number, internal_id),
+                    PublicDocumentId::new(table_id.table_number, internal_id),
                 );
                 let value = assert_obj!("body" => d.text);
                 let creation_time = CreationTime::try_from(1.)?;

--- a/crates/search/src/query.rs
+++ b/crates/search/src/query.rs
@@ -1168,9 +1168,9 @@ mod tests {
         types::IndexDescriptor,
     };
     use value::{
-        ConvexObject,
         ConvexString,
         ConvexValue,
+        DocumentObject,
         ResolvedDocumentId,
         TabletId,
     };
@@ -1187,7 +1187,7 @@ mod tests {
             "title".parse()?,
             ConvexValue::String(ConvexString::try_from("hello world")?),
         );
-        let object = ConvexObject::try_from(map)?;
+        let object = DocumentObject::try_from(map)?;
         let doc = PackedDocument::pack(&ResolvedDocument::new(
             ResolvedDocumentId::MIN,
             CreationTime::ONE,
@@ -1222,7 +1222,7 @@ mod tests {
             "title".parse()?,
             ConvexValue::String(ConvexString::try_from("bonjour")?),
         );
-        let object = ConvexObject::try_from(map)?;
+        let object = DocumentObject::try_from(map)?;
         let doc = PackedDocument::pack(&ResolvedDocument::new(
             ResolvedDocumentId::MIN,
             CreationTime::ONE,
@@ -1248,7 +1248,7 @@ mod tests {
         let doc = PackedDocument::pack(&ResolvedDocument::new(
             ResolvedDocumentId::MIN,
             CreationTime::ONE,
-            ConvexObject::try_from(btreemap! {})?,
+            DocumentObject::try_from(btreemap! {})?,
         )?);
 
         assert!(!tries.overlaps_document(&doc));

--- a/crates/search/src/searcher/searcher.rs
+++ b/crates/search/src/searcher/searcher.rs
@@ -1476,9 +1476,9 @@ mod tests {
     };
     use value::{
         assert_obj,
-        DeveloperDocumentId,
         FieldPath,
         InternalId,
+        PublicDocumentId,
         ResolvedDocumentId,
         TabletIdAndTableNumber,
     };
@@ -1551,7 +1551,7 @@ mod tests {
         let revisions = strings.into_iter().map(|s| {
             let id = ResolvedDocumentId::new(
                 TEST_TABLE.tablet_id,
-                DeveloperDocumentId::new(TEST_TABLE.table_number, id_generator.generate_internal()),
+                PublicDocumentId::new(TEST_TABLE.table_number, id_generator.generate_internal()),
             );
             strings_by_id.insert(id, s.clone());
             let creation_time = CreationTime::try_from(10.)?;
@@ -1696,7 +1696,7 @@ mod tests {
             println!("{:?} @ {}", result.internal_id, result.bm25_score);
             let id = ResolvedDocumentId::new(
                 TEST_TABLE.tablet_id,
-                DeveloperDocumentId::new(TEST_TABLE.table_number, result.internal_id),
+                PublicDocumentId::new(TEST_TABLE.table_number, result.internal_id),
             );
             println!("  {}", strings_by_id[&id]);
         }
@@ -1736,7 +1736,7 @@ mod tests {
              }| {
                 let id = ResolvedDocumentId::new(
                     TEST_TABLE.tablet_id,
-                    DeveloperDocumentId::new(TEST_TABLE.table_number, id),
+                    PublicDocumentId::new(TEST_TABLE.table_number, id),
                 );
                 strings_by_id.entry(id).or_insert(new_str.clone());
                 let creation_time = CreationTime::try_from(10.)?;
@@ -1946,7 +1946,7 @@ mod tests {
             println!("{:?} @ {}", result.internal_id, result.bm25_score);
             let id = ResolvedDocumentId::new(
                 TEST_TABLE.tablet_id,
-                DeveloperDocumentId::new(TEST_TABLE.table_number, result.internal_id),
+                PublicDocumentId::new(TEST_TABLE.table_number, result.internal_id),
             );
             let s = test_index.strings_by_id[&id].as_ref().unwrap();
             println!("  {s}",);

--- a/crates/shape_inference/src/contains.rs
+++ b/crates/shape_inference/src/contains.rs
@@ -1,5 +1,5 @@
 use value::{
-    id_v6::DeveloperDocumentId,
+    id_v6::PublicDocumentId,
     ConvexValue,
     FieldName,
 };
@@ -31,7 +31,7 @@ impl<C: ShapeConfig> CountedShape<C> {
             (ConvexValue::Boolean(..), ShapeEnum::Boolean) => true,
             (ConvexValue::String(s), ShapeEnum::StringLiteral(literal)) => s[..] == literal[..],
             (ConvexValue::String(s), ShapeEnum::Id(table)) => {
-                if let Ok(ref id) = DeveloperDocumentId::decode(s) {
+                if let Ok(ref id) = PublicDocumentId::decode(s) {
                     id.table() == *table
                 } else {
                     false

--- a/crates/shape_inference/src/export_context.rs
+++ b/crates/shape_inference/src/export_context.rs
@@ -28,9 +28,9 @@ use serde_json::{
     Value as JsonValue,
 };
 #[cfg(any(test, feature = "testing"))]
-use value::ConvexObject;
+use value::DocumentObject;
 use value::{
-    id_v6::DeveloperDocumentId,
+    id_v6::PublicDocumentId,
     ConvexValue,
     FieldName,
     IdentifierFieldName,
@@ -176,7 +176,7 @@ impl ExportContext {
 
     #[cfg(any(test, feature = "testing"))]
     pub fn of_object<C: ShapeConfig, S: ShapeCounter>(
-        object: &ConvexObject,
+        object: &DocumentObject,
         shape: &Shape<C, S>,
     ) -> ExportContext {
         let shape_options = btreeset!(shape);
@@ -185,7 +185,7 @@ impl ExportContext {
 
     #[cfg(any(test, feature = "testing"))]
     fn of_object_inner<C: ShapeConfig, S: ShapeCounter>(
-        fields: &ConvexObject,
+        fields: &DocumentObject,
         shape: &BTreeSet<&Shape<C, S>>,
     ) -> ExportContext {
         if !Self::is_ambiguous_inner(shape) {
@@ -1002,7 +1002,7 @@ pub enum GeneratedSchema<T: ShapeConfig> {
     /// zip exports.
     LegacyInferred {
         inferred_shape: StructuralShape<T>,
-        overrides: BTreeMap<DeveloperDocumentId, ExportContext>,
+        overrides: BTreeMap<PublicDocumentId, ExportContext>,
     },
     /// Indicates that values are encoded using a uniform encoding (i.e.
     /// [`value::export::ValueFormat::ConvexExportJSON`]).
@@ -1020,7 +1020,7 @@ impl<T: ShapeConfig> GeneratedSchema<T> {
     }
 
     #[cfg(any(test, feature = "testing"))]
-    pub fn insert(&mut self, object: &ConvexObject, id: DeveloperDocumentId) {
+    pub fn insert(&mut self, object: &DocumentObject, id: PublicDocumentId) {
         match self {
             GeneratedSchema::LegacyInferred {
                 inferred_shape,
@@ -1060,7 +1060,7 @@ impl<T: ShapeConfig> GeneratedSchema<T> {
             }) => {
                 let export_context =
                     if let Some(JsonValue::String(id_str)) = exported_object.get("_id") {
-                        let id = DeveloperDocumentId::decode(id_str)?;
+                        let id = PublicDocumentId::decode(id_str)?;
                         overrides.remove(&id).unwrap_or(ExportContext::Infer)
                     } else {
                         ExportContext::Infer
@@ -1103,8 +1103,8 @@ mod test_generated_schema {
     use value::{
         assert_val,
         export::ValueFormat,
-        id_v6::DeveloperDocumentId,
-        ConvexObject,
+        id_v6::PublicDocumentId,
+        DocumentObject,
     };
 
     use crate::{
@@ -1119,7 +1119,7 @@ mod test_generated_schema {
         })]
         #[test]
         fn generated_schema_object_roundtrip(
-            objects in prop::collection::vec(any::<(ConvexObject, DeveloperDocumentId)>(), 1..3),
+            objects in prop::collection::vec(any::<(DocumentObject, PublicDocumentId)>(), 1..3),
         ) {
             let mut inferred_shape = CountedShape::<SmallTestConfig>::empty();
             let mut id_to_object = BTreeMap::new();

--- a/crates/shape_inference/src/lib.rs
+++ b/crates/shape_inference/src/lib.rs
@@ -41,9 +41,9 @@ pub use union::{
     UnionShape,
 };
 use value::{
-    id_v6::DeveloperDocumentId,
-    ConvexObject,
+    id_v6::PublicDocumentId,
     ConvexValue,
+    DocumentObject,
     FieldName,
     IdentifierFieldName,
     TableNumber,
@@ -265,7 +265,7 @@ impl<C: ShapeConfig> CountedShape<C> {
         Self::new(variant, 1)
     }
 
-    fn shape_of_object(object: &ConvexObject) -> Self {
+    fn shape_of_object(object: &DocumentObject) -> Self {
         Self::new(ObjectShape::shape_of(object), 1)
     }
 
@@ -279,7 +279,7 @@ impl<C: ShapeConfig> CountedShape<C> {
     }
 
     /// Insert an object into a shape, returning the updated shape.
-    pub fn insert(&self, object: &ConvexObject) -> Self {
+    pub fn insert(&self, object: &DocumentObject) -> Self {
         let union_builder = match &*self.variant {
             ShapeEnum::Union(union) => union.clone().into_builder(),
             _ => UnionBuilder::new().push(self.clone()),
@@ -300,7 +300,7 @@ impl<C: ShapeConfig> CountedShape<C> {
     /// must have been previously inserted into the shape, and this function
     /// may return `Err` if it wasn't. Since there may be false successes,
     /// it's usually not safe to recover from this `Err`.
-    pub fn remove(&self, object: &ConvexObject) -> anyhow::Result<Self> {
+    pub fn remove(&self, object: &DocumentObject) -> anyhow::Result<Self> {
         self._remove_object(object).ok_or_else(|| {
             anyhow::anyhow!(
                 "Object with shape {:?} and id {:?} not in {self:?}",
@@ -359,7 +359,7 @@ impl<C: ShapeConfig> CountedShape<C> {
                 ShapeEnum::StringLiteral(s2.clone())
             },
             (ConvexValue::String(s), ShapeEnum::Id(table_number)) => {
-                if let Ok(id) = DeveloperDocumentId::decode(s)
+                if let Ok(id) = PublicDocumentId::decode(s)
                     && id.table() == *table_number
                 {
                     ShapeEnum::Id(*table_number)
@@ -401,7 +401,7 @@ impl<C: ShapeConfig> CountedShape<C> {
         Some(Self::new(new_variant, self.num_values - 1))
     }
 
-    fn _remove_object(&self, object: &ConvexObject) -> Option<Self> {
+    fn _remove_object(&self, object: &DocumentObject) -> Option<Self> {
         if self.num_values == 0 {
             return None;
         }

--- a/crates/shape_inference/src/object.rs
+++ b/crates/shape_inference/src/object.rs
@@ -5,7 +5,7 @@ use std::{
 
 use value::{
     identifier::is_valid_identifier,
-    ConvexObject,
+    DocumentObject,
     IdentifierFieldName,
 };
 
@@ -75,7 +75,7 @@ impl<C: ShapeConfig> ObjectShape<C, u64> {
             .all(|f| f.value_shape.num_values < num_values));
     }
 
-    pub fn shape_of(object: &ConvexObject) -> CountedShapeEnum<C> {
+    pub fn shape_of(object: &DocumentObject) -> CountedShapeEnum<C> {
         // N.B.: check is_valid_identifier separately to avoid creating
         // anyhow::Errors, which is expensive
         if object.len() <= C::MAX_OBJECT_FIELDS

--- a/crates/shape_inference/src/string.rs
+++ b/crates/shape_inference/src/string.rs
@@ -5,7 +5,7 @@ use std::{
 };
 
 use value::{
-    id_v6::DeveloperDocumentId,
+    id_v6::PublicDocumentId,
     identifier::is_valid_field_name,
     ConvexString,
 };
@@ -47,7 +47,7 @@ impl<C: ShapeConfig> StringLiteralShape<C> {
             };
             return ShapeEnum::StringLiteral(literal_shape);
         }
-        if let Ok(id) = DeveloperDocumentId::decode(s) {
+        if let Ok(id) = PublicDocumentId::decode(s) {
             return ShapeEnum::Id(id.table());
         }
         if is_valid_field_name(s) {

--- a/crates/shape_inference/src/subtype.rs
+++ b/crates/shape_inference/src/subtype.rs
@@ -1,7 +1,7 @@
 use std::collections::BTreeMap;
 
 use value::{
-    id_v6::DeveloperDocumentId,
+    id_v6::PublicDocumentId,
     FieldName,
 };
 
@@ -42,7 +42,7 @@ impl<C: ShapeConfig, S: ShapeCounter> ShapeEnum<C, S> {
             },
             // A string literal type is a subtype of an `id<t>` type if it's a valid ID in `t`.
             (ShapeEnum::StringLiteral(s), ShapeEnum::Id(table_number)) => {
-                match DeveloperDocumentId::decode(s) {
+                match PublicDocumentId::decode(s) {
                     Ok(id) => id.table() == *table_number,
                     Err(_) => false,
                 }
@@ -224,7 +224,7 @@ impl<C: ShapeConfig> CountedShape<C> {
                 ShapeEnum::StringLiteral(s.clone())
             },
             (ShapeEnum::StringLiteral(s), ShapeEnum::Id(table_number)) => {
-                let Ok(id) = DeveloperDocumentId::decode(s) else {
+                let Ok(id) = PublicDocumentId::decode(s) else {
                     return None;
                 };
                 if id.table() != *table_number {

--- a/crates/shape_inference/src/supertype.rs
+++ b/crates/shape_inference/src/supertype.rs
@@ -7,7 +7,7 @@ use std::{
 };
 
 use value::{
-    id_v6::DeveloperDocumentId,
+    id_v6::PublicDocumentId,
     FieldName,
     IdentifierFieldName,
 };
@@ -121,7 +121,7 @@ fn id_candidates<C: ShapeConfig>(
             let mut candidates = BTreeMap::new();
             for (i, t) in types.iter().enumerate() {
                 if let ShapeEnum::StringLiteral(s) = &*t.variant
-                    && let Ok(id) = DeveloperDocumentId::decode(s)
+                    && let Ok(id) = PublicDocumentId::decode(s)
                 {
                     candidates
                         .entry(id.table())

--- a/crates/shape_inference/src/testing/arbitrary_export_context.rs
+++ b/crates/shape_inference/src/testing/arbitrary_export_context.rs
@@ -1,6 +1,6 @@
 use proptest::prelude::*;
 use value::{
-    id_v6::DeveloperDocumentId,
+    id_v6::PublicDocumentId,
     FieldName,
 };
 
@@ -44,11 +44,7 @@ impl<T: ShapeConfig> Arbitrary for GeneratedSchema<T> {
     fn arbitrary_with((): Self::Parameters) -> Self::Strategy {
         (
             any::<StructuralShape<T>>(),
-            prop::collection::btree_map(
-                any::<DeveloperDocumentId>(),
-                any::<ExportContext>(),
-                0..10,
-            ),
+            prop::collection::btree_map(any::<PublicDocumentId>(), any::<ExportContext>(), 0..10),
         )
             .prop_map(|(inferred_shape, overrides)| Self::LegacyInferred {
                 inferred_shape,

--- a/crates/shape_inference/src/testing/arbitrary_value.rs
+++ b/crates/shape_inference/src/testing/arbitrary_value.rs
@@ -2,11 +2,11 @@ use std::collections::BTreeMap;
 
 use proptest::prelude::*;
 use value::{
-    id_v6::DeveloperDocumentId,
+    id_v6::PublicDocumentId,
     proptest::float64_strategy,
     ConvexArray,
-    ConvexObject,
     ConvexValue,
+    DocumentObject,
     FieldName,
     InternalId,
 };
@@ -40,7 +40,7 @@ pub fn shape_member_strategy<C: ShapeConfig>(t: &CountedShape<C>) -> BoxedStrate
             let table = *table;
             any::<InternalId>()
                 .prop_map(move |id| {
-                    let id = DeveloperDocumentId::new(table, id);
+                    let id = PublicDocumentId::new(table, id);
                     ConvexValue::String(String::from(id).try_into().unwrap())
                 })
                 .boxed()
@@ -95,7 +95,7 @@ pub fn shape_member_strategy<C: ShapeConfig>(t: &CountedShape<C>) -> BoxedStrate
                 shape_member_strategy(record.value()),
                 0..BRANCHING,
             )
-            .prop_map(|value| ConvexValue::Object(ConvexObject::try_from(value).unwrap()))
+            .prop_map(|value| ConvexValue::Object(DocumentObject::try_from(value).unwrap()))
             .boxed()
         },
         ShapeEnum::Union(union) => {

--- a/crates/simulation/src/test_helpers/js_client/mod.rs
+++ b/crates/simulation/src/test_helpers/js_client/mod.rs
@@ -7,8 +7,8 @@ use common::{
         SpawnHandle,
     },
     value::{
-        ConvexObject,
         ConvexValue,
+        DocumentObject,
     },
 };
 use js_protocol::SyncMutationStatus;
@@ -39,14 +39,14 @@ pub type MutationId = String;
 #[serde(rename_all = "camelCase")]
 pub struct MutationInfo {
     pub mutation_path: String,
-    pub opt_update_args: ConvexObject,
-    pub server_args: ConvexObject,
+    pub opt_update_args: DocumentObject,
+    pub server_args: DocumentObject,
 }
 
 pub enum JsClientThreadRequest {
     AddQuery {
         udf_path: UdfPath,
-        args: ConvexObject,
+        args: DocumentObject,
         sender: oneshot::Sender<QueryToken>,
     },
     QueryResult {
@@ -59,14 +59,14 @@ pub enum JsClientThreadRequest {
     },
     RunMutation {
         udf_path: UdfPath,
-        args: ConvexObject,
+        args: DocumentObject,
         sender: oneshot::Sender<Result<ConvexValue, JsError>>,
     },
 
     AddSyncQuery {
         id: String,
         name: String,
-        args: ConvexObject,
+        args: DocumentObject,
         sender: oneshot::Sender<()>,
     },
     SyncQueryResult {
@@ -118,7 +118,7 @@ impl JsClientThread {
     pub async fn add_query(
         &self,
         udf_path: UdfPath,
-        args: ConvexObject,
+        args: DocumentObject,
     ) -> anyhow::Result<QueryToken> {
         let (sender, receiver) = oneshot::channel();
         self.tx.send(JsClientThreadRequest::AddQuery {
@@ -146,7 +146,7 @@ impl JsClientThread {
     pub async fn run_mutation(
         &self,
         udf_path: UdfPath,
-        args: ConvexObject,
+        args: DocumentObject,
     ) -> anyhow::Result<Result<ConvexValue, JsError>> {
         let (sender, receiver) = oneshot::channel();
         self.tx.send(JsClientThreadRequest::RunMutation {
@@ -160,7 +160,7 @@ impl JsClientThread {
     pub async fn add_sync_query(
         &self,
         name: &str,
-        args: ConvexObject,
+        args: DocumentObject,
     ) -> anyhow::Result<SyncQuerySubscriptionId> {
         let (sender, receiver) = oneshot::channel();
         let id = Uuid::new_v4().to_string();

--- a/crates/simulation/src/test_helpers/server.rs
+++ b/crates/simulation/src/test_helpers/server.rs
@@ -19,7 +19,7 @@ use common::{
         SpawnHandle,
     },
     types::FunctionCaller,
-    value::ConvexObject,
+    value::DocumentObject,
     RequestId,
 };
 use keybroker::Identity;
@@ -58,7 +58,7 @@ pub enum ServerRequest {
     },
     Mutation {
         udf_path: UdfPath,
-        args: ConvexObject,
+        args: DocumentObject,
         result: oneshot::Sender<Result<RedactedMutationReturn, RedactedMutationError>>,
     },
     LatestTimestamp {
@@ -150,7 +150,7 @@ impl ServerThread {
     pub async fn mutation(
         &self,
         udf_path: UdfPath,
-        args: ConvexObject,
+        args: DocumentObject,
     ) -> anyhow::Result<Result<RedactedMutationReturn, RedactedMutationError>> {
         let (tx, rx) = oneshot::channel();
         self.tx.send(ServerRequest::Mutation {

--- a/crates/simulation/src/tests/sync.rs
+++ b/crates/simulation/src/tests/sync.rs
@@ -4,8 +4,8 @@ use common::{
     value::{
         array,
         ConvexArray,
-        ConvexObject,
         ConvexValue,
+        DocumentObject,
     },
 };
 use must_let::must_let;
@@ -55,7 +55,7 @@ fn assert_results_match(expected: &ConvexValue, actual: &ConvexValue) -> anyhow:
     Ok(())
 }
 
-fn assert_objects_match(expected: &ConvexObject, actual: &ConvexObject) -> anyhow::Result<()> {
+fn assert_objects_match(expected: &DocumentObject, actual: &DocumentObject) -> anyhow::Result<()> {
     for (key, value) in expected.iter() {
         let actual_value = actual
             .get(key)

--- a/crates/sync/src/tests.rs
+++ b/crates/sync/src/tests.rs
@@ -33,8 +33,8 @@ use common::{
     },
     value::{
         assert_val,
-        ConvexObject,
         ConvexValue,
+        DocumentObject,
     },
     version::ClientVersion,
     RequestId,
@@ -225,7 +225,7 @@ impl<RT: Runtime> TestSyncWorker<RT> {
     async fn mutation(
         &mut self,
         path: &str,
-        args: ConvexObject,
+        args: DocumentObject,
         request_id: SessionRequestSeqNumber,
     ) -> anyhow::Result<(ConvexValue, Timestamp)> {
         self.send(ClientMessage::Mutation {

--- a/crates/value/src/document_id.rs
+++ b/crates/value/src/document_id.rs
@@ -29,7 +29,7 @@ use crate::{
     TabletId,
 };
 
-/// A raw reference to a document. `DocumentId`s can appear in `Value`s as
+/// A raw reference to a document. `PublicDocumentId`s can appear in `Value`s as
 /// `Id`s, `StrongRef`s, or `WeakRef`s.
 #[derive(Clone, Eq, PartialEq, Hash, Ord, PartialOrd, Copy)]
 pub struct InternalDocumentId {
@@ -38,7 +38,7 @@ pub struct InternalDocumentId {
 }
 
 #[derive(Clone, Eq, PartialEq, Hash, Ord, PartialOrd, Copy)]
-pub struct DeveloperDocumentId {
+pub struct PublicDocumentId {
     table: TableNumber,
     internal_id: InternalId,
 }
@@ -46,7 +46,7 @@ pub struct DeveloperDocumentId {
 #[derive(Clone, Eq, PartialEq, Hash, Ord, PartialOrd, Copy, Debug)]
 pub struct ResolvedDocumentId {
     pub tablet_id: TabletId,
-    pub developer_id: DeveloperDocumentId,
+    pub document_id: PublicDocumentId,
 }
 
 #[cfg(any(test, feature = "testing"))]
@@ -62,7 +62,7 @@ impl proptest::arbitrary::Arbitrary for InternalDocumentId {
 }
 
 #[cfg(any(test, feature = "testing"))]
-impl proptest::arbitrary::Arbitrary for DeveloperDocumentId {
+impl proptest::arbitrary::Arbitrary for PublicDocumentId {
     type Parameters = ();
 
     type Strategy = impl proptest::strategy::Strategy<Value = Self>;
@@ -81,11 +81,9 @@ impl proptest::arbitrary::Arbitrary for ResolvedDocumentId {
 
     fn arbitrary_with((): Self::Parameters) -> Self::Strategy {
         use proptest::prelude::*;
-        (any::<TabletId>(), any::<DeveloperDocumentId>()).prop_map(|(tablet_id, developer_id)| {
-            Self {
-                tablet_id,
-                developer_id,
-            }
+        (any::<TabletId>(), any::<PublicDocumentId>()).prop_map(|(tablet_id, document_id)| Self {
+            tablet_id,
+            document_id,
         })
     }
 }
@@ -111,7 +109,7 @@ impl InternalDocumentId {
         self.internal_id
     }
 
-    /// How large is the given `DocumentId`?
+    /// How large is the given `PublicDocumentId`?
     pub fn size(&self) -> usize {
         self.table.size() + self.internal_id.size()
     }
@@ -121,14 +119,12 @@ impl InternalDocumentId {
     }
 }
 
-impl DeveloperDocumentId {
-    pub const MAX: DeveloperDocumentId =
-        DeveloperDocumentId::new(TableNumber::MAX, InternalId::MAX);
-    /// Minimum valid [`DeveloperDocumentId`].
-    pub const MIN: DeveloperDocumentId =
-        DeveloperDocumentId::new(TableNumber::MIN, InternalId::MIN);
+impl PublicDocumentId {
+    pub const MAX: PublicDocumentId = PublicDocumentId::new(TableNumber::MAX, InternalId::MAX);
+    /// Minimum valid [`PublicDocumentId`].
+    pub const MIN: PublicDocumentId = PublicDocumentId::new(TableNumber::MIN, InternalId::MIN);
 
-    /// Create a new [`DeveloperDocumentId`] from a [`TableNumber`] and an
+    /// Create a new [`PublicDocumentId`] from a [`TableNumber`] and an
     /// [`InternalId`].
     pub const fn new(table: TableNumber, internal_id: InternalId) -> Self {
         Self { table, internal_id }
@@ -144,7 +140,7 @@ impl DeveloperDocumentId {
         self.internal_id
     }
 
-    /// How large is the given `DocumentId`?
+    /// How large is the given `PublicDocumentId`?
     pub fn size(&self) -> usize {
         self.table.size() + self.internal_id.size()
     }
@@ -160,7 +156,7 @@ impl Debug for InternalDocumentId {
     }
 }
 
-impl Debug for DeveloperDocumentId {
+impl Debug for PublicDocumentId {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{self}")
     }
@@ -172,8 +168,8 @@ impl From<InternalDocumentId> for String {
     }
 }
 
-impl From<DeveloperDocumentId> for String {
-    fn from(id: DeveloperDocumentId) -> Self {
+impl From<PublicDocumentId> for String {
+    fn from(id: PublicDocumentId) -> Self {
         id.table().document_id_to_string(id.internal_id)
     }
 }
@@ -184,8 +180,8 @@ impl From<InternalDocumentId> for JsonValue {
     }
 }
 
-impl From<DeveloperDocumentId> for JsonValue {
-    fn from(id: DeveloperDocumentId) -> JsonValue {
+impl From<PublicDocumentId> for JsonValue {
+    fn from(id: PublicDocumentId) -> JsonValue {
         serde_json::Value::String(id.into())
     }
 }
@@ -196,7 +192,7 @@ impl Display for InternalDocumentId {
     }
 }
 
-impl Display for DeveloperDocumentId {
+impl Display for PublicDocumentId {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", String::from(*self))
     }
@@ -229,7 +225,7 @@ impl HeapSize for InternalDocumentId {
     }
 }
 
-impl HeapSize for DeveloperDocumentId {
+impl HeapSize for PublicDocumentId {
     fn heap_size(&self) -> usize {
         self.table.heap_size()
     }
@@ -237,27 +233,27 @@ impl HeapSize for DeveloperDocumentId {
 
 impl From<ResolvedDocumentId> for InternalDocumentId {
     fn from(value: ResolvedDocumentId) -> Self {
-        InternalDocumentId::new(value.tablet_id, value.developer_id.internal_id)
+        InternalDocumentId::new(value.tablet_id, value.document_id.internal_id)
     }
 }
 
 impl ResolvedDocumentId {
     pub const MIN: ResolvedDocumentId =
-        ResolvedDocumentId::new(TabletId::MIN, DeveloperDocumentId::MIN);
+        ResolvedDocumentId::new(TabletId::MIN, PublicDocumentId::MIN);
 
-    pub const fn new(tablet_id: TabletId, developer_id: DeveloperDocumentId) -> Self {
+    pub const fn new(tablet_id: TabletId, document_id: PublicDocumentId) -> Self {
         Self {
             tablet_id,
-            developer_id,
+            document_id,
         }
     }
 
     pub fn internal_id(&self) -> InternalId {
-        self.developer_id.internal_id
+        self.document_id.internal_id
     }
 
     pub fn size(&self) -> usize {
-        self.tablet_id.size() + self.developer_id.size()
+        self.tablet_id.size() + self.document_id.size()
     }
 }
 
@@ -269,7 +265,7 @@ impl HeapSize for ResolvedDocumentId {
 
 impl Display for ResolvedDocumentId {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.developer_id)
+        write!(f, "{}", self.document_id)
     }
 }
 
@@ -277,7 +273,7 @@ impl InternalDocumentId {
     pub fn to_resolved(&self, table_number: TableNumber) -> ResolvedDocumentId {
         ResolvedDocumentId {
             tablet_id: self.table,
-            developer_id: DeveloperDocumentId::new(table_number, self.internal_id),
+            document_id: PublicDocumentId::new(table_number, self.internal_id),
         }
     }
 }

--- a/crates/value/src/export.rs
+++ b/crates/value/src/export.rs
@@ -10,8 +10,8 @@ use serde_json::{
 };
 
 use crate::{
-    ConvexObject,
     ConvexValue,
+    DocumentObject,
     FieldName,
 };
 
@@ -72,7 +72,7 @@ impl ValueFormat {
     }
 }
 
-impl ConvexObject {
+impl DocumentObject {
     pub fn export(self, value_format: ValueFormat) -> JsonValue {
         let v: serde_json::Map<_, _> = self
             .into_iter()

--- a/crates/value/src/id_v6.rs
+++ b/crates/value/src/id_v6.rs
@@ -12,7 +12,7 @@ use std::str::FromStr;
 
 use thiserror::Error;
 
-pub use crate::document_id::DeveloperDocumentId;
+pub use crate::document_id::PublicDocumentId;
 use crate::{
     base32::{
         self,
@@ -55,7 +55,7 @@ pub enum IdDecodeError {
     InvalidIdVersion(u16, u16),
 }
 
-impl DeveloperDocumentId {
+impl PublicDocumentId {
     pub fn encoded_len(&self) -> usize {
         let byte_length = vint_len(self.table().into()) + 16 + 2;
         base32::encoded_len(byte_length)
@@ -135,7 +135,7 @@ impl DeveloperDocumentId {
             return Err(IdDecodeError::InvalidLength(s.len()));
         }
 
-        let id = DeveloperDocumentId::new(table_number, internal_id);
+        let id = PublicDocumentId::new(table_number, internal_id);
 
         // Check that decoding was one-to-one.
         // TODO: Checking base32 decoding above alone isn't sufficient, see
@@ -154,22 +154,22 @@ impl DeveloperDocumentId {
     ) -> anyhow::Result<ResolvedDocumentId> {
         Ok(ResolvedDocumentId {
             tablet_id: f(self.table())?,
-            developer_id: *self,
+            document_id: *self,
         })
     }
 }
 
-impl From<ResolvedDocumentId> for DeveloperDocumentId {
+impl From<ResolvedDocumentId> for PublicDocumentId {
     fn from(document_id: ResolvedDocumentId) -> Self {
-        document_id.developer_id
+        document_id.document_id
     }
 }
 
-impl FromStr for DeveloperDocumentId {
+impl FromStr for PublicDocumentId {
     type Err = IdDecodeError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        DeveloperDocumentId::decode(s)
+        PublicDocumentId::decode(s)
     }
 }
 
@@ -278,8 +278,8 @@ mod tests {
             vint_encode,
             vint_len,
         },
-        DeveloperDocumentId,
         InternalId,
+        PublicDocumentId,
     };
 
     #[test]
@@ -289,7 +289,7 @@ mod tests {
             internal_id[i] = internal_id[i - 1].wrapping_mul(251);
         }
         let document_id =
-            DeveloperDocumentId::new(1017.try_into().unwrap(), InternalId::from(internal_id));
+            PublicDocumentId::new(1017.try_into().unwrap(), InternalId::from(internal_id));
         assert_eq!(
             document_id.encode(),
             "z43zp6c3e75gkmz1kfwj6mbbx5sw281h".to_string()
@@ -302,7 +302,7 @@ mod tests {
         // table code ends up taking two bytes, which then causes parsing to
         // fail downstream. This is a regression test where we used to panic in
         // this condition.
-        let _ = DeveloperDocumentId::decode("sssswsgggggggggsgcsssfafffsffks");
+        let _ = PublicDocumentId::decode("sssswsgggggggggsgcsssfafffsffks");
     }
 
     proptest! {
@@ -328,33 +328,33 @@ mod tests {
         }
 
         #[test]
-        fn proptest_document_idv6(id in any::<DeveloperDocumentId>()) {
-            assert_eq!(DeveloperDocumentId::decode(&id.encode()).unwrap(), id);
+        fn proptest_document_idv6(id in any::<PublicDocumentId>()) {
+            assert_eq!(PublicDocumentId::decode(&id.encode()).unwrap(), id);
         }
 
         #[test]
-        fn proptest_encoded_len(id in any::<DeveloperDocumentId>()) {
+        fn proptest_encoded_len(id in any::<PublicDocumentId>()) {
             assert_eq!(id.encode().len(), id.encoded_len());
         }
 
         #[test]
         fn proptest_decode_invalid_string(s in any::<String>()) {
             // Check that we don't panic on any input string.
-            let _ = DeveloperDocumentId::decode(&s);
+            let _ = PublicDocumentId::decode(&s);
         }
 
         #[test]
         fn proptest_decode_invalid_bytes(bytes in prop::collection::vec(any::<u8>(), 19..=23)) {
             // Generate bytestrings that pass the first few checks in decode to get more code
             // coverage for later panics.
-            let _ = DeveloperDocumentId::decode(&crate::base32::encode(&bytes));
+            let _ = PublicDocumentId::decode(&crate::base32::encode(&bytes));
         }
 
         #[test]
         fn proptest_id_decoding_one_to_one(
             s in "[0123456789abcdefghjkmnpqrstvwxyz]{31,37}"
         ) {
-            if let Ok(id) = DeveloperDocumentId::decode(&s) {
+            if let Ok(id) = PublicDocumentId::decode(&s) {
                 assert_eq!(id.encode(), s);
             }
         }
@@ -363,6 +363,6 @@ mod tests {
     #[test]
     fn test_id_decoding_one_to_one() {
         let s = "mz1xn7tymdnktmmzqy5xxhn7tjs2nkkfmtjjr";
-        DeveloperDocumentId::decode(s).unwrap_err();
+        PublicDocumentId::decode(s).unwrap_err();
     }
 }

--- a/crates/value/src/json/mod.rs
+++ b/crates/value/src/json/mod.rs
@@ -36,7 +36,7 @@ use crate::{
         integer::JsonInteger,
     },
     numeric::is_negative_zero,
-    object::ConvexObject,
+    object::DocumentObject,
     walk::ConvexValueType,
     ConvexArray,
     ConvexValue,
@@ -169,23 +169,23 @@ pub mod object {
 
     use crate::{
         walk::ConvexValueType,
-        ConvexObject,
         ConvexValue,
+        DocumentObject,
     };
 
     pub fn serialize<S: Serializer>(
-        object: &ConvexObject,
+        object: &DocumentObject,
         serializer: S,
     ) -> Result<S::Ok, S::Error> {
         super::value::serialize(ConvexValueType::<&ConvexValue>::Object(object), serializer)
     }
 
-    pub fn deserialize<'de, D>(deserializer: D) -> Result<ConvexObject, D::Error>
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<DocumentObject, D::Error>
     where
         D: Deserializer<'de>,
     {
         let value = JsonValue::deserialize(deserializer)?;
-        ConvexObject::try_from(value).map_err(serde::de::Error::custom)
+        DocumentObject::try_from(value).map_err(serde::de::Error::custom)
     }
 }
 
@@ -236,7 +236,7 @@ impl TryFrom<JsonValue> for ConvexValue {
                             }
                             Self::from(n)
                         },
-                        _ => Self::Object(ConvexObject::for_value(
+                        _ => Self::Object(DocumentObject::for_value(
                             key.parse()?,
                             Self::try_from(value)?,
                         )?),
@@ -262,7 +262,7 @@ impl TryFrom<JsonValue> for ConvexArray {
     }
 }
 
-impl TryFrom<JsonValue> for ConvexObject {
+impl TryFrom<JsonValue> for DocumentObject {
     type Error = anyhow::Error;
 
     fn try_from(object: JsonValue) -> anyhow::Result<Self> {
@@ -287,13 +287,13 @@ impl ConvexValue {
     }
 }
 
-impl From<ConvexObject> for JsonValue {
-    fn from(value: ConvexObject) -> Self {
+impl From<DocumentObject> for JsonValue {
+    fn from(value: DocumentObject) -> Self {
         value.to_internal_json()
     }
 }
 
-impl ConvexObject {
+impl DocumentObject {
     pub fn to_internal_json(&self) -> JsonValue {
         value::serialize(
             ConvexValueType::<&ConvexValue>::Object(self),

--- a/crates/value/src/lib.rs
+++ b/crates/value/src/lib.rs
@@ -61,9 +61,9 @@ pub use crate::{
     array::ConvexArray,
     bytes::ConvexBytes,
     document_id::{
-        DeveloperDocumentId,
         InternalDocumentId,
         InternalId,
+        PublicDocumentId,
         ResolvedDocumentId,
     },
     field_name::{
@@ -94,7 +94,7 @@ pub use crate::{
         remove_string,
         remove_vec,
         remove_vec_of_strings,
-        ConvexObject,
+        DocumentObject,
         MAX_OBJECT_FIELDS,
     },
     size::{
@@ -126,7 +126,7 @@ pub mod testing {
     pub use sync_types::testing::assert_roundtrips;
 }
 
-/// The various types that can be stored as a field in a [`ConvexObject`].
+/// The various types that can be stored as a field in a [`DocumentObject`].
 #[derive(Clone, Debug)]
 pub enum ConvexValue {
     /// Sentinel `Null` value.
@@ -156,7 +156,7 @@ pub enum ConvexValue {
 
     /// Nested object with [`FieldName`] keys and (potentially heterogenous)
     /// values.
-    Object(ConvexObject),
+    Object(DocumentObject),
 }
 
 impl ConvexValue {
@@ -167,20 +167,20 @@ impl ConvexValue {
     }
 }
 
-impl From<ConvexObject> for ConvexValue {
-    fn from(o: ConvexObject) -> ConvexValue {
+impl From<DocumentObject> for ConvexValue {
+    fn from(o: DocumentObject) -> ConvexValue {
         ConvexValue::Object(o)
     }
 }
 
 impl From<ResolvedDocumentId> for ConvexValue {
     fn from(value: ResolvedDocumentId) -> Self {
-        DeveloperDocumentId::from(value).into()
+        PublicDocumentId::from(value).into()
     }
 }
 
-impl From<DeveloperDocumentId> for ConvexValue {
-    fn from(value: DeveloperDocumentId) -> Self {
+impl From<PublicDocumentId> for ConvexValue {
+    fn from(value: PublicDocumentId) -> Self {
         ConvexValue::String(
             value
                 .encode()
@@ -190,12 +190,12 @@ impl From<DeveloperDocumentId> for ConvexValue {
     }
 }
 
-impl TryFrom<ConvexValue> for DeveloperDocumentId {
+impl TryFrom<ConvexValue> for PublicDocumentId {
     type Error = anyhow::Error;
 
     fn try_from(value: ConvexValue) -> Result<Self, Self::Error> {
         if let ConvexValue::String(s) = value {
-            DeveloperDocumentId::decode(&s).map_err(|e| anyhow::anyhow!(e))
+            PublicDocumentId::decode(&s).map_err(|e| anyhow::anyhow!(e))
         } else {
             Err(anyhow::anyhow!("Value is not an ID"))
         }
@@ -323,7 +323,7 @@ impl TryFrom<ConvexValue> for ConvexArray {
     }
 }
 
-impl TryFrom<ConvexValue> for ConvexObject {
+impl TryFrom<ConvexValue> for DocumentObject {
     type Error = Error;
 
     fn try_from(v: ConvexValue) -> anyhow::Result<Self> {
@@ -582,14 +582,14 @@ pub mod proptest {
         S: Strategy<Value = FieldName> + 'static,
     {
         use crate::{
-            id_v6::DeveloperDocumentId,
+            id_v6::PublicDocumentId,
             resolved_object_strategy,
             ConvexArray,
         };
 
         // https://altsysrq.github.io/proptest-book/proptest/tutorial/recursive.html
         let leaf = prop_oneof![
-            1 => any::<DeveloperDocumentId>()
+            1 => any::<PublicDocumentId>()
                 .prop_map(|id| {
                     let s = id.encode().try_into().expect("Could not create String value from ID");
                     ConvexValue::String(s)
@@ -605,7 +605,7 @@ pub mod proptest {
                     }
                 }),
             1 => any::<bool>().prop_map(ConvexValue::from),
-            1 => any::<ConvexString>().prop_filter_map("String ID", |s| match DeveloperDocumentId::decode(&s) {
+            1 => any::<ConvexString>().prop_filter_map("String ID", |s| match PublicDocumentId::decode(&s) {
                 Ok(_) => None,
                 Err(_) => Some(ConvexValue::String(s))
             }),

--- a/crates/value/src/macros.rs
+++ b/crates/value/src/macros.rs
@@ -200,14 +200,14 @@ macro_rules! val {
     };
 
     ({}) => {
-        $crate::ConvexValue::Object($crate::ConvexObject::empty())
+        $crate::ConvexValue::Object($crate::DocumentObject::empty())
     };
 
     ({ $($tt:tt)+ }) => {
         $crate::ConvexValue::Object({
             let mut object = std::collections::BTreeMap::new();
             val!(@object object () ($($tt)+) ($($tt)+));
-            $crate::ConvexObject::try_from(object)?
+            $crate::DocumentObject::try_from(object)?
         })
     };
 
@@ -243,12 +243,12 @@ macro_rules! val_expect_expr_comma {
 /// object.
 macro_rules! obj {
     () => ({
-        anyhow::Ok($crate::ConvexObject::empty())
+        anyhow::Ok($crate::DocumentObject::empty())
     });
     ( $($tt:tt)+ ) => ({
         let mut object = std::collections::BTreeMap::new();
         val!(@object object () ($($tt)+) ($($tt)+));
-        $crate::ConvexObject::try_from(object)
+        $crate::DocumentObject::try_from(object)
     });
 }
 
@@ -266,7 +266,7 @@ macro_rules! assert_val {
 #[macro_export(local_inner_macros)]
 macro_rules! assert_obj {
     () => ({
-        $crate::ConvexObject::empty()
+        $crate::DocumentObject::empty()
     });
     ( $($tt:tt)+ ) => ({
         try bikeshed anyhow::Result<_> {

--- a/crates/value/src/object.rs
+++ b/crates/value/src/object.rs
@@ -32,7 +32,7 @@ pub const MAX_OBJECT_FIELDS: usize = 1024;
 /// map, and then use `Object::try_from` to convert it back to an object. This
 /// ensures that we check the object invariants after the modifications.
 #[derive(Clone, Debug)]
-pub struct ConvexObject {
+pub struct DocumentObject {
     // Precomputed 1 + (len(field1) + 1) + size(v1) + ... + (len(fieldN) + 1) + size(vN) + 1
     size: usize,
     // Precomputed 1 + max(nesting(v1), ..., nesting(vN))
@@ -41,7 +41,7 @@ pub struct ConvexObject {
     fields: BTreeMap<FieldName, ConvexValue>,
 }
 
-impl PartialEq for ConvexObject {
+impl PartialEq for DocumentObject {
     fn eq(&self, other: &Self) -> bool {
         if self.fields == other.fields {
             // We're just comparing based on fields but make sure the derived data always
@@ -54,9 +54,9 @@ impl PartialEq for ConvexObject {
     }
 }
 
-impl Eq for ConvexObject {}
+impl Eq for DocumentObject {}
 
-impl TryFrom<BTreeMap<FieldName, ConvexValue>> for ConvexObject {
+impl TryFrom<BTreeMap<FieldName, ConvexValue>> for DocumentObject {
     type Error = anyhow::Error;
 
     fn try_from(fields: BTreeMap<FieldName, ConvexValue>) -> anyhow::Result<Self> {
@@ -86,7 +86,7 @@ impl TryFrom<BTreeMap<FieldName, ConvexValue>> for ConvexObject {
     }
 }
 
-impl ConvexObject {
+impl DocumentObject {
     /// Create an empty object.
     pub fn empty() -> Self {
         Self {
@@ -153,7 +153,7 @@ impl ConvexObject {
     ///     job: "mechanic",
     ///     age: 42,
     ///   }`.
-    pub fn shallow_merge(self, other: ConvexObject) -> anyhow::Result<Self> {
+    pub fn shallow_merge(self, other: DocumentObject) -> anyhow::Result<Self> {
         let mut self_fields: BTreeMap<_, _> = self.into();
         let other_fields: BTreeMap<_, _> = other.into();
 
@@ -177,7 +177,7 @@ impl ConvexObject {
     }
 }
 
-impl IntoIterator for ConvexObject {
+impl IntoIterator for DocumentObject {
     type IntoIter = std::collections::btree_map::IntoIter<FieldName, ConvexValue>;
     type Item = (FieldName, ConvexValue);
 
@@ -186,19 +186,19 @@ impl IntoIterator for ConvexObject {
     }
 }
 
-impl fmt::Display for ConvexObject {
+impl fmt::Display for DocumentObject {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         display_map(f, ["{", "}"], self.iter())
     }
 }
 
-impl From<ConvexObject> for BTreeMap<FieldName, ConvexValue> {
-    fn from(o: ConvexObject) -> Self {
+impl From<DocumentObject> for BTreeMap<FieldName, ConvexValue> {
+    fn from(o: DocumentObject) -> Self {
         o.fields
     }
 }
 
-// Helpers for parsing ConvexObject.
+// Helpers for parsing DocumentObject.
 pub fn remove_string(
     fields: &mut BTreeMap<FieldName, ConvexValue>,
     field: &str,
@@ -250,7 +250,7 @@ pub fn remove_nullable_int64(
     }
 }
 
-pub fn remove_object<E, T: TryFrom<ConvexObject, Error = E>>(
+pub fn remove_object<E, T: TryFrom<DocumentObject, Error = E>>(
     fields: &mut BTreeMap<FieldName, ConvexValue>,
     field: &str,
 ) -> anyhow::Result<T>
@@ -262,7 +262,7 @@ where
         v => anyhow::bail!("expected object for {field}, got {v:?}"),
     }
 }
-pub fn remove_nullable_object<E, T: TryFrom<ConvexObject, Error = E>>(
+pub fn remove_nullable_object<E, T: TryFrom<DocumentObject, Error = E>>(
     fields: &mut BTreeMap<FieldName, ConvexValue>,
     field: &str,
 ) -> anyhow::Result<Option<T>>
@@ -327,7 +327,7 @@ pub fn remove_nullable_vec_of_strings(
     ))
 }
 
-impl Size for ConvexObject {
+impl Size for DocumentObject {
     fn size(&self) -> usize {
         self.size
     }
@@ -337,7 +337,7 @@ impl Size for ConvexObject {
     }
 }
 
-impl Deref for ConvexObject {
+impl Deref for DocumentObject {
     type Target = BTreeMap<FieldName, ConvexValue>;
 
     fn deref(&self) -> &Self::Target {
@@ -345,7 +345,7 @@ impl Deref for ConvexObject {
     }
 }
 
-impl Hash for ConvexObject {
+impl Hash for DocumentObject {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
         self.fields.hash(state);
     }
@@ -355,7 +355,7 @@ impl Hash for ConvexObject {
 mod proptest {
     use proptest::prelude::*;
 
-    use super::ConvexObject;
+    use super::DocumentObject;
     use crate::{
         field_name::FieldName,
         proptest::{
@@ -365,7 +365,7 @@ mod proptest {
         ConvexValue,
     };
 
-    impl Arbitrary for ConvexObject {
+    impl Arbitrary for DocumentObject {
         type Parameters = (
             prop::collection::SizeRange,
             <FieldName as Arbitrary>::Parameters,
@@ -373,7 +373,7 @@ mod proptest {
             RestrictNaNs,
         );
 
-        type Strategy = impl Strategy<Value = ConvexObject>;
+        type Strategy = impl Strategy<Value = DocumentObject>;
 
         fn arbitrary_with(
             (size, field_params, branching, restrict_nans): Self::Parameters,
@@ -390,10 +390,10 @@ mod proptest {
         field_strategy: impl Strategy<Value = FieldName>,
         value_strategy: impl Strategy<Value = ConvexValue>,
         size: impl Into<prop::collection::SizeRange>,
-    ) -> impl Strategy<Value = ConvexObject> {
+    ) -> impl Strategy<Value = DocumentObject> {
         prop::collection::btree_map(field_strategy, value_strategy, size)
             .prop_filter_map("Map wasn't a valid Convex value", |s| {
-                ConvexObject::try_from(s).ok()
+                DocumentObject::try_from(s).ok()
             })
     }
 }

--- a/crates/value/src/serde/de.rs
+++ b/crates/value/src/serde/de.rs
@@ -24,8 +24,8 @@ use crate::{
         ConvexValueType,
         ConvexValueWalker,
     },
-    ConvexObject,
     ConvexValue,
+    DocumentObject,
 };
 
 #[derive(thiserror::Error)]
@@ -799,7 +799,7 @@ where
     }
 }
 
-pub fn from_object<T: DeserializeOwned>(object: ConvexObject) -> anyhow::Result<T> {
+pub fn from_object<T: DeserializeOwned>(object: DocumentObject) -> anyhow::Result<T> {
     from_value(ConvexValueType::<ConvexValue>::Object(object))
 }
 

--- a/crates/value/src/serde/mod.rs
+++ b/crates/value/src/serde/mod.rs
@@ -16,7 +16,7 @@ use serde::{
     Serialize,
 };
 
-use crate::ConvexObject;
+use crate::DocumentObject;
 
 pub trait ConvexSerializable: Sized {
     type Serialized: Serialize
@@ -31,10 +31,10 @@ macro_rules! codegen_convex_serialization {
         codegen_convex_serialization!($struct, $serialized_struct, test_cases = 256);
     };
     ($struct:ident, $serialized_struct:ident, test_cases = $test_cases:expr) => {
-        impl TryFrom<$struct> for value::ConvexObject {
+        impl TryFrom<$struct> for value::DocumentObject {
             type Error = anyhow::Error;
 
-            fn try_from(s: $struct) -> anyhow::Result<value::ConvexObject> {
+            fn try_from(s: $struct) -> anyhow::Result<value::DocumentObject> {
                 value::serde::to_object($serialized_struct::try_from(s)?)
             }
         }
@@ -43,14 +43,14 @@ macro_rules! codegen_convex_serialization {
             type Error = anyhow::Error;
 
             fn try_from(s: $struct) -> anyhow::Result<value::ConvexValue> {
-                Ok(value::ConvexObject::try_from(s)?.into())
+                Ok(value::DocumentObject::try_from(s)?.into())
             }
         }
 
-        impl TryFrom<value::ConvexObject> for $struct {
+        impl TryFrom<value::DocumentObject> for $struct {
             type Error = anyhow::Error;
 
-            fn try_from(s: value::ConvexObject) -> anyhow::Result<$struct> {
+            fn try_from(s: value::DocumentObject) -> anyhow::Result<$struct> {
                 let r = value::serde::from_object::<$serialized_struct>(s)?.try_into()?;
                 Ok(r)
             }
@@ -60,7 +60,7 @@ macro_rules! codegen_convex_serialization {
             type Error = anyhow::Error;
 
             fn try_from(s: value::ConvexValue) -> anyhow::Result<$struct> {
-                value::ConvexObject::try_from(s)?.try_into()
+                value::DocumentObject::try_from(s)?.try_into()
             }
         }
 
@@ -89,7 +89,7 @@ macro_rules! codegen_convex_serialization {
                     proptest::test_runner::TestRunner::new(config)
                         .run(&any::<S>(), |left| {
                             let right = S::try_from(
-                                value::ConvexObject::try_from(left.clone()).unwrap()
+                                value::DocumentObject::try_from(left.clone()).unwrap()
                             ).unwrap();
                             prop_assert_eq!(left, right);
                             Ok(())
@@ -102,7 +102,7 @@ macro_rules! codegen_convex_serialization {
 }
 
 /// For forwards compatibility on enums, it's often useful to preserve an
-/// unknown variant as a raw `ConvexObject`. To do so, wrap your enum in this
+/// unknown variant as a raw `DocumentObject`. To do so, wrap your enum in this
 /// struct:
 /// ```ignore,rust
 /// #[derive(Serialize, Deserialize)]
@@ -129,5 +129,5 @@ macro_rules! codegen_convex_serialization {
 #[serde(untagged)]
 pub enum WithUnknown<T> {
     Known(T),
-    Unknown(ConvexObject),
+    Unknown(DocumentObject),
 }

--- a/crates/value/src/serde/ser.rs
+++ b/crates/value/src/serde/ser.rs
@@ -16,8 +16,8 @@ use serde::{
 };
 
 use crate::{
-    ConvexObject,
     ConvexValue,
+    DocumentObject,
     FieldName,
 };
 
@@ -670,6 +670,6 @@ pub fn to_value<T: Serialize>(value: T) -> anyhow::Result<ConvexValue> {
     }
 }
 
-pub fn to_object<T: Serialize>(value: T) -> anyhow::Result<ConvexObject> {
+pub fn to_object<T: Serialize>(value: T) -> anyhow::Result<DocumentObject> {
     to_value(value)?.try_into()
 }

--- a/crates/value/src/serde/value.rs
+++ b/crates/value/src/serde/value.rs
@@ -12,8 +12,8 @@ use serde::{
 
 use crate::{
     ConvexArray,
-    ConvexObject,
     ConvexValue,
+    DocumentObject,
     FieldName,
 };
 
@@ -35,7 +35,7 @@ impl Serialize for ConvexValue {
     }
 }
 
-impl Serialize for ConvexObject {
+impl Serialize for DocumentObject {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
@@ -157,8 +157,8 @@ impl<'de> Deserialize<'de> for ConvexValue {
     }
 }
 
-impl<'de> Deserialize<'de> for ConvexObject {
-    fn deserialize<D>(deserializer: D) -> Result<ConvexObject, D::Error>
+impl<'de> Deserialize<'de> for DocumentObject {
+    fn deserialize<D>(deserializer: D) -> Result<DocumentObject, D::Error>
     where
         D: serde::Deserializer<'de>,
     {

--- a/crates/value/src/sorting.rs
+++ b/crates/value/src/sorting.rs
@@ -123,7 +123,7 @@ pub mod sorting_decode {
     use bytes::Buf;
 
     use super::*;
-    use crate::ConvexObject;
+    use crate::DocumentObject;
 
     fn read_escaped_string<R: Buf>(reader: &mut R) -> anyhow::Result<String> {
         Ok(String::from_utf8(read_escaped_bytes(reader)?)?)
@@ -272,7 +272,7 @@ pub mod sorting_decode {
                             anyhow::bail!("Duplicate element in encoded object");
                         }
                     }
-                    ConvexValue::Object(ConvexObject::try_from(elements)?)
+                    ConvexValue::Object(DocumentObject::try_from(elements)?)
                 },
 
                 ESCAPE_BYTE => bail!("Escape code used as tag"),
@@ -518,7 +518,7 @@ mod tests {
     use proptest::prelude::*;
 
     use crate::{
-        id_v6::DeveloperDocumentId,
+        id_v6::PublicDocumentId,
         sorting::{
             sorting_decode::bytes_to_values,
             TotalOrdF64,
@@ -526,9 +526,9 @@ mod tests {
         values_to_bytes,
         ConvexArray,
         ConvexBytes,
-        ConvexObject,
         ConvexString,
         ConvexValue,
+        DocumentObject,
         InternalId,
         ResolvedDocumentId,
         TableNumber,
@@ -540,7 +540,7 @@ mod tests {
         // The random portion of this ID starts with the 0xFF byte which
         // used to break our sorting serialization.
         let id_str = "074wwt1x3qmwz35bvscy44eq2yngrt8";
-        let id = DeveloperDocumentId::decode(id_str)?;
+        let id = PublicDocumentId::decode(id_str)?;
         let trophies = vec![ConvexValue::from(-1), ConvexValue::from(id)];
         for v in trophies {
             assert_eq!(
@@ -588,7 +588,7 @@ mod tests {
         }
 
         #[test]
-        fn test_id_roundtrips(v in any::<DeveloperDocumentId>()) {
+        fn test_id_roundtrips(v in any::<PublicDocumentId>()) {
             let v: ConvexValue = v.into();
             assert_eq!(ConvexValue::read_sort_key(&mut &v.sort_key()[..]).unwrap(), v);
         }
@@ -626,8 +626,8 @@ mod tests {
 
         #[test]
         fn test_compatible_with_id_string(
-            l in any::<DeveloperDocumentId>(),
-            r in any::<DeveloperDocumentId>(),
+            l in any::<PublicDocumentId>(),
+            r in any::<PublicDocumentId>(),
         )  {
             test_compatible_with_ord(l.encode(), r.encode())
         }
@@ -638,11 +638,11 @@ mod tests {
             let table_number = TableNumber::MIN;
             let l = ResolvedDocumentId {
                 tablet_id,
-                developer_id: DeveloperDocumentId::new(table_number, l),
+                document_id: PublicDocumentId::new(table_number, l),
             };
             let r = ResolvedDocumentId {
                 tablet_id,
-                developer_id: DeveloperDocumentId::new(table_number, r),
+                document_id: PublicDocumentId::new(table_number, r),
             };
             test_compatible_with_ord(ConvexValue::from(l), ConvexValue::from(r))
         }
@@ -665,8 +665,8 @@ mod tests {
 
         #[test]
         fn test_compatible_with_object(
-            l in any::<ConvexObject>(),
-            r in any::<ConvexObject>(),
+            l in any::<DocumentObject>(),
+            r in any::<DocumentObject>(),
         )  {
             test_compatible_with_ord(BTreeMap::from(l), BTreeMap::from(r))
         }

--- a/crates/value/src/table_mapping.rs
+++ b/crates/value/src/table_mapping.rs
@@ -6,7 +6,7 @@ use imbl::OrdMap;
 use serde::Serialize;
 
 use crate::{
-    DeveloperDocumentId,
+    PublicDocumentId,
     TableName,
     TableNumber,
     TabletId,
@@ -23,7 +23,7 @@ pub enum TableNamespace {
 
     /// Some tables are namespaced by component, like user tables,
     /// _file_storage, etc.
-    ByComponent(DeveloperDocumentId),
+    ByComponent(PublicDocumentId),
 }
 
 impl TableNamespace {
@@ -37,7 +37,7 @@ impl TableNamespace {
 
     #[cfg(any(test, feature = "testing"))]
     pub const fn test_component() -> Self {
-        Self::ByComponent(DeveloperDocumentId::MIN)
+        Self::ByComponent(PublicDocumentId::MIN)
     }
 
     /// Use this to make it clear that a table pertains to the root component.

--- a/crates/value/src/table_name.rs
+++ b/crates/value/src/table_name.rs
@@ -23,8 +23,8 @@ use crate::{
         check_valid_identifier,
         MIN_IDENTIFIER,
     },
-    DeveloperDocumentId,
     Namespace,
+    PublicDocumentId,
     Size,
 };
 
@@ -207,7 +207,7 @@ impl TableNumber {
     pub const MIN: TableNumber = TableNumber(1);
 
     pub fn document_id_to_string(&self, internal_id: InternalId) -> String {
-        let id_v6 = DeveloperDocumentId::new(*self, internal_id);
+        let id_v6 = PublicDocumentId::new(*self, internal_id);
         id_v6.encode()
     }
 
@@ -228,9 +228,9 @@ pub struct TabletIdAndTableNumber {
 
 impl Size for TableNumber {
     fn size(&self) -> usize {
-        // In order to compute size consistently for both DocumentId<TableName> and
-        // DocumentId<TableId> so it represents the size as stored in persistence,
-        // assume that the size is the maximum internal id size.
+        // In order to compute size consistently for both PublicDocumentId<TableName>
+        // and PublicDocumentId<TableId> so it represents the size as stored in
+        // persistence, assume that the size is the maximum internal id size.
         InternalId::MAX_SIZE
     }
 
@@ -241,9 +241,9 @@ impl Size for TableNumber {
 
 impl Size for TabletId {
     fn size(&self) -> usize {
-        // In order to compute size consistently for both DocumentId<TableName> and
-        // DocumentId<TableId> so it represents the size as stored in persistence,
-        // assume that the size is the maximum internal id size.
+        // In order to compute size consistently for both PublicDocumentId<TableName>
+        // and PublicDocumentId<TableId> so it represents the size as stored in
+        // persistence, assume that the size is the maximum internal id size.
         InternalId::MAX_SIZE
     }
 

--- a/crates/value/src/tests.rs
+++ b/crates/value/src/tests.rs
@@ -6,8 +6,8 @@ use std::{
 use crate::{
     assert_obj,
     obj,
-    ConvexObject,
     ConvexValue,
+    DocumentObject,
     ResolvedDocumentId,
     Size,
 };
@@ -29,28 +29,28 @@ fn test_value_size() -> anyhow::Result<()> {
 #[test]
 fn test_object_cmp() -> anyhow::Result<()> {
     // Equal ignoring order.
-    let o1: ConvexObject = assert_obj!(
+    let o1: DocumentObject = assert_obj!(
         "chambers" => 36,
         "cuban_linx" => 4,
     );
-    let o2: ConvexObject = assert_obj!(
+    let o2: DocumentObject = assert_obj!(
         "cuban_linx" => 4,
         "chambers" => 36,
     );
     assert!(*o1 == *o2);
 
     // Lexicographic ordering on fields.
-    let o1: ConvexObject = assert_obj!(
+    let o1: DocumentObject = assert_obj!(
         "nested" => { "compton" => 187 },
     );
-    let o2: ConvexObject = assert_obj!(
+    let o2: DocumentObject = assert_obj!(
         "nested" => { "bompton" => 187 },
     );
     assert!(*o2 < *o1);
 
     // Ordered on values if same fields.
-    let o1: ConvexObject = assert_obj!("_93_til" => 94);
-    let o2: ConvexObject = assert_obj!("_93_til" => 95);
+    let o1: DocumentObject = assert_obj!("_93_til" => 94);
+    let o2: DocumentObject = assert_obj!("_93_til" => 95);
     assert!(*o1 < *o2);
 
     Ok(())
@@ -59,7 +59,7 @@ fn test_object_cmp() -> anyhow::Result<()> {
 #[test]
 fn test_shallow_merge() -> anyhow::Result<()> {
     // Overwrite objects with non-objects
-    let mut old: ConvexObject = assert_obj!(
+    let mut old: DocumentObject = assert_obj!(
         "name" => {
             "first" => "Mr",
             "last" => {
@@ -84,7 +84,7 @@ fn test_shallow_merge() -> anyhow::Result<()> {
     assert!(*old == *expected);
 
     // Overwrite non-objects with objects
-    let mut old: ConvexObject = assert_obj!(
+    let mut old: DocumentObject = assert_obj!(
         "name" => "Mr",
     );
     let new = assert_obj!(
@@ -103,7 +103,7 @@ fn test_shallow_merge() -> anyhow::Result<()> {
     assert!(*old == *expected);
 
     // Don't merge sub-fields
-    let mut old: ConvexObject = assert_obj!(
+    let mut old: DocumentObject = assert_obj!(
         "name" => {
             "first" => "Mr",
             "last" => "Fantastik",

--- a/crates/value/src/walk.rs
+++ b/crates/value/src/walk.rs
@@ -8,9 +8,9 @@ use std::fmt::{
 use crate::{
     ConvexArray,
     ConvexBytes,
-    ConvexObject,
     ConvexString,
     ConvexValue,
+    DocumentObject,
     FieldName,
 };
 
@@ -92,7 +92,7 @@ impl ConvexValueWalker for ConvexValue {
     type Bytes = ConvexBytes;
     type Error = !;
     type FieldName = FieldName;
-    type Object = ConvexObject;
+    type Object = DocumentObject;
     type String = ConvexString;
 
     fn walk(self) -> Result<ConvexValueType<Self>, !> {
@@ -114,7 +114,7 @@ impl<'a> ConvexValueWalker for &'a ConvexValue {
     type Bytes = &'a ConvexBytes;
     type Error = !;
     type FieldName = &'a FieldName;
-    type Object = &'a ConvexObject;
+    type Object = &'a DocumentObject;
     type String = &'a ConvexString;
 
     fn walk(self) -> Result<ConvexValueType<Self>, !> {
@@ -197,7 +197,7 @@ impl<'a> ConvexArrayWalker for &'a ConvexArray {
     }
 }
 
-impl ConvexObjectWalker for ConvexObject {
+impl ConvexObjectWalker for DocumentObject {
     type Error = !;
     type Walker = ConvexValue;
 
@@ -206,7 +206,7 @@ impl ConvexObjectWalker for ConvexObject {
     }
 }
 
-impl<'a> ConvexObjectWalker for &'a ConvexObject {
+impl<'a> ConvexObjectWalker for &'a DocumentObject {
     type Error = !;
     type Walker = &'a ConvexValue;
 
@@ -216,7 +216,7 @@ impl<'a> ConvexObjectWalker for &'a ConvexObject {
 }
 
 // This impl is useful for callers that already know the concrete type of their
-// ConvexValue (e.g. when holding a `&'a ConvexObject`)
+// ConvexValue (e.g. when holding a `&'a DocumentObject`)
 impl<V: ConvexValueWalker> ConvexValueWalker for ConvexValueType<V> {
     type Array = V::Array;
     type Bytes = V::Bytes;
@@ -244,7 +244,7 @@ impl<'a> ConvexValueWalker for &'a str {
     type Bytes = ConvexBytes;
     type Error = !;
     type FieldName = FieldName;
-    type Object = ConvexObject;
+    type Object = DocumentObject;
     type String = &'a str;
 
     fn walk(self) -> Result<ConvexValueType<Self>, !> {
@@ -257,7 +257,7 @@ impl ConvexValueWalker for ! {
     type Bytes = &'static [u8];
     type Error = !;
     type FieldName = &'static str;
-    type Object = &'static ConvexObject;
+    type Object = &'static DocumentObject;
     type String = &'static str;
 
     fn walk(self) -> Result<ConvexValueType<Self>, Self::Error> {
@@ -270,7 +270,7 @@ impl ConvexValueWalker for i64 {
     type Bytes = &'static [u8];
     type Error = !;
     type FieldName = &'static str;
-    type Object = &'static ConvexObject;
+    type Object = &'static DocumentObject;
     type String = &'static str;
 
     fn walk(self) -> Result<ConvexValueType<Self>, Self::Error> {
@@ -283,7 +283,7 @@ impl ConvexValueWalker for f64 {
     type Bytes = &'static [u8];
     type Error = !;
     type FieldName = &'static str;
-    type Object = &'static ConvexObject;
+    type Object = &'static DocumentObject;
     type String = &'static str;
 
     fn walk(self) -> Result<ConvexValueType<Self>, Self::Error> {

--- a/crates/vector/src/query.rs
+++ b/crates/vector/src/query.rs
@@ -34,7 +34,7 @@ use serde_json::{
     Value as JsonValue,
 };
 use value::{
-    id_v6::DeveloperDocumentId,
+    id_v6::PublicDocumentId,
     ConvexValue,
     FieldPath,
     InternalId,
@@ -464,7 +464,7 @@ impl PartialEq for VectorSearchQueryResult {
 impl VectorSearchQueryResult {
     pub fn to_public(self, table_number: TableNumber) -> PublicVectorSearchQueryResult {
         PublicVectorSearchQueryResult {
-            id: DeveloperDocumentId::new(table_number, self.id),
+            id: PublicDocumentId::new(table_number, self.id),
             score: self.score,
         }
     }
@@ -579,7 +579,7 @@ impl TryFrom<proto::VectorQueryResult> for VectorSearchQueryResult {
 #[cfg_attr(any(test, feature = "testing"), derive(proptest_derive::Arbitrary))]
 pub struct PublicVectorSearchQueryResult {
     pub score: f32,
-    pub id: DeveloperDocumentId,
+    pub id: PublicDocumentId,
 }
 
 impl Size for PublicVectorSearchQueryResult {

--- a/docs/issue-journal.md
+++ b/docs/issue-journal.md
@@ -1,0 +1,149 @@
+# Engineering Issue Journal
+
+This document tracks the concrete distributed-systems issues we hit while
+building horizontal scaling for Convex, how we diagnosed them, how we fixed
+them, and how we validated the fix.
+
+The goal is simple: no important bug should live only in chat history or in
+someone's memory.
+
+## Update Rule
+
+For each meaningful issue, record:
+
+1. **Symptom** — what failed and where it showed up.
+2. **Root Cause** — what was actually wrong in the code or design.
+3. **Fix** — what changed.
+4. **Validation** — exactly which tests or cluster runs confirmed the result.
+5. **Status** — `fixed`, `open`, or `regressed`.
+
+## Validation Policy
+
+For changes that affect clustered behavior, validation is not complete until we
+do all of the following:
+
+1. Build a fresh backend image from the current branch.
+2. Push that exact image to GHCR with a unique tag.
+3. Reset the cluster with `docker compose down -v`.
+4. Start the cluster on that exact image.
+5. Run the full write-scaling suite (`77` tests), and when relevant the full
+   top-level suite (`self-hosted/docker/test.sh`).
+
+Unit and integration tests are still useful, but they are not enough on their
+own for distributed changes.
+
+## Solved Issues
+
+### 2026-04 — Cross-partition OCC was unsound under replication lag
+
+- **Status:** fixed
+- **Related issues:** `#78`, `#84`
+- **Symptom:** cross-partition transactions could commit even when a node had
+  not actually caught up on the remote partition it had read from.
+- **Root Cause:** OCC used a coarse replicated timestamp and could log a
+  warning about lag, then continue anyway. That made validation best-effort
+  instead of strict.
+- **Fix:** track replication freshness per partition, wait for the exact remote
+  partitions read by the transaction to reach the transaction begin timestamp,
+  and reject stale validation paths instead of warning and continuing.
+- **Validation:** targeted database tests covering prepare/commit wait behavior
+  and replication frontier persistence across restart.
+
+### 2026-04 — Remote 2PC `Prepare` over gRPC was missing
+
+- **Status:** fixed
+- **Related issue:** `#79`
+- **Symptom:** cross-partition transactions had coordinator scaffolding, but
+  the real remote participant prepare path was incomplete.
+- **Root Cause:** the coordinator could not send a real participant-local
+  prepare request carrying the correct read/write slice and assigned prepare
+  timestamp over gRPC.
+- **Fix:** implement participant transaction protobufs, database-layer gRPC
+  client/server handling, participant-local validation, prepare timestamp
+  fencing, and coordinator retries for too-low prepare timestamps.
+- **Validation:** database tests covering idempotent remote prepare,
+  cross-partition commit, and rollback on participant failure; `cargo check`
+  for `local_backend`.
+
+### 2026-04 — Forwarded `deploy2` requests failed auth on the metadata owner
+
+- **Status:** fixed
+- **Symptom:** deploys sent to a non-owner node failed once that node forwarded
+  them to the metadata owner. The owner rejected them with invalid admin key
+  errors.
+- **Root Cause:** we changed deploy ownership, but kept per-instance admin-key
+  semantics. The forwarded request arrived at the owner with credentials valid
+  for the original node, not for the owner.
+- **Fix:** authenticate on the receiving node, then forward with owner-valid
+  credentials instead of blindly proxying the original request body.
+- **Validation:** fresh image build and full cluster deploy run; the suite
+  moved past `Deploying functions...` on both nodes and no longer failed with
+  owner auth errors.
+
+### 2026-04 — Idle replication frontier heartbeats polluted write-log state
+
+- **Status:** fixed
+- **Symptom:** heartbeat-style replica deltas that carried no user writes could
+  still advance local write-log state, which then interfered with timestamp and
+  frontier logic.
+- **Root Cause:** no-op replica deltas were treated like real writes for
+  write-log append purposes.
+- **Fix:** publish idle replication frontier heartbeats explicitly, but do not
+  append them to the write log when the delta contains no writes.
+- **Validation:** fresh image build and clean-cluster rerun changed the failure
+  mode away from the earlier heartbeat/write-log corruption path.
+
+### 2026-04 — Queued local table creation could be erased by later replica publish
+
+- **Status:** fixed
+- **Symptom:** on a clean cluster, the write-scaling suite failed in Test 1.
+  All writes reported success, but one node returned `500` for dashboard-style
+  queries and the other only saw one `tasks` row out of three.
+- **Root Cause:** replica deltas were building from the latest published
+  snapshot instead of the latest queued unpublished snapshot. If a local table
+  creation was staged but not yet published, a later replica publish could
+  overwrite the request node’s next visible snapshot with a version that did
+  not include the locally created table. The next local write then recreated
+  `_tables` metadata for the same logical table.
+- **Fix:** make local commits and replica deltas both build on the latest
+  queued snapshot state, not just the latest published snapshot, and add a
+  regression test covering “paused local table creation + replica delta +
+  second local write”.
+- **Validation:** the queued-snapshot regression no longer reproduced, and the
+  full clean-cluster suite later passed end to end on
+  `backend-heartbeat-nonfatal-c2410ab-20260424-101611-dirty`.
+
+### 2026-04 — Idle frontier heartbeat crashed nodes during NATS partition
+
+- **Status:** fixed
+- **Symptom:** the full clean-cluster suite reached Test 26 (`NATS Partition
+  Simulation`), then Node B killed itself and the Raft failover suite could
+  not start cleanly afterward.
+- **Root Cause:** the idle replication frontier heartbeat path asked the
+  timestamp oracle for a fresh timestamp even though it was only trying to
+  advance follower-read safety metadata. When NATS JetStream KV was
+  unavailable, the TSO call timed out and the `?` in the committer loop treated
+  that background heartbeat failure as a fatal process error.
+- **Fix:** keep idle frontier heartbeats best-effort. The committer now logs a
+  warning and skips the heartbeat interval when the TSO is unavailable instead
+  of shutting the node down. A targeted regression test covers the exact
+  failing-oracle path.
+- **Validation:**
+  - `cargo test -p database test_idle_replication_frontier_heartbeat_tso_failure_is_nonfatal`
+  - fresh image build and push:
+    `ghcr.io/martinkalema/convex-horizontal-scaling:backend-heartbeat-nonfatal-c2410ab-20260424-101611-dirty`
+  - pushed digest:
+    `sha256:4894b55eb0fb95e7e5ba95c5be5f740c9fa27996dda5797b693e7f91b0228fc4`
+  - clean-cluster rerun via `self-hosted/docker/test.sh`: all `77` write-scaling
+    tests passed, Test 26 passed, and the Raft failover suite passed.
+
+## Open Issues
+
+None currently tracked in this journal after the latest clean-cluster run.
+
+## Notes
+
+- This journal is intentionally short and high-signal. Deep architectural
+  writeups still belong in the other docs.
+- When an issue is fixed, append the exact validation command set or point to
+  the test suite that proved it.

--- a/self-hosted/docker-build/read_credentials.sh
+++ b/self-hosted/docker-build/read_credentials.sh
@@ -2,17 +2,31 @@
 
 DATA_DIR=${DATA_DIR:-/convex/data}
 CREDENTIALS_DIR=${CREDENTIALS_DIR:-"$DATA_DIR/credentials"}
+SHARED_INSTANCE_SECRET_PATH=${SHARED_INSTANCE_SECRET_PATH:-}
 
 set -e
 mkdir -p "$CREDENTIALS_DIR"
 
 # Set INSTANCE_SECRET by checking in order:
 # 1. Use existing INSTANCE_SECRET env var if set
-# 2. Read from CREDENTIALS_DIR/instance_secret if file exists
-# 3. Generate new random secret if neither exists
+# 2. Read from SHARED_INSTANCE_SECRET_PATH if configured and present
+# 3. Read from CREDENTIALS_DIR/instance_secret if file exists
+# 4. Generate new random secret if none exist
 # Finally, save the secret to disk for persistence
-export INSTANCE_SECRET=${INSTANCE_SECRET:-$(cat "$CREDENTIALS_DIR/instance_secret" 2>/dev/null || openssl rand -hex 32)}
+if [[ -n "$SHARED_INSTANCE_SECRET_PATH" ]]; then
+  mkdir -p "$(dirname "$SHARED_INSTANCE_SECRET_PATH")"
+fi
+
+SHARED_INSTANCE_SECRET=""
+if [[ -n "$SHARED_INSTANCE_SECRET_PATH" ]]; then
+  SHARED_INSTANCE_SECRET=$(cat "$SHARED_INSTANCE_SECRET_PATH" 2>/dev/null || true)
+fi
+
+export INSTANCE_SECRET=${INSTANCE_SECRET:-${SHARED_INSTANCE_SECRET:-$(cat "$CREDENTIALS_DIR/instance_secret" 2>/dev/null || openssl rand -hex 32)}}
 echo "$INSTANCE_SECRET" > "$CREDENTIALS_DIR/instance_secret"
+if [[ -n "$SHARED_INSTANCE_SECRET_PATH" ]]; then
+  echo "$INSTANCE_SECRET" > "$SHARED_INSTANCE_SECRET_PATH"
+fi
 
 # Set INSTANCE_NAME by checking in order:
 # 1. Use existing INSTANCE_NAME env var if set

--- a/self-hosted/docker/docker-compose.yml
+++ b/self-hosted/docker/docker-compose.yml
@@ -31,6 +31,7 @@ x-node-env-common: &node-env-common
   NATS_URL: nats://nats:4222
   GRPC_PORT: "50051"
   CHECKPOINT_STORAGE_PATH: /convex/data/checkpoints
+  SHARED_INSTANCE_SECRET_PATH: /convex/data/storage/cluster_credentials/instance_secret
   REPLICATION_MODE: primary
 
 # ── Infrastructure ─────────────────────────────────────────────────
@@ -122,6 +123,7 @@ services:
       PARTITION_ID: "0"
       PARTITION_MAP: messages=0,users=0,projects=1,tasks=1
       NUM_PARTITIONS: "2"
+      NODE_ADDRESSES: 0=node-p0a:50051,1=node-p1a:50051
       RAFT_NODE_ID: "1"
       RAFT_PEERS: 1=http://node-p0a:50051,2=http://node-p0b:50051,3=http://node-p0c:50051
     depends_on:
@@ -148,6 +150,7 @@ services:
       PARTITION_ID: "0"
       PARTITION_MAP: messages=0,users=0,projects=1,tasks=1
       NUM_PARTITIONS: "2"
+      NODE_ADDRESSES: 0=node-p0a:50051,1=node-p1a:50051
       RAFT_NODE_ID: "2"
       RAFT_PEERS: 1=http://node-p0a:50051,2=http://node-p0b:50051,3=http://node-p0c:50051
       REPLICA_STORAGE_PATH: /convex/data/storage
@@ -175,6 +178,7 @@ services:
       PARTITION_ID: "0"
       PARTITION_MAP: messages=0,users=0,projects=1,tasks=1
       NUM_PARTITIONS: "2"
+      NODE_ADDRESSES: 0=node-p0a:50051,1=node-p1a:50051
       RAFT_NODE_ID: "3"
       RAFT_PEERS: 1=http://node-p0a:50051,2=http://node-p0b:50051,3=http://node-p0c:50051
       REPLICA_STORAGE_PATH: /convex/data/storage
@@ -204,6 +208,7 @@ services:
       PARTITION_ID: "1"
       PARTITION_MAP: messages=0,users=0,projects=1,tasks=1
       NUM_PARTITIONS: "2"
+      NODE_ADDRESSES: 0=node-p0a:50051,1=node-p1a:50051
       RAFT_NODE_ID: "1"
       RAFT_PEERS: 1=http://node-p1a:50051,2=http://node-p1b:50051,3=http://node-p1c:50051
     depends_on:
@@ -230,6 +235,7 @@ services:
       PARTITION_ID: "1"
       PARTITION_MAP: messages=0,users=0,projects=1,tasks=1
       NUM_PARTITIONS: "2"
+      NODE_ADDRESSES: 0=node-p0a:50051,1=node-p1a:50051
       RAFT_NODE_ID: "2"
       RAFT_PEERS: 1=http://node-p1a:50051,2=http://node-p1b:50051,3=http://node-p1c:50051
       REPLICA_STORAGE_PATH: /convex/data/storage
@@ -257,6 +263,7 @@ services:
       PARTITION_ID: "1"
       PARTITION_MAP: messages=0,users=0,projects=1,tasks=1
       NUM_PARTITIONS: "2"
+      NODE_ADDRESSES: 0=node-p0a:50051,1=node-p1a:50051
       RAFT_NODE_ID: "3"
       RAFT_PEERS: 1=http://node-p1a:50051,2=http://node-p1b:50051,3=http://node-p1c:50051
       REPLICA_STORAGE_PATH: /convex/data/storage


### PR DESCRIPTION
## Summary
- add Raft snapshot catch-up and queued-snapshot ordering so replica apply and local commits build on consistent state
- harden cross-partition replication, deploy ownership, and metadata routing across the cluster path
- make idle replication-frontier heartbeats non-fatal under TSO/NATS outages and document the issue/fix history

## Validation
- env PROTOC=/Users/martin/Desktop/convex-horizontal-scaling/crates/pb_build/protoc/protoc-macos-universal cargo test --target-dir /tmp/convex-target-heartbeat-nonfatal -p database test_idle_replication_frontier_heartbeat_tso_failure_is_nonfatal -- --nocapture
- fresh image build and push: ghcr.io/martinkalema/convex-horizontal-scaling:backend-heartbeat-nonfatal-c2410ab-20260424-101611-dirty
- clean cluster reset and full suite: self-hosted/docker/test.sh
- result: ALL 77 TESTS PASSED, ALL 10 TESTS PASSED, ALL SUITES PASSED