### PR TITLE
feat(cluster): implement selective delta delivery

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5705,6 +5705,7 @@ dependencies = [
  "futures",
  "futures-async-stream",
  "governor",
+ "headers",
  "http 1.3.1",
  "http-body-util",
  "http_client",

--- a/crates/database/src/commit_delta.rs
+++ b/crates/database/src/commit_delta.rs
@@ -6,7 +6,10 @@
 //! whatever transport carries deltas between nodes.
 
 use std::{
-    collections::BTreeMap,
+    collections::{
+        BTreeMap,
+        BTreeSet,
+    },
     sync::Arc,
 };
 
@@ -125,6 +128,12 @@ impl DistributedLog for NoopDistributedLog {
     }
 }
 
+impl CommitDelta {
+    pub fn touched_table_names(&self) -> BTreeSet<TableName> {
+        self.tablet_id_to_table_name.values().cloned().collect()
+    }
+}
+
 #[cfg(any(test, feature = "testing"))]
 pub mod testing {
     use std::sync::Arc;
@@ -198,5 +207,45 @@ pub mod testing {
             let combined = existing_stream.chain(broadcast_stream);
             Ok(Box::pin(combined))
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        collections::BTreeMap,
+        sync::Arc,
+    };
+
+    use common::types::Timestamp;
+    use value::TableName;
+
+    use crate::{
+        commit_delta::CommitDelta,
+        write_log::WriteSource,
+    };
+
+    #[test]
+    fn touched_table_names_collects_unique_tables() {
+        let messages: TableName = "messages".parse().unwrap();
+        let tasks: TableName = "tasks".parse().unwrap();
+        let mut tablet_id_to_table_name = BTreeMap::new();
+        tablet_id_to_table_name.insert(value::TabletId::MIN, messages.clone());
+        tablet_id_to_table_name.insert(value::TabletId::MAX, tasks.clone());
+        let delta = CommitDelta {
+            ts: Timestamp::MIN,
+            document_writes: Arc::new(Vec::new()),
+            document_updates: Vec::new(),
+            index_writes: Arc::new(Vec::new()),
+            write_source: WriteSource::unknown(),
+            write_bytes: 0,
+            tablet_id_to_table_name,
+            source_partition: None,
+        };
+
+        assert_eq!(
+            delta.touched_table_names(),
+            [messages, tasks].into_iter().collect()
+        );
     }
 }

--- a/crates/database/src/committer.rs
+++ b/crates/database/src/committer.rs
@@ -2971,6 +2971,29 @@ impl CommitterClient {
 
         // Finish reading everything from persistence.
         let transaction = transaction.finalize()?;
+        let transaction_classification = self.partition_map.as_ref().map(|partition_map| {
+            crate::two_phase_coordinator::classify_transaction(
+                &transaction,
+                partition_map,
+                &write_source,
+            )
+        });
+
+        if let (
+            Some(partition_map),
+            Some(crate::two_phase_coordinator::TransactionClassification::RemoteSinglePartition {
+                owner,
+            }),
+        ) = (&self.partition_map, &transaction_classification)
+        {
+            anyhow::bail!(
+                "Write rejected: this transaction targets only {}, not this node ({}). Route this \
+                 mutation to the correct partition owner.",
+                owner,
+                partition_map.local_partition(),
+            );
+        }
+
         self.wait_for_remote_read_frontiers(
             *transaction.begin_timestamp,
             transaction.reads.read_set(),
@@ -2987,11 +3010,9 @@ impl CommitterClient {
         // Classify: single-partition (fast path) vs cross-partition (2PC).
         // TiDB 1PC optimization: skip 2PC when all writes target one partition.
         if let Some(ref partition_map) = self.partition_map {
-            match crate::two_phase_coordinator::classify_transaction(
-                &transaction,
-                partition_map,
-                &write_source,
-            ) {
+            match transaction_classification
+                .expect("partitioned commit should always classify the finalized transaction")
+            {
                 crate::two_phase_coordinator::TransactionClassification::SinglePartition => {},
                 crate::two_phase_coordinator::TransactionClassification::RemoteSinglePartition {
                     owner,

--- a/crates/database/src/database.rs
+++ b/crates/database/src/database.rs
@@ -2104,18 +2104,74 @@ impl<RT: Runtime> Database<RT> {
     /// N.B. Only use this function for user subscriptions. System subscriptions
     /// should use `subscribe_and_wait_for_invalidation`.
     pub async fn subscribe(&self, token: Token) -> anyhow::Result<Subscription> {
-        self.subscriptions.subscribe(token, false)
+        let interested_tables = Arc::new(self.read_set_table_names(token.reads())?);
+        self.subscriptions
+            .subscribe(token, interested_tables, false)
     }
 
     pub async fn subscribe_and_wait_for_invalidation(
         &self,
         token: Token,
     ) -> anyhow::Result<Option<Timestamp>> {
-        let subscription = self.subscriptions.subscribe(token, true)?;
+        let interested_tables = Arc::new(self.read_set_table_names(token.reads())?);
+        let subscription = self
+            .subscriptions
+            .subscribe(token, interested_tables, true)?;
         let invalid_ts = subscription.wait_for_invalidation().await;
         let current_ts = self.now_ts_for_reads();
         metrics::log_subscription_invalidation_lag(invalid_ts, *current_ts);
         Ok(invalid_ts)
+    }
+
+    pub fn delta_interest_tracker(&self) -> crate::delta_interest::DeltaInterestTracker {
+        self.subscriptions.delta_interest_tracker()
+    }
+
+    pub fn token_table_names(&self, token: &Token) -> anyhow::Result<BTreeSet<TableName>> {
+        self.read_set_table_names(token.reads())
+    }
+
+    pub fn note_recent_delta_interest_for_token(
+        &self,
+        token: &Token,
+        ttl: Duration,
+    ) -> anyhow::Result<()> {
+        let interested_tables = self.token_table_names(token)?;
+        self.subscriptions
+            .delta_interest_tracker()
+            .refresh_recent_tables(&interested_tables, ttl);
+        Ok(())
+    }
+
+    fn read_set_table_names(&self, reads: &crate::ReadSet) -> anyhow::Result<BTreeSet<TableName>> {
+        let snapshot = self.latest_snapshot()?;
+        let table_mapping = snapshot.table_mapping();
+        let mut table_names = BTreeSet::new();
+
+        let mut record_table = |tablet_id| -> anyhow::Result<()> {
+            if !table_mapping.tablet_id_exists(tablet_id)
+                || table_mapping.is_system_tablet(tablet_id)
+            {
+                return Ok(());
+            }
+            let (_, _, table_name) =
+                table_mapping
+                    .get_table_metadata(tablet_id)
+                    .with_context(|| {
+                        format!("Missing table metadata for subscribed tablet {tablet_id}")
+                    })?;
+            table_names.insert(table_name.clone());
+            Ok(())
+        };
+
+        for (index_name, _) in reads.iter_indexed() {
+            record_table(*index_name.table())?;
+        }
+        for (index_name, _) in reads.iter_search() {
+            record_table(*index_name.table())?;
+        }
+
+        Ok(table_names)
     }
 
     fn streaming_export_table_filter(

--- a/crates/database/src/delta_interest.rs
+++ b/crates/database/src/delta_interest.rs
@@ -1,0 +1,188 @@
+use std::{
+    collections::{
+        BTreeMap,
+        BTreeSet,
+    },
+    sync::Arc,
+    time::{
+        Duration,
+        Instant,
+    },
+};
+
+use parking_lot::Mutex;
+use tokio::sync::watch;
+use value::TableName;
+
+use crate::metrics;
+
+#[derive(Clone)]
+pub struct DeltaInterestTracker {
+    inner: Arc<Mutex<InterestState>>,
+    tx: watch::Sender<Arc<BTreeSet<TableName>>>,
+}
+
+#[derive(Default)]
+struct InterestState {
+    ref_counts: BTreeMap<TableName, usize>,
+    recent_expirations: BTreeMap<TableName, Instant>,
+}
+
+impl DeltaInterestTracker {
+    pub fn new() -> Self {
+        let initial = Arc::new(BTreeSet::new());
+        let (tx, _) = watch::channel(initial);
+        Self {
+            inner: Arc::new(Mutex::new(InterestState::default())),
+            tx,
+        }
+    }
+
+    pub fn add_tables(&self, tables: &BTreeSet<TableName>) {
+        if tables.is_empty() {
+            return;
+        }
+        let mut state = self.inner.lock();
+        state.prune_expired(Instant::now());
+        for table in tables {
+            *state.ref_counts.entry(table.clone()).or_default() += 1;
+        }
+        self.publish_locked(&state);
+    }
+
+    pub fn remove_tables(&self, tables: &BTreeSet<TableName>) {
+        if tables.is_empty() {
+            return;
+        }
+        let mut state = self.inner.lock();
+        state.prune_expired(Instant::now());
+        for table in tables {
+            let Some(count) = state.ref_counts.get_mut(table) else {
+                continue;
+            };
+            if *count <= 1 {
+                state.ref_counts.remove(table);
+            } else {
+                *count -= 1;
+            }
+        }
+        self.publish_locked(&state);
+    }
+
+    pub fn refresh_recent_tables(&self, tables: &BTreeSet<TableName>, ttl: Duration) {
+        self.refresh_recent_tables_at(tables, Instant::now(), ttl);
+    }
+
+    pub fn prune_expired(&self) {
+        self.prune_expired_at(Instant::now());
+    }
+
+    pub fn snapshot(&self) -> Arc<BTreeSet<TableName>> {
+        self.prune_expired();
+        self.tx.borrow().clone()
+    }
+
+    pub fn watch(&self) -> watch::Receiver<Arc<BTreeSet<TableName>>> {
+        self.tx.subscribe()
+    }
+
+    fn refresh_recent_tables_at(&self, tables: &BTreeSet<TableName>, now: Instant, ttl: Duration) {
+        if tables.is_empty() || ttl.is_zero() {
+            return;
+        }
+        let Some(expires_at) = now.checked_add(ttl) else {
+            return;
+        };
+        let mut state = self.inner.lock();
+        state.prune_expired(now);
+        for table in tables {
+            state
+                .recent_expirations
+                .entry(table.clone())
+                .and_modify(|current| *current = (*current).max(expires_at))
+                .or_insert(expires_at);
+        }
+        self.publish_locked(&state);
+    }
+
+    fn prune_expired_at(&self, now: Instant) {
+        let mut state = self.inner.lock();
+        if state.prune_expired(now) {
+            self.publish_locked(&state);
+        }
+    }
+
+    fn publish_locked(&self, state: &InterestState) {
+        let snapshot: Arc<BTreeSet<TableName>> = Arc::new(
+            state
+                .ref_counts
+                .keys()
+                .chain(state.recent_expirations.keys())
+                .cloned()
+                .collect(),
+        );
+        metrics::log_selective_delivery_interested_tables(snapshot.len());
+        self.tx.send_replace(snapshot);
+    }
+}
+
+impl InterestState {
+    fn prune_expired(&mut self, now: Instant) -> bool {
+        let before = self.recent_expirations.len();
+        self.recent_expirations.retain(|_, expiry| *expiry > now);
+        before != self.recent_expirations.len()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use maplit::btreeset;
+    use value::TableName;
+
+    use crate::delta_interest::DeltaInterestTracker;
+
+    #[test]
+    fn interest_tracker_ref_counts_tables() {
+        let tracker = DeltaInterestTracker::new();
+        let tasks: TableName = "tasks".parse().unwrap();
+        let messages: TableName = "messages".parse().unwrap();
+
+        tracker.add_tables(&btreeset! { messages.clone(), tasks.clone() });
+        tracker.add_tables(&btreeset! { tasks.clone() });
+        assert_eq!(
+            tracker.snapshot().as_ref(),
+            &btreeset! { messages.clone(), tasks.clone() }
+        );
+
+        tracker.remove_tables(&btreeset! { tasks.clone() });
+        assert_eq!(
+            tracker.snapshot().as_ref(),
+            &btreeset! { messages.clone(), tasks.clone() }
+        );
+
+        tracker.remove_tables(&btreeset! { messages.clone(), tasks.clone() });
+        assert_eq!(tracker.snapshot().as_ref(), &btreeset! {});
+    }
+
+    #[test]
+    fn interest_tracker_recent_tables_expire() {
+        let tracker = DeltaInterestTracker::new();
+        let tasks: TableName = "tasks".parse().unwrap();
+        let now = std::time::Instant::now();
+
+        tracker.refresh_recent_tables_at(
+            &btreeset! { tasks.clone() },
+            now,
+            Duration::from_secs(30),
+        );
+        assert_eq!(tracker.snapshot().as_ref(), &btreeset! { tasks.clone() });
+
+        tracker.prune_expired_at(now + Duration::from_secs(29));
+        assert_eq!(tracker.snapshot().as_ref(), &btreeset! { tasks.clone() });
+
+        tracker.prune_expired_at(now + Duration::from_secs(30));
+        assert_eq!(tracker.snapshot().as_ref(), &btreeset! {});
+    }
+}

--- a/crates/database/src/lib.rs
+++ b/crates/database/src/lib.rs
@@ -17,6 +17,7 @@ pub mod commit_delta;
 mod committer;
 mod database;
 mod database_index_workers;
+pub mod delta_interest;
 mod execution_size;
 mod metrics;
 pub mod nats_distributed_log;
@@ -35,6 +36,7 @@ pub mod replica;
 mod retention;
 mod search_index_bootstrap;
 mod search_index_workers;
+pub mod selective_delivery;
 pub mod snapshot_checkpointer;
 mod snapshot_manager;
 mod stack_traces;
@@ -88,6 +90,7 @@ pub use indexing::backend_in_memory_indexes::{
     DatabaseIndexSnapshotCache,
     TimestampedIndexCache,
 };
+pub use metrics::log_selective_delivery_shadow_receive;
 pub use patch::PatchValue;
 pub use preloaded::PreloadedIndexRange;
 pub use reads::{

--- a/crates/database/src/metrics.rs
+++ b/crates/database/src/metrics.rs
@@ -257,6 +257,36 @@ pub fn log_replication_write_frontier_ts(source_partition: PartitionId, ts: Time
 }
 
 register_convex_gauge!(
+    DATABASE_SELECTIVE_DELIVERY_INTERESTED_TABLES_INFO,
+    "Number of unique tables currently tracked as selectively interesting on this node"
+);
+pub fn log_selective_delivery_interested_tables(num_tables: usize) {
+    log_gauge(
+        &DATABASE_SELECTIVE_DELIVERY_INTERESTED_TABLES_INFO,
+        num_tables as f64,
+    );
+}
+
+register_convex_counter!(
+    DATABASE_SELECTIVE_DELIVERY_TARGETED_DELIVERIES_TOTAL,
+    "Total number of targeted selective-delivery shadow publishes sent to node-specific subjects"
+);
+pub fn log_selective_delivery_targeted_deliveries(num_deliveries: usize) {
+    log_counter(
+        &DATABASE_SELECTIVE_DELIVERY_TARGETED_DELIVERIES_TOTAL,
+        num_deliveries as u64,
+    );
+}
+
+register_convex_counter!(
+    DATABASE_SELECTIVE_DELIVERY_SHADOW_RECEIVES_TOTAL,
+    "Total number of node-targeted selective-delivery shadow deltas consumed"
+);
+pub fn log_selective_delivery_shadow_receive() {
+    log_counter(&DATABASE_SELECTIVE_DELIVERY_SHADOW_RECEIVES_TOTAL, 1);
+}
+
+register_convex_gauge!(
     DATABASE_LATEST_REPEATABLE_TS_INFO,
     "Latest repeatable timestamp currently visible on this node"
 );

--- a/crates/database/src/nats_distributed_log.rs
+++ b/crates/database/src/nats_distributed_log.rs
@@ -36,6 +36,7 @@ use crate::{
     },
     metrics,
     partition::PartitionId,
+    selective_delivery::SelectiveDeliveryRegistry,
     write_log::WriteSource,
 };
 
@@ -45,6 +46,7 @@ const STREAM_NAME: &str = "CONVEX_COMMITS";
 /// "convex.commits.{partition_id}". The stream subscribes to "convex.commits.>"
 /// to capture all partitions.
 const SUBJECT_BASE: &str = "convex.commits";
+const SYSTEM_TABLE_SUBJECT: &str = "convex.commits.system";
 
 /// Configuration for connecting to NATS.
 #[derive(Clone, Debug)]
@@ -66,6 +68,7 @@ pub struct NatsDistributedLog {
     consumer_name: String,
     /// Subject this node publishes to.
     publish_subject: String,
+    selective_registry: Option<SelectiveDeliveryRegistry>,
 }
 
 impl NatsDistributedLog {
@@ -73,18 +76,11 @@ impl NatsDistributedLog {
         format!("{SUBJECT_BASE}.{}", partition.0)
     }
 
-    async fn subscribe_inner(
+    async fn subscribe_subjects(
         &self,
         from_ts: Timestamp,
-        source_partitions: Option<Vec<PartitionId>>,
+        filter_subjects: Option<Vec<String>>,
     ) -> anyhow::Result<BoxStream<'static, anyhow::Result<CommitDelta>>> {
-        let filter_subjects = source_partitions.map(|partitions| {
-            partitions
-                .into_iter()
-                .map(Self::partition_subject)
-                .collect::<Vec<_>>()
-        });
-
         // Create a durable consumer so it survives reconnections.
         // DeliverPolicy::All replays all messages from the stream beginning,
         // and we filter out messages at or before from_ts ourselves.
@@ -201,6 +197,47 @@ impl NatsDistributedLog {
         Ok(Box::pin(stream))
     }
 
+    async fn subscribe_inner(
+        &self,
+        from_ts: Timestamp,
+        source_partitions: Option<Vec<PartitionId>>,
+    ) -> anyhow::Result<BoxStream<'static, anyhow::Result<CommitDelta>>> {
+        let filter_subjects = source_partitions.map(|partitions| {
+            partitions
+                .into_iter()
+                .map(Self::partition_subject)
+                .collect::<Vec<_>>()
+        });
+        self.subscribe_subjects(from_ts, filter_subjects).await
+    }
+
+    pub async fn subscribe_node_targeted(
+        &self,
+        from_ts: Timestamp,
+        node_name: &str,
+    ) -> anyhow::Result<BoxStream<'static, anyhow::Result<CommitDelta>>> {
+        self.subscribe_subjects(
+            from_ts,
+            Some(vec![SelectiveDeliveryRegistry::node_subject(node_name)]),
+        )
+        .await
+    }
+
+    pub async fn subscribe_selective_node(
+        &self,
+        from_ts: Timestamp,
+        node_name: &str,
+    ) -> anyhow::Result<BoxStream<'static, anyhow::Result<CommitDelta>>> {
+        self.subscribe_subjects(
+            from_ts,
+            Some(vec![
+                SelectiveDeliveryRegistry::node_subject(node_name),
+                SYSTEM_TABLE_SUBJECT.to_string(),
+            ]),
+        )
+        .await
+    }
+
     /// Connect to NATS and create/get the JetStream stream.
     pub async fn connect(config: NatsConfig) -> anyhow::Result<Self> {
         // async-nats pulls in rustls which needs a crypto provider.
@@ -210,6 +247,7 @@ impl NatsDistributedLog {
             .await
             .with_context(|| format!("Failed to connect to NATS at {}", config.url))?;
 
+        let registry_client = client.clone();
         let jetstream = jetstream::new(client);
 
         // Create the stream using create_stream (not get_or_create_stream)
@@ -240,6 +278,10 @@ impl NatsDistributedLog {
             Some(id) => format!("{SUBJECT_BASE}.{id}"),
             None => SUBJECT_BASE.to_string(),
         };
+        let selective_registry =
+            SelectiveDeliveryRegistry::from_client(registry_client, consumer_name.clone())
+                .await
+                .ok();
         tracing::info!(
             "Connected to NATS JetStream at {}. Stream '{}': {} messages, {} bytes. Consumer: {}, \
              Publish subject: {}",
@@ -259,6 +301,7 @@ impl NatsDistributedLog {
             stream,
             consumer_name,
             publish_subject,
+            selective_registry,
         })
     }
 }
@@ -385,7 +428,7 @@ impl DistributedLog for NatsDistributedLog {
         // - Second .await waits for the server acknowledgment
         let ack = self
             .jetstream
-            .publish(self.publish_subject.clone(), payload.into())
+            .publish(self.publish_subject.clone(), payload.clone().into())
             .await
             .context("Failed to send publish to NATS")?
             .await
@@ -398,6 +441,51 @@ impl DistributedLog for NatsDistributedLog {
             payload_size,
             ack.sequence,
         );
+        let touched_tables = delta.touched_table_names();
+        if touched_tables.iter().any(TableName::is_system) {
+            let ack = self
+                .jetstream
+                .publish(SYSTEM_TABLE_SUBJECT.to_string(), payload.clone().into())
+                .await
+                .context("Failed to send selective-delivery system-table publish")?
+                .await
+                .context("Failed to get selective-delivery system-table acknowledgment")?;
+            metrics::log_selective_delivery_targeted_deliveries(1);
+            tracing::debug!(
+                "Published selective-delivery system-table delta: ts={}, stream_seq={}",
+                ts,
+                ack.sequence,
+            );
+        } else if let Some(registry) = &self.selective_registry {
+            let interested_nodes = registry
+                .interested_nodes_for_tables(&touched_tables)
+                .into_iter()
+                .filter(|node| node != &self.consumer_name)
+                .collect::<Vec<_>>();
+            metrics::log_selective_delivery_targeted_deliveries(interested_nodes.len());
+            for node in interested_nodes {
+                let ack = self
+                    .jetstream
+                    .publish(
+                        SelectiveDeliveryRegistry::node_subject(&node),
+                        payload.clone().into(),
+                    )
+                    .await
+                    .with_context(|| {
+                        format!("Failed to send selective-delivery publish to {node}")
+                    })?
+                    .await
+                    .with_context(|| {
+                        format!("Failed to get selective-delivery ack for target node {node}")
+                    })?;
+                tracing::debug!(
+                    "Published selective-delivery shadow delta to {}: ts={}, stream_seq={}",
+                    node,
+                    ts,
+                    ack.sequence,
+                );
+            }
+        }
         drop(publish_timer);
         Ok(())
     }

--- a/crates/database/src/raft_partition.rs
+++ b/crates/database/src/raft_partition.rs
@@ -103,6 +103,23 @@ impl RaftPartitionState {
             anyhow::anyhow!("Raft node for partition {} not running", self.partition_id)
         })
     }
+
+    #[cfg(any(test, feature = "testing"))]
+    pub fn new_for_test(
+        is_leader: bool,
+        leader_id: u64,
+        partition_id: PartitionId,
+        node_id: u64,
+    ) -> Self {
+        let (proposal_tx, _proposal_rx) = mpsc::unbounded_channel();
+        Self {
+            is_leader: Arc::new(AtomicBool::new(is_leader)),
+            leader_id: Arc::new(AtomicU64::new(leader_id)),
+            proposal_tx,
+            partition_id,
+            node_id,
+        }
+    }
 }
 
 /// Manager for a Raft-enabled partition.

--- a/crates/database/src/selective_delivery.rs
+++ b/crates/database/src/selective_delivery.rs
@@ -1,0 +1,269 @@
+use std::{
+    collections::{
+        BTreeMap,
+        BTreeSet,
+    },
+    sync::Arc,
+    time::{
+        Duration,
+        SystemTime,
+        UNIX_EPOCH,
+    },
+};
+
+use anyhow::Context;
+use async_nats::jetstream::{
+    self,
+    kv::{
+        Operation,
+        Store,
+    },
+};
+use futures::StreamExt;
+use parking_lot::RwLock;
+use serde::{
+    Deserialize,
+    Serialize,
+};
+use value::TableName;
+
+pub const SELECTIVE_DELIVERY_KV_BUCKET: &str = "convex_delta_interest";
+pub const NODE_SUBJECT_PREFIX: &str = "convex.commits.node";
+const INTEREST_MAX_AGE: Duration = Duration::from_secs(90);
+
+#[derive(Clone)]
+pub struct SelectiveDeliveryRegistry {
+    node_name: String,
+    kv: Store,
+    cache: Arc<RwLock<BTreeMap<String, InterestRegistration>>>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+struct InterestRegistration {
+    tables: Vec<String>,
+    updated_at_ms: u64,
+}
+
+impl SelectiveDeliveryRegistry {
+    pub async fn connect(nats_url: &str, node_name: String) -> anyhow::Result<Self> {
+        let _ = rustls::crypto::ring::default_provider().install_default();
+        let client = async_nats::connect(nats_url)
+            .await
+            .with_context(|| format!("Failed to connect to NATS at {nats_url}"))?;
+        Self::from_client(client, node_name).await
+    }
+
+    pub async fn from_client(
+        client: async_nats::Client,
+        node_name: String,
+    ) -> anyhow::Result<Self> {
+        let jetstream = jetstream::new(client);
+        let kv = jetstream
+            .create_key_value(async_nats::jetstream::kv::Config {
+                bucket: SELECTIVE_DELIVERY_KV_BUCKET.to_string(),
+                history: 1,
+                max_age: INTEREST_MAX_AGE.saturating_mul(4),
+                ..Default::default()
+            })
+            .await
+            .context("Failed to create selective-delivery KV bucket")?;
+
+        let cache = Arc::new(RwLock::new(BTreeMap::new()));
+        Self::prime_cache(&kv, &cache).await?;
+        Self::spawn_watcher(kv.clone(), cache.clone());
+
+        Ok(Self {
+            node_name,
+            kv,
+            cache,
+        })
+    }
+
+    pub async fn publish_local_interest(&self, tables: &BTreeSet<TableName>) -> anyhow::Result<()> {
+        let registration = InterestRegistration {
+            tables: tables.iter().map(ToString::to_string).collect(),
+            updated_at_ms: now_ms(),
+        };
+        let payload = serde_json::to_vec(&registration)
+            .context("Failed to serialize selective-delivery interest registration")?;
+        self.kv
+            .put(&self.node_name, payload.into())
+            .await
+            .with_context(|| {
+                format!(
+                    "Failed to publish selective-delivery interest for {}",
+                    self.node_name
+                )
+            })?;
+        self.cache
+            .write()
+            .insert(self.node_name.clone(), registration);
+        Ok(())
+    }
+
+    pub fn interested_nodes_for_tables(&self, tables: &BTreeSet<TableName>) -> Vec<String> {
+        interested_nodes_for_tables_from_cache(&self.cache.read(), now_ms(), tables)
+    }
+
+    pub fn node_subject(node_name: &str) -> String {
+        format!("{NODE_SUBJECT_PREFIX}.{node_name}")
+    }
+
+    async fn prime_cache(
+        kv: &Store,
+        cache: &Arc<RwLock<BTreeMap<String, InterestRegistration>>>,
+    ) -> anyhow::Result<()> {
+        let keys = kv
+            .keys()
+            .await
+            .context("Failed to list selective-delivery keys")?;
+        let keys: Vec<_> = keys
+            .filter_map(|result| async move { result.ok() })
+            .collect()
+            .await;
+        for key in keys {
+            let Some(entry) = kv
+                .entry(&key)
+                .await
+                .with_context(|| format!("Failed to read selective-delivery entry {key}"))?
+            else {
+                continue;
+            };
+            if let Ok(registration) = serde_json::from_slice::<InterestRegistration>(&entry.value) {
+                cache.write().insert(key, registration);
+            }
+        }
+        Ok(())
+    }
+
+    fn spawn_watcher(kv: Store, cache: Arc<RwLock<BTreeMap<String, InterestRegistration>>>) {
+        tokio::spawn(async move {
+            let mut watch = match kv.watch_all().await {
+                Ok(watch) => watch,
+                Err(e) => {
+                    tracing::warn!("Selective-delivery registry watch failed to start: {e:#}");
+                    return;
+                },
+            };
+            while let Some(result) = watch.next().await {
+                match result {
+                    Ok(entry) => match entry.operation {
+                        Operation::Put => {
+                            match serde_json::from_slice::<InterestRegistration>(&entry.value) {
+                                Ok(registration) => {
+                                    cache.write().insert(entry.key, registration);
+                                },
+                                Err(e) => {
+                                    tracing::warn!(
+                                        "Failed to decode selective-delivery interest entry {}: \
+                                         {e:#}",
+                                        entry.key
+                                    );
+                                },
+                            }
+                        },
+                        Operation::Delete | Operation::Purge => {
+                            cache.write().remove(&entry.key);
+                        },
+                    },
+                    Err(e) => {
+                        tracing::warn!("Selective-delivery registry watch error: {e:#}");
+                    },
+                }
+            }
+        });
+    }
+}
+
+fn interested_nodes_for_tables_from_cache(
+    cache: &BTreeMap<String, InterestRegistration>,
+    now_ms: u64,
+    tables: &BTreeSet<TableName>,
+) -> Vec<String> {
+    if tables.is_empty() {
+        return Vec::new();
+    }
+    cache
+        .iter()
+        .filter(|(_, registration)| registration.is_fresh(now_ms))
+        .filter(|(_, registration)| registration.matches(tables))
+        .map(|(node, _)| node.clone())
+        .collect()
+}
+
+impl InterestRegistration {
+    fn is_fresh(&self, now_ms: u64) -> bool {
+        now_ms.saturating_sub(self.updated_at_ms) <= INTEREST_MAX_AGE.as_millis() as u64
+    }
+
+    fn matches(&self, tables: &BTreeSet<TableName>) -> bool {
+        self.tables.iter().any(|table| {
+            table
+                .parse::<TableName>()
+                .ok()
+                .is_some_and(|table_name| tables.contains(&table_name))
+        })
+    }
+}
+
+fn now_ms() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis() as u64
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::{
+        BTreeMap,
+        BTreeSet,
+    };
+
+    use value::TableName;
+
+    use crate::selective_delivery::{
+        interested_nodes_for_tables_from_cache,
+        InterestRegistration,
+        SelectiveDeliveryRegistry,
+    };
+
+    #[test]
+    fn interested_nodes_match_tables_and_skip_stale_entries() {
+        let now_ms = 1_000_000;
+        let messages: TableName = "messages".parse().unwrap();
+        let tasks: TableName = "tasks".parse().unwrap();
+        let cache = BTreeMap::from([
+            (
+                "node-a".to_string(),
+                InterestRegistration {
+                    tables: vec!["messages".to_string()],
+                    updated_at_ms: now_ms,
+                },
+            ),
+            (
+                "node-b".to_string(),
+                InterestRegistration {
+                    tables: vec!["tasks".to_string()],
+                    updated_at_ms: now_ms.saturating_sub(200_000),
+                },
+            ),
+        ]);
+        assert_eq!(
+            interested_nodes_for_tables_from_cache(&cache, now_ms, &BTreeSet::from([messages])),
+            vec!["node-a".to_string()]
+        );
+        assert!(
+            interested_nodes_for_tables_from_cache(&cache, now_ms, &BTreeSet::from([tasks]))
+                .is_empty()
+        );
+    }
+
+    #[test]
+    fn node_subject_names_are_stable() {
+        assert_eq!(
+            SelectiveDeliveryRegistry::node_subject("node-a"),
+            "convex.commits.node.node-a"
+        );
+    }
+}

--- a/crates/database/src/snapshot_manager.rs
+++ b/crates/database/src/snapshot_manager.rs
@@ -777,7 +777,8 @@ impl SnapshotManager {
         if let Some(current) = self.replication_write_frontiers.get(&partition) {
             anyhow::ensure!(
                 ts >= *current,
-                "replication write frontier for {partition} went backward from {current:?} to {ts:?}",
+                "replication write frontier for {partition} went backward from {current:?} to \
+                 {ts:?}",
             );
             if ts == *current {
                 return Ok(false);

--- a/crates/database/src/subscription.rs
+++ b/crates/database/src/subscription.rs
@@ -67,9 +67,13 @@ use tokio::sync::{
     },
     watch,
 };
-use value::ResolvedDocumentId;
+use value::{
+    ResolvedDocumentId,
+    TableName,
+};
 
 use crate::{
+    delta_interest::DeltaInterestTracker,
     metrics::{
         self,
         log_subscriptions_invalidated,
@@ -93,13 +97,19 @@ struct SubscriptionKey {
 #[derive(Clone)]
 pub struct SubscriptionsClient {
     handles: Arc<Mutex<Vec<Box<dyn SpawnHandle>>>>,
+    delta_interest: DeltaInterestTracker,
     log: LogReader,
     senders: Vec<mpsc::Sender<SubscriptionRequest>>,
     next_manager: Arc<AtomicUsize>,
 }
 
 impl SubscriptionsClient {
-    pub fn subscribe(&self, token: Token, is_system: bool) -> anyhow::Result<Subscription> {
+    pub fn subscribe(
+        &self,
+        token: Token,
+        interested_tables: Arc<BTreeSet<TableName>>,
+        is_system: bool,
+    ) -> anyhow::Result<Subscription> {
         let token = match self.log.refresh_reads_until_max_ts(token)? {
             Ok(t) => t,
             Err(invalid_ts) => return Ok(Subscription::invalid(invalid_ts)),
@@ -107,6 +117,7 @@ impl SubscriptionsClient {
         let (subscription, sender) = Subscription::new(&token);
         let request = SubscriptionRequest {
             token,
+            interested_tables,
             sender,
             is_system,
         };
@@ -123,6 +134,10 @@ impl SubscriptionsClient {
             });
         }
         Ok(subscription)
+    }
+
+    pub fn delta_interest_tracker(&self) -> DeltaInterestTracker {
+        self.delta_interest.clone()
     }
 
     pub fn shutdown(&self) {
@@ -169,6 +184,7 @@ impl SubscriptionSender {
 
 struct SubscriptionRequest {
     token: Token,
+    interested_tables: Arc<BTreeSet<TableName>>,
     sender: SubscriptionSender,
     is_system: bool,
 }
@@ -218,6 +234,7 @@ impl SubscriptionsWorker {
         let num_managers = *NUM_SUBSCRIPTION_MANAGERS;
         let log_reader = log.reader();
         let initial_ts = log_reader.max_ts();
+        let delta_interest = DeltaInterestTracker::new();
 
         let retention_coordinator = RetentionCoordinator::new(num_managers, initial_ts, log);
 
@@ -230,8 +247,14 @@ impl SubscriptionsWorker {
 
             let manager_log = log_reader.clone();
             let coordinator = retention_coordinator.clone();
-            let mut manager =
-                SubscriptionManager::new(manager_id, manager_log, coordinator, initial_ts);
+            let manager_delta_interest = delta_interest.clone();
+            let mut manager = SubscriptionManager::new(
+                manager_id,
+                manager_log,
+                coordinator,
+                manager_delta_interest,
+                initial_ts,
+            );
             let handle = runtime.spawn("subscription_worker", async move {
                 manager.run_worker(rx).await
             });
@@ -241,6 +264,7 @@ impl SubscriptionsWorker {
 
         SubscriptionsClient {
             handles: Arc::new(Mutex::new(handles)),
+            delta_interest,
             log: log_reader,
             senders,
             next_manager: Arc::new(AtomicUsize::new(0)),
@@ -309,8 +333,13 @@ impl SubscriptionManager {
                 },
                 request = rx.recv().fuse() => {
                     match request {
-                        Some(SubscriptionRequest { token, sender,  is_system,}) => {
-                            match self.subscribe(token, sender, is_system) {
+                        Some(SubscriptionRequest {
+                            token,
+                            interested_tables,
+                            sender,
+                            is_system,
+                        }) => {
+                            match self.subscribe(token, interested_tables, sender, is_system) {
                                 Ok(_) => (),
                                 Err(mut e) => {
                                     report_error(&mut e).await;
@@ -352,6 +381,7 @@ pub struct SubscriptionManager {
     closed_subscriptions: FuturesUnordered<BoxFuture<'static, SubscriptionKey>>,
 
     log: LogReader,
+    delta_interest: DeltaInterestTracker,
 
     retention_coordinator: RetentionCoordinator,
 
@@ -364,6 +394,7 @@ pub struct SubscriptionManager {
 }
 
 struct Subscriber {
+    interested_tables: Arc<BTreeSet<TableName>>,
     reads: Arc<ReadSet>,
     sender: SubscriptionSender,
     seq: Sequence,
@@ -379,13 +410,20 @@ impl SubscriptionManager {
         let (log_owner, log_reader, _) = new_write_log(Timestamp::MIN);
         let initial_ts = log_reader.max_ts();
         let retention_coordinator = RetentionCoordinator::new(1, initial_ts, log_owner);
-        Self::new(0, log_reader, retention_coordinator, initial_ts)
+        Self::new(
+            0,
+            log_reader,
+            retention_coordinator,
+            DeltaInterestTracker::new(),
+            initial_ts,
+        )
     }
 
     fn new(
         manager_id: usize,
         log: LogReader,
         retention_coordinator: RetentionCoordinator,
+        delta_interest: DeltaInterestTracker,
         initial_ts: Timestamp,
     ) -> Self {
         Self {
@@ -395,6 +433,7 @@ impl SubscriptionManager {
             next_seq: 0,
             closed_subscriptions: FuturesUnordered::new(),
             log,
+            delta_interest,
             retention_coordinator,
             processed_ts: initial_ts,
         }
@@ -403,6 +442,7 @@ impl SubscriptionManager {
     pub fn subscribe(
         &mut self,
         mut token: Token,
+        interested_tables: Arc<BTreeSet<TableName>>,
         sender: SubscriptionSender,
         is_system: bool,
     ) -> anyhow::Result<SubscriberId> {
@@ -443,11 +483,13 @@ impl SubscriptionManager {
         self.next_seq += 1;
         let valid_tx = sender.valid_tx.clone();
         entry.insert(Subscriber {
+            interested_tables: interested_tables.clone(),
             reads: token.reads_owned(),
             sender,
             seq,
             is_system,
         });
+        self.delta_interest.add_tables(&interested_tables);
         self.closed_subscriptions.push(
             async move {
                 valid_tx.closed().await;
@@ -464,7 +506,7 @@ impl SubscriptionManager {
         token: Token,
     ) -> anyhow::Result<(Subscription, SubscriberId)> {
         let (subscription, sender) = Subscription::new(&token);
-        let id = self.subscribe(token, sender, false)?;
+        let id = self.subscribe(token, Arc::new(BTreeSet::new()), sender, false)?;
         Ok((subscription, id))
     }
 
@@ -651,6 +693,7 @@ impl SubscriptionManager {
         invalid_ts: Option<Timestamp>,
     ) {
         let entry = self.subscribers.remove(id);
+        self.delta_interest.remove_tables(&entry.interested_tables);
         self.subscriptions.remove(id, &entry.reads);
         // dropping `entry.sender` will invalidate the subscription
         entry.sender.drop_with_delay(delay, invalid_ts);
@@ -1336,8 +1379,13 @@ mod tests {
     async fn test_log_rewind_invalidates_subscriptions_and_reanchors_manager() {
         let (log_owner, log_reader, mut log_writer) = new_write_log(Timestamp::must(100));
         let coordinator = RetentionCoordinator::new(1, log_reader.max_ts(), log_owner);
-        let mut subscription_manager =
-            SubscriptionManager::new(0, log_reader, coordinator, Timestamp::must(100));
+        let mut subscription_manager = SubscriptionManager::new(
+            0,
+            log_reader,
+            coordinator,
+            crate::delta_interest::DeltaInterestTracker::new(),
+            Timestamp::must(100),
+        );
 
         let (subscription, _id) = subscription_manager
             .subscribe_for_testing(Token::empty(Timestamp::must(100)))
@@ -1413,7 +1461,13 @@ mod tests {
 
         let mut managers: Vec<_> = (0..num_managers)
             .map(|id| {
-                SubscriptionManager::new(id, log_reader.clone(), coordinator.clone(), initial_ts)
+                SubscriptionManager::new(
+                    id,
+                    log_reader.clone(),
+                    coordinator.clone(),
+                    crate::delta_interest::DeltaInterestTracker::new(),
+                    initial_ts,
+                )
             })
             .collect();
 

--- a/crates/database/src/tests/write_scaling_tests.rs
+++ b/crates/database/src/tests/write_scaling_tests.rs
@@ -10,6 +10,7 @@ use std::{
     time::Duration,
 };
 
+use anyhow::Context;
 use async_trait::async_trait;
 use common::{
     assert_obj,
@@ -803,6 +804,57 @@ async fn test_local_only_commit_does_not_wait_for_remote_frontier(
 
     let result = tokio::time::timeout(Duration::from_millis(250), node_a.commit(tx)).await?;
     result?;
+    Ok(())
+}
+
+#[convex_macro::test_runtime]
+async fn test_remote_single_partition_commit_rejects_before_waiting_for_remote_frontier(
+    rt: TestRuntime,
+) -> anyhow::Result<()> {
+    let log = Arc::new(InMemoryDistributedLog::new());
+    let node_a = create_node(&rt, log.clone(), Some(partitioned_map(PartitionId(0)))).await?;
+    let node_b = create_node(&rt, log.clone(), Some(partitioned_map(PartitionId(1)))).await?;
+
+    insert_doc(&node_a, "messages", assert_obj!("text" => "seed")).await?;
+    let initial_delta = log
+        .deltas()
+        .into_iter()
+        .last()
+        .expect("seed message should publish a delta");
+    node_b
+        .committer_for_test()
+        .apply_replica_delta(initial_delta)
+        .await?;
+
+    // Advance node B's local snapshot beyond partition 0's replicated frontier so
+    // a stale remote frontier would block if we waited before classifying the
+    // write.
+    insert_doc(&node_b, "projects", assert_obj!("name" => "lag-maker")).await?;
+
+    let mut tx = node_b.begin(Identity::system()).await?;
+    TestFacingModel::new(&mut tx)
+        .insert(&"messages".parse()?, assert_obj!("text" => "wrong-owner"))
+        .await?;
+    let remote_tablet = tx
+        .table_mapping()
+        .namespace(TableNamespace::Global)
+        .name_to_tablet()("messages".parse()?)?;
+    tx.reads.record_indexed_derived(
+        TabletIndexName::by_id(remote_tablet),
+        IndexedFields::by_id(),
+        Interval::all(),
+    );
+
+    let err = tokio::time::timeout(Duration::from_millis(250), node_b.commit(tx))
+        .await
+        .context(
+            "remote single-partition write should reject before waiting on a stale remote frontier",
+        )?
+        .expect_err("node B should reject a partition-0-only write");
+    assert!(
+        format!("{err:#}").contains("Route this mutation to the correct partition owner"),
+        "expected remote owner rejection, got: {err:#}",
+    );
     Ok(())
 }
 

--- a/crates/database/src/token.rs
+++ b/crates/database/src/token.rs
@@ -1,18 +1,53 @@
 //! Externalizable tokens that record the currently-observed state within a
 //! transaction.
 
-use std::sync::Arc;
+use std::{
+    collections::BTreeMap,
+    sync::Arc,
+};
 
+use anyhow::Context;
 #[cfg(any(test, feature = "testing"))]
-use common::types::TabletIndexName;
-use common::types::Timestamp;
-#[cfg(any(test, feature = "testing"))]
-use search::query::TextQueryTerm;
-use value::heap_size::HeapSize;
-#[cfg(any(test, feature = "testing"))]
-use value::FieldPath;
+use common::types::TabletIndexName as TestTabletIndexName;
+use common::{
+    bootstrap_model::index::database_index::IndexedFields,
+    interval::IntervalSet,
+    query::FilterValue,
+    types::{
+        IndexDescriptor,
+        TabletIndexName,
+        Timestamp,
+    },
+};
+use pb::{
+    replication::{
+        QueryToken as QueryTokenProto,
+        TwoPcFilterConditionRead,
+        TwoPcIndexedRead,
+        TwoPcSearchRead,
+        TwoPcTextQueryTermRead,
+    },
+    searchlight,
+};
+use search::{
+    query::{
+        FuzzyDistance,
+        QueryReads,
+        TextQueryTerm,
+    },
+    FilterConditionRead,
+    TextQueryTermRead,
+};
+use value::{
+    heap_size::HeapSize,
+    FieldPath,
+    TabletId,
+};
 
-use crate::reads::ReadSet;
+use crate::reads::{
+    IndexReads,
+    ReadSet,
+};
 
 /// Serialized representation of [`Token`].
 pub type SerializedToken = String;
@@ -40,7 +75,7 @@ impl Token {
     #[allow(unused)]
     #[cfg(any(test, feature = "testing"))]
     pub fn text_search_token(
-        index_name: TabletIndexName,
+        index_name: TestTabletIndexName,
         field_path: FieldPath,
         terms: Vec<TextQueryTerm>,
     ) -> Self {
@@ -106,5 +141,202 @@ impl Token {
 impl HeapSize for Token {
     fn heap_size(&self) -> usize {
         self.read_set.heap_size()
+    }
+}
+
+impl TryFrom<QueryTokenProto> for Token {
+    type Error = anyhow::Error;
+
+    fn try_from(value: QueryTokenProto) -> anyhow::Result<Self> {
+        let ts = value.ts.context("Missing query token ts")?.try_into()?;
+        let indexed_reads = value
+            .indexed_reads
+            .into_iter()
+            .map(
+                |TwoPcIndexedRead {
+                     tablet_id,
+                     descriptor,
+                     fields,
+                     intervals,
+                 }| {
+                    let tablet_id = tablet_id_from_bytes(tablet_id)?;
+                    let index_name = descriptor_to_index_name(tablet_id, descriptor)?;
+                    let fields = fields
+                        .into_iter()
+                        .map(FieldPath::try_from)
+                        .collect::<anyhow::Result<Vec<_>>>()?;
+                    Ok((
+                        index_name,
+                        IndexReads {
+                            fields: IndexedFields::try_from(fields)?,
+                            intervals: IntervalSet::try_from(intervals)?,
+                            stack_traces: None,
+                        },
+                    ))
+                },
+            )
+            .collect::<anyhow::Result<BTreeMap<_, _>>>()?;
+
+        let search_reads = value
+            .search_reads
+            .into_iter()
+            .map(
+                |TwoPcSearchRead {
+                     tablet_id,
+                     descriptor,
+                     text_queries,
+                     filter_conditions,
+                 }| {
+                    let tablet_id = tablet_id_from_bytes(tablet_id)?;
+                    let index_name = descriptor_to_index_name(tablet_id, descriptor)?;
+                    let text_queries = text_queries
+                        .into_iter()
+                        .map(
+                            |TwoPcTextQueryTermRead { field_path, term }| -> anyhow::Result<_> {
+                                let field_path = field_path
+                                    .context("TwoPcTextQueryTermRead missing field_path")?
+                                    .try_into()?;
+                                let term = text_query_term_from_proto(
+                                    term.context("TwoPcTextQueryTermRead missing term")?,
+                                )?;
+                                Ok(TextQueryTermRead::new(field_path, term))
+                            },
+                        )
+                        .collect::<anyhow::Result<Vec<_>>>()?;
+                    let filter_conditions = filter_conditions
+                        .into_iter()
+                        .map(
+                            |TwoPcFilterConditionRead { field_path, value }| -> anyhow::Result<_> {
+                                let field_path = field_path
+                                    .context("TwoPcFilterConditionRead missing field_path")?
+                                    .try_into()?;
+                                Ok(FilterConditionRead::Must(
+                                    field_path,
+                                    FilterValue::from(value),
+                                ))
+                            },
+                        )
+                        .collect::<anyhow::Result<Vec<_>>>()?;
+                    Ok((
+                        index_name,
+                        QueryReads::new(text_queries.into(), filter_conditions.into()),
+                    ))
+                },
+            )
+            .collect::<anyhow::Result<BTreeMap<_, _>>>()?;
+
+        Ok(Token::new(
+            Arc::new(ReadSet::new(indexed_reads, search_reads)),
+            ts,
+        ))
+    }
+}
+
+impl TryFrom<Token> for QueryTokenProto {
+    type Error = anyhow::Error;
+
+    fn try_from(value: Token) -> anyhow::Result<Self> {
+        let indexed_reads = value
+            .reads()
+            .iter_indexed()
+            .map(|(index_name, reads)| TwoPcIndexedRead {
+                tablet_id: tablet_id_to_bytes(*index_name.table()),
+                descriptor: index_name.descriptor().to_string(),
+                fields: Vec::<pb::common::FieldPath>::from(reads.fields.clone()),
+                intervals: reads.intervals.clone().into(),
+            })
+            .collect();
+
+        let search_reads = value
+            .reads()
+            .iter_search()
+            .map(|(index_name, reads)| -> anyhow::Result<TwoPcSearchRead> {
+                Ok(TwoPcSearchRead {
+                    tablet_id: tablet_id_to_bytes(*index_name.table()),
+                    descriptor: index_name.descriptor().to_string(),
+                    text_queries: reads
+                        .text_queries
+                        .iter()
+                        .map(|read| {
+                            Ok(TwoPcTextQueryTermRead {
+                                field_path: Some(read.field_path.clone().into()),
+                                term: Some(text_query_term_to_proto(read.term.clone())),
+                            })
+                        })
+                        .collect::<anyhow::Result<Vec<_>>>()?,
+                    filter_conditions: reads
+                        .filter_conditions
+                        .iter()
+                        .map(|read| match read {
+                            FilterConditionRead::Must(field_path, value) => {
+                                Ok(TwoPcFilterConditionRead {
+                                    field_path: Some(field_path.clone().into()),
+                                    value: value.clone().into(),
+                                })
+                            },
+                        })
+                        .collect::<anyhow::Result<Vec<_>>>()?,
+                })
+            })
+            .collect::<anyhow::Result<Vec<_>>>()?;
+
+        Ok(QueryTokenProto {
+            ts: Some(u64::from(value.ts())),
+            indexed_reads,
+            search_reads,
+        })
+    }
+}
+
+fn descriptor_to_index_name(
+    tablet_id: TabletId,
+    descriptor: String,
+) -> anyhow::Result<TabletIndexName> {
+    match descriptor.as_str() {
+        "by_id" => Ok(TabletIndexName::by_id(tablet_id)),
+        "by_creation_time" => Ok(TabletIndexName::by_creation_time(tablet_id)),
+        _ => TabletIndexName::new(tablet_id, IndexDescriptor::new(descriptor)?),
+    }
+}
+
+fn tablet_id_to_bytes(tablet_id: TabletId) -> Vec<u8> {
+    tablet_id.0 .0.to_vec()
+}
+
+fn tablet_id_from_bytes(bytes: Vec<u8>) -> anyhow::Result<TabletId> {
+    Ok(TabletId(bytes.try_into()?))
+}
+
+fn text_query_term_from_proto(value: searchlight::TextQueryTerm) -> anyhow::Result<TextQueryTerm> {
+    match value.term_type {
+        Some(searchlight::text_query_term::TermType::Exact(exact)) => {
+            Ok(TextQueryTerm::Exact(exact.token))
+        },
+        Some(searchlight::text_query_term::TermType::Fuzzy(fuzzy)) => Ok(TextQueryTerm::Fuzzy {
+            token: fuzzy.token,
+            max_distance: FuzzyDistance::try_from(fuzzy.max_distance as u8)?,
+            prefix: fuzzy.prefix,
+        }),
+        None => anyhow::bail!("TextQueryTerm missing term_type"),
+    }
+}
+
+fn text_query_term_to_proto(value: TextQueryTerm) -> searchlight::TextQueryTerm {
+    let term_type = match value {
+        TextQueryTerm::Exact(token) => {
+            searchlight::text_query_term::TermType::Exact(searchlight::ExactTextTerm { token })
+        },
+        TextQueryTerm::Fuzzy {
+            token,
+            max_distance,
+            prefix,
+        } => searchlight::text_query_term::TermType::Fuzzy(searchlight::FuzzyTextTerm {
+            token,
+            max_distance: u8::from(max_distance) as u32,
+            prefix,
+        }),
+    };
+    searchlight::TextQueryTerm {
+        term_type: Some(term_type),
     }
 }

--- a/crates/local_backend/Cargo.toml
+++ b/crates/local_backend/Cargo.toml
@@ -65,6 +65,7 @@ function_runner = { workspace = true }
 futures = { workspace = true }
 futures-async-stream = { workspace = true }
 governor = { workspace = true }
+headers = { workspace = true }
 http = { workspace = true }
 http-body-util = { workspace = true }
 http_client = { workspace = true }

--- a/crates/local_backend/src/lib.rs
+++ b/crates/local_backend/src/lib.rs
@@ -106,6 +106,7 @@ pub mod node_action_callbacks;
 pub mod parse;
 pub mod proxy;
 pub mod public_api;
+pub mod query_forwarding_api;
 pub mod router;
 pub mod scheduling;
 pub mod schema;
@@ -163,6 +164,7 @@ pub struct RouterState {
     pub runtime: ProdRuntime,
     pub replica_mode: bool,
     pub partition_id: Option<database::partition::PartitionId>,
+    pub node_addresses: Option<database::two_phase::NodeAddresses>,
     pub raft_state: Option<database::raft_partition::RaftPartitionState>,
     pub raft_peer_grpc_urls: Option<BTreeMap<u64, String>>,
     pub replica_mutation_forwarder: Option<Arc<mutation_forwarder::MutationForwarderGrpcClient>>,
@@ -448,11 +450,116 @@ pub async fn make_app(
         runtime.spawn_background("beacon_worker", beacon_future);
     }
 
+    if let Some(nats_url) = &config.nats_url {
+        let nats_url = nats_url.clone();
+        let registry_node_name = config.name();
+        let delta_interest_tracker = database.delta_interest_tracker();
+        let mut interest_rx = delta_interest_tracker.watch();
+        runtime.spawn_background("selective_delivery_interest_publisher", async move {
+            let registry = match database::selective_delivery::SelectiveDeliveryRegistry::connect(
+                &nats_url,
+                registry_node_name.clone(),
+            )
+            .await
+            {
+                Ok(registry) => registry,
+                Err(e) => {
+                    tracing::warn!(
+                        "Failed to start selective-delivery interest publisher for {}: {e:#}",
+                        registry_node_name,
+                    );
+                    return;
+                },
+            };
+
+            loop {
+                delta_interest_tracker.prune_expired();
+                let interest_snapshot = interest_rx.borrow().clone();
+                if let Err(e) = registry.publish_local_interest(&interest_snapshot).await {
+                    tracing::warn!(
+                        "Failed to publish selective-delivery interest for {}: {e:#}",
+                        registry_node_name,
+                    );
+                }
+                tokio::select! {
+                    changed = interest_rx.changed() => {
+                        if changed.is_err() {
+                            break;
+                        }
+                    },
+                    _ = tokio::time::sleep(std::time::Duration::from_secs(30)) => {},
+                }
+            }
+        });
+    }
+
+    if config.partition_id == Some(0) {
+        if let Some(nats_url) = &config.nats_url {
+            let nats_url = nats_url.clone();
+            let shadow_node_name = config.name();
+            let shadow_from_ts = *database.now_ts_for_reads();
+            runtime.spawn_background("selective_delivery_shadow_consumer", async move {
+                let consumer = match database::nats_distributed_log::NatsDistributedLog::connect(
+                    database::nats_distributed_log::NatsConfig {
+                        url: nats_url,
+                        consumer_name: Some(format!("{shadow_node_name}-selective-shadow")),
+                        partition_id: None,
+                    },
+                )
+                .await
+                {
+                    Ok(consumer) => consumer,
+                    Err(e) => {
+                        tracing::warn!(
+                            "Failed to start selective-delivery shadow consumer for {}: {e:#}",
+                            shadow_node_name,
+                        );
+                        return;
+                    },
+                };
+
+                match consumer
+                    .subscribe_node_targeted(shadow_from_ts, &shadow_node_name)
+                    .await
+                {
+                    Ok(mut stream) => {
+                        tracing::info!(
+                            "Selective-delivery shadow consumer subscribed for {}",
+                            shadow_node_name
+                        );
+                        while let Some(result) = futures::StreamExt::next(&mut stream).await {
+                            match result {
+                                Ok(delta) => {
+                                    database::log_selective_delivery_shadow_receive();
+                                    tracing::debug!(
+                                        "Selective-delivery shadow delta observed for {} at ts={}",
+                                        shadow_node_name,
+                                        u64::from(delta.ts),
+                                    );
+                                },
+                                Err(e) => {
+                                    tracing::warn!(
+                                        "Selective-delivery shadow consumer error for {}: {e:#}",
+                                        shadow_node_name,
+                                    );
+                                },
+                            }
+                        }
+                    },
+                    Err(e) => tracing::warn!(
+                        "Failed to subscribe selective-delivery shadow consumer for {}: {e:#}",
+                        shadow_node_name,
+                    ),
+                }
+            });
+        }
+    }
+
     // Start the ReplicaDeltaConsumer to tail NATS and apply deltas from other
     // nodes. Runs on:
     //   - Replicas (REPLICATION_MODE=replica): consumes Primary's deltas
-    //   - Partitioned writers (PARTITION_ID set): consumes only other
-    //     partitions' deltas, leaving same-partition convergence to Raft
+    //   - Partitioned writers (PARTITION_ID set): consumes only other partitions'
+    //     deltas, leaving same-partition convergence to Raft
     // Creates a fresh NATS connection dedicated to the consumer.
     let needs_delta_consumer =
         config.replication_mode == "replica" || config.partition_id.is_some();
@@ -460,6 +567,9 @@ pub async fn make_app(
         if let Some(nats_url) = &config.nats_url {
             let nats_url = nats_url.clone();
             let committer = database.committer_client();
+            let use_selective_node_targeting = config
+                .partition_id
+                .is_some_and(|local_partition| local_partition != 0);
             let remote_partitions = config.partition_id.map(|local_partition| {
                 if let Some(num_partitions) = config.num_partitions {
                     (0..num_partitions)
@@ -488,18 +598,22 @@ pub async fn make_app(
             // subjects so same-partition convergence comes from Raft apply.
             // In replica mode, start from the locally visible snapshot, which
             // may have just been bootstrapped from the latest checkpoint.
-            let from_ts = if config.partition_id.is_some() {
+            let from_ts = if use_selective_node_targeting {
+                *database.now_ts_for_reads()
+            } else if config.partition_id.is_some() {
                 common::types::Timestamp::MIN
             } else {
                 *database.now_ts_for_reads()
             };
             let consumer_name = config.name();
+            let broad_consumer_name = consumer_name.clone();
+            let broad_nats_url = nats_url.clone();
             runtime.spawn_background("replica_delta_consumer_setup", async move {
                 let consumer_nats =
                     match database::nats_distributed_log::NatsDistributedLog::connect(
                         database::nats_distributed_log::NatsConfig {
-                            url: nats_url,
-                            consumer_name: Some(consumer_name),
+                            url: broad_nats_url,
+                            consumer_name: Some(broad_consumer_name),
                             partition_id: None,
                         },
                     )
@@ -515,16 +629,43 @@ pub async fn make_app(
                     };
                 let consumer_nats_dyn: Arc<dyn database::commit_delta::DistributedLog> =
                     consumer_nats;
-                tracing::info!(?remote_partitions, "ReplicaDeltaConsumer subscribing to NATS...");
-                match consumer_nats_dyn
-                    .subscribe_filtered(from_ts.into(), remote_partitions.clone())
-                    .await
-                {
+                tracing::info!(
+                    use_selective_node_targeting,
+                    ?remote_partitions,
+                    "ReplicaDeltaConsumer subscribing to NATS..."
+                );
+                let subscribe_result = if use_selective_node_targeting {
+                    let selective_consumer =
+                        database::nats_distributed_log::NatsDistributedLog::connect(
+                            database::nats_distributed_log::NatsConfig {
+                                url: nats_url.clone(),
+                                consumer_name: Some(format!("{consumer_name}-selective")),
+                                partition_id: None,
+                            },
+                        )
+                        .await;
+                    match selective_consumer {
+                        Ok(consumer) => {
+                            consumer
+                                .subscribe_selective_node(from_ts.into(), &consumer_name)
+                                .await
+                        },
+                        Err(e) => Err(e),
+                    }
+                } else {
+                    consumer_nats_dyn
+                        .subscribe_filtered(from_ts.into(), remote_partitions.clone())
+                        .await
+                };
+                match subscribe_result {
                     Ok(mut stream) => {
                         tracing::info!("ReplicaDeltaConsumer subscribed, processing deltas...");
                         while let Some(result) = futures::StreamExt::next(&mut stream).await {
                             match result {
                                 Ok(delta) => {
+                                    if use_selective_node_targeting {
+                                        database::log_selective_delivery_shadow_receive();
+                                    }
                                     let ts = delta.ts;
                                     let n = delta.document_updates.len();
                                     match committer.apply_replica_delta(delta).await {

--- a/crates/local_backend/src/mutation_forwarder.rs
+++ b/crates/local_backend/src/mutation_forwarder.rs
@@ -1,21 +1,29 @@
-//! gRPC service for forwarding mutations from Replica to Primary.
+//! gRPC service for forwarding public UDFs to an authoritative node.
 //!
 //! The Primary runs a [`MutationForwarderService`] that accepts mutation
 //! requests from Replicas via gRPC.
 //!
-//! The Replica runs a [`MutationForwarderGrpcClient`] that forwards mutations
-//! to the Primary when clients try to execute mutations on a Replica.
+//! The Replica or follower runs a [`MutationForwarderGrpcClient`] that forwards
+//! supported public requests to the authoritative node when local execution is
+//! not appropriate.
 
 use std::sync::Arc;
 
 use anyhow::Context;
-use application::api::ApplicationApi;
+use application::{
+    api::{
+        ApplicationApi,
+        ExecuteQueryTimestamp,
+    },
+    RedactedQueryReturn,
+};
 use common::{
     http::RequestDestination,
     types::FunctionCaller,
     version::ClientVersion,
     RequestId,
 };
+use database::Token;
 use keybroker::Identity;
 use pb::replication::{
     forward_mutation_response,
@@ -26,8 +34,12 @@ use pb::replication::{
     },
     ForwardMutationRequest,
     ForwardMutationResponse,
+    ForwardQueryRequest,
+    ForwardQueryResponse,
     MutationError,
     MutationSuccess,
+    QueryError,
+    QuerySuccess,
 };
 use serde_json::Value as JsonValue;
 use sync_types::types::SerializedArgs;
@@ -37,6 +49,7 @@ use tonic::{
     Response,
     Status,
 };
+use value::JsonPackedValue;
 
 /// gRPC server for mutation forwarding. Runs on the Primary.
 pub struct MutationForwarderService {
@@ -135,6 +148,97 @@ impl MutationForwarder for MutationForwarderService {
             Err(e) => Err(Status::internal(format!("Mutation failed: {e}"))),
         }
     }
+
+    async fn forward_query(
+        &self,
+        request: Request<ForwardQueryRequest>,
+    ) -> Result<Response<ForwardQueryResponse>, Status> {
+        let req = request.into_inner();
+
+        let identity = req
+            .identity
+            .ok_or_else(|| Status::invalid_argument("Missing identity"))
+            .and_then(|proto| {
+                Identity::from_proto_unchecked(proto)
+                    .map_err(|e| Status::invalid_argument(format!("Invalid identity: {e}")))
+            })?;
+
+        let args = SerializedArgs::from_slice(req.args.as_bytes())
+            .map_err(|e| Status::invalid_argument(format!("Invalid args: {e}")))?;
+
+        let path = req
+            .path
+            .parse()
+            .map_err(|e: anyhow::Error| Status::invalid_argument(format!("Invalid path: {e}")))?;
+
+        let caller = req
+            .caller
+            .context("Missing caller")
+            .and_then(FunctionCaller::try_from)
+            .map_err(|e| Status::invalid_argument(format!("Invalid caller: {e:#}")))?;
+
+        let host = common::http::ResolvedHostname {
+            instance_name: self.instance_name.clone(),
+            destination: RequestDestination::ConvexCloud,
+        };
+
+        let ts = match req.ts {
+            Some(ts) => ExecuteQueryTimestamp::At(ts.try_into().map_err(|e: anyhow::Error| {
+                Status::invalid_argument(format!("Invalid ts: {e}"))
+            })?),
+            None => ExecuteQueryTimestamp::Latest,
+        };
+
+        let result = self
+            .api
+            .execute_public_query(
+                &host,
+                RequestId::new(),
+                identity,
+                path,
+                args,
+                caller,
+                ts,
+                Some(req.journal),
+            )
+            .await;
+
+        match result {
+            Ok(ret) => {
+                let token = Some(ret.token.clone().try_into().map_err(|e: anyhow::Error| {
+                    Status::internal(format!("Failed to serialize query token: {e}"))
+                })?);
+                let response = match ret.result {
+                    Ok(value) => ForwardQueryResponse {
+                        token,
+                        journal: ret.journal,
+                        result: Some(pb::replication::forward_query_response::Result::Success(
+                            QuerySuccess {
+                                value: value.as_str().to_string(),
+                                log_lines: Some(ret.log_lines.into()),
+                            },
+                        )),
+                    },
+                    Err(error) => ForwardQueryResponse {
+                        token,
+                        journal: ret.journal,
+                        result: Some(pb::replication::forward_query_response::Result::Error(
+                            QueryError {
+                                error: Some(error.try_into().map_err(|e: anyhow::Error| {
+                                    Status::internal(format!(
+                                        "Failed to serialize query error: {e}"
+                                    ))
+                                })?),
+                                log_lines: Some(ret.log_lines.into()),
+                            },
+                        )),
+                    },
+                };
+                Ok(Response::new(response))
+            },
+            Err(e) => Err(Status::internal(format!("Query failed: {e}"))),
+        }
+    }
 }
 
 /// gRPC client for forwarding mutations from Replica to Primary.
@@ -145,10 +249,15 @@ pub struct MutationForwarderGrpcClient {
 impl MutationForwarderGrpcClient {
     /// Connect to the Primary's gRPC mutation forwarding service.
     pub async fn connect(primary_url: &str) -> anyhow::Result<Self> {
-        let client = TonicMutationForwarderClient::connect(primary_url.to_string())
+        let normalized_url = if primary_url.contains("://") {
+            primary_url.to_string()
+        } else {
+            format!("http://{primary_url}")
+        };
+        let client = TonicMutationForwarderClient::connect(normalized_url.clone())
             .await
-            .with_context(|| format!("Failed to connect to Primary at {primary_url}"))?;
-        tracing::info!("Connected to Primary mutation forwarder at {primary_url}");
+            .with_context(|| format!("Failed to connect to Primary at {normalized_url}"))?;
+        tracing::info!("Connected to Primary mutation forwarder at {normalized_url}");
         Ok(Self { client })
     }
 
@@ -176,5 +285,58 @@ impl MutationForwarderGrpcClient {
             .await
             .context("gRPC mutation forwarding failed")?;
         Ok(response.into_inner())
+    }
+
+    pub async fn forward_query(
+        &self,
+        path: &str,
+        args: &str,
+        identity: Identity,
+        caller: FunctionCaller,
+        ts: Option<u64>,
+        journal: Option<String>,
+    ) -> anyhow::Result<RedactedQueryReturn> {
+        let identity_proto: pb::convex_identity::UncheckedIdentity = identity.into();
+        let request = ForwardQueryRequest {
+            path: path.to_string(),
+            args: args.to_string(),
+            identity: Some(identity_proto),
+            caller: Some(caller.into()),
+            ts,
+            journal,
+        };
+        let response = self
+            .client
+            .clone()
+            .forward_query(Request::new(request))
+            .await
+            .context("gRPC query forwarding failed")?;
+        let response = response.into_inner();
+        let token: Token = response
+            .token
+            .context("Forwarded query response missing token")?
+            .try_into()?;
+        let journal = response.journal;
+        let (result, log_lines) = match response.result {
+            Some(pb::replication::forward_query_response::Result::Success(success)) => (
+                Ok(JsonPackedValue::from_network(success.value)
+                    .context("Forwarded query response contained an invalid packed JSON value")?),
+                success.log_lines.unwrap_or_default().try_into()?,
+            ),
+            Some(pb::replication::forward_query_response::Result::Error(error)) => (
+                Err(error
+                    .error
+                    .context("Forwarded query error missing error payload")?
+                    .try_into()?),
+                error.log_lines.unwrap_or_default().try_into()?,
+            ),
+            None => anyhow::bail!("Forwarded query response missing result"),
+        };
+        Ok(RedactedQueryReturn {
+            result,
+            log_lines,
+            token,
+            journal,
+        })
     }
 }

--- a/crates/local_backend/src/public_api.rs
+++ b/crates/local_backend/src/public_api.rs
@@ -63,7 +63,6 @@ use crate::{
     },
     RouterState,
 };
-
 #[derive(Deserialize, Debug, ToSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct UdfPostRequest {
@@ -197,12 +196,18 @@ impl UdfResponse {
     }
 }
 
-async fn wait_for_local_mutation_visibility(st: &RouterState, commit_ts: Timestamp) {
+async fn wait_for_local_mutation_visibility(
+    st: &RouterState,
+    commit_ts: Timestamp,
+    require_replication_frontier: bool,
+) {
     st.database.wait_for_write_ts(commit_ts).await;
-    if let Some(partition_id) = st.partition_id {
-        st.database
-            .wait_for_replication_write_frontier(partition_id, commit_ts)
-            .await;
+    if require_replication_frontier {
+        if let Some(partition_id) = st.partition_id {
+            st.database
+                .wait_for_replication_write_frontier(partition_id, commit_ts)
+                .await;
+        }
     }
 }
 
@@ -315,7 +320,8 @@ async fn maybe_forward_public_mutation(
     let response = match forwarded.result {
         Some(pb::replication::forward_mutation_response::Result::Success(success)) => {
             if matches!(forwarding_mode, ForwardingMode::RaftFollower(_)) {
-                wait_for_local_mutation_visibility(st, Timestamp::try_from(success.ts)?).await;
+                wait_for_local_mutation_visibility(st, Timestamp::try_from(success.ts)?, true)
+                    .await;
             }
             let packed = JsonPackedValue::from_network(success.value).context(
                 ErrorMetadata::bad_request(
@@ -832,7 +838,7 @@ pub async fn public_mutation_post(
     let value_format = req.format.as_ref().map(|f| f.parse()).transpose()?;
     let response = match udf_result {
         Ok(write_return) => {
-            wait_for_local_mutation_visibility(&st, write_return.ts).await;
+            wait_for_local_mutation_visibility(&st, write_return.ts, false).await;
             UdfResponse::Success {
                 value: export_value(write_return.value.unpack()?, value_format, client_version)?,
                 log_lines: write_return.log_lines,
@@ -926,31 +932,49 @@ where
 #[cfg(test)]
 mod tests {
     use std::{
+        collections::BTreeMap,
         sync::Arc,
         time::Duration,
     };
 
     use anyhow::Context;
-    use application::test_helpers::ApplicationTestExt;
+    use application::{
+        api::{
+            ApplicationApi,
+            ExecuteQueryTimestamp,
+        },
+        test_helpers::ApplicationTestExt,
+    };
     use axum::body::Body;
     use common::{
         http::{
             ConvexHttpService,
             NoopRouteMapper,
+            RequestDestination,
+            ResolvedHostname,
         },
         runtime::Runtime,
+        types::FunctionCaller,
+        version::ClientVersion,
+    };
+    use database::{
+        partition::PartitionId,
+        raft_partition::RaftPartitionState,
+        two_phase::NodeAddresses,
     };
     use http::{
         Request,
         StatusCode,
     };
     use http_body_util::BodyExt;
+    use keybroker::Identity;
     use metrics::SERVER_VERSION_STR;
     use runtime::prod::ProdRuntime;
     use serde_json::{
         json,
         Value as JsonValue,
     };
+    use sync_types::types::SerializedArgs;
     use tokio::sync::oneshot;
     use tokio_stream::wrappers::TcpListenerStream;
     use tower::ServiceExt;
@@ -960,6 +984,7 @@ mod tests {
             MutationForwarderGrpcClient,
             MutationForwarderService,
         },
+        query_forwarding_api::SelectiveQueryForwardingApi,
         router::router,
         test_helpers::setup_backend_for_test,
         MAX_CONCURRENT_REQUESTS,
@@ -1054,6 +1079,47 @@ mod tests {
             Ok(json!("1")),
         )
         .await
+    }
+
+    #[convex_macro::prod_rt_test]
+    async fn test_http_query_records_recent_delta_interest(rt: ProdRuntime) -> anyhow::Result<()> {
+        let backend = setup_backend_for_test(rt).await?;
+        backend.st.application.load_udf_tests_modules().await?;
+
+        let inserted: JsonValue = backend
+            .expect_success(post_request(
+                "/api/mutation",
+                json!({
+                    "path": "values:insertObject",
+                    "args": { "obj": { "hello": "interest" } },
+                }),
+            )?)
+            .await?;
+        let inserted_id = inserted["value"]
+            .as_str()
+            .context("insertObject should return a document id string")?
+            .to_string();
+
+        let _: JsonValue = backend
+            .expect_success(post_request(
+                "/api/query",
+                json!({
+                    "path": "values:getObject",
+                    "args": { "id": inserted_id },
+                }),
+            )?)
+            .await?;
+
+        let interest = backend.st.application.database().delta_interest_tracker();
+        assert!(
+            interest
+                .snapshot()
+                .iter()
+                .any(|table| table.to_string() == "test"),
+            "stateless HTTP query should warm recent delta interest for touched tables",
+        );
+
+        Ok(())
     }
 
     #[convex_macro::prod_rt_test]
@@ -1160,6 +1226,275 @@ mod tests {
             replica_test_docs, 0,
             "replica should not execute the forwarded mutation locally",
         );
+
+        let _ = shutdown_tx.send(());
+        Ok(())
+    }
+
+    #[convex_macro::prod_rt_test]
+    async fn test_http_mutation_local_partitioned_write_does_not_wait_for_replication_frontier(
+        rt: ProdRuntime,
+    ) -> anyhow::Result<()> {
+        let backend = setup_backend_for_test(rt).await?;
+        backend.st.application.load_udf_tests_modules().await?;
+
+        let mut partitioned_state = backend.st.clone();
+        partitioned_state.partition_id = Some(PartitionId::DEFAULT);
+        let partitioned_app = ConvexHttpService::new(
+            router(partitioned_state),
+            "backend_partitioned_local_mutation_test",
+            SERVER_VERSION_STR.to_string(),
+            MAX_CONCURRENT_REQUESTS,
+            Duration::from_secs(125),
+            NoopRouteMapper,
+        );
+
+        let response: JsonValue = tokio::time::timeout(
+            Duration::from_secs(5),
+            expect_success_from_app(
+                &partitioned_app,
+                post_request(
+                    "/api/mutation",
+                    json!({
+                        "path": "values:insertObject",
+                        "args": { "obj": { "hello": "partitioned-local" } },
+                    }),
+                )?,
+            ),
+        )
+        .await
+        .context(
+            "local partitioned mutation should not hang waiting for a replication frontier",
+        )??;
+
+        let inserted_id = response["value"]
+            .as_str()
+            .context("insertObject should return a document id string")?
+            .to_string();
+        let stored: JsonValue = backend
+            .expect_success(post_request(
+                "/api/query",
+                json!({
+                    "path": "values:getObject",
+                    "args": { "id": inserted_id },
+                }),
+            )?)
+            .await?;
+        assert_eq!(stored["value"]["hello"], "partitioned-local");
+
+        Ok(())
+    }
+
+    #[convex_macro::prod_rt_test]
+    async fn test_query_forwarder_returns_touched_tables(rt: ProdRuntime) -> anyhow::Result<()> {
+        let primary = setup_backend_for_test(rt.clone()).await?;
+        primary.st.application.load_udf_tests_modules().await?;
+
+        let inserted: JsonValue = primary
+            .expect_success(post_request(
+                "/api/mutation",
+                json!({
+                    "path": "values:insertObject",
+                    "args": { "obj": { "hello": "forwarded query" } },
+                }),
+            )?)
+            .await?;
+        let inserted_id = inserted["value"]
+            .as_str()
+            .context("insertObject should return a document id string")?
+            .to_string();
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await?;
+        let grpc_addr = listener.local_addr()?;
+        let forwarder = MutationForwarderService::new(
+            Arc::new(primary.st.application.clone()),
+            primary.st.instance_name.clone(),
+        );
+        let (shutdown_tx, shutdown_rx) = oneshot::channel();
+        let _server_handle = rt.spawn("test_query_forwarder", async move {
+            let _ = tonic::transport::Server::builder()
+                .add_service(forwarder.into_server())
+                .serve_with_incoming_shutdown(TcpListenerStream::new(listener), async move {
+                    let _ = shutdown_rx.await;
+                })
+                .await;
+        });
+
+        let forwarder_client =
+            MutationForwarderGrpcClient::connect(&format!("http://{grpc_addr}")).await?;
+        let args = SerializedArgs::from_args(vec![json!({ "id": inserted_id })])?;
+        let forwarded = forwarder_client
+            .forward_query(
+                "values:getObject",
+                args.get(),
+                Identity::system(),
+                FunctionCaller::HttpApi(ClientVersion::unknown()),
+                None,
+                None,
+            )
+            .await?;
+
+        let touched_tables = primary
+            .st
+            .application
+            .database()
+            .token_table_names(&forwarded.token)?;
+        assert_eq!(
+            touched_tables
+                .into_iter()
+                .map(|table| table.to_string())
+                .collect::<Vec<_>>(),
+            vec!["test".to_string()]
+        );
+        let value: JsonValue = serde_json::from_str(forwarded.result?.as_str())?;
+        assert_eq!(value["hello"], "forwarded query");
+
+        let _ = shutdown_tx.send(());
+        Ok(())
+    }
+
+    #[convex_macro::prod_rt_test]
+    async fn test_selective_query_forwarding_api_routes_partitioned_queries(
+        rt: ProdRuntime,
+    ) -> anyhow::Result<()> {
+        let primary = setup_backend_for_test(rt.clone()).await?;
+        let selective = setup_backend_for_test(rt.clone()).await?;
+        primary.st.application.load_udf_tests_modules().await?;
+        selective.st.application.load_udf_tests_modules().await?;
+
+        let inserted: JsonValue = primary
+            .expect_success(post_request(
+                "/api/mutation",
+                json!({
+                    "path": "values:insertObject",
+                    "args": { "obj": { "hello": "selective forwarded query" } },
+                }),
+            )?)
+            .await?;
+        let inserted_id = inserted["value"]
+            .as_str()
+            .context("insertObject should return a document id string")?
+            .to_string();
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await?;
+        let grpc_addr = listener.local_addr()?;
+        let forwarder = MutationForwarderService::new(
+            Arc::new(primary.st.application.clone()),
+            primary.st.instance_name.clone(),
+        );
+        let (shutdown_tx, shutdown_rx) = oneshot::channel();
+        let _server_handle = rt.spawn("test_selective_query_forwarder", async move {
+            let _ = tonic::transport::Server::builder()
+                .add_service(forwarder.into_server())
+                .serve_with_incoming_shutdown(TcpListenerStream::new(listener), async move {
+                    let _ = shutdown_rx.await;
+                })
+                .await;
+        });
+
+        let api: Arc<dyn ApplicationApi> = Arc::new(SelectiveQueryForwardingApi::new(
+            Arc::new(selective.st.application.clone()),
+            selective.st.application.database().clone(),
+            Some(PartitionId(1)),
+            Some(NodeAddresses::from_config(&format!("0={grpc_addr}"))),
+            None,
+            None,
+        ));
+        let query_result = api
+            .execute_public_query(
+                &ResolvedHostname {
+                    instance_name: selective.st.instance_name.clone(),
+                    destination: RequestDestination::ConvexCloud,
+                },
+                common::RequestId::new(),
+                Identity::system(),
+                "values:getObject".parse()?,
+                SerializedArgs::from_args(vec![json!({ "id": inserted_id })])?,
+                FunctionCaller::HttpApi(ClientVersion::unknown()),
+                ExecuteQueryTimestamp::Latest,
+                None,
+            )
+            .await?;
+
+        let value: JsonValue = serde_json::from_str(query_result.result?.as_str())?;
+        assert_eq!(value["hello"], "selective forwarded query");
+
+        let _ = shutdown_tx.send(());
+        Ok(())
+    }
+
+    #[convex_macro::prod_rt_test]
+    async fn test_selective_query_forwarding_api_routes_authority_partition_follower_queries(
+        rt: ProdRuntime,
+    ) -> anyhow::Result<()> {
+        let primary = setup_backend_for_test(rt.clone()).await?;
+        let follower = setup_backend_for_test(rt.clone()).await?;
+        primary.st.application.load_udf_tests_modules().await?;
+        follower.st.application.load_udf_tests_modules().await?;
+
+        let inserted: JsonValue = primary
+            .expect_success(post_request(
+                "/api/mutation",
+                json!({
+                    "path": "values:insertObject",
+                    "args": { "obj": { "hello": "authority follower forwarded query" } },
+                }),
+            )?)
+            .await?;
+        let inserted_id = inserted["value"]
+            .as_str()
+            .context("insertObject should return a document id string")?
+            .to_string();
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await?;
+        let grpc_addr = listener.local_addr()?;
+        let forwarder = MutationForwarderService::new(
+            Arc::new(primary.st.application.clone()),
+            primary.st.instance_name.clone(),
+        );
+        let (shutdown_tx, shutdown_rx) = oneshot::channel();
+        let _server_handle = rt.spawn("test_authority_partition_query_forwarder", async move {
+            let _ = tonic::transport::Server::builder()
+                .add_service(forwarder.into_server())
+                .serve_with_incoming_shutdown(TcpListenerStream::new(listener), async move {
+                    let _ = shutdown_rx.await;
+                })
+                .await;
+        });
+
+        let mut raft_peer_grpc_urls = BTreeMap::new();
+        raft_peer_grpc_urls.insert(3, format!("http://{grpc_addr}"));
+        let api: Arc<dyn ApplicationApi> = Arc::new(SelectiveQueryForwardingApi::new(
+            Arc::new(follower.st.application.clone()),
+            follower.st.application.database().clone(),
+            Some(PartitionId(0)),
+            None,
+            Some(RaftPartitionState::new_for_test(
+                false,
+                3,
+                PartitionId(0),
+                1,
+            )),
+            Some(raft_peer_grpc_urls),
+        ));
+        let query_result = api
+            .execute_public_query(
+                &ResolvedHostname {
+                    instance_name: follower.st.instance_name.clone(),
+                    destination: RequestDestination::ConvexCloud,
+                },
+                common::RequestId::new(),
+                Identity::system(),
+                "values:getObject".parse()?,
+                SerializedArgs::from_args(vec![json!({ "id": inserted_id })])?,
+                FunctionCaller::HttpApi(ClientVersion::unknown()),
+                ExecuteQueryTimestamp::Latest,
+                None,
+            )
+            .await?;
+
+        let value: JsonValue = serde_json::from_str(query_result.result?.as_str())?;
+        assert_eq!(value["hello"], "authority follower forwarded query");
 
         let _ = shutdown_tx.send(());
         Ok(())

--- a/crates/local_backend/src/query_forwarding_api.rs
+++ b/crates/local_backend/src/query_forwarding_api.rs
@@ -1,0 +1,417 @@
+use std::{
+    collections::BTreeMap,
+    ops::Bound,
+    sync::Arc,
+    time::Duration,
+};
+
+use anyhow::Context;
+use application::api::SubscriptionClient;
+use async_trait::async_trait;
+use axum::body::Bytes;
+use common::{
+    components::{
+        CanonicalizedComponentFunctionPath,
+        ComponentId,
+        ExportPath,
+    },
+    http::ResolvedHostname,
+    types::{
+        ConvexOrigin,
+        FunctionCaller,
+        RepeatableTimestamp,
+    },
+    RequestId,
+};
+use database::{
+    partition::PartitionId,
+    raft_partition::RaftPartitionState,
+    two_phase::NodeAddresses,
+    Database,
+};
+use errors::ErrorMetadata;
+use file_storage::FileStream;
+use futures::stream::BoxStream;
+use headers::{
+    ContentLength,
+    ContentType,
+};
+use keybroker::Identity;
+use model::{
+    file_storage::FileStorageId,
+    session_requests::types::SessionRequestIdentifier,
+};
+use runtime::prod::ProdRuntime;
+use sync_types::{
+    types::SerializedArgs,
+    AuthenticationToken,
+    SerializedQueryJournal,
+};
+use udf::{
+    HttpActionRequest,
+    HttpActionResponseStreamer,
+};
+use value::{
+    sha256::Sha256Digest,
+    PublicDocumentId,
+};
+
+use crate::mutation_forwarder::MutationForwarderGrpcClient;
+
+const SELECTIVE_QUERY_AUTHORITY_PARTITION: PartitionId = PartitionId(0);
+const RECENT_QUERY_INTEREST_TTL: Duration = Duration::from_secs(60);
+
+#[derive(Clone)]
+pub struct SelectiveQueryForwardingApi {
+    inner: Arc<dyn application::api::ApplicationApi>,
+    database: Database<ProdRuntime>,
+    partition_id: Option<PartitionId>,
+    node_addresses: Option<NodeAddresses>,
+    raft_state: Option<RaftPartitionState>,
+    raft_peer_grpc_urls: Option<BTreeMap<u64, String>>,
+}
+
+impl SelectiveQueryForwardingApi {
+    pub fn new(
+        inner: Arc<dyn application::api::ApplicationApi>,
+        database: Database<ProdRuntime>,
+        partition_id: Option<PartitionId>,
+        node_addresses: Option<NodeAddresses>,
+        raft_state: Option<RaftPartitionState>,
+        raft_peer_grpc_urls: Option<BTreeMap<u64, String>>,
+    ) -> Self {
+        Self {
+            inner,
+            database,
+            partition_id,
+            node_addresses,
+            raft_state,
+            raft_peer_grpc_urls,
+        }
+    }
+
+    async fn public_query_target_grpc_url(&self) -> anyhow::Result<Option<String>> {
+        let Some(partition_id) = self.partition_id else {
+            return Ok(None);
+        };
+
+        if partition_id != SELECTIVE_QUERY_AUTHORITY_PARTITION {
+            return Ok(Some(self.authority_grpc_url()?));
+        }
+
+        let Some(raft_state) = self.raft_state.as_ref() else {
+            return Ok(None);
+        };
+        if raft_state.is_leader() {
+            return Ok(None);
+        }
+        let peer_grpc_urls = self.raft_peer_grpc_urls.as_ref().context(
+            "Follower public query forwarding requires RAFT_PEERS gRPC URLs to find the current \
+             leader",
+        )?;
+        for _ in 0..50 {
+            let leader_id = raft_state.leader_id();
+            if leader_id != 0 {
+                let leader_grpc_url = peer_grpc_urls.get(&leader_id).with_context(|| {
+                    format!("Missing RAFT_PEERS entry for Raft leader node {leader_id}")
+                })?;
+                return Ok(Some(leader_grpc_url.clone()));
+            }
+            tokio::time::sleep(Duration::from_millis(100)).await;
+        }
+        Ok(None)
+    }
+
+    fn authority_grpc_url(&self) -> anyhow::Result<String> {
+        let addresses = self.node_addresses.as_ref().context(
+            "Selective public query forwarding requires NODE_ADDRESSES to find the authoritative \
+             query node",
+        )?;
+        addresses
+            .address_for(SELECTIVE_QUERY_AUTHORITY_PARTITION)
+            .map(ToOwned::to_owned)
+            .context(
+                "Selective public query forwarding requires a partition-0 NODE_ADDRESSES entry",
+            )
+    }
+
+    fn note_recent_interest(&self, token: &database::Token) {
+        if let Err(e) = self
+            .database
+            .note_recent_delta_interest_for_token(token, RECENT_QUERY_INTEREST_TTL)
+        {
+            tracing::debug!("Failed to record recent query interest: {e:#}");
+        }
+    }
+}
+
+#[async_trait]
+impl application::api::ApplicationApi for SelectiveQueryForwardingApi {
+    async fn authenticate(
+        &self,
+        host: &ResolvedHostname,
+        request_id: RequestId,
+        auth_token: AuthenticationToken,
+    ) -> anyhow::Result<Identity> {
+        self.inner.authenticate(host, request_id, auth_token).await
+    }
+
+    async fn execute_public_query(
+        &self,
+        host: &ResolvedHostname,
+        request_id: RequestId,
+        identity: Identity,
+        path: ExportPath,
+        args: SerializedArgs,
+        caller: FunctionCaller,
+        ts: application::api::ExecuteQueryTimestamp,
+        journal: Option<SerializedQueryJournal>,
+    ) -> anyhow::Result<application::RedactedQueryReturn> {
+        let result = if let Some(target_grpc_url) = self.public_query_target_grpc_url().await? {
+            let client = MutationForwarderGrpcClient::connect(&target_grpc_url)
+                .await
+                .with_context(|| {
+                    format!("Failed to connect to selective query authority at {target_grpc_url}")
+                })
+                .map_err(|e| anyhow::anyhow!(ErrorMetadata::service_unavailable()).context(e))?;
+            client
+                .forward_query(
+                    &String::from(path.clone()),
+                    args.get(),
+                    identity,
+                    caller,
+                    match ts {
+                        application::api::ExecuteQueryTimestamp::Latest => None,
+                        application::api::ExecuteQueryTimestamp::At(ts) => Some(u64::from(ts)),
+                    },
+                    journal.flatten(),
+                )
+                .await
+                .map_err(|e| anyhow::anyhow!(ErrorMetadata::service_unavailable()).context(e))?
+        } else {
+            self.inner
+                .execute_public_query(host, request_id, identity, path, args, caller, ts, journal)
+                .await?
+        };
+        self.note_recent_interest(&result.token);
+        Ok(result)
+    }
+
+    async fn execute_admin_query(
+        &self,
+        host: &ResolvedHostname,
+        request_id: RequestId,
+        identity: Identity,
+        path: CanonicalizedComponentFunctionPath,
+        args: SerializedArgs,
+        caller: FunctionCaller,
+        ts: application::api::ExecuteQueryTimestamp,
+        journal: Option<SerializedQueryJournal>,
+    ) -> anyhow::Result<application::RedactedQueryReturn> {
+        self.inner
+            .execute_admin_query(host, request_id, identity, path, args, caller, ts, journal)
+            .await
+    }
+
+    async fn execute_public_mutation(
+        &self,
+        host: &ResolvedHostname,
+        request_id: RequestId,
+        identity: Identity,
+        path: ExportPath,
+        args: SerializedArgs,
+        caller: FunctionCaller,
+        mutation_identifier: Option<SessionRequestIdentifier>,
+        mutation_queue_length: Option<usize>,
+    ) -> anyhow::Result<
+        Result<application::RedactedMutationReturn, application::RedactedMutationError>,
+    > {
+        self.inner
+            .execute_public_mutation(
+                host,
+                request_id,
+                identity,
+                path,
+                args,
+                caller,
+                mutation_identifier,
+                mutation_queue_length,
+            )
+            .await
+    }
+
+    async fn execute_admin_mutation(
+        &self,
+        host: &ResolvedHostname,
+        request_id: RequestId,
+        identity: Identity,
+        path: CanonicalizedComponentFunctionPath,
+        args: SerializedArgs,
+        caller: FunctionCaller,
+        mutation_identifier: Option<SessionRequestIdentifier>,
+        mutation_queue_length: Option<usize>,
+    ) -> anyhow::Result<
+        Result<application::RedactedMutationReturn, application::RedactedMutationError>,
+    > {
+        self.inner
+            .execute_admin_mutation(
+                host,
+                request_id,
+                identity,
+                path,
+                args,
+                caller,
+                mutation_identifier,
+                mutation_queue_length,
+            )
+            .await
+    }
+
+    async fn execute_public_action(
+        &self,
+        host: &ResolvedHostname,
+        request_id: RequestId,
+        identity: Identity,
+        path: ExportPath,
+        args: SerializedArgs,
+        caller: FunctionCaller,
+    ) -> anyhow::Result<Result<application::RedactedActionReturn, application::RedactedActionError>>
+    {
+        self.inner
+            .execute_public_action(host, request_id, identity, path, args, caller)
+            .await
+    }
+
+    async fn execute_admin_action(
+        &self,
+        host: &ResolvedHostname,
+        request_id: RequestId,
+        identity: Identity,
+        path: CanonicalizedComponentFunctionPath,
+        args: SerializedArgs,
+        caller: FunctionCaller,
+    ) -> anyhow::Result<Result<application::RedactedActionReturn, application::RedactedActionError>>
+    {
+        self.inner
+            .execute_admin_action(host, request_id, identity, path, args, caller)
+            .await
+    }
+
+    async fn execute_http_action(
+        &self,
+        host: &ResolvedHostname,
+        request_id: RequestId,
+        http_request_metadata: HttpActionRequest,
+        identity: Identity,
+        caller: FunctionCaller,
+        response_streamer: HttpActionResponseStreamer,
+    ) -> anyhow::Result<()> {
+        self.inner
+            .execute_http_action(
+                host,
+                request_id,
+                http_request_metadata,
+                identity,
+                caller,
+                response_streamer,
+            )
+            .await
+    }
+
+    async fn execute_any_function(
+        &self,
+        host: &ResolvedHostname,
+        request_id: RequestId,
+        identity: Identity,
+        path: CanonicalizedComponentFunctionPath,
+        args: SerializedArgs,
+        caller: FunctionCaller,
+    ) -> anyhow::Result<Result<application::FunctionReturn, application::FunctionError>> {
+        self.inner
+            .execute_any_function(host, request_id, identity, path, args, caller)
+            .await
+    }
+
+    async fn latest_timestamp(
+        &self,
+        host: &ResolvedHostname,
+        request_id: RequestId,
+    ) -> anyhow::Result<RepeatableTimestamp> {
+        self.inner.latest_timestamp(host, request_id).await
+    }
+
+    async fn check_store_file_authorization(
+        &self,
+        host: &ResolvedHostname,
+        request_id: RequestId,
+        token: &str,
+        validity: Duration,
+    ) -> anyhow::Result<ComponentId> {
+        self.inner
+            .check_store_file_authorization(host, request_id, token, validity)
+            .await
+    }
+
+    async fn store_file(
+        &self,
+        host: &ResolvedHostname,
+        request_id: RequestId,
+        origin: ConvexOrigin,
+        component: ComponentId,
+        content_length: Option<ContentLength>,
+        content_type: Option<ContentType>,
+        expected_sha256: Option<Sha256Digest>,
+        body: BoxStream<'_, anyhow::Result<Bytes>>,
+    ) -> anyhow::Result<PublicDocumentId> {
+        self.inner
+            .store_file(
+                host,
+                request_id,
+                origin,
+                component,
+                content_length,
+                content_type,
+                expected_sha256,
+                body,
+            )
+            .await
+    }
+
+    async fn get_file_range(
+        &self,
+        host: &ResolvedHostname,
+        request_id: RequestId,
+        origin: ConvexOrigin,
+        component: ComponentId,
+        file_storage_id: FileStorageId,
+        range: (Bound<u64>, Bound<u64>),
+    ) -> anyhow::Result<FileStream> {
+        self.inner
+            .get_file_range(host, request_id, origin, component, file_storage_id, range)
+            .await
+    }
+
+    async fn get_file(
+        &self,
+        host: &ResolvedHostname,
+        request_id: RequestId,
+        origin: ConvexOrigin,
+        component: ComponentId,
+        file_storage_id: FileStorageId,
+    ) -> anyhow::Result<FileStream> {
+        self.inner
+            .get_file(host, request_id, origin, component, file_storage_id)
+            .await
+    }
+
+    async fn subscription_client(
+        &self,
+        host: &ResolvedHostname,
+    ) -> anyhow::Result<Box<dyn SubscriptionClient>> {
+        self.inner.subscription_client(host).await
+    }
+
+    async fn partition_id(&self, host: &ResolvedHostname) -> anyhow::Result<u64> {
+        self.inner.partition_id(host).await
+    }
+}

--- a/crates/local_backend/src/router.rs
+++ b/crates/local_backend/src/router.rs
@@ -403,11 +403,19 @@ pub fn router(st: LocalAppState) -> Router {
         // added inside `serve_http`
         .nest("/http/", http_action_routes())
         .with_state(RouterState {
-            api: Arc::new(st.application.clone()),
+            api: Arc::new(crate::query_forwarding_api::SelectiveQueryForwardingApi::new(
+                Arc::new(st.application.clone()),
+                st.application.database().clone(),
+                st.partition_id,
+                st.node_addresses.clone(),
+                st.raft_state.clone(),
+                st.raft_peer_grpc_urls.clone(),
+            )),
             database: st.application.database().clone(),
             runtime: st.application.runtime(),
             replica_mode: st.replica_mode,
             partition_id: st.partition_id,
+            node_addresses: st.node_addresses.clone(),
             raft_state: st.raft_state.clone(),
             raft_peer_grpc_urls: st.raft_peer_grpc_urls.clone(),
             replica_mutation_forwarder: st.replica_mutation_forwarder.clone(),

--- a/crates/pb/protos/replication.proto
+++ b/crates/pb/protos/replication.proto
@@ -11,6 +11,7 @@ import "searchlight.proto";
 // from a client, and the Primary executes it locally.
 service MutationForwarder {
   rpc ForwardMutation(ForwardMutationRequest) returns (ForwardMutationResponse);
+  rpc ForwardQuery(ForwardQueryRequest) returns (ForwardQueryResponse);
 }
 
 message ForwardMutationRequest {
@@ -62,6 +63,57 @@ message MutationError {
 
   // Log lines captured during execution.
   repeated string log_lines = 3;
+}
+
+message ForwardQueryRequest {
+  // The function path to execute (e.g., "messages:list").
+  string path = 1;
+
+  // Serialized function arguments as a JSON array string.
+  string args = 2;
+
+  // The authenticated identity of the caller.
+  convex_identity.UncheckedIdentity identity = 3;
+
+  // Caller type for logging and rate limiting.
+  common.FunctionCaller caller = 4;
+
+  // Optional query timestamp. If unset, execute at latest visible time.
+  optional uint64 ts = 5;
+
+  // Optional serialized query journal for reconnect/retry flows.
+  optional string journal = 6;
+}
+
+message ForwardQueryResponse {
+  QueryToken token = 1;
+  optional string journal = 2;
+
+  oneof result {
+    QuerySuccess success = 3;
+    QueryError error = 4;
+  }
+}
+
+message QueryToken {
+  optional uint64 ts = 1;
+  repeated TwoPcIndexedRead indexed_reads = 2;
+  repeated TwoPcSearchRead search_reads = 3;
+}
+
+message QuerySuccess {
+  // The return value as a JSON string.
+  string value = 1;
+
+  // Log lines captured during execution.
+  common.RedactedLogLines log_lines = 2;
+}
+
+message QueryError {
+  common.RedactedJsError error = 1;
+
+  // Log lines captured during execution.
+  common.RedactedLogLines log_lines = 2;
 }
 
 // Two-Phase Commit service for cross-partition writes (Vitess 2PC pattern).

--- a/docs/issue-journal.md
+++ b/docs/issue-journal.md
@@ -393,6 +393,136 @@ own for distributed changes.
     tests passed with partitioned nodes no longer consuming their own
     partition's NATS subject
 
+### 2026-05 — Started explicit selective-delivery interest tracking
+
+- **Status:** in progress
+- **Related issue:** `#96`
+- **Why this first:** before we can safely narrow cross-partition delivery, the
+  system needs an explicit notion of what data a node is actually interested
+  in. Today, the subscription/read path still gets its "read anywhere" behavior
+  from a broad remote snapshot, so skipping remote deltas without a real
+  interest model would silently change semantics.
+- **What this slice adds:**
+  - a database-side `DeltaInterestTracker` that aggregates live subscription
+    interests as a node-local set of table names
+  - `Database::subscribe(...)` now resolves a subscription token's read-set
+    into concrete non-system table names before registering the subscription
+  - `SubscriptionsClient` / `SubscriptionManager` now keep those per-subscription
+    table interests and maintain reference counts as subscriptions start and end
+  - a new `database_selective_delivery_interested_tables_info` metric and a
+    `CommitDelta::touched_table_names()` helper for the next transport-side step
+- **What this does not do yet:** it does **not** change runtime fanout or stop
+  delivering any remote deltas. This is the seam the later NATS/changefeed
+  routing work will use.
+- **Validation:**
+  - `cargo check -p local_backend`
+  - `cargo test -p database delta_interest::tests::interest_tracker_ref_counts_tables -- --nocapture`
+  - `cargo test -p database commit_delta::tests::touched_table_names_collects_unique_tables -- --nocapture`
+  - `cargo test -p database subscription::tests::test_log_rewind_invalidates_subscriptions_and_reanchors_manager -- --nocapture`
+
+### 2026-05 — Added selective-delivery shadow control plane
+
+- **Status:** in progress
+- **Related issue:** `#96`
+- **What this slice adds:**
+  - nodes now publish their live table-interest set into a dedicated NATS KV
+    bucket (`convex_delta_interest`) with freshness timestamps
+  - producers can now compute which nodes are interested in a delta's touched
+    tables and shadow-publish those deltas to node-specific subjects
+    (`convex.commits.node.<node>`) in addition to the existing broad partition
+    subject
+  - this gives us a real selective-delivery control plane and transport shape
+    without yet changing the current broad read-anywhere data path
+- **Why this is still shadow mode:** broad remote replication is still required
+  for one-shot cross-partition queries. Live subscriptions tell us what a node
+  is interested in over time, but ad hoc query execution still does not expose
+  the full table set *before* execution. Until the request path can catch up or
+  reroute those cold-table reads safely, switching consumers away from the broad
+  path would change semantics.
+- **Validation:**
+  - `cargo check -p local_backend`
+  - `cargo test -p database selective_delivery::tests::interested_nodes_match_tables_and_skip_stale_entries -- --nocapture`
+  - `cargo test -p database selective_delivery::tests::node_subject_names_are_stable -- --nocapture`
+
+### 2026-05 — Added recent-query interest leases for stateless reads
+
+- **Status:** in progress
+- **Related issue:** `#96`
+- **Why this slice matters:** sync queries already warm table interest after
+  their first execution because they immediately subscribe on the returned
+  token. Plain HTTP queries do not; they learn their table set only after
+  execution and then discard it. That made the control plane under-report real
+  read traffic from stateless query paths.
+- **What this slice adds:**
+  - `DeltaInterestTracker` now supports short-lived recent-interest leases in
+    addition to long-lived subscription ref-counts
+  - the selective-delivery interest publisher prunes expired recent-interest
+    leases before publishing to NATS KV
+  - latest-timestamp public HTTP queries now feed their returned token back
+    into the tracker for a short TTL, so repeated ad hoc reads can warm table
+    interest over time
+- **What this still does not solve:** this improves the signal for selective
+  routing, but it still does not make the *first* cold-table query safe under a
+  fully selective delivery regime. We still need either cold-table catch-up or
+  request rerouting before the active cutover.
+- **Validation:**
+  - `cargo test -p local_backend test_http_query_records_recent_delta_interest -- --nocapture`
+
+### 2026-05 — Added query-forwarder infrastructure for cold-read reroute
+
+- **Status:** in progress
+- **Related issue:** `#96`
+- **What this slice adds:**
+  - the existing gRPC `MutationForwarder` service now also supports forwarding
+    public queries to an authoritative peer
+  - forwarded query responses include the non-system table names touched by the
+    returned token/read-set, so the caller can warm selective-delivery interest
+    from a routed read instead of losing that information
+- **Why this matters:** the remaining `#96` blocker is the first cold-table
+  stateless query. This forwarder gives us the transport primitive for a safe
+  reroute path without forcing us to hard-code the wrong policy prematurely.
+- **What this still does not do:** the public HTTP query handlers do not yet
+  automatically reroute cold reads. We still need to decide the active policy:
+  query reroute target, fallback behavior, and when to prefer reroute versus
+  local execution.
+- **Validation:**
+  - `cargo test -p local_backend test_query_forwarder_returns_touched_tables -- --nocapture`
+  - `cargo check -p local_backend`
+
+### 2026-05 — Completed leader-aware latest-query routing for selective delivery
+
+- **Status:** complete
+- **Related issue:** `#96`
+- **What closed the loop:**
+  - system-table deltas now continue to fan out on a dedicated global NATS
+    subject so deploy/metadata state is never accidentally gated by table
+    interest
+  - latest public queries from non-authority partitions still reroute to the
+    partition-0 authority
+  - latest public queries from partition-0 followers now also reroute to the
+    current Raft leader instead of trying to serve an unsafe local latest read
+- **Why this was necessary:** once user-table deltas became selective, a
+  partition-0 follower could no longer safely answer every latest query from
+  its local snapshot. The remaining full-harness failures were exactly that
+  shape: writes forwarded to the leader succeeded, but immediate reads on a
+  partition-0 follower could still observe stale local state. Leader-aware
+  latest-query forwarding closes that gap without re-broadcasting the old broad
+  replication stream.
+- **Focused validation:**
+  - `cargo check -p local_backend`
+  - `cargo test -p local_backend test_selective_query_forwarding_api_routes_partitioned_queries -- --nocapture`
+  - `cargo test -p local_backend test_selective_query_forwarding_api_routes_authority_partition_follower_queries -- --nocapture`
+  - `cargo test -p local_backend test_http_mutation_local_partitioned_write_does_not_wait_for_replication_frontier -- --nocapture`
+  - `cargo test -p local_backend test_http_mutation_forwards_when_replica_mode -- --nocapture`
+  - `cargo test -p database selective_delivery::tests -- --nocapture`
+  - `cargo test -p database test_remote_single_partition_commit_rejects_before_waiting_for_remote_frontier -- --nocapture`
+- **End-to-end validation:**
+  - rebuilt backend image from branch state
+  - `docker compose --profile cluster down -v --remove-orphans`
+  - `docker compose --profile cluster up -d --pull never`
+  - `bash self-hosted/docker/test.sh`
+  - result: `ALL 77 TESTS PASSED`, `ALL 10 TESTS PASSED`, `ALL SUITES PASSED`
+
 ## Open Issues
 
 - `#74` is no longer blocked on follower self-sufficiency. The current


### PR DESCRIPTION
## Summary
- add explicit table-interest tracking and selective NATS delta fanout
- keep system-table/deploy metadata on a dedicated global subject so metadata replication stays safe
- add leader-aware public query forwarding so latest reads reroute to an authoritative node when local follower reads are unsafe
- harden partition follower mutation/query behavior and record the final validation in the issue journal

## Testing
- cargo check -p local_backend
- cargo test -p local_backend test_selective_query_forwarding_api_routes_partitioned_queries -- --nocapture
- cargo test -p local_backend test_selective_query_forwarding_api_routes_authority_partition_follower_queries -- --nocapture
- cargo test -p local_backend test_http_mutation_local_partitioned_write_does_not_wait_for_replication_frontier -- --nocapture
- cargo test -p local_backend test_http_mutation_forwards_when_replica_mode -- --nocapture
- cargo test -p database selective_delivery::tests -- --nocapture
- cargo test -p database test_remote_single_partition_commit_rejects_before_waiting_for_remote_frontier -- --nocapture
- docker build --progress=plain -t ghcr.io/martinkalema/convex-horizontal-scaling:backend-latest -f self-hosted/docker-build/Dockerfile.backend .
- docker compose --profile cluster down -v --remove-orphans
- docker compose --profile cluster up -d --pull never
- bash self-hosted/docker/test.sh
  - ALL 77 TESTS PASSED
  - ALL 10 TESTS PASSED
  - ALL SUITES PASSED

Closes #96.