### PR TITLE
feat(local_backend): forward replica mutations to primary

### DIFF
--- a/crates/application/src/redaction.rs
+++ b/crates/application/src/redaction.rs
@@ -55,6 +55,10 @@ impl RedactedLogLines {
         Self(vec![])
     }
 
+    pub fn from_vec(log_lines: Vec<String>) -> Self {
+        Self(log_lines)
+    }
+
     pub fn iter(&self) -> impl Iterator<Item = &String> {
         self.0.iter()
     }

--- a/crates/database/src/database.rs
+++ b/crates/database/src/database.rs
@@ -1154,12 +1154,12 @@ impl<RT: Runtime> Database<RT> {
         self.committer.finish_table_summary_bootstrap().await
     }
 
-    #[cfg(any(test, feature = "testing"))]
+    #[cfg(test)]
     pub(crate) fn committer_for_test(&self) -> CommitterClient {
         self.committer.clone()
     }
 
-    #[cfg(any(test, feature = "testing"))]
+    #[cfg(test)]
     pub(crate) fn replication_frontier_for_test(
         &self,
         partition: crate::partition::PartitionId,
@@ -1167,7 +1167,7 @@ impl<RT: Runtime> Database<RT> {
         self.snapshot_manager.lock().replication_frontier(partition)
     }
 
-    #[cfg(any(test, feature = "testing"))]
+    #[cfg(test)]
     pub(crate) fn persisted_max_repeatable_ts_for_test(&self) -> RepeatableTimestamp {
         self.snapshot_manager.lock().persisted_max_repeatable_ts()
     }

--- a/crates/database/src/raft_node.rs
+++ b/crates/database/src/raft_node.rs
@@ -425,7 +425,7 @@ impl RaftNode {
 
     /// Process one Ready cycle manually (for testing without the full run
     /// loop). Returns committed entry data.
-    #[cfg(any(test, feature = "testing"))]
+    #[cfg(test)]
     pub(crate) fn process_ready_test(&mut self) -> Vec<Vec<u8>> {
         let mut committed = Vec::new();
         if !self.raw_node.has_ready() {

--- a/crates/local_backend/src/lib.rs
+++ b/crates/local_backend/src/lib.rs
@@ -130,8 +130,10 @@ pub struct LocalAppState {
     pub instance_secret: InstanceSecret,
     pub application: Application<ProdRuntime>,
     pub zombify_rx: async_broadcast::Receiver<()>,
+    pub replica_mode: bool,
     pub partition_id: Option<database::partition::PartitionId>,
     pub node_addresses: Option<database::two_phase::NodeAddresses>,
+    pub replica_mutation_forwarder: Option<Arc<mutation_forwarder::MutationForwarderGrpcClient>>,
     /// Raft partition mailbox for receiving Raft messages from peers.
     /// None if Raft is not enabled.
     pub raft_mailbox_tx:
@@ -153,6 +155,8 @@ impl LocalAppState {
 pub struct RouterState {
     pub api: Arc<dyn ApplicationApi>,
     pub runtime: ProdRuntime,
+    pub replica_mode: bool,
+    pub replica_mutation_forwarder: Option<Arc<mutation_forwarder::MutationForwarderGrpcClient>>,
 }
 
 #[derive(Serialize)]
@@ -201,6 +205,18 @@ pub async fn make_app(
             Some(Arc::new(tso))
         } else {
             None
+        }
+    } else {
+        None
+    };
+
+    let replica_mutation_forwarder = if config.replication_mode == "replica" {
+        match config.primary_grpc_url.as_deref() {
+            Some(primary_grpc_url) => Some(Arc::new(
+                mutation_forwarder::MutationForwarderGrpcClient::connect(primary_grpc_url)
+                    .await?,
+            )),
+            None => None,
         }
     } else {
         None
@@ -644,8 +660,10 @@ pub async fn make_app(
         instance_secret,
         application,
         zombify_rx,
+        replica_mode: config.replication_mode == "replica",
         partition_id,
         node_addresses,
+        replica_mutation_forwarder,
         raft_mailbox_tx,
     };
 

--- a/crates/local_backend/src/mutation_forwarder.rs
+++ b/crates/local_backend/src/mutation_forwarder.rs
@@ -29,6 +29,7 @@ use pb::replication::{
     MutationError,
     MutationSuccess,
 };
+use serde_json::Value as JsonValue;
 use sync_types::types::SerializedArgs;
 use tonic::{
     transport::Channel,
@@ -112,13 +113,23 @@ impl MutationForwarder for MutationForwarderService {
                     },
                 )),
             })),
-            Ok(Err(err)) => Ok(Response::new(ForwardMutationResponse {
-                result: Some(forward_mutation_response::Result::Error(MutationError {
-                    error_message: format!("{}", err.error),
-                    error_data: None,
-                    log_lines: err.log_lines.iter().cloned().collect(),
-                })),
-            })),
+            Ok(Err(err)) => {
+                let error_message = format!("{}", err.error);
+                let error_data = err
+                    .error
+                    .custom_data_if_any()
+                    .map(JsonValue::from)
+                    .map(|value| serde_json::to_string(&value))
+                    .transpose()
+                    .map_err(|e| Status::internal(format!("Failed to serialize error data: {e}")))?;
+                Ok(Response::new(ForwardMutationResponse {
+                    result: Some(forward_mutation_response::Result::Error(MutationError {
+                        error_message,
+                        error_data,
+                        log_lines: err.log_lines.iter().cloned().collect(),
+                    })),
+                }))
+            },
             Err(e) => Err(Status::internal(format!("Mutation failed: {e}"))),
         }
     }

--- a/crates/local_backend/src/public_api.rs
+++ b/crates/local_backend/src/public_api.rs
@@ -1,3 +1,4 @@
+use anyhow::Context;
 use application::{
     api::ExecuteQueryTimestamp,
     redaction::{
@@ -47,6 +48,7 @@ use utoipa_axum::router::OpenApiRouter;
 use value::{
     export::ValueFormat,
     ConvexValue,
+    JsonPackedValue,
 };
 
 use crate::{
@@ -190,6 +192,78 @@ impl UdfResponse {
             log_lines,
         })
     }
+}
+
+async fn maybe_forward_public_mutation(
+    st: &RouterState,
+    path: &str,
+    serialized_args: &sync_types::types::SerializedArgs,
+    format: Option<&str>,
+    identity: keybroker::Identity,
+    client_version: &ClientVersion,
+) -> Result<Option<Result<UdfResponse, HttpResponseError>>, HttpResponseError> {
+    if !st.replica_mode {
+        return Ok(None);
+    }
+
+    let Some(forwarder) = &st.replica_mutation_forwarder else {
+        return Ok(Some(Err(anyhow::anyhow!(ErrorMetadata::service_unavailable())
+            .context(
+                "Replica mutation forwarding is not configured. Set PRIMARY_GRPC_URL for replica mode.",
+            )
+            .into())));
+    };
+
+    let value_format = format.map(|f| f.parse()).transpose()?;
+    let forwarded = forwarder
+        .forward(
+            path,
+            serialized_args.get(),
+            identity,
+            &client_version.to_string(),
+        )
+        .await
+        .map_err(|e| {
+            anyhow::anyhow!(ErrorMetadata::service_unavailable())
+                .context(format!("Failed to forward mutation to primary: {e:#}"))
+        })?;
+
+    let response = match forwarded.result {
+        Some(pb::replication::forward_mutation_response::Result::Success(success)) => {
+            let packed = JsonPackedValue::from_network(success.value).context(
+                ErrorMetadata::bad_request(
+                    "InvalidForwardedMutationValue",
+                    "Primary returned an invalid forwarded mutation value.",
+                ),
+            )?;
+            UdfResponse::Success {
+                value: export_value(
+                    packed.unpack()?,
+                    value_format,
+                    client_version.clone(),
+                )?,
+                log_lines: RedactedLogLines::from_vec(success.log_lines),
+            }
+        },
+        Some(pb::replication::forward_mutation_response::Result::Error(error)) => UdfResponse::Error {
+            error_message: error.error_message,
+            error_data: error
+                .error_data
+                .map(|value| serde_json::from_str(&value))
+                .transpose()
+                .context(ErrorMetadata::bad_request(
+                    "InvalidForwardedMutationErrorData",
+                    "Primary returned invalid forwarded mutation error data.",
+                ))?,
+            log_lines: RedactedLogLines::from_vec(error.log_lines),
+        },
+        None => {
+            return Ok(Some(Err(anyhow::anyhow!(ErrorMetadata::service_unavailable())
+                .context("Primary returned an empty forwarded mutation response.")
+                .into())));
+        },
+    };
+    Ok(Some(Ok(response)))
 }
 
 /// Execute any function
@@ -634,6 +708,7 @@ pub async fn public_mutation_post(
     Json(req): Json<UdfPostRequest>,
 ) -> Result<impl IntoResponse, HttpResponseError> {
     let export_path = parse_export_path(&req.path)?;
+    let serialized_args = req.args.into_serialized_args()?;
     // NOTE: We could coalesce authenticating and executing the query into one
     // rpc but we keep things simple by reusing the same method as the sync worker.
     // Round trip latency between Usher and Backend is much smaller than between
@@ -642,6 +717,19 @@ pub async fn public_mutation_post(
         .api
         .authenticate(&host, request_id.clone(), auth_token)
         .await?;
+    if let Some(response) =
+        maybe_forward_public_mutation(
+            &st,
+            &req.path,
+            &serialized_args,
+            req.format.as_deref(),
+            identity.clone(),
+            &client_version,
+        )
+        .await?
+    {
+        return response.map(Json);
+    }
     let udf_result = st
         .api
         .execute_public_mutation(
@@ -649,7 +737,7 @@ pub async fn public_mutation_post(
             request_id,
             identity,
             export_path,
-            req.args.into_serialized_args()?,
+            serialized_args,
             FunctionCaller::HttpApi(client_version.clone()),
             None,
             None,
@@ -748,19 +836,66 @@ where
 
 #[cfg(test)]
 mod tests {
+    use std::{
+        sync::Arc,
+        time::Duration,
+    };
+
+    use anyhow::Context;
     use application::test_helpers::ApplicationTestExt;
     use axum::body::Body;
+    use common::{
+        http::{
+            ConvexHttpService,
+            NoopRouteMapper,
+        },
+        runtime::Runtime,
+    };
     use http::{
         Request,
         StatusCode,
     };
+    use http_body_util::BodyExt;
+        use metrics::SERVER_VERSION_STR;
     use runtime::prod::ProdRuntime;
     use serde_json::{
         json,
         Value as JsonValue,
     };
+    use tokio::sync::oneshot;
+    use tokio_stream::wrappers::TcpListenerStream;
+    use tower::ServiceExt;
 
-    use crate::test_helpers::setup_backend_for_test;
+    use crate::{
+        mutation_forwarder::{
+            MutationForwarderGrpcClient,
+            MutationForwarderService,
+        },
+        router::router,
+        test_helpers::setup_backend_for_test,
+        MAX_CONCURRENT_REQUESTS,
+    };
+
+    async fn expect_success_from_app<T: serde::de::DeserializeOwned>(
+        app: &ConvexHttpService,
+        req: Request<Body>,
+    ) -> anyhow::Result<T> {
+        let (parts, body) = app.router().clone().oneshot(req).await?.into_parts();
+        let bytes = body.collect().await?.to_bytes();
+        let msg = format!("Got response: {}", String::from_utf8_lossy(&bytes));
+        assert_eq!(parts.status, StatusCode::OK, "{msg}");
+        serde_json::from_slice(if bytes.is_empty() { b"null" } else { &bytes })
+            .map_err(Into::into)
+    }
+
+    fn post_request(uri: &'static str, json_body: JsonValue) -> anyhow::Result<Request<Body>> {
+        Ok(Request::builder()
+            .uri(uri)
+            .method("POST")
+            .header("Content-Type", "application/json")
+            .header("Host", "localhost")
+            .body(Body::from(serde_json::to_vec(&json_body)?))?)
+    }
 
     async fn http_format_tester(
         rt: ProdRuntime,
@@ -858,6 +993,91 @@ mod tests {
             Ok(json!("1")),
         )
         .await
+    }
+
+    #[convex_macro::prod_rt_test]
+    async fn test_http_mutation_forwards_when_replica_mode(
+        rt: ProdRuntime,
+    ) -> anyhow::Result<()> {
+        let primary = setup_backend_for_test(rt.clone()).await?;
+        let replica = setup_backend_for_test(rt.clone()).await?;
+        primary.st.application.load_udf_tests_modules().await?;
+        replica.st.application.load_udf_tests_modules().await?;
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await?;
+        let grpc_addr = listener.local_addr()?;
+        let forwarder = MutationForwarderService::new(
+            Arc::new(primary.st.application.clone()),
+            primary.st.instance_name.clone(),
+        );
+        let (shutdown_tx, shutdown_rx) = oneshot::channel();
+        let _server_handle = rt.spawn("test_mutation_forwarder", async move {
+            let _ = tonic::transport::Server::builder()
+                .add_service(forwarder.into_server())
+                .serve_with_incoming_shutdown(TcpListenerStream::new(listener), async move {
+                    let _ = shutdown_rx.await;
+                })
+                .await;
+        });
+
+        let forwarder_client =
+            MutationForwarderGrpcClient::connect(&format!("http://{grpc_addr}")).await?;
+        let mut replica_state = replica.st.clone();
+        replica_state.replica_mode = true;
+        replica_state.replica_mutation_forwarder = Some(Arc::new(forwarder_client));
+        let replica_app = ConvexHttpService::new(
+            router(replica_state),
+            "backend_forwarding_test",
+            SERVER_VERSION_STR.to_string(),
+            MAX_CONCURRENT_REQUESTS,
+            Duration::from_secs(125),
+            NoopRouteMapper,
+        );
+
+        let mutation_response: JsonValue = expect_success_from_app(
+            &replica_app,
+            post_request(
+                "/api/mutation",
+                json!({
+                    "path": "values:insertObject",
+                    "args": { "obj": { "hello": "forwarded" } },
+                }),
+            )?,
+        )
+        .await?;
+        let inserted_id = mutation_response["value"]
+            .as_str()
+            .context("insertObject should return a document id string")?
+            .to_string();
+
+        let primary_query: JsonValue = primary
+            .expect_success(post_request(
+                "/api/query",
+                json!({
+                    "path": "values:getObject",
+                    "args": { "id": inserted_id.clone() },
+                }),
+            )?)
+            .await?;
+        assert_eq!(primary_query["status"], "success");
+        assert_eq!(primary_query["value"]["hello"], "forwarded");
+
+        let replica_snapshot = replica.st.application.database().latest_snapshot()?;
+        let mut replica_test_docs = 0;
+        for entry in replica_snapshot.iter_table_summaries()? {
+            let (_, _, table_name, summary) = entry?;
+            if table_name.to_string() == "test" {
+                replica_test_docs += summary.num_values();
+            }
+        }
+        assert_eq!(
+            replica_test_docs,
+            0,
+            "replica should not execute the forwarded mutation locally",
+        );
+
+        let _ = shutdown_tx.send(());
+        Ok(())
     }
 
     #[convex_macro::prod_rt_test]

--- a/crates/local_backend/src/router.rs
+++ b/crates/local_backend/src/router.rs
@@ -405,6 +405,8 @@ pub fn router(st: LocalAppState) -> Router {
         .with_state(RouterState {
             api: Arc::new(st.application.clone()),
             runtime: st.application.runtime(),
+            replica_mode: st.replica_mode,
+            replica_mutation_forwarder: st.replica_mutation_forwarder.clone(),
         });
 
     let version = SERVER_VERSION_STR.to_string();

--- a/docs/issue-journal.md
+++ b/docs/issue-journal.md
@@ -177,3 +177,31 @@ None currently tracked in this journal after the latest clean-cluster run.
   writeups still belong in the other docs.
 - When an issue is fixed, append the exact validation command set or point to
   the test suite that proved it.
+
+### 2026-04 — Replica public mutations were not routed through the active forwarding path
+
+- **Status:** fixed
+- **Related issue:** `#76`
+- **Symptom:** the repo already had a gRPC mutation forwarder service and a
+  `PRIMARY_GRPC_URL` config knob, but live `/api/mutation` requests on a
+  replica still executed the normal local path. The forwarding machinery
+  existed, but it was not actually on the active public mutation route.
+- **Root Cause:** the request path in `public_api.rs` authenticated and then
+  called into the local application/database commit path directly. The
+  primary/replica forwarding client was never consulted by the live HTTP
+  handler, so the gateway-node behavior used by CockroachDB, TiDB/TiKV,
+  YugabyteDB, and Spanner was only partially implemented.
+- **Fix:** wire replica-mode `/api/mutation` requests through the
+  `MutationForwarderGrpcClient`, preserving serialized args, caller identity,
+  returned value, log lines, and structured mutation error data. Add a focused
+  local-backend regression test that proves a replica-shaped HTTP router
+  forwards the mutation to the primary and does not execute it locally.
+- **Validation:**
+  - `cargo test -p local_backend test_http_mutation_forwards_when_replica_mode -- --nocapture`
+  - fresh image build and push:
+    `ghcr.io/martinkalema/convex-horizontal-scaling:backend-issue76-forwarding-4389d7f-20260425-224218-dirty`
+  - pushed digest:
+    `sha256:8f74c123c9e225da8f32851b3702e8460fd9dcaaa4b1f073c8758e425b2aeb64`
+  - clean-cluster rerun via `self-hosted/docker/test.sh`: all `77` write-scaling
+    tests passed and all `10` Raft failover tests passed, confirming the
+    routing change did not regress the distributed cluster paths.


### PR DESCRIPTION
## Summary
- route replica-mode `/api/mutation` requests through the gRPC mutation forwarder instead of the local commit path
- preserve forwarded mutation values, log lines, and structured error data in the HTTP response
- add a focused regression test and document the issue/validation history

## Validation
- `cargo test -p local_backend test_http_mutation_forwards_when_replica_mode -- --nocapture`
- fresh image build and push: `ghcr.io/martinkalema/convex-horizontal-scaling:backend-issue76-forwarding-4389d7f-20260425-224218-dirty`
- pushed digest: `sha256:8f74c123c9e225da8f32851b3702e8460fd9dcaaa4b1f073c8758e425b2aeb64`
- clean cluster reset plus full `self-hosted/docker/test.sh` run: all `77` write-scaling tests passed and all `10` Raft failover tests passed

Closes #76
