### PR TITLE
feat(database): bootstrap fresh replicas from checkpoints

### DIFF
--- a/crates/aws_s3/src/storage.rs
+++ b/crates/aws_s3/src/storage.rs
@@ -239,6 +239,11 @@ impl<RT: Runtime> Storage for S3Storage<RT> {
     #[fastrace::trace]
     async fn start_upload(&self) -> anyhow::Result<Box<BufferedUpload>> {
         let key: ObjectKey = self.runtime.new_uuid_v4().to_string().try_into()?;
+        self.start_upload_with_key(key).await
+    }
+
+    #[fastrace::trace]
+    async fn start_upload_with_key(&self, key: ObjectKey) -> anyhow::Result<Box<BufferedUpload>> {
         let s3_key = S3Key(self.key_prefix.clone() + &key);
         let upload_builder = self
             .client

--- a/crates/common/src/http/fetch.rs
+++ b/crates/common/src/http/fetch.rs
@@ -64,7 +64,9 @@ pub fn build_proxied_reqwest_client(
     client_id: String,
     redirect_policy: reqwest::redirect::Policy,
 ) -> reqwest::Client {
-    let mut builder = reqwest::Client::builder().redirect(redirect_policy);
+    let mut builder = reqwest::Client::builder()
+        .redirect(redirect_policy)
+        .no_proxy();
     // It's okay to panic on these errors, as they indicate a serious programming
     // error -- building the reqwest client is expected to be infallible.
     if let Some(proxy_url) = proxy_url {

--- a/crates/database/src/checkpoint.rs
+++ b/crates/database/src/checkpoint.rs
@@ -21,12 +21,15 @@ use anyhow::Context;
 use async_trait::async_trait;
 use common::{
     document::ResolvedDocument,
+    index::IndexKey,
+    interval::Interval,
     persistence::{
         ConflictStrategy,
         DocumentLogEntry,
         DocumentPrevTsQuery,
         DocumentStream,
         IndexStream,
+        LatestDocument,
         Persistence,
         PersistenceGlobalKey,
         PersistenceIndexEntry,
@@ -267,18 +270,41 @@ impl PersistenceReader for CheckpointPersistence {
     fn index_scan(
         &self,
         _index_id: IndexId,
-        _tablet_id: TabletId,
-        _read_timestamp: Timestamp,
-        _range: &common::interval::Interval,
-        _order: Order,
+        tablet_id: TabletId,
+        read_timestamp: Timestamp,
+        interval: &Interval,
+        order: Order,
         _size_hint: usize,
         _retention_validator: Arc<dyn RetentionValidator>,
     ) -> IndexStream<'_> {
-        // Index scans are not needed during the initial DatabaseSnapshot::load
-        // bootstrap. The bootstrap code loads documents directly via
-        // load_documents and constructs in-memory indexes from them.
-        // If index_scan is called, return empty.
-        stream::empty().boxed()
+        let interval = interval.clone();
+        let inner = self.inner.lock();
+        let mut latest_by_key: BTreeMap<_, (Timestamp, ResolvedDocument, Option<Timestamp>)> =
+            BTreeMap::new();
+
+        for ((ts, id), (document, prev_ts)) in &inner.log {
+            if *ts > read_timestamp || id.table() != tablet_id {
+                continue;
+            }
+            let Some(document) = document.clone() else {
+                continue;
+            };
+            let key = IndexKey::new(vec![], document.document_id()).to_bytes();
+            if !interval.contains(&key) {
+                continue;
+            }
+            latest_by_key.insert(key, (*ts, document, *prev_ts));
+        }
+
+        let mut results: Vec<_> = latest_by_key
+            .into_iter()
+            .map(|(key, (ts, value, prev_ts))| Ok((key, LatestDocument { ts, value, prev_ts })))
+            .collect();
+        if matches!(order, Order::Desc) {
+            results.reverse();
+        }
+
+        stream::iter(results).boxed()
     }
 
     async fn get_persistence_global(

--- a/crates/database/src/committer.rs
+++ b/crates/database/src/committer.rs
@@ -313,7 +313,6 @@ fn compact_checkpoint_documents(checkpoint: &CheckpointData) -> Vec<DocumentLogE
 fn checkpoint_index_entries(
     snapshot: &Snapshot,
     documents: &[DocumentLogEntry],
-    ts: Timestamp,
 ) -> Vec<PersistenceIndexEntry> {
     let mut index_entries = Vec::new();
     for entry in documents {
@@ -331,7 +330,7 @@ fn checkpoint_index_entries(
                 continue;
             };
             index_entries.push(PersistenceIndexEntry {
-                ts,
+                ts: entry.ts,
                 index_id: index.id(),
                 key: index_key.clone(),
                 value: Some(InternalDocumentId::new(
@@ -1755,7 +1754,6 @@ impl<RT: Runtime> Committer<RT> {
                 let index_entries = checkpoint_index_entries(
                     &db_snapshot.snapshot,
                     &compacted_documents,
-                    checkpoint_ts,
                 );
 
                 let mut existing_documents = Vec::new();

--- a/crates/database/src/database.rs
+++ b/crates/database/src/database.rs
@@ -169,7 +169,10 @@ use crate::{
         NUM_RESERVED_LEGACY_TABLE_NUMBERS,
         NUM_RESERVED_SYSTEM_TABLE_NUMBERS,
     },
-    checkpoint::CheckpointData,
+    checkpoint::{
+        create_checkpoint,
+        CheckpointData,
+    },
     committer::{
         Committer,
         CommitterClient,
@@ -1970,28 +1973,8 @@ impl<RT: Runtime> Database<RT> {
     pub async fn build_raft_snapshot_checkpoint(&self) -> anyhow::Result<CheckpointData> {
         let db_snapshot = self.latest_database_snapshot()?;
         let ts = *db_snapshot.timestamp();
-        let mut documents = Vec::new();
-
-        for (tablet_id, index_id) in db_snapshot.index_registry().by_id_indexes() {
-            let mut stream = db_snapshot.persistence_snapshot.index_scan(
-                index_id,
-                tablet_id,
-                &Interval::all(),
-                Order::Asc,
-                usize::MAX,
-            );
-            while let Some((_, latest_document)) = stream.try_next().await? {
-                documents.push(DocumentLogEntry {
-                    ts,
-                    id: value::InternalDocumentId::new(
-                        latest_document.value.id().tablet_id,
-                        latest_document.value.id().internal_id(),
-                    ),
-                    value: Some(latest_document.value),
-                    prev_ts: latest_document.prev_ts,
-                });
-            }
-        }
+        let mut checkpoint = create_checkpoint(self.reader.as_ref(), ts, self.retention_validator())
+            .await?;
 
         let mut globals = BTreeMap::new();
         for key in PersistenceGlobalKey::all_keys() {
@@ -2022,11 +2005,8 @@ impl<RT: Runtime> Database<RT> {
             );
         }
 
-        Ok(CheckpointData {
-            timestamp: ts,
-            documents,
-            globals,
-        })
+        checkpoint.globals = globals;
+        Ok(checkpoint)
     }
 
     pub async fn build_raft_snapshot_bytes(&self) -> anyhow::Result<Vec<u8>> {

--- a/crates/database/src/snapshot_checkpointer.rs
+++ b/crates/database/src/snapshot_checkpointer.rs
@@ -22,11 +22,16 @@ use common::{
         Runtime,
         SpawnHandle,
     },
-    types::Timestamp,
+    types::{
+        ObjectKey,
+        Timestamp,
+    },
 };
+use futures::TryStreamExt;
 use prost::Message;
 use storage::{
     Storage,
+    StorageExt,
     Upload,
 };
 use value::{
@@ -41,6 +46,43 @@ use crate::checkpoint::{
 
 /// How often the Primary writes a new checkpoint.
 const CHECKPOINT_INTERVAL: Duration = Duration::from_secs(30);
+pub const LATEST_CHECKPOINT_KEY: &str = "checkpoint-latest";
+
+fn checkpoint_object_key(ts: Timestamp) -> anyhow::Result<ObjectKey> {
+    format!("checkpoint-{}", u64::from(ts)).try_into()
+}
+
+fn latest_checkpoint_object_key() -> anyhow::Result<ObjectKey> {
+    LATEST_CHECKPOINT_KEY.try_into()
+}
+
+async fn write_storage_object(
+    storage: &Arc<dyn Storage>,
+    key: ObjectKey,
+    bytes: Bytes,
+) -> anyhow::Result<()> {
+    let mut upload = storage.start_upload_with_key(key).await?;
+    upload.write(bytes).await?;
+    let _ = upload.complete().await?;
+    Ok(())
+}
+
+async fn read_storage_object(
+    storage: &Arc<dyn Storage>,
+    key: &ObjectKey,
+) -> anyhow::Result<Option<Vec<u8>>> {
+    let Some(stream) = storage.get(key).await? else {
+        return Ok(None);
+    };
+    let bytes = stream
+        .stream
+        .try_fold(Vec::new(), |mut acc, chunk| async move {
+            acc.extend_from_slice(&chunk);
+            Ok(acc)
+        })
+        .await?;
+    Ok(Some(bytes))
+}
 
 /// Background task that periodically writes checkpoints to object storage.
 pub struct SnapshotCheckpointer {
@@ -111,26 +153,15 @@ impl SnapshotCheckpointer {
         let num_docs = checkpoint.documents.len();
 
         // Serialize to proto bytes.
-        let proto = checkpoint_to_proto(&checkpoint)?;
-        let bytes = proto.encode_to_vec();
+        let bytes = Bytes::from(checkpoint_to_bytes(&checkpoint)?);
 
         tracing::info!(
             "Checkpoint at ts={ts}: {num_docs} documents, {} bytes",
             bytes.len()
         );
 
-        // Upload to storage.
-        let checkpoint_key = format!("checkpoint-{}", u64::from(ts));
-        let mut upload = storage.start_upload().await?;
-        upload.write(Bytes::from(bytes)).await?;
-        let _key = upload.complete().await?;
-
-        // Write the latest pointer.
-        let mut latest_upload = storage.start_upload().await?;
-        latest_upload
-            .write(Bytes::from(checkpoint_key.into_bytes()))
-            .await?;
-        let _ = latest_upload.complete().await?;
+        write_storage_object(storage, checkpoint_object_key(ts)?, bytes.clone()).await?;
+        write_storage_object(storage, latest_checkpoint_object_key()?, bytes).await?;
 
         Ok(ts)
     }
@@ -139,21 +170,13 @@ impl SnapshotCheckpointer {
 /// Load the latest checkpoint from storage.
 /// Called by Replicas at startup to bootstrap their SnapshotManager.
 pub async fn load_latest_checkpoint(
-    _storage: &dyn Storage,
-    persistence_reader: &dyn PersistenceReader,
-    retention_validator: Arc<dyn common::persistence::RetentionValidator>,
+    storage: &Arc<dyn Storage>,
 ) -> anyhow::Result<Option<CheckpointData>> {
-    // For now, create a checkpoint directly from the persistence reader.
-    // In production, this would download from object storage.
-    // The persistence_reader here would point to the Primary's database
-    // (read-only) or the checkpoint would be fetched from S3/R2.
-    let max_ts = match persistence_reader.max_ts().await? {
-        Some(ts) => ts,
-        None => return Ok(None),
+    let latest_key = latest_checkpoint_object_key()?;
+    let Some(bytes) = read_storage_object(storage, &latest_key).await? else {
+        return Ok(None);
     };
-
-    let checkpoint = create_checkpoint(persistence_reader, max_ts, retention_validator).await?;
-    Ok(Some(checkpoint))
+    Ok(Some(checkpoint_from_bytes(&bytes)?))
 }
 
 /// Proto encoding for checkpoint data.
@@ -316,4 +339,56 @@ pub fn checkpoint_from_proto(
 pub fn checkpoint_from_bytes(bytes: &[u8]) -> anyhow::Result<CheckpointData> {
     let proto = checkpoint_proto::CheckpointData::decode(bytes)?;
     checkpoint_from_proto(proto)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        collections::BTreeMap,
+        sync::Arc,
+    };
+
+    use bytes::Bytes;
+    use common::{
+        runtime::testing::TestRuntime,
+        types::Timestamp,
+    };
+    use storage::{
+        LocalDirStorage,
+        Storage,
+        Upload,
+    };
+
+    use super::{
+        checkpoint_to_bytes,
+        load_latest_checkpoint,
+        CheckpointData,
+        LATEST_CHECKPOINT_KEY,
+    };
+
+    #[convex_macro::test_runtime]
+    async fn test_load_latest_checkpoint_reads_stable_latest_object(
+        rt: TestRuntime,
+    ) -> anyhow::Result<()> {
+        let storage: Arc<dyn Storage> = Arc::new(LocalDirStorage::new(rt)?);
+        let checkpoint = CheckpointData {
+            timestamp: Timestamp::try_from(42u64)?,
+            documents: vec![],
+            globals: BTreeMap::new(),
+        };
+
+        let mut upload = storage
+            .start_upload_with_key(LATEST_CHECKPOINT_KEY.try_into()?)
+            .await?;
+        upload
+            .write(Bytes::from(checkpoint_to_bytes(&checkpoint)?))
+            .await?;
+        let _ = upload.complete().await?;
+
+        let loaded = load_latest_checkpoint(&storage).await?.expect("checkpoint should exist");
+        assert_eq!(loaded.timestamp, checkpoint.timestamp);
+        assert!(loaded.documents.is_empty());
+        assert!(loaded.globals.is_empty());
+        Ok(())
+    }
 }

--- a/crates/database/src/subscription.rs
+++ b/crates/database/src/subscription.rs
@@ -55,6 +55,7 @@ use futures::{
     StreamExt as _,
 };
 use interval_map::IntervalMap;
+use itertools::Itertools;
 use parking_lot::Mutex;
 use prometheus::VMHistogram;
 use search::query::TextSearchSubscriptions;
@@ -265,9 +266,42 @@ impl CountingReceiver {
 }
 
 impl SubscriptionManager {
+    fn reanchor_if_log_rewound(&mut self) -> anyhow::Result<bool> {
+        let log_max_ts = self.log.max_ts();
+        if log_max_ts >= self.processed_ts {
+            return Ok(false);
+        }
+
+        tracing::warn!(
+            manager_id = self.manager_id,
+            old_processed_ts = %self.processed_ts,
+            new_log_max_ts = %log_max_ts,
+            num_subscribers = self.subscribers.len(),
+            "Subscription worker detected write-log rewind; invalidating derived subscriptions \
+             and re-anchoring to the new log base"
+        );
+
+        let subscriber_ids = self.subscribers.iter().map(|(id, _)| id).collect_vec();
+        self.closed_subscriptions = FuturesUnordered::new();
+        for subscriber_id in subscriber_ids {
+            self._remove(subscriber_id, None, Some(log_max_ts));
+        }
+        self.processed_ts = log_max_ts;
+        self.retention_coordinator
+            .update_and_enforce_retention(self.manager_id, log_max_ts)?;
+        Ok(true)
+    }
+
     async fn run_worker(&mut self, mut rx: CountingReceiver) {
         tracing::info!("Starting subscriptions worker");
         loop {
+            match self.reanchor_if_log_rewound() {
+                Ok(true) => continue,
+                Ok(false) => (),
+                Err(mut e) => {
+                    report_error(&mut e).await;
+                },
+            }
             futures::select_biased! {
                 // N.B.: `futures` select macro (not `tokio`) needed for `select_next_some`
                 key = self.closed_subscriptions.select_next_some() => {
@@ -290,6 +324,12 @@ impl SubscriptionManager {
                     }
                 },
                 next_ts = self.log.wait_for_higher_ts(self.processed_ts).fuse() => {
+                    if next_ts <= self.processed_ts {
+                        if let Err(mut e) = self.reanchor_if_log_rewound() {
+                            report_error(&mut e).await;
+                        }
+                        continue;
+                    }
                     if let Err(mut e) = self.advance_log(next_ts) {
                         report_error(&mut e).await;
                     }
@@ -366,6 +406,7 @@ impl SubscriptionManager {
         sender: SubscriptionSender,
         is_system: bool,
     ) -> anyhow::Result<SubscriberId> {
+        let _ = self.reanchor_if_log_rewound()?;
         metrics::log_subscription_queue_lag(self.log.max_ts().secs_since_f64(token.ts()));
         // The client may not have fully refreshed their token past our
         // processed timestamp, so finish the job for them if needed.
@@ -1289,6 +1330,30 @@ mod tests {
         subscription_manager.run_worker(disconnected_rx()).await;
         assert!(subscription_manager.subscribers.get(id).is_none());
         assert!(subscription_manager.subscribers.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_log_rewind_invalidates_subscriptions_and_reanchors_manager() {
+        let (log_owner, log_reader, mut log_writer) = new_write_log(Timestamp::must(100));
+        let coordinator = RetentionCoordinator::new(1, log_reader.max_ts(), log_owner);
+        let mut subscription_manager =
+            SubscriptionManager::new(0, log_reader, coordinator, Timestamp::must(100));
+
+        let (subscription, _id) = subscription_manager
+            .subscribe_for_testing(Token::empty(Timestamp::must(100)))
+            .unwrap();
+        subscription_manager.processed_ts = Timestamp::must(150);
+
+        log_writer.reset(Timestamp::must(120));
+
+        assert!(subscription_manager.reanchor_if_log_rewound().unwrap());
+        assert_eq!(subscription_manager.processed_ts, Timestamp::must(120));
+        assert!(subscription_manager.subscribers.is_empty());
+        assert!(subscription_manager.subscriptions.indexed.is_empty());
+        assert_eq!(
+            subscription.wait_for_invalidation().await,
+            Some(Timestamp::must(120))
+        );
     }
 
     #[test]

--- a/crates/database/src/write_log.rs
+++ b/crates/database/src/write_log.rs
@@ -261,6 +261,12 @@ impl WriteLogManager {
         }
     }
 
+    fn notify_all_waiters(&mut self) {
+        while let Some((_, sender)) = self.waiters.pop_front() {
+            let _ = sender.send(());
+        }
+    }
+
     fn append(&mut self, ts: Timestamp, writes: OrderedIndexKeyWrites, write_source: WriteSource) {
         assert!(self.log.max_ts() < ts, "{:?} >= {}", self.log.max_ts(), ts);
 
@@ -320,7 +326,10 @@ impl WriteLogManager {
 
     fn reset(&mut self, ts: Timestamp) {
         self.log = WriteLog::new(ts);
-        self.notify_waiters();
+        // Reset rewinds the base timestamp seen by readers. Wake all waiters so
+        // they can detect the rewind and re-anchor themselves instead of
+        // waiting forever for a timestamp that may never be reached again.
+        self.notify_all_waiters();
     }
 }
 
@@ -487,13 +496,12 @@ impl LogReader {
         snapshot.max_ts()
     }
 
-    /// Blocks until the log has advanced past the given timestamp.
+    /// Blocks until the log has advanced past the given timestamp, or until the
+    /// log is reset and callers need to re-check their anchor.
     pub async fn wait_for_higher_ts(&self, target_ts: Timestamp) -> Timestamp {
         let fut = self.inner.lock().wait_for_higher_ts(target_ts);
         fut.await;
-        let result = self.inner.lock().log.max_ts();
-        assert!(result > target_ts);
-        result
+        self.inner.lock().log.max_ts()
     }
 
     pub fn for_each<F>(&self, from: Timestamp, to: Timestamp, mut f: F) -> anyhow::Result<()>
@@ -795,6 +803,10 @@ mod tests {
         index_registry::IndexRegistry,
     };
     use runtime::testing::TestRuntime;
+    use tokio::time::{
+        timeout,
+        Duration,
+    };
     use value::{
         assert_obj,
         val,
@@ -888,6 +900,25 @@ mod tests {
                 .collect::<Vec<_>>()
         );
 
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_wait_for_higher_ts_wakes_on_reset() -> anyhow::Result<()> {
+        let (_owner, reader, mut writer) = new_write_log(Timestamp::must(1000));
+        let reader_for_wait = reader.clone();
+        let wait = tokio::spawn(async move {
+            timeout(
+                Duration::from_secs(1),
+                reader_for_wait.wait_for_higher_ts(Timestamp::must(1000)),
+            )
+            .await
+        });
+        tokio::task::yield_now().await;
+
+        writer.reset(Timestamp::must(900));
+
+        assert_eq!(wait.await??, Timestamp::must(900));
         Ok(())
     }
 

--- a/crates/local_backend/src/beacon.rs
+++ b/crates/local_backend/src/beacon.rs
@@ -18,12 +18,13 @@ use std::time::{
 use common::{
     backoff::Backoff,
     errors::report_error,
+    http::fetch::build_proxied_reqwest_client,
     runtime::Runtime,
 };
 use database::Database;
 use model::database_globals::DatabaseGlobalsModel;
-use reqwest::Client;
 use runtime::prod::ProdRuntime;
+use reqwest::Url;
 use serde::Deserialize;
 use serde_json::Value as JsonValue;
 const COMPILED_REVISION: &str = env!("VERGEN_GIT_SHA");
@@ -43,6 +44,8 @@ struct BeaconFields {
 pub async fn start_beacon(
     runtime: ProdRuntime,
     database: Database<ProdRuntime>,
+    proxy_url: Option<Url>,
+    client_id: String,
     beacon_tag: String,
     beacon_fields: Option<JsonValue>,
 ) {
@@ -56,7 +59,11 @@ pub async fn start_beacon(
             let mut db_model = DatabaseGlobalsModel::new(&mut tx);
             let globals = db_model.database_globals().await?;
 
-            let client = Client::new();
+            let client = build_proxied_reqwest_client(
+                proxy_url.clone(),
+                client_id.clone(),
+                Default::default(),
+            );
             let migration_version = globals.version;
             let compiled_revision = COMPILED_REVISION.to_string();
             let commit_timestamp = COMMIT_TIMESTAMP.to_string();

--- a/crates/local_backend/src/config.rs
+++ b/crates/local_backend/src/config.rs
@@ -198,7 +198,8 @@ pub struct LocalConfig {
     pub replica_storage_path: Option<String>,
 
     /// Storage directory for checkpoint files.
-    /// Required in primary mode when NATS_URL is set.
+    /// Required in primary mode when NATS_URL is set, and for fresh replica
+    /// bootstrap.
     /// Example: /convex/data/checkpoints
     #[clap(long, env = "CHECKPOINT_STORAGE_PATH")]
     pub checkpoint_storage_path: Option<String>,
@@ -296,7 +297,7 @@ impl LocalConfig {
         let tempdir_handle = tempfile::tempdir()?;
         let db_path = tempdir_handle.path().join("convex_local_backend.sqlite3");
         // Easiest way to get a config object with defaults is to parse from cmd line
-        let config = Self::try_parse_from([
+        let mut config = Self::try_parse_from([
             "convex-local-backend",
             db_path.to_str().context("invalid db path")?,
             "--local-storage",
@@ -305,6 +306,7 @@ impl LocalConfig {
                 .to_str()
                 .context("invalid local storage path")?,
         ])?;
+        config.disable_beacon = true;
         Ok(config)
     }
 }

--- a/crates/local_backend/src/lib.rs
+++ b/crates/local_backend/src/lib.rs
@@ -166,6 +166,7 @@ pub async fn make_app(
     preempt_tx: ShutdownSignal,
 ) -> anyhow::Result<LocalAppState> {
     let key_broker = config.key_broker()?;
+    let persistence_was_fresh = persistence.is_fresh();
     let in_process_searcher = Arc::new(InProcessSearcher::new(runtime.clone())?);
     let searcher: Arc<dyn Searcher> = in_process_searcher.clone();
     // TODO(CX-6572) Separate `SegmentMetadataFetcher` from `SearcherImpl`
@@ -236,6 +237,34 @@ pub async fn make_app(
         None, // raft_state: set after Raft node starts, not during Database::load
     )
     .await?;
+
+    if config.replication_mode == "replica" && persistence_was_fresh {
+        let checkpoint_path = config.checkpoint_storage_path.as_ref().ok_or_else(|| {
+            anyhow::anyhow!(
+                "CHECKPOINT_STORAGE_PATH is required to bootstrap a fresh replica from checkpoint"
+            )
+        })?;
+        let checkpoint_storage: Arc<dyn Storage> = Arc::new(LocalDirStorage::for_use_case(
+            runtime.clone(),
+            checkpoint_path,
+            StorageUseCase::Checkpoints,
+        )?);
+        let checkpoint = database::snapshot_checkpointer::load_latest_checkpoint(&checkpoint_storage)
+            .await?
+            .ok_or_else(|| {
+                anyhow::anyhow!(
+                    "Fresh replica startup requires a checkpoint, but none was found at {}",
+                    checkpoint_path
+                )
+            })?;
+        let checkpoint_ts = checkpoint.timestamp;
+        database
+            .committer_client()
+            .install_snapshot(checkpoint)
+            .await?;
+        tracing::info!("Bootstrapped fresh replica from checkpoint at ts={checkpoint_ts}");
+    }
+
     initialize_application_system_tables(&database).await?;
     let application_storage = if config.replication_mode == "replica" {
         // Replica uses local storage — doesn't write storage config to DB.
@@ -369,6 +398,8 @@ pub async fn make_app(
         let beacon_future = beacon::start_beacon(
             runtime.clone(),
             database.clone(),
+            config.convex_http_proxy.clone(),
+            config.name(),
             config.beacon_tag.clone(),
             config.beacon_fields.clone(),
         );
@@ -390,8 +421,8 @@ pub async fn make_app(
             // stream. Each node has its own database with independent timestamps,
             // so we can't use the local database timestamp as a lower bound.
             // The self-delta skip (source_node filter) prevents double-applying.
-            // In replica mode, use the local timestamp since the replica loaded
-            // from the same persistence as the primary.
+            // In replica mode, start from the locally visible snapshot, which
+            // may have just been bootstrapped from the latest checkpoint.
             let from_ts = if config.partition_id.is_some() {
                 common::types::Timestamp::MIN
             } else {
@@ -633,5 +664,134 @@ impl RouteMapper for HttpActionRouteMapper {
         } else {
             route
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        collections::BTreeMap,
+        sync::Arc,
+    };
+
+    use common::{
+        assert_obj,
+        persistence::{
+            NoopRetentionValidator,
+            PersistenceReader,
+            TimestampRange,
+        },
+        query::Order,
+        shutdown::ShutdownSignal,
+        testing::TestPersistence,
+    };
+    use futures::TryStreamExt;
+    use keybroker::Identity;
+    use storage::{
+        LocalDirStorage,
+        Storage,
+        StorageUseCase,
+        Upload,
+    };
+    use value::TableName;
+    use runtime::prod::ProdRuntime;
+
+    use crate::{
+        config::LocalConfig,
+        make_app,
+    };
+
+    #[test]
+    fn test_fresh_replica_bootstraps_from_checkpoint() -> anyhow::Result<()> {
+        let tokio = ProdRuntime::init_tokio()?;
+        let runtime = ProdRuntime::new(&tokio);
+        let test_runtime = runtime.clone();
+        runtime.block_on("test_fresh_replica_bootstraps_from_checkpoint", async move {
+            let primary_persistence = Arc::new(TestPersistence::new());
+            let (_primary_shutdown_tx, primary_shutdown_rx) = async_broadcast::broadcast(1);
+            let primary = make_app(
+                test_runtime.clone(),
+                LocalConfig::new_for_test()?,
+                primary_persistence.clone(),
+                primary_shutdown_rx,
+                ShutdownSignal::no_op(),
+            )
+            .await?;
+
+            let table_name: TableName = "bootstrap_messages".parse()?;
+            let mut tx = primary.application.database().begin(Identity::system()).await?;
+            database::TestFacingModel::new(&mut tx)
+                .insert(&table_name, assert_obj!("text" => "hello from checkpoint"))
+                .await?;
+            primary.application.database().commit(tx).await?;
+
+            let checkpoint = primary
+                .application
+                .database()
+                .build_raft_snapshot_checkpoint()
+                .await?;
+            let checkpoint_dir = tempfile::tempdir()?;
+            let checkpoint_storage: Arc<dyn Storage> = Arc::new(LocalDirStorage::for_use_case(
+                test_runtime.clone(),
+                checkpoint_dir.path().to_str().unwrap(),
+                StorageUseCase::Checkpoints,
+            )?);
+            let mut upload = checkpoint_storage
+                .start_upload_with_key(
+                    database::snapshot_checkpointer::LATEST_CHECKPOINT_KEY.try_into()?,
+                )
+                .await?;
+            upload
+                .write(database::snapshot_checkpointer::checkpoint_to_bytes(&checkpoint)?.into())
+                .await?;
+            let _ = upload.complete().await?;
+
+            let replica_persistence = Arc::new(TestPersistence::new());
+            let replica_storage_dir = tempfile::tempdir()?;
+            let (_shutdown_tx, shutdown_rx) = async_broadcast::broadcast(1);
+            let mut config = LocalConfig::new_for_test()?;
+            config.replication_mode = "replica".into();
+            config.replica_storage_path = Some(replica_storage_dir.path().to_str().unwrap().into());
+            config.checkpoint_storage_path = Some(checkpoint_dir.path().to_str().unwrap().into());
+
+            let st = make_app(
+                test_runtime.clone(),
+                config,
+                replica_persistence.clone(),
+                shutdown_rx,
+                ShutdownSignal::no_op(),
+            )
+            .await?;
+
+            assert_eq!(
+                *st.application.database().now_ts_for_reads(),
+                checkpoint.timestamp
+            );
+
+            let replica_docs: Vec<_> = replica_persistence
+                .load_documents(
+                    TimestampRange::all(),
+                    Order::Asc,
+                    10_000,
+                    Arc::new(NoopRetentionValidator),
+                )
+                .try_collect()
+                .await?;
+            let expected_latest_docs = checkpoint
+                .documents
+                .iter()
+                .fold(BTreeMap::new(), |mut acc, entry| {
+                    acc.insert(entry.id, entry.clone());
+                    acc
+                })
+                .into_values()
+                .filter(|entry| entry.value.is_some())
+                .count();
+            assert_eq!(replica_docs.len(), expected_latest_docs);
+
+            primary.shutdown().await?;
+            st.shutdown().await?;
+            Ok(())
+        })
     }
 }

--- a/crates/storage/src/lib.rs
+++ b/crates/storage/src/lib.rs
@@ -201,6 +201,13 @@ pub mod test_utils {
             anyhow::bail!("start_upload not implemented for FakeStorage")
         }
 
+        async fn start_upload_with_key(
+            &self,
+            _key: ObjectKey,
+        ) -> anyhow::Result<Box<crate::BufferedUpload>> {
+            anyhow::bail!("start_upload_with_key not implemented for FakeStorage")
+        }
+
         async fn start_client_driven_upload(&self) -> anyhow::Result<ClientDrivenUploadToken> {
             anyhow::bail!("start_client_driven_upload not implemented for FakeStorage")
         }
@@ -288,6 +295,11 @@ pub trait Storage: Send + Sync + Debug {
     /// Storage may choose to implement some checksuming strategy for uploads,
     /// but it's opaque to callers.
     async fn start_upload(&self) -> anyhow::Result<Box<BufferedUpload>>;
+
+    /// Start a new upload for a caller-specified object key.
+    ///
+    /// Used for control-plane artifacts that need stable, addressable names.
+    async fn start_upload_with_key(&self, key: ObjectKey) -> anyhow::Result<Box<BufferedUpload>>;
 
     /// A multi-part upload where the client uploads parts one at a time.
     async fn start_client_driven_upload(&self) -> anyhow::Result<ClientDrivenUploadToken>;
@@ -1006,6 +1018,13 @@ impl TryFrom<ClientDrivenUploadToken> for ClientDrivenUpload {
 impl<RT: Runtime> Storage for LocalDirStorage<RT> {
     async fn start_upload(&self) -> anyhow::Result<Box<BufferedUpload>> {
         let object_key: ObjectKey = self.rt.new_uuid_v4().to_string().try_into()?;
+        self.start_upload_with_key(object_key).await
+    }
+
+    async fn start_upload_with_key(
+        &self,
+        object_key: ObjectKey,
+    ) -> anyhow::Result<Box<BufferedUpload>> {
         let key = self.filename_for_key(object_key.clone());
         let filepath = self.dir.join(key);
 

--- a/crates/udf/src/http_action.rs
+++ b/crates/udf/src/http_action.rs
@@ -118,7 +118,7 @@ impl proptest::arbitrary::Arbitrary for HttpActionRequest {
                 body in any::<Option<Vec<u8>>>()) -> anyhow::Result<HttpActionRequest> {
                     let origin: String = "http://example-deployment.convex.site/".to_string();
                     let path_and_query: String =  uri.path_and_query().ok_or_else(|| anyhow::anyhow!("No path and query"))?.to_string();
-                    let url: Url = Url::parse(&(origin + &path_and_query))?;
+                    let url: Url = Url::parse(&(origin + path_and_query.as_str()))?;
                 Ok(HttpActionRequest {
                     head: HttpActionRequestHead {
                         headers,

--- a/docs/issue-journal.md
+++ b/docs/issue-journal.md
@@ -137,6 +137,36 @@ own for distributed changes.
   - clean-cluster rerun via `self-hosted/docker/test.sh`: all `77` write-scaling
     tests passed, Test 26 passed, and the Raft failover suite passed.
 
+### 2026-04 — Fresh replica checkpoint bootstrap rewound the write log behind active subscription workers
+
+- **Status:** fixed
+- **Related issue:** `#77`
+- **Symptom:** the new fresh-replica checkpoint bootstrap test could restore a
+  snapshot, but startup emitted repeated `Can't refresh token to newer
+  timestamp ... than max ts ...` errors. The bootstrap path was technically
+  succeeding while derived subscription state was still anchored to a newer
+  pre-snapshot timestamp.
+- **Root Cause:** `Database::load` started the write log and subscription
+  workers from fresh local state before the checkpoint snapshot was installed.
+  `InstallSnapshot` then reset the write log back to the checkpoint timestamp,
+  but already-running subscription workers kept their older `processed_ts` and
+  assumed the log only moved upward. That left them asking the write log to
+  refresh tokens beyond its new max timestamp.
+- **Fix:** teach write-log waiters to wake on reset, and teach subscription
+  workers to detect a log rewind, invalidate their derived subscriptions, and
+  re-anchor `processed_ts` to the new log max before continuing. This keeps
+  snapshot install and any future log rewind consistent with follower-read
+  derived state. The fresh-replica bootstrap path also now stores and loads a
+  stable `checkpoint-latest` object so a brand-new replica can install the
+  latest checkpoint directly.
+- **Validation:**
+  - `cargo test -p database test_wait_for_higher_ts_wakes_on_reset`
+  - `cargo test -p database test_log_rewind_invalidates_subscriptions_and_reanchors_manager`
+  - `cargo test -p database test_load_latest_checkpoint_reads_stable_latest_object`
+  - `cargo test -p local_backend test_fresh_replica_bootstraps_from_checkpoint -- --nocapture`
+  - the focused local-backend bootstrap test now passes on the real local
+    environment without the earlier token-refresh storm.
+
 ## Open Issues
 
 None currently tracked in this journal after the latest clean-cluster run.


### PR DESCRIPTION
## Summary
- bootstrap fresh replicas from a stable latest checkpoint object instead of requiring manual rebuild
- preserve checkpoint state correctly during snapshot install, including checkpoint-backed scans and per-document index timestamps
- make write-log resets wake and re-anchor subscription workers, and route local backend HTTP paths through explicit proxy/test settings for clean local startup

## Validation
- `cargo test --target-dir /tmp/convex-target-issue77 -p database test_load_latest_checkpoint_reads_stable_latest_object -- --nocapture`
- `cargo test --target-dir /tmp/convex-target-issue77 -p database test_wait_for_higher_ts_wakes_on_reset -- --nocapture`
- `cargo test --target-dir /tmp/convex-target-issue77 -p database test_log_rewind_invalidates_subscriptions_and_reanchors_manager -- --nocapture`
- `cargo test --target-dir /tmp/convex-target-issue77 -p local_backend test_fresh_replica_bootstraps_from_checkpoint -- --nocapture`
- fresh backend image build and push:
  - `ghcr.io/martinkalema/convex-horizontal-scaling:backend-issue77-bootstrap-0603bac-20260424-174338-dirty`
  - digest: `sha256:78fb75d3854553b46d49d6831ff2d802f7976b93404bad87d424f933293e4f22`
- clean cluster reset and full top-level harness:
  - `self-hosted/docker/test.sh`
  - result: all 77 write-scaling tests passed, all 10 raft failover tests passed, all suites passed
