### PR TITLE
feat(observability): expand clustered operator metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,21 @@ Full details: [docs/what-we-built.md](docs/what-we-built.md)
 Issue journal for regressions, fixes, and validation history:
 [docs/issue-journal.md](docs/issue-journal.md)
 
+Operator observability, alert suggestions, and cluster runbooks:
+[docs/cluster-observability.md](docs/cluster-observability.md)
+
+## Recently Landed
+
+- **Raft snapshot catch-up for lagging followers:** followers that fall behind
+  compacted log history can now recover by installing a Raft snapshot instead
+  of requiring manual re-bootstrap.
+- **Fresh replica checkpoint bootstrap:** brand-new replicas can start from the
+  latest stored checkpoint object and then catch up from there, instead of
+  reconstructing from scratch.
+- **Active replica mutation forwarding:** in primary/replica mode, replica
+  `/api/mutation` requests now forward to the primary through gRPC instead of
+  executing the local write path.
+
 ## Results
 
 ### Raft Failover Tests
@@ -174,9 +189,14 @@ Client ──mutation──▶ Primary ──persist──▶ PostgreSQL
                         ├──publish delta──▶ NATS JetStream
                         │                        │
 Client ──query──▶ Replica ◀──consume delta───────┘
+Client ──mutation──▶ Replica ──gRPC forward──▶ Primary
 ```
 
-One Primary handles writes, multiple Replicas serve reads. Replicas remap TabletIds from the Primary's namespace to their own using the `tablet_id_to_table_name` mapping in each CommitDelta.
+One Primary handles writes, multiple Replicas serve reads. Replicas remap
+TabletIds from the Primary's namespace to their own using the
+`tablet_id_to_table_name` mapping in each CommitDelta. If a client sends a
+mutation to a Replica, the Replica now forwards that request to the Primary
+over gRPC and returns the Primary's result.
 
 ## Quick Start
 

--- a/crates/database/src/committer.rs
+++ b/crates/database/src/committer.rs
@@ -425,13 +425,16 @@ impl<RT: Runtime> Committer<RT> {
                 *last_commit_id < commit_id,
                 "queued snapshots must be ordered by commit id"
             );
-            assert!(*last_ts <= ts, "queued snapshots must be monotonic by timestamp");
+            assert!(
+                *last_ts <= ts,
+                "queued snapshots must be monotonic by timestamp"
+            );
         }
         self.queued_snapshots.push_back((commit_id, ts, snapshot));
     }
 
     fn dequeue_snapshot(&mut self, commit_id: usize) {
-        let (queued_commit_id, _, _) = self
+        let (queued_commit_id, ..) = self
             .queued_snapshots
             .pop_front()
             .expect("missing queued snapshot for published write");
@@ -1185,6 +1188,7 @@ impl<RT: Runtime> Committer<RT> {
         if let Some(ref raft) = self.raft_state {
             if !raft.is_leader() {
                 let leader = raft.leader_id();
+                metrics::log_write_rejected_not_leader(raft.partition_id());
                 anyhow::bail!(
                     "Not the Raft leader for partition {}. Current leader: node {}. Forward this \
                      mutation to the leader.",
@@ -1751,10 +1755,8 @@ impl<RT: Runtime> Committer<RT> {
                     db_snapshot.snapshot.table_summaries = Some(table_summaries);
                 }
 
-                let index_entries = checkpoint_index_entries(
-                    &db_snapshot.snapshot,
-                    &compacted_documents,
-                );
+                let index_entries =
+                    checkpoint_index_entries(&db_snapshot.snapshot, &compacted_documents);
 
                 let mut existing_documents = Vec::new();
                 let persistence_reader = persistence.reader();
@@ -2836,9 +2838,7 @@ impl CommitterClient {
     }
 
     #[cfg(any(test, feature = "testing"))]
-    pub async fn tick_idle_replication_frontier_heartbeat_for_test(
-        &self,
-    ) -> anyhow::Result<()> {
+    pub async fn tick_idle_replication_frontier_heartbeat_for_test(&self) -> anyhow::Result<()> {
         let (tx, rx) = oneshot::channel();
         let message = CommitterMessage::TickIdleReplicationFrontierHeartbeat { result: tx };
         self.sender.try_send(message).map_err(|e| match e {
@@ -3126,7 +3126,17 @@ impl CommitterClient {
             TrySendError::Full(..) => metrics::committer_full_error().into(),
             TrySendError::Closed(..) => metrics::shutdown_error(),
         })?;
-        rx.await.map_err(|_| metrics::shutdown_error())?
+        let result = rx.await.map_err(|_| metrics::shutdown_error())?;
+        match &result {
+            Ok(ts) => {
+                metrics::log_snapshot_install_result(true);
+                metrics::log_snapshot_installed_ts(*ts);
+            },
+            Err(_) => {
+                metrics::log_snapshot_install_result(false);
+            },
+        }
+        result
     }
 
     #[cfg(any(test, feature = "testing"))]

--- a/crates/database/src/database.rs
+++ b/crates/database/src/database.rs
@@ -1973,8 +1973,8 @@ impl<RT: Runtime> Database<RT> {
     pub async fn build_raft_snapshot_checkpoint(&self) -> anyhow::Result<CheckpointData> {
         let db_snapshot = self.latest_database_snapshot()?;
         let ts = *db_snapshot.timestamp();
-        let mut checkpoint = create_checkpoint(self.reader.as_ref(), ts, self.retention_validator())
-            .await?;
+        let mut checkpoint =
+            create_checkpoint(self.reader.as_ref(), ts, self.retention_validator()).await?;
 
         let mut globals = BTreeMap::new();
         for key in PersistenceGlobalKey::all_keys() {

--- a/crates/database/src/metrics.rs
+++ b/crates/database/src/metrics.rs
@@ -1,7 +1,3 @@
-use ::search::metrics::{
-    SearchType,
-    SEARCH_TYPE_LABEL,
-};
 use common::{
     identity::IDENTITY_LABEL,
     runtime::Runtime,
@@ -14,6 +10,8 @@ use metrics::{
     log_counter_with_labels,
     log_distribution,
     log_distribution_with_labels,
+    log_gauge,
+    log_gauge_with_labels,
     register_convex_counter,
     register_convex_gauge,
     register_convex_histogram,
@@ -29,12 +27,454 @@ use prometheus::{
     VMHistogram,
     VMHistogramVec,
 };
+use ::search::metrics::{
+    SearchType,
+    SEARCH_TYPE_LABEL,
+};
 
 use crate::{
+    partition::PartitionId,
     transaction::FinalTransaction,
     RetentionType,
     Transaction,
 };
+
+const PARTITION_LABELS: [&str; 1] = ["partition"];
+const SOURCE_PARTITION_LABELS: [&str; 1] = ["source_partition"];
+const OUTCOME_LABELS: [&str; 1] = ["outcome"];
+const PHASE_LABELS: [&str; 1] = ["phase"];
+
+fn partition_label(partition: PartitionId) -> StaticMetricLabel {
+    StaticMetricLabel::new("partition", partition.0.to_string())
+}
+
+fn source_partition_label(partition: PartitionId) -> StaticMetricLabel {
+    StaticMetricLabel::new("source_partition", partition.0.to_string())
+}
+
+fn outcome_label(outcome: &'static str) -> StaticMetricLabel {
+    StaticMetricLabel::new("outcome", outcome)
+}
+
+fn phase_label(phase: &'static str) -> StaticMetricLabel {
+    StaticMetricLabel::new("phase", phase)
+}
+
+register_convex_gauge!(
+    DATABASE_RAFT_IS_LEADER_INFO,
+    "Whether this node is currently the Raft leader for the partition (1 or 0)",
+    &PARTITION_LABELS
+);
+pub fn log_raft_is_leader(partition: PartitionId, is_leader: bool) {
+    log_gauge_with_labels(
+        &DATABASE_RAFT_IS_LEADER_INFO,
+        if is_leader { 1.0 } else { 0.0 },
+        vec![partition_label(partition)],
+    );
+}
+
+register_convex_gauge!(
+    DATABASE_RAFT_LEADER_ID_INFO,
+    "Current known Raft leader node ID for the partition (0 if unknown)",
+    &PARTITION_LABELS
+);
+pub fn log_raft_leader_id(partition: PartitionId, leader_id: u64) {
+    log_gauge_with_labels(
+        &DATABASE_RAFT_LEADER_ID_INFO,
+        leader_id as f64,
+        vec![partition_label(partition)],
+    );
+}
+
+register_convex_counter!(
+    DATABASE_RAFT_LEADER_CHANGES_TOTAL,
+    "Number of observed Raft leader changes for a partition",
+    &PARTITION_LABELS
+);
+pub fn log_raft_leader_change(partition: PartitionId) {
+    log_counter_with_labels(
+        &DATABASE_RAFT_LEADER_CHANGES_TOTAL,
+        1,
+        vec![partition_label(partition)],
+    );
+}
+
+register_convex_gauge!(
+    DATABASE_RAFT_TERM_INFO,
+    "Current Raft term for the partition",
+    &PARTITION_LABELS
+);
+pub fn log_raft_term(partition: PartitionId, term: u64) {
+    log_gauge_with_labels(
+        &DATABASE_RAFT_TERM_INFO,
+        term as f64,
+        vec![partition_label(partition)],
+    );
+}
+
+register_convex_gauge!(
+    DATABASE_RAFT_COMMITTED_INDEX_INFO,
+    "Current committed Raft log index for the partition",
+    &PARTITION_LABELS
+);
+pub fn log_raft_committed_index(partition: PartitionId, committed_index: u64) {
+    log_gauge_with_labels(
+        &DATABASE_RAFT_COMMITTED_INDEX_INFO,
+        committed_index as f64,
+        vec![partition_label(partition)],
+    );
+}
+
+register_convex_gauge!(
+    DATABASE_RAFT_APPLIED_INDEX_INFO,
+    "Current applied Raft log index for the partition",
+    &PARTITION_LABELS
+);
+pub fn log_raft_applied_index(partition: PartitionId, applied_index: u64) {
+    log_gauge_with_labels(
+        &DATABASE_RAFT_APPLIED_INDEX_INFO,
+        applied_index as f64,
+        vec![partition_label(partition)],
+    );
+}
+
+register_convex_gauge!(
+    DATABASE_RAFT_CONFIGURED_VOTERS_INFO,
+    "Configured number of Raft voting replicas for the partition",
+    &PARTITION_LABELS
+);
+register_convex_gauge!(
+    DATABASE_RAFT_RECENT_ACTIVE_VOTERS_INFO,
+    "Number of recently active Raft voting replicas for the partition",
+    &PARTITION_LABELS
+);
+register_convex_gauge!(
+    DATABASE_RAFT_LAGGING_FOLLOWERS_INFO,
+    "Number of follower replicas whose matched index is behind the leader commit index",
+    &PARTITION_LABELS
+);
+register_convex_gauge!(
+    DATABASE_RAFT_MAX_FOLLOWER_LAG_ENTRIES_INFO,
+    "Largest Raft log lag in entries observed across followers for the partition",
+    &PARTITION_LABELS
+);
+register_convex_gauge!(
+    DATABASE_RAFT_TOTAL_FOLLOWER_LAG_ENTRIES_INFO,
+    "Total Raft log lag in entries summed across followers for the partition",
+    &PARTITION_LABELS
+);
+register_convex_gauge!(
+    DATABASE_RAFT_UNDER_REPLICATED_INFO,
+    "Whether the partition currently has fewer active voting replicas than configured (1 or 0)",
+    &PARTITION_LABELS
+);
+register_convex_gauge!(
+    DATABASE_RAFT_QUORUM_UNAVAILABLE_INFO,
+    "Whether the partition currently lacks an active write quorum (1 or 0)",
+    &PARTITION_LABELS
+);
+pub fn log_raft_replication_health(
+    partition: PartitionId,
+    configured_voters: usize,
+    recent_active_voters: usize,
+    lagging_followers: usize,
+    max_follower_lag_entries: u64,
+    total_follower_lag_entries: u64,
+) {
+    let quorum_size = if configured_voters == 0 {
+        0
+    } else {
+        (configured_voters / 2) + 1
+    };
+    let under_replicated = configured_voters > 0 && recent_active_voters < configured_voters;
+    let quorum_unavailable = quorum_size > 0 && recent_active_voters < quorum_size;
+
+    log_gauge_with_labels(
+        &DATABASE_RAFT_CONFIGURED_VOTERS_INFO,
+        configured_voters as f64,
+        vec![partition_label(partition)],
+    );
+    log_gauge_with_labels(
+        &DATABASE_RAFT_RECENT_ACTIVE_VOTERS_INFO,
+        recent_active_voters as f64,
+        vec![partition_label(partition)],
+    );
+    log_gauge_with_labels(
+        &DATABASE_RAFT_LAGGING_FOLLOWERS_INFO,
+        lagging_followers as f64,
+        vec![partition_label(partition)],
+    );
+    log_gauge_with_labels(
+        &DATABASE_RAFT_MAX_FOLLOWER_LAG_ENTRIES_INFO,
+        max_follower_lag_entries as f64,
+        vec![partition_label(partition)],
+    );
+    log_gauge_with_labels(
+        &DATABASE_RAFT_TOTAL_FOLLOWER_LAG_ENTRIES_INFO,
+        total_follower_lag_entries as f64,
+        vec![partition_label(partition)],
+    );
+    log_gauge_with_labels(
+        &DATABASE_RAFT_UNDER_REPLICATED_INFO,
+        if under_replicated { 1.0 } else { 0.0 },
+        vec![partition_label(partition)],
+    );
+    log_gauge_with_labels(
+        &DATABASE_RAFT_QUORUM_UNAVAILABLE_INFO,
+        if quorum_unavailable { 1.0 } else { 0.0 },
+        vec![partition_label(partition)],
+    );
+}
+
+pub fn reset_raft_replication_health(partition: PartitionId) {
+    log_raft_replication_health(partition, 0, 0, 0, 0, 0);
+}
+
+register_convex_gauge!(
+    DATABASE_REPLICATION_FRONTIER_TS_INFO,
+    "Latest applied replication frontier timestamp for a source partition on this node",
+    &SOURCE_PARTITION_LABELS
+);
+pub fn log_replication_frontier_ts(source_partition: PartitionId, ts: Timestamp) {
+    log_gauge_with_labels(
+        &DATABASE_REPLICATION_FRONTIER_TS_INFO,
+        u64::from(ts) as f64,
+        vec![source_partition_label(source_partition)],
+    );
+}
+
+register_convex_gauge!(
+    DATABASE_LATEST_REPEATABLE_TS_INFO,
+    "Latest repeatable timestamp currently visible on this node"
+);
+pub fn log_latest_repeatable_ts(ts: Timestamp) {
+    log_gauge(&DATABASE_LATEST_REPEATABLE_TS_INFO, u64::from(ts) as f64);
+}
+
+register_convex_gauge!(
+    DATABASE_PERSISTED_MAX_REPEATABLE_TS_INFO,
+    "Latest repeatable timestamp durably persisted for this node"
+);
+pub fn log_persisted_max_repeatable_ts(ts: Timestamp) {
+    log_gauge(
+        &DATABASE_PERSISTED_MAX_REPEATABLE_TS_INFO,
+        u64::from(ts) as f64,
+    );
+}
+
+register_convex_gauge!(
+    DATABASE_CHECKPOINT_WRITTEN_TS_INFO,
+    "Latest checkpoint timestamp successfully written by this node"
+);
+pub fn log_checkpoint_written_ts(ts: Timestamp) {
+    log_gauge(&DATABASE_CHECKPOINT_WRITTEN_TS_INFO, u64::from(ts) as f64);
+}
+
+register_convex_counter!(
+    DATABASE_CHECKPOINT_WRITE_TOTAL,
+    "Number of checkpoint write attempts by status",
+    &STATUS_LABEL
+);
+pub fn log_checkpoint_write_result(success: bool) {
+    log_counter_with_labels(
+        &DATABASE_CHECKPOINT_WRITE_TOTAL,
+        1,
+        vec![StaticMetricLabel::status(success)],
+    );
+}
+
+register_convex_gauge!(
+    DATABASE_CHECKPOINT_LOADED_TS_INFO,
+    "Latest checkpoint timestamp successfully loaded by this node"
+);
+pub fn log_checkpoint_loaded_ts(ts: Timestamp) {
+    log_gauge(&DATABASE_CHECKPOINT_LOADED_TS_INFO, u64::from(ts) as f64);
+}
+
+register_convex_counter!(
+    DATABASE_CHECKPOINT_LOAD_TOTAL,
+    "Number of checkpoint load attempts by status",
+    &STATUS_LABEL
+);
+pub fn log_checkpoint_load_result(success: bool) {
+    log_counter_with_labels(
+        &DATABASE_CHECKPOINT_LOAD_TOTAL,
+        1,
+        vec![StaticMetricLabel::status(success)],
+    );
+}
+
+register_convex_gauge!(
+    DATABASE_SNAPSHOT_INSTALLED_TS_INFO,
+    "Latest checkpoint timestamp successfully installed into this node"
+);
+pub fn log_snapshot_installed_ts(ts: Timestamp) {
+    log_gauge(&DATABASE_SNAPSHOT_INSTALLED_TS_INFO, u64::from(ts) as f64);
+}
+
+register_convex_counter!(
+    DATABASE_SNAPSHOT_INSTALL_TOTAL,
+    "Number of snapshot install attempts by status",
+    &STATUS_LABEL
+);
+pub fn log_snapshot_install_result(success: bool) {
+    log_counter_with_labels(
+        &DATABASE_SNAPSHOT_INSTALL_TOTAL,
+        1,
+        vec![StaticMetricLabel::status(success)],
+    );
+}
+
+register_convex_histogram!(
+    DATABASE_RAFT_SNAPSHOT_APPLY_SECONDS,
+    "Time to persist and apply an incoming Raft snapshot",
+    &STATUS_LABEL
+);
+pub fn raft_snapshot_apply_timer() -> StatusTimer {
+    StatusTimer::new(&DATABASE_RAFT_SNAPSHOT_APPLY_SECONDS)
+}
+
+register_convex_histogram!(
+    DATABASE_RAFT_SNAPSHOT_APPLY_BYTES,
+    "Size of incoming Raft snapshot payloads applied by this node"
+);
+pub fn log_raft_snapshot_apply_bytes(bytes: usize) {
+    log_distribution(&DATABASE_RAFT_SNAPSHOT_APPLY_BYTES, bytes as f64);
+}
+
+register_convex_counter!(
+    DATABASE_WRITE_REJECTED_NOT_LEADER_TOTAL,
+    "Number of writes rejected because this node is not the Raft leader for the partition",
+    &PARTITION_LABELS
+);
+pub fn log_write_rejected_not_leader(partition: PartitionId) {
+    log_counter_with_labels(
+        &DATABASE_WRITE_REJECTED_NOT_LEADER_TOTAL,
+        1,
+        vec![partition_label(partition)],
+    );
+}
+
+register_convex_counter!(
+    DATABASE_TWO_PHASE_COORDINATOR_DECISIONS_TOTAL,
+    "Number of 2PC coordinator decisions by outcome",
+    &OUTCOME_LABELS
+);
+pub fn log_two_phase_decision(outcome: &'static str) {
+    log_counter_with_labels(
+        &DATABASE_TWO_PHASE_COORDINATOR_DECISIONS_TOTAL,
+        1,
+        vec![outcome_label(outcome)],
+    );
+}
+
+register_convex_counter!(
+    DATABASE_TWO_PHASE_COORDINATOR_ERRORS_TOTAL,
+    "Number of 2PC coordinator errors by phase",
+    &PHASE_LABELS
+);
+pub fn log_two_phase_error(phase: &'static str) {
+    log_counter_with_labels(
+        &DATABASE_TWO_PHASE_COORDINATOR_ERRORS_TOTAL,
+        1,
+        vec![phase_label(phase)],
+    );
+}
+
+register_convex_counter!(
+    DATABASE_TWO_PHASE_PREPARE_RETRIES_TOTAL,
+    "Number of 2PC prepare timestamp retries"
+);
+pub fn log_two_phase_prepare_retry() {
+    log_counter(&DATABASE_TWO_PHASE_PREPARE_RETRIES_TOTAL, 1);
+}
+
+register_convex_histogram!(
+    DATABASE_TWO_PHASE_COORDINATOR_SECONDS,
+    "End-to-end duration of a 2PC coordinator attempt",
+    &STATUS_LABEL
+);
+pub fn two_phase_coordinator_timer() -> StatusTimer {
+    StatusTimer::new(&DATABASE_TWO_PHASE_COORDINATOR_SECONDS)
+}
+
+register_convex_histogram!(
+    DATABASE_TWO_PHASE_PARTICIPANTS_TOTAL,
+    "Number of participants involved in a 2PC transaction"
+);
+pub fn log_two_phase_participants(num_participants: usize) {
+    log_distribution(&DATABASE_TWO_PHASE_PARTICIPANTS_TOTAL, num_participants as f64);
+}
+
+register_convex_histogram!(
+    DATABASE_TWO_PHASE_PREPARE_ATTEMPTS_TOTAL,
+    "Number of prepare timestamp allocation attempts for a 2PC transaction"
+);
+pub fn log_two_phase_prepare_attempts(num_attempts: usize) {
+    log_distribution(&DATABASE_TWO_PHASE_PREPARE_ATTEMPTS_TOTAL, num_attempts as f64);
+}
+
+register_convex_histogram!(
+    DATABASE_REPLICATION_TRANSPORT_PUBLISH_SECONDS,
+    "Time to publish a replication delta to the distributed log"
+);
+pub fn replication_transport_publish_timer() -> Timer<VMHistogram> {
+    Timer::new(&DATABASE_REPLICATION_TRANSPORT_PUBLISH_SECONDS)
+}
+
+register_convex_histogram!(
+    DATABASE_REPLICATION_TRANSPORT_MESSAGE_BYTES,
+    "Size of replication transport messages by phase",
+    &PHASE_LABELS
+);
+pub fn log_replication_transport_message_bytes(phase: &'static str, bytes: usize) {
+    log_distribution_with_labels(
+        &DATABASE_REPLICATION_TRANSPORT_MESSAGE_BYTES,
+        bytes as f64,
+        vec![phase_label(phase)],
+    );
+}
+
+register_convex_histogram!(
+    DATABASE_REPLICATION_TRANSPORT_LAG_SECONDS,
+    "Time from replication message publish to local delivery"
+);
+pub fn log_replication_transport_lag(seconds: f64) {
+    log_distribution(&DATABASE_REPLICATION_TRANSPORT_LAG_SECONDS, seconds);
+}
+
+register_convex_gauge!(
+    DATABASE_REPLICATION_TRANSPORT_PENDING_MESSAGES_INFO,
+    "Current number of JetStream replication messages pending for this consumer"
+);
+pub fn log_replication_transport_pending_messages(pending: u64) {
+    log_gauge(
+        &DATABASE_REPLICATION_TRANSPORT_PENDING_MESSAGES_INFO,
+        pending as f64,
+    );
+}
+
+register_convex_gauge!(
+    DATABASE_REPLICATION_TRANSPORT_STREAM_SEQUENCE_INFO,
+    "Latest JetStream stream sequence observed by this consumer"
+);
+pub fn log_replication_transport_stream_sequence(sequence: u64) {
+    log_gauge(
+        &DATABASE_REPLICATION_TRANSPORT_STREAM_SEQUENCE_INFO,
+        sequence as f64,
+    );
+}
+
+register_convex_gauge!(
+    DATABASE_REPLICATION_TRANSPORT_CONSUMER_SEQUENCE_INFO,
+    "Latest JetStream consumer sequence observed by this consumer"
+);
+pub fn log_replication_transport_consumer_sequence(sequence: u64) {
+    log_gauge(
+        &DATABASE_REPLICATION_TRANSPORT_CONSUMER_SEQUENCE_INFO,
+        sequence as f64,
+    );
+}
 
 register_convex_histogram!(
     DOCUMENTS_SIZE_BYTES,

--- a/crates/database/src/nats_distributed_log.rs
+++ b/crates/database/src/nats_distributed_log.rs
@@ -34,6 +34,7 @@ use crate::{
         CommitDelta,
         DistributedLog,
     },
+    metrics,
     partition::PartitionId,
     write_log::WriteSource,
 };
@@ -117,6 +118,9 @@ impl NatsDistributedLog {
             consumer_name,
             publish_subject,
         );
+        metrics::log_replication_transport_pending_messages(0);
+        metrics::log_replication_transport_stream_sequence(0);
+        metrics::log_replication_transport_consumer_sequence(0);
 
         Ok(Self {
             jetstream,
@@ -227,6 +231,8 @@ impl DistributedLog for NatsDistributedLog {
         let envelope = DeltaEnvelope::from_delta(&delta, &self.consumer_name)?;
         let payload = serde_json::to_vec(&envelope).context("Failed to serialize CommitDelta")?;
         let payload_size = payload.len();
+        let publish_timer = metrics::replication_transport_publish_timer();
+        metrics::log_replication_transport_message_bytes("publish", payload_size);
 
         // Publish and wait for acknowledgment from NATS server.
         // The double .await is intentional:
@@ -247,6 +253,7 @@ impl DistributedLog for NatsDistributedLog {
             payload_size,
             ack.sequence,
         );
+        drop(publish_timer);
         Ok(())
     }
 
@@ -258,7 +265,7 @@ impl DistributedLog for NatsDistributedLog {
         // DeliverPolicy::All replays all messages from the stream beginning,
         // and we filter out messages at or before from_ts ourselves.
         let consumer_name = self.consumer_name.clone();
-        let consumer: PullConsumer = self
+        let mut consumer: PullConsumer = self
             .stream
             .get_or_create_consumer(
                 &consumer_name,
@@ -271,6 +278,18 @@ impl DistributedLog for NatsDistributedLog {
             )
             .await
             .context("Failed to create NATS durable consumer")?;
+        let consumer_info = consumer
+            .info()
+            .await
+            .context("Failed to get NATS consumer info")?
+            .clone();
+        metrics::log_replication_transport_pending_messages(consumer_info.num_pending);
+        metrics::log_replication_transport_stream_sequence(
+            consumer_info.delivered.stream_sequence,
+        );
+        metrics::log_replication_transport_consumer_sequence(
+            consumer_info.delivered.consumer_sequence,
+        );
 
         let from_ts_u64 = u64::from(from_ts);
         let messages = consumer
@@ -291,6 +310,34 @@ impl DistributedLog for NatsDistributedLog {
             async move {
                 match msg_result {
                     Ok(msg) => {
+                        metrics::log_replication_transport_message_bytes(
+                            "consume",
+                            msg.payload.len(),
+                        );
+                        match msg.info() {
+                            Ok(info) => {
+                                metrics::log_replication_transport_pending_messages(info.pending);
+                                metrics::log_replication_transport_stream_sequence(
+                                    info.stream_sequence,
+                                );
+                                metrics::log_replication_transport_consumer_sequence(
+                                    info.consumer_sequence,
+                                );
+                                let now_ns = std::time::SystemTime::now()
+                                    .duration_since(std::time::UNIX_EPOCH)
+                                    .unwrap_or_default()
+                                    .as_nanos() as i128;
+                                let published_ns = info.published.unix_timestamp_nanos();
+                                if now_ns >= published_ns {
+                                    metrics::log_replication_transport_lag(
+                                        (now_ns - published_ns) as f64 / 1_000_000_000.0,
+                                    );
+                                }
+                            },
+                            Err(e) => {
+                                tracing::debug!("Failed to parse JetStream message info: {e}");
+                            },
+                        }
                         if let Err(e) = msg.ack().await {
                             tracing::warn!("Failed to ack NATS message: {e:?}");
                         }

--- a/crates/database/src/raft_node.rs
+++ b/crates/database/src/raft_node.rs
@@ -32,6 +32,7 @@ use slog::o;
 use tokio::sync::mpsc;
 
 use crate::{
+    metrics,
     partition::PartitionId,
     raft_storage::ConvexRaftStorage,
 };
@@ -239,6 +240,46 @@ impl RaftNode {
 
             // Process Ready state.
             if self.raw_node.has_ready() {
+                let replication_health = {
+                    let status = self.raw_node.status();
+                    status.progress.map(|progress| {
+                        let voter_ids: Vec<u64> = progress.conf().voters().ids().iter().collect();
+                        let configured_voters = voter_ids.len();
+                        let leader_committed = status.hs.commit;
+                        let mut recent_active_voters = 0usize;
+                        let mut lagging_followers = 0usize;
+                        let mut max_follower_lag_entries = 0u64;
+                        let mut total_follower_lag_entries = 0u64;
+
+                        for voter_id in voter_ids {
+                            if voter_id == self.config.node_id {
+                                recent_active_voters += 1;
+                                continue;
+                            }
+                            let Some(peer_progress) = progress.get(voter_id) else {
+                                continue;
+                            };
+                            if peer_progress.recent_active {
+                                recent_active_voters += 1;
+                            }
+                            let lag = leader_committed.saturating_sub(peer_progress.matched);
+                            if lag > 0 {
+                                lagging_followers += 1;
+                            }
+                            max_follower_lag_entries = max_follower_lag_entries.max(lag);
+                            total_follower_lag_entries =
+                                total_follower_lag_entries.saturating_add(lag);
+                        }
+
+                        (
+                            configured_voters,
+                            recent_active_voters,
+                            lagging_followers,
+                            max_follower_lag_entries,
+                            total_follower_lag_entries,
+                        )
+                    })
+                };
                 let mut ready = self.raw_node.ready();
 
                 // Detect leadership changes (TiKV SoftState pattern).
@@ -273,6 +314,35 @@ impl RaftNode {
                     }
                 }
 
+                metrics::log_raft_term(self.config.partition_id, self.raw_node.raft.term);
+                metrics::log_raft_committed_index(
+                    self.config.partition_id,
+                    self.raw_node.raft.raft_log.committed,
+                );
+                metrics::log_raft_applied_index(
+                    self.config.partition_id,
+                    self.raw_node.raft.raft_log.applied,
+                );
+                if let Some((
+                    configured_voters,
+                    recent_active_voters,
+                    lagging_followers,
+                    max_follower_lag_entries,
+                    total_follower_lag_entries,
+                )) = replication_health
+                {
+                    metrics::log_raft_replication_health(
+                        self.config.partition_id,
+                        configured_voters,
+                        recent_active_voters,
+                        lagging_followers,
+                        max_follower_lag_entries,
+                        total_follower_lag_entries,
+                    );
+                } else {
+                    metrics::reset_raft_replication_health(self.config.partition_id);
+                }
+
                 // 1. Send messages to peers.
                 for msg in ready.take_messages() {
                     let to = msg.to;
@@ -291,10 +361,17 @@ impl RaftNode {
 
                 // 2. Persist and apply any incoming snapshot before appending entries.
                 if !ready.snapshot().is_empty() {
+                    let snapshot_timer = metrics::raft_snapshot_apply_timer();
+                    let snapshot_bytes = ready.snapshot().get_data().len();
+                    metrics::log_raft_snapshot_apply_bytes(snapshot_bytes);
                     if let Err(e) = self.storage.apply_snapshot(ready.snapshot()) {
                         tracing::error!("Failed to persist snapshot: {e}");
+                        drop(snapshot_timer);
                     } else if let Err(e) = on_snapshot(ready.snapshot().get_data()) {
                         tracing::error!("Failed to apply snapshot to state machine: {e}");
+                        drop(snapshot_timer);
+                    } else {
+                        snapshot_timer.finish();
                     }
                 }
 

--- a/crates/database/src/raft_partition.rs
+++ b/crates/database/src/raft_partition.rs
@@ -50,6 +50,7 @@ use raft::prelude::Message;
 use tokio::sync::mpsc;
 
 use crate::{
+    metrics,
     partition::PartitionId,
     raft_node::{
         LeadershipCallbacks,
@@ -138,6 +139,7 @@ impl RaftPartitionManager {
         node.set_leadership_callbacks(LeadershipCallbacks {
             on_became_leader: Box::new(move || {
                 is_leader_cb.store(true, Ordering::SeqCst);
+                metrics::log_raft_is_leader(partition_id, true);
                 tracing::info!(
                     "Raft partition {}: Committer ACTIVATED (this node is leader)",
                     partition_id,
@@ -148,6 +150,8 @@ impl RaftPartitionManager {
                 let partition_id_lost = partition_id;
                 move || {
                     is_leader_lost.store(false, Ordering::SeqCst);
+                    metrics::log_raft_is_leader(partition_id_lost, false);
+                    metrics::reset_raft_replication_health(partition_id_lost);
                     tracing::info!(
                         "Raft partition {}: Committer DEACTIVATED (lost leadership)",
                         partition_id_lost,
@@ -159,7 +163,9 @@ impl RaftPartitionManager {
                 let partition_id_changed = partition_id;
                 move |new_leader_id| {
                     let old = leader_id_changed.swap(new_leader_id, Ordering::SeqCst);
+                    metrics::log_raft_leader_id(partition_id_changed, new_leader_id);
                     if old != new_leader_id {
+                        metrics::log_raft_leader_change(partition_id_changed);
                         tracing::info!(
                             "Raft partition {}: leader changed from {} to {}",
                             partition_id_changed,
@@ -177,6 +183,9 @@ impl RaftPartitionManager {
             proposal_tx: mailbox_tx.clone(),
             partition_id: config.partition_id,
         };
+        metrics::log_raft_is_leader(config.partition_id, false);
+        metrics::log_raft_leader_id(config.partition_id, 0);
+        metrics::reset_raft_replication_health(config.partition_id);
 
         Ok(Self {
             node: Some(node),

--- a/crates/database/src/snapshot_checkpointer.rs
+++ b/crates/database/src/snapshot_checkpointer.rs
@@ -39,9 +39,12 @@ use value::{
     TabletId,
 };
 
-use crate::checkpoint::{
-    create_checkpoint,
-    CheckpointData,
+use crate::{
+    checkpoint::{
+        create_checkpoint,
+        CheckpointData,
+    },
+    metrics,
 };
 
 /// How often the Primary writes a new checkpoint.
@@ -124,9 +127,12 @@ impl SnapshotCheckpointer {
                 .await
             {
                 Ok(ts) => {
+                    metrics::log_checkpoint_write_result(true);
+                    metrics::log_checkpoint_written_ts(ts);
                     tracing::info!("Wrote checkpoint at ts={ts}");
                 },
                 Err(e) => {
+                    metrics::log_checkpoint_write_result(false);
                     tracing::error!("Failed to write checkpoint: {e:?}");
                 },
             }
@@ -173,10 +179,26 @@ pub async fn load_latest_checkpoint(
     storage: &Arc<dyn Storage>,
 ) -> anyhow::Result<Option<CheckpointData>> {
     let latest_key = latest_checkpoint_object_key()?;
-    let Some(bytes) = read_storage_object(storage, &latest_key).await? else {
+    let bytes = match read_storage_object(storage, &latest_key).await {
+        Ok(bytes) => bytes,
+        Err(e) => {
+            metrics::log_checkpoint_load_result(false);
+            return Err(e);
+        },
+    };
+    let Some(bytes) = bytes else {
         return Ok(None);
     };
-    Ok(Some(checkpoint_from_bytes(&bytes)?))
+    let checkpoint = match checkpoint_from_bytes(&bytes) {
+        Ok(checkpoint) => checkpoint,
+        Err(e) => {
+            metrics::log_checkpoint_load_result(false);
+            return Err(e);
+        },
+    };
+    metrics::log_checkpoint_load_result(true);
+    metrics::log_checkpoint_loaded_ts(checkpoint.timestamp);
+    Ok(Some(checkpoint))
 }
 
 /// Proto encoding for checkpoint data.
@@ -385,7 +407,9 @@ mod tests {
             .await?;
         let _ = upload.complete().await?;
 
-        let loaded = load_latest_checkpoint(&storage).await?.expect("checkpoint should exist");
+        let loaded = load_latest_checkpoint(&storage)
+            .await?
+            .expect("checkpoint should exist");
         assert_eq!(loaded.timestamp, checkpoint.timestamp);
         assert!(loaded.documents.is_empty());
         assert!(loaded.globals.is_empty());

--- a/crates/database/src/snapshot_manager.rs
+++ b/crates/database/src/snapshot_manager.rs
@@ -59,6 +59,7 @@ use vector::{
 };
 
 use crate::{
+    metrics,
     partition::PartitionId,
     schema_registry::SchemaRegistry,
     table_registry::{
@@ -589,6 +590,11 @@ impl SnapshotManager {
     ) -> Self {
         let mut versions = VecDeque::new();
         versions.push_back((initial_ts, initial_snapshot));
+        metrics::log_latest_repeatable_ts(initial_ts);
+        metrics::log_persisted_max_repeatable_ts(initial_ts);
+        for (partition, frontier) in &replication_frontiers {
+            metrics::log_replication_frontier_ts(*partition, *frontier);
+        }
         Self {
             versions,
             persisted_max_repeatable_ts: initial_ts,
@@ -717,6 +723,7 @@ impl SnapshotManager {
             }
         }
         self.replication_frontiers.insert(partition, ts);
+        metrics::log_replication_frontier_ts(partition, ts);
         self.notify_replication_waiters(partition);
         Ok(true)
     }
@@ -875,6 +882,7 @@ impl SnapshotManager {
             self.versions.pop_front();
         }
         self.versions.push_back((ts, snapshot));
+        metrics::log_latest_repeatable_ts(ts);
         self.notify_waiters();
         self.write_throughput_limiter.record_write(ts, write_bytes);
     }
@@ -889,6 +897,11 @@ impl SnapshotManager {
         self.versions.push_back((ts, snapshot));
         self.persisted_max_repeatable_ts = ts;
         self.replication_frontiers = replication_frontiers;
+        metrics::log_latest_repeatable_ts(ts);
+        metrics::log_persisted_max_repeatable_ts(ts);
+        for (partition, frontier) in &self.replication_frontiers {
+            metrics::log_replication_frontier_ts(*partition, *frontier);
+        }
         self.notify_waiters();
         let partitions: Vec<_> = self.replication_frontiers.keys().copied().collect();
         for partition in partitions {
@@ -919,6 +932,7 @@ impl SnapshotManager {
             ts
         );
         self.persisted_max_repeatable_ts = ts;
+        metrics::log_persisted_max_repeatable_ts(ts);
         let (latest_ts, snapshot) = self.latest();
         if ts > *latest_ts {
             self.push(ts, snapshot, 0);
@@ -927,7 +941,6 @@ impl SnapshotManager {
             Ok(false)
         }
     }
-
 }
 
 pub fn replication_frontiers_to_json(frontiers: &BTreeMap<PartitionId, Timestamp>) -> JsonValue {

--- a/crates/database/src/tests/write_scaling_tests.rs
+++ b/crates/database/src/tests/write_scaling_tests.rs
@@ -79,6 +79,7 @@ use crate::{
         PartitionId,
         PartitionMap,
     },
+    tests::run_query,
     timestamp_oracle::{
         testing::InMemoryTimestampOracle,
         TimestampOracle,
@@ -89,7 +90,6 @@ use crate::{
         TwoPhaseCommitGrpcClient,
         TwoPhaseTransactionId,
     },
-    tests::run_query,
     Database,
     TestFacingModel,
     UserFacingModel,
@@ -895,7 +895,11 @@ async fn test_replication_frontier_heartbeat_does_not_advance_snapshot_ts(
         Query::full_table_scan("projects".parse()?, Order::Asc),
     )
     .await?;
-    assert_eq!(projects.len(), 1, "replica should expose the seeded project");
+    assert_eq!(
+        projects.len(),
+        1,
+        "replica should expose the seeded project"
+    );
 
     let heartbeat_ts = node_b.bump_max_repeatable_ts().await?;
     node_a

--- a/crates/database/src/two_phase_coordinator.rs
+++ b/crates/database/src/two_phase_coordinator.rs
@@ -17,6 +17,7 @@ use common::types::Timestamp;
 
 use crate::{
     committer::CommitterClient,
+    metrics,
     partition::{
         routed_partition_for_table,
         PartitionId,
@@ -223,6 +224,7 @@ pub async fn coordinate_two_phase_commit(
     write_source: WriteSource,
     partition_map: &PartitionMap,
 ) -> anyhow::Result<Timestamp> {
+    let timer = metrics::two_phase_coordinator_timer();
     let TransactionClassification::CrossPartition { partitions: _ } =
         classify_transaction(&transaction, partition_map, &write_source)
     else {
@@ -247,9 +249,12 @@ pub async fn coordinate_two_phase_commit(
             ))
         })
         .collect::<anyhow::Result<_>>()?;
+    metrics::log_two_phase_participants(participants.len());
 
     let mut last_retryable_error = None;
+    let mut prepare_attempts = 0usize;
     for attempt in 0..MAX_PREPARE_TS_RETRIES {
+        prepare_attempts = attempt + 1;
         let prepare_ts = local_committer.allocate_commit_ts().await?;
         tracing::info!(
             "2PC Coordinator: starting txn={}, participants={:?}, prepare_ts={}, attempt={}",
@@ -301,6 +306,7 @@ pub async fn coordinate_two_phase_commit(
                     }
 
                     if is_retryable_prepare_ts_error(&err) && attempt + 1 < MAX_PREPARE_TS_RETRIES {
+                        metrics::log_two_phase_prepare_retry();
                         tracing::info!(
                             "2PC Coordinator: retrying txn={} with a newer prepare timestamp \
                              after participant {} rejected ts on attempt {}",
@@ -312,6 +318,9 @@ pub async fn coordinate_two_phase_commit(
                         retry_prepare = true;
                         break;
                     }
+                    metrics::log_two_phase_error("prepare");
+                    metrics::log_two_phase_decision("rollback");
+                    metrics::log_two_phase_prepare_attempts(prepare_attempts);
                     return Err(err);
                 },
             }
@@ -323,14 +332,21 @@ pub async fn coordinate_two_phase_commit(
 
         let mut commit_results = Vec::new();
         for participant in &prepared_participants {
-            let commit_ts = commit_participant(
+            let commit_ts = match commit_participant(
                 local_committer,
                 node_addresses,
                 partition_map,
                 &txn_id,
                 *participant,
             )
-            .await?;
+            .await
+            {
+                Ok(commit_ts) => commit_ts,
+                Err(err) => {
+                    metrics::log_two_phase_error("commit");
+                    return Err(err);
+                },
+            };
             commit_results.push((*participant, commit_ts));
         }
 
@@ -349,9 +365,15 @@ pub async fn coordinate_two_phase_commit(
             txn_id,
             u64::from(prepare_ts),
         );
+        metrics::log_two_phase_prepare_attempts(prepare_attempts);
+        metrics::log_two_phase_decision("commit");
+        timer.finish();
         return Ok(prepare_ts);
     }
 
+    metrics::log_two_phase_error("prepare");
+    metrics::log_two_phase_decision("rollback");
+    metrics::log_two_phase_prepare_attempts(prepare_attempts.max(1));
     Err(last_retryable_error.unwrap_or_else(|| {
         anyhow::anyhow!(
             "2PC coordinator exhausted prepare timestamp retries for txn={}",

--- a/crates/local_backend/src/beacon.rs
+++ b/crates/local_backend/src/beacon.rs
@@ -23,8 +23,8 @@ use common::{
 };
 use database::Database;
 use model::database_globals::DatabaseGlobalsModel;
-use runtime::prod::ProdRuntime;
 use reqwest::Url;
+use runtime::prod::ProdRuntime;
 use serde::Deserialize;
 use serde_json::Value as JsonValue;
 const COMPILED_REVISION: &str = env!("VERGEN_GIT_SHA");

--- a/crates/local_backend/src/lib.rs
+++ b/crates/local_backend/src/lib.rs
@@ -99,6 +99,7 @@ pub mod environment_variables;
 pub mod http_actions;
 pub mod log_sinks;
 pub mod logs;
+mod metrics;
 pub mod mutation_forwarder;
 pub mod node_action_callbacks;
 pub mod parse;
@@ -213,8 +214,7 @@ pub async fn make_app(
     let replica_mutation_forwarder = if config.replication_mode == "replica" {
         match config.primary_grpc_url.as_deref() {
             Some(primary_grpc_url) => Some(Arc::new(
-                mutation_forwarder::MutationForwarderGrpcClient::connect(primary_grpc_url)
-                    .await?,
+                mutation_forwarder::MutationForwarderGrpcClient::connect(primary_grpc_url).await?,
             )),
             None => None,
         }
@@ -265,19 +265,34 @@ pub async fn make_app(
             checkpoint_path,
             StorageUseCase::Checkpoints,
         )?);
-        let checkpoint = database::snapshot_checkpointer::load_latest_checkpoint(&checkpoint_storage)
-            .await?
-            .ok_or_else(|| {
-                anyhow::anyhow!(
+        let checkpoint = match database::snapshot_checkpointer::load_latest_checkpoint(
+            &checkpoint_storage,
+        )
+        .await
+        {
+            Ok(Some(checkpoint)) => checkpoint,
+            Ok(None) => {
+                metrics::log_replica_bootstrap_result(false);
+                anyhow::bail!(
                     "Fresh replica startup requires a checkpoint, but none was found at {}",
                     checkpoint_path
-                )
-            })?;
+                );
+            },
+            Err(e) => {
+                metrics::log_replica_bootstrap_result(false);
+                return Err(e);
+            },
+        };
         let checkpoint_ts = checkpoint.timestamp;
-        database
+        if let Err(e) = database
             .committer_client()
             .install_snapshot(checkpoint)
-            .await?;
+            .await
+        {
+            metrics::log_replica_bootstrap_result(false);
+            return Err(e);
+        }
+        metrics::log_replica_bootstrap_result(true);
         tracing::info!("Bootstrapped fresh replica from checkpoint at ts={checkpoint_ts}");
     }
 
@@ -705,6 +720,7 @@ mod tests {
     };
     use futures::TryStreamExt;
     use keybroker::Identity;
+    use runtime::prod::ProdRuntime;
     use storage::{
         LocalDirStorage,
         Storage,
@@ -712,7 +728,6 @@ mod tests {
         Upload,
     };
     use value::TableName;
-    use runtime::prod::ProdRuntime;
 
     use crate::{
         config::LocalConfig,
@@ -724,92 +739,103 @@ mod tests {
         let tokio = ProdRuntime::init_tokio()?;
         let runtime = ProdRuntime::new(&tokio);
         let test_runtime = runtime.clone();
-        runtime.block_on("test_fresh_replica_bootstraps_from_checkpoint", async move {
-            let primary_persistence = Arc::new(TestPersistence::new());
-            let (_primary_shutdown_tx, primary_shutdown_rx) = async_broadcast::broadcast(1);
-            let primary = make_app(
-                test_runtime.clone(),
-                LocalConfig::new_for_test()?,
-                primary_persistence.clone(),
-                primary_shutdown_rx,
-                ShutdownSignal::no_op(),
-            )
-            .await?;
-
-            let table_name: TableName = "bootstrap_messages".parse()?;
-            let mut tx = primary.application.database().begin(Identity::system()).await?;
-            database::TestFacingModel::new(&mut tx)
-                .insert(&table_name, assert_obj!("text" => "hello from checkpoint"))
-                .await?;
-            primary.application.database().commit(tx).await?;
-
-            let checkpoint = primary
-                .application
-                .database()
-                .build_raft_snapshot_checkpoint()
-                .await?;
-            let checkpoint_dir = tempfile::tempdir()?;
-            let checkpoint_storage: Arc<dyn Storage> = Arc::new(LocalDirStorage::for_use_case(
-                test_runtime.clone(),
-                checkpoint_dir.path().to_str().unwrap(),
-                StorageUseCase::Checkpoints,
-            )?);
-            let mut upload = checkpoint_storage
-                .start_upload_with_key(
-                    database::snapshot_checkpointer::LATEST_CHECKPOINT_KEY.try_into()?,
+        runtime.block_on(
+            "test_fresh_replica_bootstraps_from_checkpoint",
+            async move {
+                let primary_persistence = Arc::new(TestPersistence::new());
+                let (_primary_shutdown_tx, primary_shutdown_rx) = async_broadcast::broadcast(1);
+                let primary = make_app(
+                    test_runtime.clone(),
+                    LocalConfig::new_for_test()?,
+                    primary_persistence.clone(),
+                    primary_shutdown_rx,
+                    ShutdownSignal::no_op(),
                 )
                 .await?;
-            upload
-                .write(database::snapshot_checkpointer::checkpoint_to_bytes(&checkpoint)?.into())
-                .await?;
-            let _ = upload.complete().await?;
 
-            let replica_persistence = Arc::new(TestPersistence::new());
-            let replica_storage_dir = tempfile::tempdir()?;
-            let (_shutdown_tx, shutdown_rx) = async_broadcast::broadcast(1);
-            let mut config = LocalConfig::new_for_test()?;
-            config.replication_mode = "replica".into();
-            config.replica_storage_path = Some(replica_storage_dir.path().to_str().unwrap().into());
-            config.checkpoint_storage_path = Some(checkpoint_dir.path().to_str().unwrap().into());
+                let table_name: TableName = "bootstrap_messages".parse()?;
+                let mut tx = primary
+                    .application
+                    .database()
+                    .begin(Identity::system())
+                    .await?;
+                database::TestFacingModel::new(&mut tx)
+                    .insert(&table_name, assert_obj!("text" => "hello from checkpoint"))
+                    .await?;
+                primary.application.database().commit(tx).await?;
 
-            let st = make_app(
-                test_runtime.clone(),
-                config,
-                replica_persistence.clone(),
-                shutdown_rx,
-                ShutdownSignal::no_op(),
-            )
-            .await?;
+                let checkpoint = primary
+                    .application
+                    .database()
+                    .build_raft_snapshot_checkpoint()
+                    .await?;
+                let checkpoint_dir = tempfile::tempdir()?;
+                let checkpoint_storage: Arc<dyn Storage> = Arc::new(LocalDirStorage::for_use_case(
+                    test_runtime.clone(),
+                    checkpoint_dir.path().to_str().unwrap(),
+                    StorageUseCase::Checkpoints,
+                )?);
+                let mut upload = checkpoint_storage
+                    .start_upload_with_key(
+                        database::snapshot_checkpointer::LATEST_CHECKPOINT_KEY.try_into()?,
+                    )
+                    .await?;
+                upload
+                    .write(
+                        database::snapshot_checkpointer::checkpoint_to_bytes(&checkpoint)?.into(),
+                    )
+                    .await?;
+                let _ = upload.complete().await?;
 
-            assert_eq!(
-                *st.application.database().now_ts_for_reads(),
-                checkpoint.timestamp
-            );
+                let replica_persistence = Arc::new(TestPersistence::new());
+                let replica_storage_dir = tempfile::tempdir()?;
+                let (_shutdown_tx, shutdown_rx) = async_broadcast::broadcast(1);
+                let mut config = LocalConfig::new_for_test()?;
+                config.replication_mode = "replica".into();
+                config.replica_storage_path =
+                    Some(replica_storage_dir.path().to_str().unwrap().into());
+                config.checkpoint_storage_path =
+                    Some(checkpoint_dir.path().to_str().unwrap().into());
 
-            let replica_docs: Vec<_> = replica_persistence
-                .load_documents(
-                    TimestampRange::all(),
-                    Order::Asc,
-                    10_000,
-                    Arc::new(NoopRetentionValidator),
+                let st = make_app(
+                    test_runtime.clone(),
+                    config,
+                    replica_persistence.clone(),
+                    shutdown_rx,
+                    ShutdownSignal::no_op(),
                 )
-                .try_collect()
                 .await?;
-            let expected_latest_docs = checkpoint
-                .documents
-                .iter()
-                .fold(BTreeMap::new(), |mut acc, entry| {
-                    acc.insert(entry.id, entry.clone());
-                    acc
-                })
-                .into_values()
-                .filter(|entry| entry.value.is_some())
-                .count();
-            assert_eq!(replica_docs.len(), expected_latest_docs);
 
-            primary.shutdown().await?;
-            st.shutdown().await?;
-            Ok(())
-        })
+                assert_eq!(
+                    *st.application.database().now_ts_for_reads(),
+                    checkpoint.timestamp
+                );
+
+                let replica_docs: Vec<_> = replica_persistence
+                    .load_documents(
+                        TimestampRange::all(),
+                        Order::Asc,
+                        10_000,
+                        Arc::new(NoopRetentionValidator),
+                    )
+                    .try_collect()
+                    .await?;
+                let expected_latest_docs = checkpoint
+                    .documents
+                    .iter()
+                    .fold(BTreeMap::new(), |mut acc, entry| {
+                        acc.insert(entry.id, entry.clone());
+                        acc
+                    })
+                    .into_values()
+                    .filter(|entry| entry.value.is_some())
+                    .count();
+                assert_eq!(replica_docs.len(), expected_latest_docs);
+
+                primary.shutdown().await?;
+                st.shutdown().await?;
+                Ok(())
+            },
+        )
     }
 }

--- a/crates/local_backend/src/metrics.rs
+++ b/crates/local_backend/src/metrics.rs
@@ -1,0 +1,20 @@
+use metrics::{
+    log_counter_with_labels,
+    register_convex_counter,
+    StaticMetricLabel,
+    STATUS_LABEL,
+};
+
+register_convex_counter!(
+    DATABASE_REPLICA_BOOTSTRAP_TOTAL,
+    "Number of fresh replica checkpoint bootstrap attempts by status",
+    &STATUS_LABEL
+);
+
+pub fn log_replica_bootstrap_result(success: bool) {
+    log_counter_with_labels(
+        &DATABASE_REPLICA_BOOTSTRAP_TOTAL,
+        1,
+        vec![StaticMetricLabel::status(success)],
+    );
+}

--- a/crates/local_backend/src/mutation_forwarder.rs
+++ b/crates/local_backend/src/mutation_forwarder.rs
@@ -121,7 +121,9 @@ impl MutationForwarder for MutationForwarderService {
                     .map(JsonValue::from)
                     .map(|value| serde_json::to_string(&value))
                     .transpose()
-                    .map_err(|e| Status::internal(format!("Failed to serialize error data: {e}")))?;
+                    .map_err(|e| {
+                        Status::internal(format!("Failed to serialize error data: {e}"))
+                    })?;
                 Ok(Response::new(ForwardMutationResponse {
                     result: Some(forward_mutation_response::Result::Error(MutationError {
                         error_message,

--- a/crates/local_backend/src/public_api.rs
+++ b/crates/local_backend/src/public_api.rs
@@ -207,11 +207,13 @@ async fn maybe_forward_public_mutation(
     }
 
     let Some(forwarder) = &st.replica_mutation_forwarder else {
-        return Ok(Some(Err(anyhow::anyhow!(ErrorMetadata::service_unavailable())
-            .context(
-                "Replica mutation forwarding is not configured. Set PRIMARY_GRPC_URL for replica mode.",
-            )
-            .into())));
+        return Ok(Some(Err(anyhow::anyhow!(
+            ErrorMetadata::service_unavailable()
+        )
+        .context(
+            "Replica mutation forwarding is not configured. Set PRIMARY_GRPC_URL for replica mode.",
+        )
+        .into())));
     };
 
     let value_format = format.map(|f| f.parse()).transpose()?;
@@ -237,30 +239,30 @@ async fn maybe_forward_public_mutation(
                 ),
             )?;
             UdfResponse::Success {
-                value: export_value(
-                    packed.unpack()?,
-                    value_format,
-                    client_version.clone(),
-                )?,
+                value: export_value(packed.unpack()?, value_format, client_version.clone())?,
                 log_lines: RedactedLogLines::from_vec(success.log_lines),
             }
         },
-        Some(pb::replication::forward_mutation_response::Result::Error(error)) => UdfResponse::Error {
-            error_message: error.error_message,
-            error_data: error
-                .error_data
-                .map(|value| serde_json::from_str(&value))
-                .transpose()
-                .context(ErrorMetadata::bad_request(
-                    "InvalidForwardedMutationErrorData",
-                    "Primary returned invalid forwarded mutation error data.",
-                ))?,
-            log_lines: RedactedLogLines::from_vec(error.log_lines),
+        Some(pb::replication::forward_mutation_response::Result::Error(error)) => {
+            UdfResponse::Error {
+                error_message: error.error_message,
+                error_data: error
+                    .error_data
+                    .map(|value| serde_json::from_str(&value))
+                    .transpose()
+                    .context(ErrorMetadata::bad_request(
+                        "InvalidForwardedMutationErrorData",
+                        "Primary returned invalid forwarded mutation error data.",
+                    ))?,
+                log_lines: RedactedLogLines::from_vec(error.log_lines),
+            }
         },
         None => {
-            return Ok(Some(Err(anyhow::anyhow!(ErrorMetadata::service_unavailable())
-                .context("Primary returned an empty forwarded mutation response.")
-                .into())));
+            return Ok(Some(Err(anyhow::anyhow!(
+                ErrorMetadata::service_unavailable()
+            )
+            .context("Primary returned an empty forwarded mutation response.")
+            .into())));
         },
     };
     Ok(Some(Ok(response)))
@@ -717,16 +719,15 @@ pub async fn public_mutation_post(
         .api
         .authenticate(&host, request_id.clone(), auth_token)
         .await?;
-    if let Some(response) =
-        maybe_forward_public_mutation(
-            &st,
-            &req.path,
-            &serialized_args,
-            req.format.as_deref(),
-            identity.clone(),
-            &client_version,
-        )
-        .await?
+    if let Some(response) = maybe_forward_public_mutation(
+        &st,
+        &req.path,
+        &serialized_args,
+        req.format.as_deref(),
+        identity.clone(),
+        &client_version,
+    )
+    .await?
     {
         return response.map(Json);
     }
@@ -856,7 +857,7 @@ mod tests {
         StatusCode,
     };
     use http_body_util::BodyExt;
-        use metrics::SERVER_VERSION_STR;
+    use metrics::SERVER_VERSION_STR;
     use runtime::prod::ProdRuntime;
     use serde_json::{
         json,
@@ -884,8 +885,7 @@ mod tests {
         let bytes = body.collect().await?.to_bytes();
         let msg = format!("Got response: {}", String::from_utf8_lossy(&bytes));
         assert_eq!(parts.status, StatusCode::OK, "{msg}");
-        serde_json::from_slice(if bytes.is_empty() { b"null" } else { &bytes })
-            .map_err(Into::into)
+        serde_json::from_slice(if bytes.is_empty() { b"null" } else { &bytes }).map_err(Into::into)
     }
 
     fn post_request(uri: &'static str, json_body: JsonValue) -> anyhow::Result<Request<Body>> {
@@ -996,9 +996,7 @@ mod tests {
     }
 
     #[convex_macro::prod_rt_test]
-    async fn test_http_mutation_forwards_when_replica_mode(
-        rt: ProdRuntime,
-    ) -> anyhow::Result<()> {
+    async fn test_http_mutation_forwards_when_replica_mode(rt: ProdRuntime) -> anyhow::Result<()> {
         let primary = setup_backend_for_test(rt.clone()).await?;
         let replica = setup_backend_for_test(rt.clone()).await?;
         primary.st.application.load_udf_tests_modules().await?;
@@ -1071,8 +1069,7 @@ mod tests {
             }
         }
         assert_eq!(
-            replica_test_docs,
-            0,
+            replica_test_docs, 0,
             "replica should not execute the forwarded mutation locally",
         );
 

--- a/docs/cluster-observability.md
+++ b/docs/cluster-observability.md
@@ -1,0 +1,278 @@
+# Cluster Observability
+
+This document is the operator-facing guide for the clustered backend.
+
+The goals are:
+
+1. Make it obvious which node currently owns a partition.
+2. Make follower lag and stalled replication visible without digging through
+   logs.
+3. Make transport backlog and publish-to-delivery lag visible.
+4. Make checkpoint bootstrap and snapshot install success/failure visible.
+5. Make 2PC latency, fanout, and retry pressure visible before they turn into
+   user-visible incidents.
+
+## Where To Look
+
+- `/metrics` is the source of truth for machine-readable health and alerting.
+- logs are for forensics and root-cause detail after an alert fires.
+- the dashboard is useful for quick orientation, but it is not the canonical
+  place to judge replication health.
+
+All metric names below are shown as their **base names**. The runtime prefixes
+them with the binary/service name automatically. For example,
+`database_raft_is_leader_info` is exported from the local backend process as:
+
+- `convex_local_backend_database_raft_is_leader_info`
+
+Likewise, the new transport and 2PC metrics below appear on `/metrics` with
+that same `convex_local_backend_` prefix.
+
+Two important scrape behaviors to know up front:
+
+- The follower-lag / under-replication Raft gauges are **leader-local**. On
+  follower nodes they are intentionally reset to `0`, because only the current
+  leader has authoritative per-follower progress.
+- Histogram metrics are **lazy**. They appear on `/metrics` only after the
+  first relevant event happens on that node, such as a 2PC transaction,
+  replication publish, or snapshot apply.
+
+## Core Metrics
+
+- `database_raft_is_leader_info{partition="N"}`
+  `1` means this node is the Raft leader for partition `N`; `0` means it is
+  not.
+- `database_raft_leader_id_info{partition="N"}`
+  Current known leader node ID for partition `N`. `0` means unknown.
+- `database_raft_leader_changes_total{partition="N"}`
+  Monotonic counter of leader changes observed on this node.
+- `database_raft_term_info{partition="N"}`
+  Current Raft term for partition `N`.
+- `database_raft_committed_index_info{partition="N"}`
+  Current committed Raft log index for partition `N`.
+- `database_raft_applied_index_info{partition="N"}`
+  Current applied Raft log index for partition `N`.
+- `database_raft_configured_voters_info{partition="N"}`
+  Number of configured voting replicas for partition `N`, reported by the
+  current leader. Followers reset this gauge to `0`.
+- `database_raft_recent_active_voters_info{partition="N"}`
+  Number of voting replicas the leader currently considers recently active.
+  Followers reset this gauge to `0`.
+- `database_raft_lagging_followers_info{partition="N"}`
+  Count of followers whose matched index is behind the leader commit index.
+  Followers reset this gauge to `0`.
+- `database_raft_max_follower_lag_entries_info{partition="N"}`
+  Worst-case follower log lag, in entries, for partition `N`.
+  Followers reset this gauge to `0`.
+- `database_raft_total_follower_lag_entries_info{partition="N"}`
+  Sum of all follower lag, in entries, for partition `N`.
+  Followers reset this gauge to `0`.
+- `database_raft_under_replicated_info{partition="N"}`
+  `1` means fewer voters are active than configured for partition `N`.
+  Followers reset this gauge to `0`.
+- `database_raft_quorum_unavailable_info{partition="N"}`
+  `1` means partition `N` currently lacks an active write quorum.
+  Followers reset this gauge to `0`.
+- `database_replication_frontier_ts_info{source_partition="N"}`
+  Latest remote frontier from source partition `N` that this node has applied.
+- `database_latest_repeatable_ts_info`
+  Latest repeatable timestamp currently visible on this node.
+- `database_persisted_max_repeatable_ts_info`
+  Latest repeatable timestamp durably persisted for this node.
+- `database_checkpoint_written_ts_info`
+  Latest checkpoint timestamp this node successfully wrote.
+- `database_checkpoint_write_total{status="success|error"}`
+  Counter of checkpoint write attempts.
+- `database_checkpoint_loaded_ts_info`
+  Latest checkpoint timestamp this node successfully loaded.
+- `database_checkpoint_load_total{status="success|error"}`
+  Counter of checkpoint load attempts.
+- `database_snapshot_installed_ts_info`
+  Latest checkpoint timestamp this node successfully installed into the local
+  database state.
+- `database_snapshot_install_total{status="success|error"}`
+  Counter of snapshot install attempts.
+- `database_raft_snapshot_apply_seconds{status="success|error"}`
+  Histogram of end-to-end snapshot persist-and-apply time. It appears after
+  the first real snapshot install on that node.
+- `database_raft_snapshot_apply_bytes`
+  Histogram of incoming Raft snapshot payload sizes. It appears after the
+  first real snapshot install on that node.
+- `database_replica_bootstrap_total{status="success|error"}`
+  Counter of fresh-replica checkpoint bootstrap attempts.
+- `database_write_rejected_not_leader_total{partition="N"}`
+  Counter of writes rejected because the node was not the leader for partition
+  `N`.
+- `database_two_phase_coordinator_decisions_total{outcome="commit|rollback"}`
+  Counter of 2PC coordinator decisions.
+- `database_two_phase_coordinator_errors_total{phase="prepare|commit"}`
+  Counter of 2PC coordinator failures by phase.
+- `database_two_phase_coordinator_seconds{status="success|error"}`
+  Histogram of end-to-end coordinator runtime. It appears after the first 2PC
+  transaction coordinated by that node.
+- `database_two_phase_participants_total`
+  Histogram of how many participant partitions each 2PC transaction touched.
+  It appears after the first 2PC transaction coordinated by that node.
+- `database_two_phase_prepare_attempts_total`
+  Histogram of how many prepare attempts were needed before a 2PC transaction
+  either committed or gave up. It appears after the first 2PC transaction
+  coordinated by that node.
+- `database_two_phase_prepare_retries_total`
+  Counter of 2PC prepare timestamp retries.
+- `database_replication_transport_publish_seconds`
+  Histogram of JetStream publish latency for replication messages.
+- `database_replication_transport_message_bytes{phase="publish|consume"}`
+  Histogram of replication message sizes by publish and consume phase.
+- `database_replication_transport_lag_seconds`
+  Histogram of publish-to-delivery lag for replication messages.
+- `database_replication_transport_pending_messages_info`
+  Current JetStream pending message count for the consumer on this node.
+- `database_replication_transport_stream_sequence_info`
+  Latest stream sequence observed by this node’s consumer.
+- `database_replication_transport_consumer_sequence_info`
+  Latest consumer sequence acknowledged by this node’s consumer.
+
+## Suggested Alerts
+
+- No leader:
+  alert if no node reports `database_raft_is_leader_info{partition="N"} == 1`
+  for more than 60 seconds.
+- Leader churn:
+  alert if `increase(database_raft_leader_changes_total[10m])` is unusually
+  high for any partition.
+- Follower lag:
+  compare `database_replication_frontier_ts_info{source_partition="N"}` across
+  nodes and watch `database_raft_lagging_followers_info`. Alert when one node
+  stays materially behind the max frontier for that partition or the leader
+  continues to report lagging followers for several minutes.
+- Under-replication:
+  alert if `database_raft_under_replicated_info{partition="N"} == 1` for more
+  than a short blip after a restart or deploy.
+- Quorum risk:
+  alert immediately if `database_raft_quorum_unavailable_info{partition="N"} == 1`.
+- Stalled apply path:
+  alert when `database_raft_committed_index_info` keeps moving but
+  `database_raft_applied_index_info` stalls on the same node.
+- Transport backlog:
+  alert when `database_replication_transport_pending_messages_info` grows
+  steadily instead of draining, or when
+  `database_replication_transport_stream_sequence_info -
+  database_replication_transport_consumer_sequence_info` remains large.
+- Transport latency:
+  alert when `database_replication_transport_lag_seconds` shifts upward
+  materially for sustained periods.
+- Checkpoint failure:
+  alert on any sustained increase in `database_checkpoint_write_total{status="error"}`.
+- Snapshot/bootstrap failure:
+  alert on any increase in `database_snapshot_install_total{status="error"}`
+  or `database_replica_bootstrap_total{status="error"}`.
+- Snapshot cost:
+  page or investigate when `database_raft_snapshot_apply_seconds` or
+  `database_raft_snapshot_apply_bytes` jumps sharply relative to normal
+  follower recovery, because large or slow snapshots usually imply a badly
+  lagging follower or storage trouble.
+- Wrong-node write traffic:
+  alert when `database_write_rejected_not_leader_total` spikes unexpectedly.
+- 2PC trouble:
+  alert when `database_two_phase_coordinator_errors_total` increases or when
+  `database_two_phase_prepare_retries_total` grows steadily.
+- 2PC latency or fanout growth:
+  investigate when `database_two_phase_coordinator_seconds`,
+  `database_two_phase_participants_total`, or
+  `database_two_phase_prepare_attempts_total` drifts upward because that often
+  precedes visible write latency regressions.
+
+## Runbooks
+
+### Lagging Follower
+
+1. Check `database_raft_leader_id_info` and confirm which node is leader for
+   the partition.
+2. Compare `database_raft_committed_index_info` and
+   `database_raft_applied_index_info` between leader and follower.
+3. Compare `database_raft_max_follower_lag_entries_info` and
+   `database_raft_total_follower_lag_entries_info` on the leader for the
+   affected partition.
+4. Compare `database_replication_frontier_ts_info` for the lagging source
+   partition on the follower.
+5. If JetStream transport is also behind, inspect
+   `database_replication_transport_pending_messages_info`,
+   `database_replication_transport_stream_sequence_info`, and
+   `database_replication_transport_consumer_sequence_info`.
+6. If the follower is far behind and log replay is not closing the gap, look
+   for a new increase in `database_snapshot_install_total{status="success"}`
+   to confirm snapshot catch-up.
+7. If snapshot install is failing, inspect logs around `install_snapshot` and
+   checkpoint decode/load.
+
+### Under-Replicated Partition
+
+1. Check `database_raft_under_replicated_info` and
+   `database_raft_recent_active_voters_info` for the affected partition.
+2. Confirm whether the missing voters are intentionally restarting or whether
+   a node is stuck.
+3. If `database_raft_quorum_unavailable_info == 1`, treat the partition as
+   write-unhealthy until voters return.
+4. Correlate with transport lag metrics and node logs before manually
+   restarting more nodes.
+
+### No Leader Or Heavy Churn
+
+1. Check whether any node reports `database_raft_is_leader_info == 1` for the
+   affected partition.
+2. If leadership keeps flipping, inspect recent increases in
+   `database_raft_leader_changes_total`.
+3. Correlate with network, restart, or NATS disruption events in logs.
+4. Do not trust write availability until a stable leader is present and
+   `database_raft_committed_index_info` is advancing again.
+
+### Fresh Replica Bootstrap Failure
+
+1. Check `database_replica_bootstrap_total{status="error"}`.
+2. Check whether `database_checkpoint_loaded_ts_info` moved at all.
+3. If load never succeeded, inspect checkpoint storage availability and the
+   checkpoint object itself.
+4. If load succeeded but install failed, inspect
+   `database_snapshot_install_total{status="error"}` and logs around snapshot
+   install/index rebuild.
+5. If installs are succeeding but are slow, inspect
+   `database_raft_snapshot_apply_seconds` and
+   `database_raft_snapshot_apply_bytes` to determine whether the issue is
+   snapshot size, disk apply time, or repeated re-installs.
+
+### Replication Transport Backlog
+
+1. Check `database_replication_transport_pending_messages_info`.
+2. Compare `database_replication_transport_stream_sequence_info` and
+   `database_replication_transport_consumer_sequence_info` to see whether the
+   consumer is catching up or stuck.
+3. Inspect `database_replication_transport_lag_seconds` to distinguish a slow
+   but draining consumer from a consumer that is no longer making progress.
+4. Correlate backlog growth with NATS availability, follower lag metrics, and
+   any snapshot installs in progress.
+
+### 2PC Failures
+
+1. Check `database_two_phase_coordinator_errors_total` to see whether the
+   failures are in `prepare` or `commit`.
+2. If `prepare` retries are climbing, inspect
+   `database_two_phase_prepare_retries_total`; this usually means timestamp
+   allocation pressure or stale participant state.
+3. Compare `database_two_phase_coordinator_seconds`,
+   `database_two_phase_participants_total`, and
+   `database_two_phase_prepare_attempts_total` to see whether the failures are
+   tied to wider fanout or repeated prepare retries.
+4. If `commit` errors are climbing, inspect the participant logs and confirm
+   which partition owner is failing.
+5. Treat repeated 2PC rollbacks as a correctness-risk signal even if retries
+   hide the issue from clients.
+
+## Scope Notes
+
+- This document covers the operator signals we expose directly from the
+  clustered backend.
+- It intentionally does not prescribe a single dashboard product. Prometheus,
+  Grafana, Datadog, or another metrics backend can all consume this surface.
+- It also intentionally stops short of shipping packaged Prometheus alert
+  rules. The metrics and runbooks are in place first; alert-rule files can be
+  layered on later if we decide to standardize on Prometheus.

--- a/docs/issue-journal.md
+++ b/docs/issue-journal.md
@@ -167,17 +167,6 @@ own for distributed changes.
   - the focused local-backend bootstrap test now passes on the real local
     environment without the earlier token-refresh storm.
 
-## Open Issues
-
-None currently tracked in this journal after the latest clean-cluster run.
-
-## Notes
-
-- This journal is intentionally short and high-signal. Deep architectural
-  writeups still belong in the other docs.
-- When an issue is fixed, append the exact validation command set or point to
-  the test suite that proved it.
-
 ### 2026-04 — Replica public mutations were not routed through the active forwarding path
 
 - **Status:** fixed
@@ -205,3 +194,88 @@ None currently tracked in this journal after the latest clean-cluster run.
   - clean-cluster rerun via `self-hosted/docker/test.sh`: all `77` write-scaling
     tests passed and all `10` Raft failover tests passed, confirming the
     routing change did not regress the distributed cluster paths.
+
+### 2026-04 — Cluster correctness outpaced operator visibility and recovery guidance
+
+- **Status:** fixed
+- **Related issue:** `#81`
+- **Symptom:** the cluster could pass the full write-scaling and failover
+  suites, but operators still had to infer leadership, follower lag,
+  checkpoint health, snapshot install activity, and 2PC health from logs and
+  code. There was no concise runbook for the most likely recovery cases.
+- **Root Cause:** we had correctness mechanisms for Raft, checkpoint bootstrap,
+  snapshot install, and 2PC, but we had not turned those internal state
+  machines into a dedicated operator-facing metrics and documentation surface.
+- **Fix:** add cluster metrics for Raft leadership and progress, replication
+  frontiers, repeatable timestamps, checkpoint write/load activity, snapshot
+  installs, non-leader write rejection, fresh-replica bootstrap outcome, and
+  2PC decisions/errors/retries. Document the new `/metrics` surface, alert
+  suggestions, and short runbooks in `docs/cluster-observability.md`, and link
+  that guide from the README.
+- **Validation:**
+  - `cargo check -p database`
+  - `cargo check -p local_backend`
+  - fresh image build and push:
+    `ghcr.io/martinkalema/convex-horizontal-scaling:backend-issue81-observability-db1454f-20260428-074208-dirty`
+  - pushed digest:
+    `sha256:1c5c280c6587a9b3bc6d64a45437665b5286d89c33b68048b3963028226c0fa0`
+  - clean-cluster rerun via `self-hosted/docker/test.sh`: all `77` write-scaling
+    tests passed and all `10` Raft failover tests passed on the exact image
+    above.
+
+### 2026-04 — The first observability slice still missed leader-lag, transport, snapshot-cost, and richer 2PC signals
+
+- **Status:** fixed
+- **Related issue:** `#81`
+- **Symptom:** the initial clustered observability work exposed leadership,
+  checkpoint, bootstrap, and coarse 2PC health, but we still could not answer
+  some operator questions cleanly: which followers are behind, whether a
+  partition is under-replicated, whether JetStream transport is backing up,
+  how expensive snapshot apply is, and whether 2PC latency/fanout/retry
+  distributions are drifting.
+- **Root Cause:** the first `#81` slice focused on basic correctness and
+  recovery signals. It did not yet include the richer leader-progress,
+  transport-latency, snapshot-cost, and 2PC-distribution metrics that mature
+  systems like CockroachDB, TiDB/TiKV, YugabyteDB, and Spanner commonly
+  surface for operators.
+- **Fix:** add leader-side Raft follower-lag and quorum-health gauges,
+  JetStream transport lag/backlog/sequence histograms and gauges, snapshot
+  apply duration and bytes histograms, and 2PC coordinator latency,
+  participant-count, and prepare-attempt histograms. Update the operator guide
+  to document the actual exported metric names, leader-local gauge semantics,
+  and lazy histogram behavior.
+- **Validation:**
+  - `cargo check -p database`
+  - host-environment `cargo check -p local_backend`
+  - fresh image build and push:
+    `ghcr.io/martinkalema/convex-horizontal-scaling:backend-issue81-observability-followup-db1454f-20260428-102451-dirty`
+  - pushed digest:
+    `sha256:11d5896bc7b7c226822e3a9efa7fb2c8b2ea4d69946e2530b845bd1dfb899af9`
+  - clean-cluster rerun via `self-hosted/docker/test.sh`: all `77` write-scaling
+    tests passed and all `10` Raft failover tests passed on the exact image
+    above
+  - live scrape verification from the running cluster confirmed the new
+    exported names and behavior for:
+    `convex_local_backend_database_raft_configured_voters_info`,
+    `..._recent_active_voters_info`, `..._lagging_followers_info`,
+    `..._under_replicated_info`, and the
+    `convex_local_backend_database_replication_transport_*` metrics
+  - a targeted post-suite redeploy plus one direct `crossPartitionWrite`
+    mutation confirmed the new 2PC histograms:
+    `convex_local_backend_database_two_phase_coordinator_seconds`,
+    `..._participants_total`, and `..._prepare_attempts_total`
+  - the snapshot-apply histograms are wired and documented as lazy/event-driven;
+    this standard `77 + 10` harness did not force a fresh Raft snapshot install
+    on the scraped node, so those names will appear after the next real
+    snapshot-apply event on that node
+
+## Open Issues
+
+None currently tracked in this journal after the latest clean-cluster run.
+
+## Notes
+
+- This journal is intentionally short and high-signal. Deep architectural
+  writeups still belong in the other docs.
+- When an issue is fixed, append the exact validation command set or point to
+  the test suite that proved it.


### PR DESCRIPTION
## Summary
- add a dedicated clustered observability guide and README links for operator-facing monitoring and recovery
- expand the metrics surface with leader-local Raft follower lag and quorum health, replication transport lag/backlog, snapshot apply cost, and richer 2PC coordinator distributions
- record the implementation and validation history in the issue journal and leave packaged alerts/dashboards as the follow-up tracked in #93

## Validation
- `env PROTOC=/Users/martin/Desktop/convex-horizontal-scaling/crates/pb_build/protoc/protoc-macos-universal cargo check --target-dir /tmp/convex-target-issue81-followup-db -p database`
- host-environment `cargo check --target-dir /tmp/convex-target-issue81-followup-lb -p local_backend`
- fresh backend image build and push:
  - `ghcr.io/martinkalema/convex-horizontal-scaling:backend-issue81-observability-followup-db1454f-20260428-102451-dirty`
  - digest: `sha256:11d5896bc7b7c226822e3a9efa7fb2c8b2ea4d69946e2530b845bd1dfb899af9`
- clean cluster reset and full top-level harness:
  - `docker compose down -v`
  - `docker compose --profile cluster up -d`
  - `bash self-hosted/docker/test.sh`
  - result: all `77` write-scaling tests passed and all `10` Raft failover tests passed
- live metrics scrapes verified the exported names and behavior for the new Raft health and replication transport metrics, and a targeted post-suite cross-partition mutation verified the new 2PC histograms

Closes #81
Refs #93
