### PR TITLE
feat(database): harden partition follower routing

### DIFF
--- a/crates/database/src/commit_delta.rs
+++ b/crates/database/src/commit_delta.rs
@@ -92,6 +92,19 @@ pub trait DistributedLog: Send + Sync + 'static {
         &self,
         from_ts: Timestamp,
     ) -> anyhow::Result<BoxStream<'static, anyhow::Result<CommitDelta>>>;
+
+    /// Subscribe to deltas starting after `from_ts`, optionally restricting
+    /// delivery to specific source partitions.
+    ///
+    /// Implementations that do not support filtering can fall back to
+    /// [`subscribe`] and perform any filtering client-side.
+    async fn subscribe_filtered(
+        &self,
+        from_ts: Timestamp,
+        _source_partitions: Option<Vec<PartitionId>>,
+    ) -> anyhow::Result<BoxStream<'static, anyhow::Result<CommitDelta>>> {
+        self.subscribe(from_ts).await
+    }
 }
 
 /// No-op implementation for single-node deployments. `publish` does nothing,

--- a/crates/database/src/committer.rs
+++ b/crates/database/src/committer.rs
@@ -636,6 +636,7 @@ impl<RT: Runtime> Committer<RT> {
                             sm.push(commit_ts, snapshot, write_bytes);
                             if let Some(source_partition) = source_partition {
                                 sm.update_replication_frontier(source_partition, commit_ts)?;
+                                sm.update_replication_write_frontier(source_partition, commit_ts)?;
                             }
                             let _ = result.send(Ok(commit_ts));
                         },
@@ -729,6 +730,16 @@ impl<RT: Runtime> Committer<RT> {
                             } else {
                                 commit_id += 1;
                             }
+                        },
+                        Some(CommitterMessage::SetRaftState { raft_state, result }) => {
+                            tracing::info!(
+                                "Committer attached to Raft partition {} (leader={}, leader_id={})",
+                                raft_state.partition_id(),
+                                raft_state.is_leader(),
+                                raft_state.leader_id(),
+                            );
+                            self.raft_state = Some(raft_state);
+                            let _ = result.send(());
                         },
                         Some(CommitterMessage::InstallSnapshot { checkpoint, result }) => {
                             self.install_snapshot(checkpoint, result, commit_id)?;
@@ -1674,7 +1685,8 @@ impl<RT: Runtime> Committer<RT> {
             if raft.is_leader() {
                 let envelope = crate::nats_distributed_log::DeltaEnvelope::from_delta(
                     &delta,
-                    &format!("raft-leader"),
+                    "",
+                    Some(raft.node_id()),
                 );
                 if let Ok(envelope) = envelope {
                     if let Ok(data) = serde_json::to_vec(&envelope) {
@@ -2826,6 +2838,23 @@ impl CommitterClient {
         rx.await.map_err(|_| metrics::shutdown_error())?
     }
 
+    pub async fn set_raft_state(
+        &self,
+        raft_state: crate::raft_partition::RaftPartitionState,
+    ) -> anyhow::Result<()> {
+        let (tx, rx) = oneshot::channel();
+        let message = CommitterMessage::SetRaftState {
+            raft_state,
+            result: tx,
+        };
+        self.sender.try_send(message).map_err(|e| match e {
+            TrySendError::Full(..) => metrics::committer_full_error().into(),
+            TrySendError::Closed(..) => metrics::shutdown_error(),
+        })?;
+        rx.await.map_err(|_| metrics::shutdown_error())?;
+        Ok(())
+    }
+
     pub async fn finish_table_summary_bootstrap(&self) -> anyhow::Result<()> {
         let (tx, rx) = oneshot::channel();
         let message = CommitterMessage::FinishTableSummaryBootstrap { result: tx };
@@ -3237,6 +3266,10 @@ enum CommitterMessage {
     ApplyReplicaDelta {
         delta: CommitDelta,
         result: oneshot::Sender<anyhow::Result<Timestamp>>,
+    },
+    SetRaftState {
+        raft_state: crate::raft_partition::RaftPartitionState,
+        result: oneshot::Sender<()>,
     },
     InstallSnapshot {
         checkpoint: CheckpointData,

--- a/crates/database/src/database.rs
+++ b/crates/database/src/database.rs
@@ -1168,6 +1168,16 @@ impl<RT: Runtime> Database<RT> {
     }
 
     #[cfg(test)]
+    pub(crate) fn replication_write_frontier_for_test(
+        &self,
+        partition: crate::partition::PartitionId,
+    ) -> Option<Timestamp> {
+        self.snapshot_manager
+            .lock()
+            .replication_write_frontier(partition)
+    }
+
+    #[cfg(test)]
     pub(crate) fn persisted_max_repeatable_ts_for_test(&self) -> RepeatableTimestamp {
         self.snapshot_manager.lock().persisted_max_repeatable_ts()
     }
@@ -1216,6 +1226,13 @@ impl<RT: Runtime> Database<RT> {
     /// the apply loop.
     pub fn committer_client(&self) -> CommitterClient {
         self.committer.clone()
+    }
+
+    pub async fn attach_raft_state(
+        &self,
+        raft_state: crate::raft_partition::RaftPartitionState,
+    ) -> anyhow::Result<()> {
+        self.committer.set_raft_state(raft_state).await
     }
 
     pub fn load_documents_in_table<'a>(
@@ -1667,6 +1684,30 @@ impl<RT: Runtime> Database<RT> {
             let fut = self.snapshot_manager.lock().wait_for_higher_ts(pred);
             fut.await;
         }
+    }
+
+    pub async fn wait_for_replication_frontier(
+        &self,
+        partition: crate::partition::PartitionId,
+        write_ts: Timestamp,
+    ) {
+        let fut = self
+            .snapshot_manager
+            .lock()
+            .wait_for_replication_frontier(partition, write_ts);
+        fut.await;
+    }
+
+    pub async fn wait_for_replication_write_frontier(
+        &self,
+        partition: crate::partition::PartitionId,
+        write_ts: Timestamp,
+    ) {
+        let fut = self
+            .snapshot_manager
+            .lock()
+            .wait_for_replication_write_frontier(partition, write_ts);
+        fut.await;
     }
 
     pub async fn begin_system(&self) -> anyhow::Result<Transaction<RT>> {

--- a/crates/database/src/metrics.rs
+++ b/crates/database/src/metrics.rs
@@ -1,3 +1,7 @@
+use ::search::metrics::{
+    SearchType,
+    SEARCH_TYPE_LABEL,
+};
 use common::{
     identity::IDENTITY_LABEL,
     runtime::Runtime,
@@ -26,10 +30,6 @@ use metrics::{
 use prometheus::{
     VMHistogram,
     VMHistogramVec,
-};
-use ::search::metrics::{
-    SearchType,
-    SEARCH_TYPE_LABEL,
 };
 
 use crate::{
@@ -244,6 +244,19 @@ pub fn log_replication_frontier_ts(source_partition: PartitionId, ts: Timestamp)
 }
 
 register_convex_gauge!(
+    DATABASE_REPLICATION_WRITE_FRONTIER_TS_INFO,
+    "Latest source-partition write timestamp that is safe for local strong reads on this node",
+    &SOURCE_PARTITION_LABELS
+);
+pub fn log_replication_write_frontier_ts(source_partition: PartitionId, ts: Timestamp) {
+    log_gauge_with_labels(
+        &DATABASE_REPLICATION_WRITE_FRONTIER_TS_INFO,
+        u64::from(ts) as f64,
+        vec![source_partition_label(source_partition)],
+    );
+}
+
+register_convex_gauge!(
     DATABASE_LATEST_REPEATABLE_TS_INFO,
     "Latest repeatable timestamp currently visible on this node"
 );
@@ -403,7 +416,10 @@ register_convex_histogram!(
     "Number of participants involved in a 2PC transaction"
 );
 pub fn log_two_phase_participants(num_participants: usize) {
-    log_distribution(&DATABASE_TWO_PHASE_PARTICIPANTS_TOTAL, num_participants as f64);
+    log_distribution(
+        &DATABASE_TWO_PHASE_PARTICIPANTS_TOTAL,
+        num_participants as f64,
+    );
 }
 
 register_convex_histogram!(
@@ -411,7 +427,10 @@ register_convex_histogram!(
     "Number of prepare timestamp allocation attempts for a 2PC transaction"
 );
 pub fn log_two_phase_prepare_attempts(num_attempts: usize) {
-    log_distribution(&DATABASE_TWO_PHASE_PREPARE_ATTEMPTS_TOTAL, num_attempts as f64);
+    log_distribution(
+        &DATABASE_TWO_PHASE_PREPARE_ATTEMPTS_TOTAL,
+        num_attempts as f64,
+    );
 }
 
 register_convex_histogram!(

--- a/crates/database/src/nats_distributed_log.rs
+++ b/crates/database/src/nats_distributed_log.rs
@@ -69,6 +69,138 @@ pub struct NatsDistributedLog {
 }
 
 impl NatsDistributedLog {
+    fn partition_subject(partition: PartitionId) -> String {
+        format!("{SUBJECT_BASE}.{}", partition.0)
+    }
+
+    async fn subscribe_inner(
+        &self,
+        from_ts: Timestamp,
+        source_partitions: Option<Vec<PartitionId>>,
+    ) -> anyhow::Result<BoxStream<'static, anyhow::Result<CommitDelta>>> {
+        let filter_subjects = source_partitions.map(|partitions| {
+            partitions
+                .into_iter()
+                .map(Self::partition_subject)
+                .collect::<Vec<_>>()
+        });
+
+        // Create a durable consumer so it survives reconnections.
+        // DeliverPolicy::All replays all messages from the stream beginning,
+        // and we filter out messages at or before from_ts ourselves.
+        let consumer_name = self.consumer_name.clone();
+        let mut consumer: PullConsumer = self
+            .stream
+            .get_or_create_consumer(
+                &consumer_name,
+                jetstream::consumer::pull::Config {
+                    durable_name: Some(consumer_name.clone()),
+                    deliver_policy: jetstream::consumer::DeliverPolicy::All,
+                    ack_policy: jetstream::consumer::AckPolicy::Explicit,
+                    filter_subjects: filter_subjects.clone().unwrap_or_default(),
+                    ..Default::default()
+                },
+            )
+            .await
+            .context("Failed to create NATS durable consumer")?;
+        let consumer_info = consumer
+            .info()
+            .await
+            .context("Failed to get NATS consumer info")?
+            .clone();
+        metrics::log_replication_transport_pending_messages(consumer_info.num_pending);
+        metrics::log_replication_transport_stream_sequence(consumer_info.delivered.stream_sequence);
+        metrics::log_replication_transport_consumer_sequence(
+            consumer_info.delivered.consumer_sequence,
+        );
+
+        let from_ts_u64 = u64::from(from_ts);
+        let messages = consumer
+            .messages()
+            .await
+            .context("Failed to start consuming NATS messages")?;
+
+        tracing::info!(
+            ?filter_subjects,
+            "Subscribed to NATS stream '{}' with durable consumer '{}', from_ts={}",
+            STREAM_NAME,
+            consumer_name,
+            from_ts_u64,
+        );
+
+        let self_node_name = consumer_name.clone();
+        let stream = messages.filter_map(move |msg_result| {
+            let node_name = self_node_name.clone();
+            async move {
+                match msg_result {
+                    Ok(msg) => {
+                        metrics::log_replication_transport_message_bytes(
+                            "consume",
+                            msg.payload.len(),
+                        );
+                        match msg.info() {
+                            Ok(info) => {
+                                metrics::log_replication_transport_pending_messages(info.pending);
+                                metrics::log_replication_transport_stream_sequence(
+                                    info.stream_sequence,
+                                );
+                                metrics::log_replication_transport_consumer_sequence(
+                                    info.consumer_sequence,
+                                );
+                                let now_ns = std::time::SystemTime::now()
+                                    .duration_since(std::time::UNIX_EPOCH)
+                                    .unwrap_or_default()
+                                    .as_nanos()
+                                    as i128;
+                                let published_ns = info.published.unix_timestamp_nanos();
+                                if now_ns >= published_ns {
+                                    metrics::log_replication_transport_lag(
+                                        (now_ns - published_ns) as f64 / 1_000_000_000.0,
+                                    );
+                                }
+                            },
+                            Err(e) => {
+                                tracing::debug!("Failed to parse JetStream message info: {e}");
+                            },
+                        }
+                        if let Err(e) = msg.ack().await {
+                            tracing::warn!("Failed to ack NATS message: {e:?}");
+                        }
+                        let envelope: DeltaEnvelope = match serde_json::from_slice(&msg.payload) {
+                            Ok(e) => e,
+                            Err(e) => {
+                                tracing::error!("Failed to deserialize delta from NATS: {e}");
+                                return Some(Err(anyhow::anyhow!(
+                                    "Failed to deserialize delta: {e}"
+                                )));
+                            },
+                        };
+                        if envelope.ts <= from_ts_u64 {
+                            return None;
+                        }
+                        // Skip deltas published by this node to avoid double-applying.
+                        if !envelope.source_node.is_empty() && envelope.source_node == node_name {
+                            tracing::debug!("Skipping self-published delta at ts={}", envelope.ts,);
+                            return None;
+                        }
+                        tracing::debug!(
+                            "Received commit delta from NATS: ts={}, source={}",
+                            envelope.ts,
+                            envelope.source_node,
+                        );
+                        Some(envelope.to_delta())
+                    },
+                    Err(e) => {
+                        tracing::error!("NATS message error: {e}");
+                        Some(Err(anyhow::anyhow!("NATS message error: {e}")))
+                    },
+                }
+            }
+        });
+
+        Ok(Box::pin(stream))
+    }
+
     /// Connect to NATS and create/get the JetStream stream.
     pub async fn connect(config: NatsConfig) -> anyhow::Result<Self> {
         // async-nats pulls in rustls which needs a crypto provider.
@@ -149,13 +281,21 @@ pub struct DeltaEnvelope {
     /// Consumers skip deltas from their own node to avoid double-applying.
     #[serde(default)]
     source_node: String,
+    /// Raft node ID that originally proposed this delta, when serialized for
+    /// intra-partition Raft replication.
+    #[serde(default)]
+    source_raft_node_id: Option<u64>,
     /// Partition that originated this replication event.
     #[serde(default)]
     source_partition: Option<u32>,
 }
 
 impl DeltaEnvelope {
-    pub fn from_delta(delta: &CommitDelta, source_node: &str) -> anyhow::Result<Self> {
+    pub fn from_delta(
+        delta: &CommitDelta,
+        source_node: &str,
+        source_raft_node_id: Option<u64>,
+    ) -> anyhow::Result<Self> {
         let document_updates_proto = delta
             .document_updates
             .iter()
@@ -178,6 +318,7 @@ impl DeltaEnvelope {
             document_updates_proto,
             tablet_mapping,
             source_node: source_node.to_string(),
+            source_raft_node_id,
             source_partition: delta.source_partition.map(|partition| partition.0),
         })
     }
@@ -220,6 +361,10 @@ impl DeltaEnvelope {
             source_partition: self.source_partition.map(PartitionId),
         })
     }
+
+    pub fn source_raft_node_id(&self) -> Option<u64> {
+        self.source_raft_node_id
+    }
 }
 
 #[async_trait]
@@ -228,7 +373,7 @@ impl DistributedLog for NatsDistributedLog {
         let ts = u64::from(delta.ts);
         let num_updates = delta.document_updates.len();
 
-        let envelope = DeltaEnvelope::from_delta(&delta, &self.consumer_name)?;
+        let envelope = DeltaEnvelope::from_delta(&delta, &self.consumer_name, None)?;
         let payload = serde_json::to_vec(&envelope).context("Failed to serialize CommitDelta")?;
         let payload_size = payload.len();
         let publish_timer = metrics::replication_transport_publish_timer();
@@ -261,118 +406,14 @@ impl DistributedLog for NatsDistributedLog {
         &self,
         from_ts: Timestamp,
     ) -> anyhow::Result<BoxStream<'static, anyhow::Result<CommitDelta>>> {
-        // Create a durable consumer so it survives reconnections.
-        // DeliverPolicy::All replays all messages from the stream beginning,
-        // and we filter out messages at or before from_ts ourselves.
-        let consumer_name = self.consumer_name.clone();
-        let mut consumer: PullConsumer = self
-            .stream
-            .get_or_create_consumer(
-                &consumer_name,
-                jetstream::consumer::pull::Config {
-                    durable_name: Some(consumer_name.clone()),
-                    deliver_policy: jetstream::consumer::DeliverPolicy::All,
-                    ack_policy: jetstream::consumer::AckPolicy::Explicit,
-                    ..Default::default()
-                },
-            )
-            .await
-            .context("Failed to create NATS durable consumer")?;
-        let consumer_info = consumer
-            .info()
-            .await
-            .context("Failed to get NATS consumer info")?
-            .clone();
-        metrics::log_replication_transport_pending_messages(consumer_info.num_pending);
-        metrics::log_replication_transport_stream_sequence(
-            consumer_info.delivered.stream_sequence,
-        );
-        metrics::log_replication_transport_consumer_sequence(
-            consumer_info.delivered.consumer_sequence,
-        );
+        self.subscribe_inner(from_ts, None).await
+    }
 
-        let from_ts_u64 = u64::from(from_ts);
-        let messages = consumer
-            .messages()
-            .await
-            .context("Failed to start consuming NATS messages")?;
-
-        tracing::info!(
-            "Subscribed to NATS stream '{}' with durable consumer '{}', from_ts={}",
-            STREAM_NAME,
-            consumer_name,
-            from_ts_u64,
-        );
-
-        let self_node_name = consumer_name.clone();
-        let stream = messages.filter_map(move |msg_result| {
-            let node_name = self_node_name.clone();
-            async move {
-                match msg_result {
-                    Ok(msg) => {
-                        metrics::log_replication_transport_message_bytes(
-                            "consume",
-                            msg.payload.len(),
-                        );
-                        match msg.info() {
-                            Ok(info) => {
-                                metrics::log_replication_transport_pending_messages(info.pending);
-                                metrics::log_replication_transport_stream_sequence(
-                                    info.stream_sequence,
-                                );
-                                metrics::log_replication_transport_consumer_sequence(
-                                    info.consumer_sequence,
-                                );
-                                let now_ns = std::time::SystemTime::now()
-                                    .duration_since(std::time::UNIX_EPOCH)
-                                    .unwrap_or_default()
-                                    .as_nanos() as i128;
-                                let published_ns = info.published.unix_timestamp_nanos();
-                                if now_ns >= published_ns {
-                                    metrics::log_replication_transport_lag(
-                                        (now_ns - published_ns) as f64 / 1_000_000_000.0,
-                                    );
-                                }
-                            },
-                            Err(e) => {
-                                tracing::debug!("Failed to parse JetStream message info: {e}");
-                            },
-                        }
-                        if let Err(e) = msg.ack().await {
-                            tracing::warn!("Failed to ack NATS message: {e:?}");
-                        }
-                        let envelope: DeltaEnvelope = match serde_json::from_slice(&msg.payload) {
-                            Ok(e) => e,
-                            Err(e) => {
-                                tracing::error!("Failed to deserialize delta from NATS: {e}");
-                                return Some(Err(anyhow::anyhow!(
-                                    "Failed to deserialize delta: {e}"
-                                )));
-                            },
-                        };
-                        if envelope.ts <= from_ts_u64 {
-                            return None;
-                        }
-                        // Skip deltas published by this node to avoid double-applying.
-                        if !envelope.source_node.is_empty() && envelope.source_node == node_name {
-                            tracing::debug!("Skipping self-published delta at ts={}", envelope.ts,);
-                            return None;
-                        }
-                        tracing::debug!(
-                            "Received commit delta from NATS: ts={}, source={}",
-                            envelope.ts,
-                            envelope.source_node,
-                        );
-                        Some(envelope.to_delta())
-                    },
-                    Err(e) => {
-                        tracing::error!("NATS message error: {e}");
-                        Some(Err(anyhow::anyhow!("NATS message error: {e}")))
-                    },
-                }
-            }
-        });
-
-        Ok(Box::pin(stream))
+    async fn subscribe_filtered(
+        &self,
+        from_ts: Timestamp,
+        source_partitions: Option<Vec<PartitionId>>,
+    ) -> anyhow::Result<BoxStream<'static, anyhow::Result<CommitDelta>>> {
+        self.subscribe_inner(from_ts, source_partitions).await
     }
 }

--- a/crates/database/src/raft_partition.rs
+++ b/crates/database/src/raft_partition.rs
@@ -72,6 +72,8 @@ pub struct RaftPartitionState {
     proposal_tx: mpsc::UnboundedSender<RaftMessage>,
     /// Partition ID.
     partition_id: PartitionId,
+    /// This node's ID within the Raft group.
+    node_id: u64,
 }
 
 impl RaftPartitionState {
@@ -88,6 +90,11 @@ impl RaftPartitionState {
     /// Get the partition ID.
     pub fn partition_id(&self) -> PartitionId {
         self.partition_id
+    }
+
+    /// Get this node's ID within the Raft group.
+    pub fn node_id(&self) -> u64 {
+        self.node_id
     }
 
     /// Send a Raft message to the node (proposals or forwarded Raft messages).
@@ -182,6 +189,7 @@ impl RaftPartitionManager {
             leader_id,
             proposal_tx: mailbox_tx.clone(),
             partition_id: config.partition_id,
+            node_id: config.node_id,
         };
         metrics::log_raft_is_leader(config.partition_id, false);
         metrics::log_raft_leader_id(config.partition_id, 0);

--- a/crates/database/src/snapshot_manager.rs
+++ b/crates/database/src/snapshot_manager.rs
@@ -1,4 +1,5 @@
 use std::{
+    cmp,
     collections::{
         BTreeMap,
         VecDeque,
@@ -92,9 +93,12 @@ pub struct SnapshotManager {
     persisted_max_repeatable_ts: Timestamp,
     versions: VecDeque<(Timestamp, Snapshot)>,
     replication_frontiers: BTreeMap<PartitionId, Timestamp>,
+    replication_write_frontiers: BTreeMap<PartitionId, Timestamp>,
     write_throughput_limiter: WriteThroughputLimiter,
     waiters: Mutex<VecDeque<(Timestamp, oneshot::Sender<()>)>>,
     replication_waiters: Mutex<BTreeMap<PartitionId, VecDeque<(Timestamp, oneshot::Sender<()>)>>>,
+    replication_write_waiters:
+        Mutex<BTreeMap<PartitionId, VecDeque<(Timestamp, oneshot::Sender<()>)>>>,
 }
 
 #[derive(Clone)]
@@ -588,6 +592,10 @@ impl SnapshotManager {
         initial_snapshot: Snapshot,
         replication_frontiers: BTreeMap<PartitionId, Timestamp>,
     ) -> Self {
+        let replication_write_frontiers = replication_frontiers
+            .iter()
+            .map(|(partition, frontier)| (*partition, cmp::min(*frontier, initial_ts)))
+            .collect::<BTreeMap<_, _>>();
         let mut versions = VecDeque::new();
         versions.push_back((initial_ts, initial_snapshot));
         metrics::log_latest_repeatable_ts(initial_ts);
@@ -595,13 +603,18 @@ impl SnapshotManager {
         for (partition, frontier) in &replication_frontiers {
             metrics::log_replication_frontier_ts(*partition, *frontier);
         }
+        for (partition, frontier) in &replication_write_frontiers {
+            metrics::log_replication_write_frontier_ts(*partition, *frontier);
+        }
         Self {
             versions,
             persisted_max_repeatable_ts: initial_ts,
             replication_frontiers,
+            replication_write_frontiers,
             write_throughput_limiter: WriteThroughputLimiter::new(),
             waiters: Mutex::new(VecDeque::new()),
             replication_waiters: Mutex::new(BTreeMap::new()),
+            replication_write_waiters: Mutex::new(BTreeMap::new()),
         }
     }
 
@@ -679,6 +692,30 @@ impl SnapshotManager {
         }
     }
 
+    fn notify_replication_write_waiters(&self, partition: PartitionId) {
+        let Some(frontier) = self.replication_write_frontiers.get(&partition).copied() else {
+            return;
+        };
+        let mut waiters = self.replication_write_waiters.lock();
+        let Some(partition_waiters) = waiters.get_mut(&partition) else {
+            return;
+        };
+        let mut i = 0;
+        while i < partition_waiters.len() {
+            if frontier >= partition_waiters[i].0 || partition_waiters[i].1.is_closed() {
+                let waiter = partition_waiters
+                    .swap_remove_back(i)
+                    .expect("checked above");
+                let _ = waiter.1.send(());
+                continue;
+            }
+            i += 1;
+        }
+        if partition_waiters.is_empty() {
+            waiters.remove(&partition);
+        }
+    }
+
     /// Returns a future that blocks until the snapshot manager has advanced
     /// past the given timestamp.
     pub fn wait_for_higher_ts(&self, target_ts: Timestamp) -> impl Future<Output = ()> + use<> {
@@ -708,6 +745,10 @@ impl SnapshotManager {
         self.replication_frontiers.clone()
     }
 
+    pub fn replication_write_frontier(&self, partition: PartitionId) -> Option<Timestamp> {
+        self.replication_write_frontiers.get(&partition).copied()
+    }
+
     pub fn update_replication_frontier(
         &mut self,
         partition: PartitionId,
@@ -728,6 +769,26 @@ impl SnapshotManager {
         Ok(true)
     }
 
+    pub fn update_replication_write_frontier(
+        &mut self,
+        partition: PartitionId,
+        ts: Timestamp,
+    ) -> anyhow::Result<bool> {
+        if let Some(current) = self.replication_write_frontiers.get(&partition) {
+            anyhow::ensure!(
+                ts >= *current,
+                "replication write frontier for {partition} went backward from {current:?} to {ts:?}",
+            );
+            if ts == *current {
+                return Ok(false);
+            }
+        }
+        self.replication_write_frontiers.insert(partition, ts);
+        metrics::log_replication_write_frontier_ts(partition, ts);
+        self.notify_replication_write_waiters(partition);
+        Ok(true)
+    }
+
     pub fn wait_for_replication_frontier(
         &self,
         partition: PartitionId,
@@ -744,6 +805,36 @@ impl SnapshotManager {
         } else {
             let (sender, receiver) = oneshot::channel();
             self.replication_waiters
+                .lock()
+                .entry(partition)
+                .or_default()
+                .push_back((target_ts, sender));
+            Some(receiver)
+        };
+
+        async move {
+            if let Some(receiver) = receiver {
+                _ = receiver.await;
+            }
+        }
+    }
+
+    pub fn wait_for_replication_write_frontier(
+        &self,
+        partition: PartitionId,
+        target_ts: Timestamp,
+    ) -> impl Future<Output = ()> + use<> {
+        self.notify_replication_write_waiters(partition);
+
+        let receiver = if self
+            .replication_write_frontiers
+            .get(&partition)
+            .is_some_and(|frontier| *frontier >= target_ts)
+        {
+            None
+        } else {
+            let (sender, receiver) = oneshot::channel();
+            self.replication_write_waiters
                 .lock()
                 .entry(partition)
                 .or_default()
@@ -893,19 +984,28 @@ impl SnapshotManager {
         snapshot: Snapshot,
         replication_frontiers: BTreeMap<PartitionId, Timestamp>,
     ) {
+        let replication_write_frontiers = replication_frontiers
+            .iter()
+            .map(|(partition, frontier)| (*partition, cmp::min(*frontier, ts)))
+            .collect::<BTreeMap<_, _>>();
         self.versions.clear();
         self.versions.push_back((ts, snapshot));
         self.persisted_max_repeatable_ts = ts;
         self.replication_frontiers = replication_frontiers;
+        self.replication_write_frontiers = replication_write_frontiers;
         metrics::log_latest_repeatable_ts(ts);
         metrics::log_persisted_max_repeatable_ts(ts);
         for (partition, frontier) in &self.replication_frontiers {
             metrics::log_replication_frontier_ts(*partition, *frontier);
         }
+        for (partition, frontier) in &self.replication_write_frontiers {
+            metrics::log_replication_write_frontier_ts(*partition, *frontier);
+        }
         self.notify_waiters();
         let partitions: Vec<_> = self.replication_frontiers.keys().copied().collect();
         for partition in partitions {
             self.notify_replication_waiters(partition);
+            self.notify_replication_write_waiters(partition);
         }
     }
 

--- a/crates/database/src/tests/write_scaling_tests.rs
+++ b/crates/database/src/tests/write_scaling_tests.rs
@@ -889,6 +889,7 @@ async fn test_replication_frontier_heartbeat_does_not_advance_snapshot_ts(
 
     let snapshot_ts_before = *node_a.now_ts_for_reads();
     let persisted_repeatable_before = *node_a.persisted_max_repeatable_ts_for_test();
+    let write_frontier_before = node_a.replication_write_frontier_for_test(PartitionId(1));
     let projects = run_query(
         node_a.clone(),
         TableNamespace::root_component(),
@@ -930,6 +931,20 @@ async fn test_replication_frontier_heartbeat_does_not_advance_snapshot_ts(
         node_a.replication_frontier_for_test(PartitionId(1)),
         Some(heartbeat_ts),
         "heartbeat should still advance the remote replication frontier",
+    );
+    assert_eq!(
+        node_a.replication_write_frontier_for_test(PartitionId(1)),
+        write_frontier_before,
+        "heartbeat must not advertise newer local strong-read visibility",
+    );
+    assert!(
+        tokio::time::timeout(
+            Duration::from_millis(100),
+            node_a.wait_for_replication_write_frontier(PartitionId(1), heartbeat_ts),
+        )
+        .await
+        .is_err(),
+        "waiting for local write visibility should stay blocked on a frontier-only heartbeat",
     );
 
     let projects_after = run_query(

--- a/crates/local_backend/src/deploy_config2.rs
+++ b/crates/local_backend/src/deploy_config2.rs
@@ -87,6 +87,36 @@ use crate::{
 
 const INTERNAL_BACKEND_HTTP_PORT: u16 = 3210;
 
+async fn raft_leader_origin(st: &LocalAppState) -> anyhow::Result<Option<String>> {
+    let Some(raft_state) = st.raft_state.as_ref() else {
+        return Ok(None);
+    };
+    if raft_state.is_leader() {
+        return Ok(None);
+    }
+    let peer_http_origins = st.raft_peer_http_origins.as_ref().context(
+        "RAFT_PEERS is required to forward deploy metadata operations to the Raft leader",
+    )?;
+    for _ in 0..50 {
+        let leader_id = raft_state.leader_id();
+        if leader_id != 0 {
+            let leader_origin = peer_http_origins.get(&leader_id).with_context(|| {
+                format!("Missing RAFT_PEERS entry for Raft leader node {leader_id}")
+            })?;
+            return Ok(Some(leader_origin.clone()));
+        }
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+    Ok(None)
+}
+
+async fn deploy_target_origin(st: &LocalAppState) -> anyhow::Result<Option<String>> {
+    if let Some(origin) = metadata_owner_origin(st)? {
+        return Ok(Some(origin));
+    }
+    raft_leader_origin(st).await
+}
+
 fn metadata_owner_origin(st: &LocalAppState) -> anyhow::Result<Option<String>> {
     let Some(local_partition) = st.partition_id else {
         return Ok(None);
@@ -104,7 +134,7 @@ fn metadata_owner_origin(st: &LocalAppState) -> anyhow::Result<Option<String>> {
     Ok(Some(http_origin_from_peer_addr(owner_addr)?))
 }
 
-fn http_origin_from_peer_addr(addr: &str) -> anyhow::Result<String> {
+pub(crate) fn http_origin_from_peer_addr(addr: &str) -> anyhow::Result<String> {
     let normalized = if addr.contains("://") {
         addr.to_string()
     } else {
@@ -179,7 +209,7 @@ where
     Req: Serialize + AdminKeyCarrier,
     Resp: DeserializeOwned,
 {
-    let Some(owner_origin) = metadata_owner_origin(st)? else {
+    let Some(target_origin) = deploy_target_origin(st).await? else {
         return Ok(None);
     };
     let identity = if needs_write_access {
@@ -197,11 +227,11 @@ where
         )
         .await?
     };
-    let owner_instance_name = metadata_owner_instance_name(&owner_origin).await?;
-    let owner_admin_key = issue_owner_admin_key(st, &owner_instance_name, &identity)?;
-    req.set_admin_key(owner_admin_key);
+    let target_instance_name = metadata_owner_instance_name(&target_origin).await?;
+    let target_admin_key = issue_owner_admin_key(st, &target_instance_name, &identity)?;
+    req.set_admin_key(target_admin_key);
     Ok(Some(
-        forward_deploy_request(&owner_origin, path, req).await?,
+        forward_deploy_request(&target_origin, path, req).await?,
     ))
 }
 

--- a/crates/local_backend/src/lib.rs
+++ b/crates/local_backend/src/lib.rs
@@ -6,6 +6,7 @@
 
 use std::{
     self,
+    collections::BTreeMap,
     sync::Arc,
     time::Duration,
 };
@@ -134,6 +135,9 @@ pub struct LocalAppState {
     pub replica_mode: bool,
     pub partition_id: Option<database::partition::PartitionId>,
     pub node_addresses: Option<database::two_phase::NodeAddresses>,
+    pub raft_state: Option<database::raft_partition::RaftPartitionState>,
+    pub raft_peer_http_origins: Option<BTreeMap<u64, String>>,
+    pub raft_peer_grpc_urls: Option<BTreeMap<u64, String>>,
     pub replica_mutation_forwarder: Option<Arc<mutation_forwarder::MutationForwarderGrpcClient>>,
     /// Raft partition mailbox for receiving Raft messages from peers.
     /// None if Raft is not enabled.
@@ -155,8 +159,12 @@ impl LocalAppState {
 #[derive(Clone)]
 pub struct RouterState {
     pub api: Arc<dyn ApplicationApi>,
+    pub database: database::Database<ProdRuntime>,
     pub runtime: ProdRuntime,
     pub replica_mode: bool,
+    pub partition_id: Option<database::partition::PartitionId>,
+    pub raft_state: Option<database::raft_partition::RaftPartitionState>,
+    pub raft_peer_grpc_urls: Option<BTreeMap<u64, String>>,
     pub replica_mutation_forwarder: Option<Arc<mutation_forwarder::MutationForwarderGrpcClient>>,
 }
 
@@ -424,6 +432,9 @@ pub async fn make_app(
         .node_addresses
         .as_deref()
         .map(database::two_phase::NodeAddresses::from_config);
+    let mut raft_state_for_app = None;
+    let mut raft_peer_http_origins = None;
+    let mut raft_peer_grpc_urls = None;
 
     if !config.disable_beacon {
         let beacon_future = beacon::start_beacon(
@@ -440,7 +451,8 @@ pub async fn make_app(
     // Start the ReplicaDeltaConsumer to tail NATS and apply deltas from other
     // nodes. Runs on:
     //   - Replicas (REPLICATION_MODE=replica): consumes Primary's deltas
-    //   - Partitioned writers (PARTITION_ID set): consumes other partitions' deltas
+    //   - Partitioned writers (PARTITION_ID set): consumes only other
+    //     partitions' deltas, leaving same-partition convergence to Raft
     // Creates a fresh NATS connection dedicated to the consumer.
     let needs_delta_consumer =
         config.replication_mode == "replica" || config.partition_id.is_some();
@@ -448,10 +460,32 @@ pub async fn make_app(
         if let Some(nats_url) = &config.nats_url {
             let nats_url = nats_url.clone();
             let committer = database.committer_client();
+            let remote_partitions = config.partition_id.map(|local_partition| {
+                if let Some(num_partitions) = config.num_partitions {
+                    (0..num_partitions)
+                        .map(database::partition::PartitionId)
+                        .filter(|partition| partition.0 != local_partition)
+                        .collect::<Vec<_>>()
+                } else {
+                    config
+                        .node_addresses
+                        .as_deref()
+                        .map(database::two_phase::NodeAddresses::from_config)
+                        .map(|addresses| {
+                            addresses
+                                .partitions()
+                                .into_iter()
+                                .filter(|partition| partition.0 != local_partition)
+                                .collect::<Vec<_>>()
+                        })
+                        .unwrap_or_default()
+                }
+            });
             // In partitioned mode, start consuming from the beginning of the
             // stream. Each node has its own database with independent timestamps,
             // so we can't use the local database timestamp as a lower bound.
-            // The self-delta skip (source_node filter) prevents double-applying.
+            // We explicitly restrict partitioned nodes to other partitions'
+            // subjects so same-partition convergence comes from Raft apply.
             // In replica mode, start from the locally visible snapshot, which
             // may have just been bootstrapped from the latest checkpoint.
             let from_ts = if config.partition_id.is_some() {
@@ -481,8 +515,11 @@ pub async fn make_app(
                     };
                 let consumer_nats_dyn: Arc<dyn database::commit_delta::DistributedLog> =
                     consumer_nats;
-                tracing::info!("ReplicaDeltaConsumer subscribing to NATS...");
-                match consumer_nats_dyn.subscribe(from_ts.into()).await {
+                tracing::info!(?remote_partitions, "ReplicaDeltaConsumer subscribing to NATS...");
+                match consumer_nats_dyn
+                    .subscribe_filtered(from_ts.into(), remote_partitions.clone())
+                    .await
+                {
                     Ok(mut stream) => {
                         tracing::info!("ReplicaDeltaConsumer subscribed, processing deltas...");
                         while let Some(result) = futures::StreamExt::next(&mut stream).await {
@@ -547,12 +584,25 @@ pub async fn make_app(
 
         // Parse peer addresses: "1=host:port,2=host:port,3=host:port"
         let mut peer_addresses = std::collections::HashMap::new();
+        let mut peer_http_origins = BTreeMap::new();
+        let mut peer_grpc_urls = BTreeMap::new();
         let mut peer_ids = Vec::new();
         for pair in raft_peers_str.split(',') {
             let pair = pair.trim();
             if let Some((id_str, addr)) = pair.split_once('=') {
                 if let Ok(id) = id_str.trim().parse::<u64>() {
-                    peer_addresses.insert(id, addr.trim().to_string());
+                    let normalized_grpc_addr = if addr.contains("://") {
+                        addr.trim().to_string()
+                    } else {
+                        format!("http://{}", addr.trim())
+                    };
+                    peer_addresses.insert(id, normalized_grpc_addr.clone());
+                    peer_grpc_urls.insert(id, normalized_grpc_addr);
+                    if let Ok(origin) =
+                        crate::deploy_config2::http_origin_from_peer_addr(addr.trim())
+                    {
+                        peer_http_origins.insert(id, origin);
+                    }
                     peer_ids.push(id);
                 }
             }
@@ -593,6 +643,9 @@ pub async fn make_app(
             Some(snapshot_provider),
         )?;
         let raft_state = manager.state();
+        raft_state_for_app = Some(raft_state.clone());
+        raft_peer_http_origins = Some(peer_http_origins);
+        raft_peer_grpc_urls = Some(peer_grpc_urls);
         let mb_tx = manager.mailbox_tx();
         raft_mailbox_tx = Some(mb_tx);
 
@@ -612,14 +665,18 @@ pub async fn make_app(
                             serde_json::from_slice(data).map_err(|e| {
                                 anyhow::anyhow!("Failed to deserialize Raft entry: {e}")
                             })?;
+                        let proposed_locally = envelope.source_raft_node_id() == Some(raft_node_id);
                         let delta = envelope.to_delta()?;
 
-                        // Leader already applied locally — skip.
-                        // Followers apply via the Committer (same path as NATS).
-                        if !raft_state_for_apply.is_leader() {
+                        // Skip only the entries this node already committed
+                        // locally before proposing them through Raft. Every
+                        // other committed entry must be applied here, even if
+                        // this node later became leader.
+                        if !proposed_locally {
                             tracing::info!(
-                                "Raft follower applying committed delta: ts={}",
+                                "Applying committed Raft delta locally: ts={}, leader_now={}",
                                 u64::from(delta.ts),
+                                raft_state_for_apply.is_leader(),
                             );
                             // apply_replica_delta is async — use block_in_place
                             // since we're in the Raft loop's sync callback.
@@ -653,6 +710,12 @@ pub async fn make_app(
             });
         }
 
+        // Defer leader enforcement until after local database/application
+        // bootstrap is complete, then attach the live Raft state to the
+        // Committer so normal writes propose through Raft and followers reject
+        // non-leader writes.
+        database.attach_raft_state(raft_state.clone()).await?;
+
         // Start transport clients for each peer.
         for client in transport_clients {
             runtime.spawn_background("raft_transport_client", async move {
@@ -678,6 +741,9 @@ pub async fn make_app(
         replica_mode: config.replication_mode == "replica",
         partition_id,
         node_addresses,
+        raft_state: raft_state_for_app,
+        raft_peer_http_origins,
+        raft_peer_grpc_urls,
         replica_mutation_forwarder,
         raft_mailbox_tx,
     };

--- a/crates/local_backend/src/main.rs
+++ b/crates/local_backend/src/main.rs
@@ -143,6 +143,8 @@ async fn run_server_inner(runtime: ProdRuntime, config: LocalConfig) -> anyhow::
         let forwarder = MutationForwarderService::new(api, st.instance_name.clone());
         let two_pc = two_phase_service::TwoPhaseCommitGrpcService::new(
             st.application.database().committer_client(),
+            st.raft_state.clone(),
+            st.raft_peer_grpc_urls.clone(),
         );
 
         // Add Raft transport server if Raft is enabled.

--- a/crates/local_backend/src/public_api.rs
+++ b/crates/local_backend/src/public_api.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use anyhow::Context;
 use application::{
     api::ExecuteQueryTimestamp,
@@ -54,6 +56,7 @@ use value::{
 use crate::{
     args_structs::UdfPostRequestWithComponent,
     authentication::ExtractAuthenticationToken,
+    mutation_forwarder::MutationForwarderGrpcClient,
     parse::{
         parse_export_path,
         parse_udf_path,
@@ -194,6 +197,15 @@ impl UdfResponse {
     }
 }
 
+async fn wait_for_local_mutation_visibility(st: &RouterState, commit_ts: Timestamp) {
+    st.database.wait_for_write_ts(commit_ts).await;
+    if let Some(partition_id) = st.partition_id {
+        st.database
+            .wait_for_replication_write_frontier(partition_id, commit_ts)
+            .await;
+    }
+}
+
 async fn maybe_forward_public_mutation(
     st: &RouterState,
     path: &str,
@@ -202,22 +214,77 @@ async fn maybe_forward_public_mutation(
     identity: keybroker::Identity,
     client_version: &ClientVersion,
 ) -> Result<Option<Result<UdfResponse, HttpResponseError>>, HttpResponseError> {
-    if !st.replica_mode {
-        return Ok(None);
+    enum ForwardingMode {
+        Replica(Arc<MutationForwarderGrpcClient>),
+        RaftFollower(Arc<MutationForwarderGrpcClient>),
     }
 
-    let Some(forwarder) = &st.replica_mutation_forwarder else {
-        return Ok(Some(Err(anyhow::anyhow!(
-            ErrorMetadata::service_unavailable()
-        )
-        .context(
-            "Replica mutation forwarding is not configured. Set PRIMARY_GRPC_URL for replica mode.",
-        )
-        .into())));
+    let forwarding_mode = if st.replica_mode {
+        Some(ForwardingMode::Replica(
+            st.replica_mutation_forwarder
+                .as_ref()
+                .context(
+                    "Replica mutation forwarding is not configured. Set PRIMARY_GRPC_URL for \
+                     replica mode.",
+                )
+                .map_err(|e| {
+                    HttpResponseError::from(
+                        anyhow::anyhow!(ErrorMetadata::service_unavailable()).context(e),
+                    )
+                })?
+                .clone(),
+        ))
+    } else if let Some(raft_state) = st.raft_state.as_ref() {
+        if raft_state.is_leader() {
+            None
+        } else {
+            let leader_id = raft_state.leader_id();
+            if leader_id == 0 {
+                tracing::warn!(
+                    "Skipping follower mutation forwarding because partition has no elected Raft \
+                     leader yet"
+                );
+                return Ok(None);
+            }
+            let Some(leader_grpc_url) = st
+                .raft_peer_grpc_urls
+                .as_ref()
+                .and_then(|urls| urls.get(&leader_id))
+                .cloned()
+            else {
+                tracing::warn!(
+                    "Skipping follower mutation forwarding because RAFT_PEERS is missing leader \
+                     node {leader_id}"
+                );
+                return Ok(None);
+            };
+            match MutationForwarderGrpcClient::connect(&leader_grpc_url).await {
+                Ok(client) => Some(ForwardingMode::RaftFollower(Arc::new(client))),
+                Err(e) => {
+                    tracing::warn!(
+                        "Skipping follower mutation forwarding because leader {} at {} is not \
+                         reachable yet: {:#}",
+                        leader_id,
+                        leader_grpc_url,
+                        e
+                    );
+                    return Ok(None);
+                },
+            }
+        }
+    } else {
+        None
+    };
+
+    let Some(forwarding_mode) = forwarding_mode else {
+        return Ok(None);
+    };
+    let forwarder = match &forwarding_mode {
+        ForwardingMode::Replica(client) | ForwardingMode::RaftFollower(client) => client,
     };
 
     let value_format = format.map(|f| f.parse()).transpose()?;
-    let forwarded = forwarder
+    let forwarded = match forwarder
         .forward(
             path,
             serialized_args.get(),
@@ -225,13 +292,31 @@ async fn maybe_forward_public_mutation(
             &client_version.to_string(),
         )
         .await
-        .map_err(|e| {
-            anyhow::anyhow!(ErrorMetadata::service_unavailable())
+    {
+        Ok(forwarded) => forwarded,
+        Err(e) => match forwarding_mode {
+            ForwardingMode::Replica(_) => {
+                return Ok(Some(Err(anyhow::anyhow!(
+                    ErrorMetadata::service_unavailable()
+                )
                 .context(format!("Failed to forward mutation to primary: {e:#}"))
-        })?;
+                .into())));
+            },
+            ForwardingMode::RaftFollower(_) => {
+                tracing::warn!(
+                    "Skipping follower mutation forwarding because the leader RPC failed: {:#}",
+                    e
+                );
+                return Ok(None);
+            },
+        },
+    };
 
     let response = match forwarded.result {
         Some(pb::replication::forward_mutation_response::Result::Success(success)) => {
+            if matches!(forwarding_mode, ForwardingMode::RaftFollower(_)) {
+                wait_for_local_mutation_visibility(st, Timestamp::try_from(success.ts)?).await;
+            }
             let packed = JsonPackedValue::from_network(success.value).context(
                 ErrorMetadata::bad_request(
                     "InvalidForwardedMutationValue",
@@ -746,9 +831,12 @@ pub async fn public_mutation_post(
         .await?;
     let value_format = req.format.as_ref().map(|f| f.parse()).transpose()?;
     let response = match udf_result {
-        Ok(write_return) => UdfResponse::Success {
-            value: export_value(write_return.value.unpack()?, value_format, client_version)?,
-            log_lines: write_return.log_lines,
+        Ok(write_return) => {
+            wait_for_local_mutation_visibility(&st, write_return.ts).await;
+            UdfResponse::Success {
+                value: export_value(write_return.value.unpack()?, value_format, client_version)?,
+                log_lines: write_return.log_lines,
+            }
         },
         Err(write_error) => UdfResponse::error(
             write_error.error,

--- a/crates/local_backend/src/router.rs
+++ b/crates/local_backend/src/router.rs
@@ -404,8 +404,12 @@ pub fn router(st: LocalAppState) -> Router {
         .nest("/http/", http_action_routes())
         .with_state(RouterState {
             api: Arc::new(st.application.clone()),
+            database: st.application.database().clone(),
             runtime: st.application.runtime(),
             replica_mode: st.replica_mode,
+            partition_id: st.partition_id,
+            raft_state: st.raft_state.clone(),
+            raft_peer_grpc_urls: st.raft_peer_grpc_urls.clone(),
             replica_mutation_forwarder: st.replica_mutation_forwarder.clone(),
         });
 

--- a/crates/local_backend/src/two_phase_service.rs
+++ b/crates/local_backend/src/two_phase_service.rs
@@ -7,9 +7,13 @@
 //! The coordinator uses the database-layer gRPC client to reach remote
 //! partitions.
 
+use std::collections::BTreeMap;
+
 use database::{
+    raft_partition::RaftPartitionState,
     two_phase::{
         ParticipantTransaction,
+        TwoPhaseCommitGrpcClient,
         TwoPhaseTransactionId,
     },
     CommitterClient,
@@ -37,15 +41,59 @@ use tonic::{
 /// forwards them to the local CommitterClient.
 pub struct TwoPhaseCommitGrpcService {
     committer: CommitterClient,
+    raft_state: Option<RaftPartitionState>,
+    raft_peer_grpc_urls: Option<BTreeMap<u64, String>>,
 }
 
 impl TwoPhaseCommitGrpcService {
-    pub fn new(committer: CommitterClient) -> Self {
-        Self { committer }
+    pub fn new(
+        committer: CommitterClient,
+        raft_state: Option<RaftPartitionState>,
+        raft_peer_grpc_urls: Option<BTreeMap<u64, String>>,
+    ) -> Self {
+        Self {
+            committer,
+            raft_state,
+            raft_peer_grpc_urls,
+        }
     }
 
     pub fn into_server(self) -> TonicTwoPcServer<Self> {
         TonicTwoPcServer::new(self)
+    }
+
+    async fn leader_client(&self) -> Result<Option<TwoPhaseCommitGrpcClient>, Status> {
+        let Some(raft_state) = self.raft_state.as_ref() else {
+            return Ok(None);
+        };
+        if raft_state.is_leader() {
+            return Ok(None);
+        }
+        let leader_id = raft_state.leader_id();
+        if leader_id == 0 {
+            return Err(Status::unavailable(
+                "No elected Raft leader for this partition yet",
+            ));
+        }
+        let leader_addr = self
+            .raft_peer_grpc_urls
+            .as_ref()
+            .and_then(|urls| urls.get(&leader_id))
+            .cloned()
+            .ok_or_else(|| {
+                Status::unavailable(format!(
+                    "Missing RAFT_PEERS entry for Raft leader node {leader_id}"
+                ))
+            })?;
+        let client = TwoPhaseCommitGrpcClient::connect(&leader_addr)
+            .await
+            .map_err(|e| {
+                Status::unavailable(format!(
+                    "Failed to connect to Raft leader {} at {}: {e:#}",
+                    leader_id, leader_addr
+                ))
+            })?;
+        Ok(Some(client))
     }
 }
 
@@ -67,6 +115,16 @@ impl TwoPhaseCommitService for TwoPhaseCommitGrpcService {
             .try_into()
             .map_err(|e| Status::invalid_argument(format!("Invalid prepare timestamp: {e:#}")))?;
 
+        if let Some(client) = self.leader_client().await? {
+            let result = client
+                .prepare(&txn_id, transaction, req.write_source.into(), prepare_ts)
+                .await
+                .map_err(|e| Status::internal(format!("Leader Prepare failed: {e:#}")))?;
+            return Ok(Response::new(TwoPcPrepareResponse {
+                prepare_ts: u64::from(result.prepare_ts),
+            }));
+        }
+
         let result = self
             .committer
             .prepare_remote(txn_id, transaction, req.write_source.into(), prepare_ts)
@@ -85,6 +143,14 @@ impl TwoPhaseCommitService for TwoPhaseCommitGrpcService {
         let req = request.into_inner();
         let txn_id = TwoPhaseTransactionId(req.transaction_id.clone());
 
+        if let Some(client) = self.leader_client().await? {
+            let commit_ts = client
+                .commit_prepared(&txn_id)
+                .await
+                .map_err(|e| Status::internal(format!("Leader CommitPrepared failed: {e:#}")))?;
+            return Ok(Response::new(TwoPcCommitResponse { commit_ts }));
+        }
+
         let ts = self
             .committer
             .commit_prepared(txn_id)
@@ -102,6 +168,14 @@ impl TwoPhaseCommitService for TwoPhaseCommitGrpcService {
     ) -> Result<Response<TwoPcRollbackResponse>, Status> {
         let req = request.into_inner();
         let txn_id = TwoPhaseTransactionId(req.transaction_id.clone());
+
+        if let Some(client) = self.leader_client().await? {
+            client
+                .rollback_prepared(&txn_id)
+                .await
+                .map_err(|e| Status::internal(format!("Leader RollbackPrepared failed: {e:#}")))?;
+            return Ok(Response::new(TwoPcRollbackResponse {}));
+        }
 
         self.committer
             .rollback_prepared(txn_id)

--- a/docs/issue-journal.md
+++ b/docs/issue-journal.md
@@ -269,9 +269,135 @@ own for distributed changes.
     on the scraped node, so those names will appear after the next real
     snapshot-apply event on that node
 
+### 2026-04 — Same-partition followers still depend on NATS for application/deploy convergence
+
+- **Status:** open
+- **Related issue:** `#74`
+- **Symptom:** the first safe-looking `#74` attempt added partition-filtered
+  JetStream subscriptions and stopped partitioned nodes from consuming their
+  own partition's NATS subject, on the assumption that same-partition followers
+  already had everything they needed from Raft. The full clean-cluster
+  validation split cleanly:
+  - `77/77` write-scaling tests still passed
+  - the `10`-test Raft failover suite broke immediately
+  - followers in the same partition no longer agreed with the leader after a
+    single write, and they could not take over correctly after the leader was
+    killed
+- **Root Cause:** our current follower state convergence path still relies on
+  same-partition `CommitDelta` delivery over NATS. Removing the local-partition
+  JetStream feed did not just reduce cross-partition fanout; it also stopped
+  same-partition followers from converging application-visible deployment/data
+  state well enough to serve queries and become healthy write leaders during
+  failover. In other words, this codebase is not yet at the point where Raft
+  alone makes a follower query-ready for its partition.
+- **Fix:** roll back the runtime behavior change so partitioned nodes continue
+  consuming all partition subjects for now, keep the filtered-subscribe support
+  in the distributed-log abstraction/NATS transport as dormant groundwork, and
+  treat `#74` as blocked on a precursor: make same-partition followers fully
+  self-sufficient from their own Raft/apply path before we try to trim local
+  partition NATS traffic.
+- **Validation:**
+  - focused cargo pass after rollback:
+    `cargo test -p local_backend test_fresh_replica_bootstraps_from_checkpoint -- --nocapture`
+  - attempted optimization image on a clean cluster:
+    - `77/77` write-scaling tests passed
+    - Raft failover suite failed at follower agreement and post-leader-kill
+      writes
+  - rebuilt rollback image and reran the full clean-cluster harness:
+    `self-hosted/docker/test.sh`
+    Result: all `77` write-scaling tests passed and all `10` Raft failover
+    tests passed
+
+### 2026-05 — Test 29 exposed that replication frontier was not a strong-read fence
+
+- **Status:** fixed
+- **Related issue:** `#74`
+- **Symptom:** Write Scaling Test 29 (`Max Batch Size 200 docs`) failed in a
+  very specific way on the clean cluster:
+  - forwarded `messages:batchWrite(count=200)` returned success via Node A
+  - the immediate local `messages:countBatch(prefix)` on that same node
+    returned `0`
+  - cross-node reads could already see all `200`
+  - the local follower converged to `200` about a second later
+- **Root Cause:** we were treating the per-partition `replication_frontier`
+  like a strong local read fence. That frontier was allowed to advance on
+  idle/empty replication heartbeats, so a same-partition follower could decide
+  "I am fresh enough" before the actual batch write had become query-visible on
+  that node. This is exactly the distinction that TiKV makes between
+  leader-side progress (`resolved-ts`) and follower-safe local read progress
+  (`safe-ts`): observed replication progress is not automatically a safe local
+  strong-read timestamp.
+- **Fix:** split the signal in the snapshot manager:
+  - keep `replication_frontier` for observed/stale-read-style progress and
+    observability
+  - add a separate per-partition `replication_write_frontier` that advances
+    only when a real replicated write is published into the local snapshot/write
+    state
+  - make forwarded follower mutations wait on this write frontier instead of
+    the heartbeat-advancing frontier before returning success to the caller
+- **Validation:**
+  - targeted regression:
+    `cargo test -p database test_replication_frontier_heartbeat_does_not_advance_snapshot_ts -- --nocapture`
+  - focused forwarding proof:
+    `cargo test -p local_backend test_http_mutation_forwards_when_replica_mode -- --nocapture`
+  - fresh image rebuild, clean profile-scoped reset
+    `docker compose --profile cluster down -v --remove-orphans`, cluster
+    restart via `docker compose --profile cluster up -d`, and full harness
+    rerun:
+    `self-hosted/docker/test.sh`
+    Result: all `77` write-scaling tests passed and all `10` Raft failover
+    tests passed, including Test 29
+
+### 2026-05 — Same-partition followers became self-sufficient from Raft/apply
+
+- **Status:** fixed
+- **Related issue:** `#74`
+- **Symptom:** the first partition-filtering attempt had shown that removing a
+  partition's own NATS subject broke failover, which looked like proof that
+  same-partition followers still needed local-partition `CommitDelta` traffic.
+- **Root Cause:** the follower gap was not inherent to the design; it was in
+  our Raft apply path. We were skipping committed Raft entries based on whether
+  the node was *currently* leader instead of whether the entry had originally
+  been proposed locally. After leader changes, a node could become leader and
+  incorrectly skip committed entries that originated on the old leader. NATS
+  happened to mask that bug by delivering the same-partition delta through a
+  second path.
+- **Fix:** make Raft apply origin-aware and then trim NATS fanout:
+  - tag intra-partition Raft-published deltas with the proposing
+    `source_raft_node_id`
+  - apply every committed Raft delta locally unless this exact node already
+    proposed and applied it itself
+  - once same-partition followers were converging correctly from Raft/apply,
+    switch partitioned `ReplicaDeltaConsumer` subscriptions to only the *other*
+    partitions' NATS subjects via `subscribe_filtered(...)`
+- **Why this matches the big databases:** mature systems treat the ordered
+  replicated log as the authoritative path for same-replica convergence, and
+  then layer changefeeds/streaming on top of that. They do not depend on a
+  secondary change stream to make Raft followers query-ready:
+  - etcd/raft requires `Ready` batches to be handled and applied in order
+  - TiKV's apply worker is explicitly responsible for committed Raft entries
+  - CockroachDB followers catch up by replaying the Raft log or loading a
+    snapshot and then replaying later actions
+  - YugabyteDB followers apply committed log entries to their state machine
+- **Validation:**
+  - focused forwarding proof:
+    `cargo test -p local_backend test_http_mutation_forwards_when_replica_mode -- --nocapture`
+  - fresh image rebuild from the filtered-subscribe branch state
+  - clean profile-scoped reset:
+    `docker compose --profile cluster down -v --remove-orphans`
+  - cluster restart:
+    `docker compose --profile cluster up -d`
+  - full clean-cluster harness rerun:
+    `self-hosted/docker/test.sh`
+    Result: all `77` write-scaling tests passed and all `10` Raft failover
+    tests passed with partitioned nodes no longer consuming their own
+    partition's NATS subject
+
 ## Open Issues
 
-None currently tracked in this journal after the latest clean-cluster run.
+- `#74` is no longer blocked on follower self-sufficiency. The current
+  remaining question is how far we want to push selective fanout beyond
+  excluding same-partition NATS traffic.
 
 ## Notes
 


### PR DESCRIPTION
## Summary

This PR hardens partition follower routing and lands the first safe fanout reduction for `#74`.

What changed:
- make same-partition followers converge from the Raft/apply path instead of depending on their own partition's NATS `CommitDelta` stream
- tag Raft-published deltas with their proposing `source_raft_node_id` and only skip local re-apply for the node that originally proposed the entry
- reduce partitioned `ReplicaDeltaConsumer` fanout so nodes subscribe only to the *other* partitions' NATS subjects
- harden follower-forwarded mutation, deploy, and 2PC participant routing so requests wait for locally safe visibility before reporting success
- split observed replication progress from strong local visibility with a dedicated `replication_write_frontier`
- document the failure analysis and validation trail in `docs/issue-journal.md`

## Why

The first filtered-subscribe attempt showed that removing a partition's own NATS subject broke failover. The real issue turned out not to be the optimization itself, but a correctness gap in the Raft apply path and follower visibility fences:
- committed Raft entries could be skipped based on *current* leadership instead of original proposal ownership
- heartbeat-only frontier movement could be mistaken for local strong-read visibility

This PR fixes those gaps first, then safely trims same-partition NATS fanout.

## Scope

This PR advances `#74`, but it does **not** implement the finer-grained CDC/changefeed-style “interested nodes only” selective delivery model. That follow-up is tracked separately in `#96`.

## Validation

Focused checks:
- `cargo test -p local_backend test_http_mutation_forwards_when_replica_mode -- --nocapture`
- `cargo test -p database test_replication_frontier_heartbeat_does_not_advance_snapshot_ts -- --nocapture`

Clean-cluster end-to-end validation:
- `docker build -t ghcr.io/martinkalema/convex-horizontal-scaling:backend-latest -f self-hosted/docker-build/Dockerfile.backend .`
- `docker compose --profile cluster down -v --remove-orphans`
- `docker compose --profile cluster up -d`
- `bash self-hosted/docker/test.sh`

Result:
- `77/77` write-scaling tests passed
- `10/10` Raft failover tests passed
- `ALL SUITES PASSED`
