### PR TITLE
fix: add durable 2PC recovery logs

### DIFF
--- a/crates/application/src/test_helpers.rs
+++ b/crates/application/src/test_helpers.rs
@@ -222,6 +222,7 @@ impl<RT: Runtime> ApplicationTestExt<RT> for Application<RT> {
             false,
             None,
             None,
+            Arc::new(database::two_phase::NoopTwoPhaseDecisionLog),
             None,
             None,
         )

--- a/crates/common/src/persistence.rs
+++ b/crates/common/src/persistence.rs
@@ -165,6 +165,10 @@ pub enum PersistenceGlobalKey {
     /// Latest snapshot of all tables' summaries, cached to speed up startup.
     TableSummary,
 
+    /// Node-local durable redo records for unresolved 2PC prepared
+    /// transactions. This must not be copied into checkpoints.
+    TwoPhaseRedoRecords,
+
     /// Internal id of _tables.by_id index, for bootstrapping.
     TablesByIdIndex,
     /// Internal id of _tables table, for bootstrapping.
@@ -193,6 +197,7 @@ impl From<PersistenceGlobalKey> for String {
             PersistenceGlobalKey::MaxRepeatableTimestamp => "max_repeatable_ts".to_string(),
             PersistenceGlobalKey::ReplicationFrontiers => "replication_frontiers".to_string(),
             PersistenceGlobalKey::TableSummary => "table_summary".to_string(),
+            PersistenceGlobalKey::TwoPhaseRedoRecords => "two_phase_redo_records".to_string(),
             PersistenceGlobalKey::TablesByIdIndex => "tables_by_id".to_string(),
             PersistenceGlobalKey::IndexByIdIndex => "index_by_id".to_string(),
             // NB: For compatibility, these are referred to as "table_id"s, not "tablet_id"s.
@@ -213,6 +218,7 @@ impl FromStr for PersistenceGlobalKey {
             "max_repeatable_ts" => Ok(Self::MaxRepeatableTimestamp),
             "replication_frontiers" => Ok(Self::ReplicationFrontiers),
             "table_summary" => Ok(Self::TableSummary),
+            "two_phase_redo_records" => Ok(Self::TwoPhaseRedoRecords),
             "tables_by_id" => Ok(Self::TablesByIdIndex),
             "tables_table_id" => Ok(Self::TablesTabletId),
             "index_by_id" => Ok(Self::IndexByIdIndex),
@@ -225,6 +231,13 @@ impl FromStr for PersistenceGlobalKey {
 impl PersistenceGlobalKey {
     pub fn all_keys() -> Vec<Self> {
         enum_iterator::all().collect()
+    }
+
+    pub fn checkpoint_keys() -> Vec<Self> {
+        Self::all_keys()
+            .into_iter()
+            .filter(|key| *key != Self::TwoPhaseRedoRecords)
+            .collect()
     }
 }
 

--- a/crates/database/src/checkpoint.rs
+++ b/crates/database/src/checkpoint.rs
@@ -84,7 +84,7 @@ pub async fn create_checkpoint(
         .context("Failed to load documents for checkpoint")?;
 
     let mut globals = BTreeMap::new();
-    for key in PersistenceGlobalKey::all_keys() {
+    for key in PersistenceGlobalKey::checkpoint_keys() {
         if let Some(value) = persistence.get_persistence_global(key).await? {
             globals.insert(String::from(key), value);
         }

--- a/crates/database/src/committer.rs
+++ b/crates/database/src/committer.rs
@@ -441,6 +441,13 @@ impl<RT: Runtime> Committer<RT> {
         self.queued_snapshots.push_back((commit_id, ts, snapshot));
     }
 
+    fn local_partition_for_two_phase(&self) -> crate::partition::PartitionId {
+        self.partition_map
+            .as_ref()
+            .map(|partition_map| partition_map.local_partition())
+            .unwrap_or(crate::partition::PartitionId(0))
+    }
+
     fn dequeue_snapshot(&mut self, commit_id: usize) {
         let (queued_commit_id, ..) = self
             .queued_snapshots
@@ -463,6 +470,7 @@ impl<RT: Runtime> Committer<RT> {
         distributed_log: Arc<dyn DistributedLog>,
         partition_map: Option<crate::partition::PartitionMap>,
         node_addresses: Option<crate::two_phase::NodeAddresses>,
+        two_phase_decision_log: Arc<dyn crate::two_phase::TwoPhaseDecisionLog>,
         timestamp_oracle: Option<Arc<dyn crate::timestamp_oracle::TimestampOracle>>,
         raft_state: Option<crate::raft_partition::RaftPartitionState>,
     ) -> CommitterClient {
@@ -506,10 +514,13 @@ impl<RT: Runtime> Committer<RT> {
             snapshot_reader,
             partition_map: client_partition_map,
             node_addresses,
+            two_phase_decision_log,
         }
     }
 
     async fn go(mut self, mut rx: mpsc::Receiver<CommitterMessage>) -> anyhow::Result<()> {
+        self.recover_two_phase_redo_records().await?;
+
         let mut last_bumped_repeatable_ts = self.runtime.monotonic_now();
         let mut last_replication_frontier_heartbeat = self.runtime.monotonic_now();
         let mut last_replication_frontier_heartbeat_ts = Timestamp::MIN;
@@ -819,7 +830,9 @@ impl<RT: Runtime> Committer<RT> {
                             write_source,
                             result,
                         }) => {
-                            let r = self.handle_prepare(transaction_id, transaction, write_source);
+                            let r = self
+                                .handle_prepare(transaction_id, transaction, write_source)
+                                .await;
                             let _ = result.send(r);
                         },
                         Some(CommitterMessage::PrepareRemote {
@@ -834,7 +847,8 @@ impl<RT: Runtime> Committer<RT> {
                                 transaction,
                                 write_source,
                                 prepare_ts,
-                            );
+                            )
+                            .await;
                             let _ = result.send(r);
                         },
                         Some(CommitterMessage::AllocateCommitTs { result }) => {
@@ -847,6 +861,7 @@ impl<RT: Runtime> Committer<RT> {
                             transaction_id,
                             result,
                         }) => {
+                            let redo_transaction_id = transaction_id.clone();
                             let published_commit = match self.handle_commit_prepared(transaction_id)
                             {
                                 Ok(published_commit) => published_commit,
@@ -870,13 +885,38 @@ impl<RT: Runtime> Committer<RT> {
                                 );
                             }
                             self.publish_commit_delta(published_commit.delta);
+                            if let Err(err) = Self::delete_two_phase_redo(
+                                self.persistence.clone(),
+                                &redo_transaction_id,
+                            )
+                            .await
+                            {
+                                tracing::warn!(
+                                    "2PC CommitPrepared: committed txn={} but failed to delete \
+                                     redo: {err:#}",
+                                    redo_transaction_id,
+                                );
+                            }
                             let _ = result.send(Ok(commit_ts));
                         },
                         Some(CommitterMessage::RollbackPrepared {
                             transaction_id,
                             result,
                         }) => {
-                            let r = self.handle_rollback_prepared(transaction_id);
+                            let r = self.handle_rollback_prepared(transaction_id.clone());
+                            if r.is_ok()
+                                && let Err(err) = Self::delete_two_phase_redo(
+                                    self.persistence.clone(),
+                                    &transaction_id,
+                                )
+                                .await
+                            {
+                                tracing::warn!(
+                                    "2PC RollbackPrepared: rolled back txn={} but failed to \
+                                     delete redo: {err:#}",
+                                    transaction_id,
+                                );
+                            }
                             let _ = result.send(r);
                         },
                     }
@@ -1921,13 +1961,19 @@ impl<RT: Runtime> Committer<RT> {
                         .write(&[], chunk, ConflictStrategy::Overwrite)
                         .await?;
                 }
-                for key in PersistenceGlobalKey::all_keys() {
+                for key in PersistenceGlobalKey::checkpoint_keys() {
                     if let Some(value) = checkpoint.globals.get(&String::from(key)) {
                         persistence
                             .write_persistence_global(key, value.clone())
                             .await?;
                     }
                 }
+                persistence
+                    .write_persistence_global(
+                        PersistenceGlobalKey::TwoPhaseRedoRecords,
+                        serde_json::json!({}),
+                    )
+                    .await?;
 
                 let replication_frontiers = checkpoint
                     .globals
@@ -2453,46 +2499,97 @@ impl<RT: Runtime> Committer<RT> {
 
     // ========== 2PC Handlers (Vitess prepare/commit/rollback pattern) ==========
 
-    /// Prepare phase: validate OCC, assign timestamp, stage writes.
-    /// Does NOT publish — the transaction is held in prepared_transactions
-    /// until CommitPrepared or RollbackPrepared arrives.
-    fn handle_prepare(
-        &mut self,
-        transaction_id: crate::two_phase::TwoPhaseTransactionId,
-        transaction: FinalTransaction,
-        write_source: WriteSource,
-    ) -> anyhow::Result<crate::two_phase::PrepareResult> {
-        tracing::info!(
-            "2PC Prepare: txn={}, {} writes",
-            transaction_id,
-            transaction.writes.coalesced_writes().count(),
-        );
-
-        self.stage_prepared_transaction(
-            transaction_id,
-            *transaction.begin_timestamp,
-            transaction.reads.read_set(),
-            transaction.writes.coalesced_writes().cloned().collect(),
-            &transaction.table_mapping,
-            write_source,
-            None,
-        )
+    async fn load_two_phase_redo_records(
+        persistence: Arc<dyn Persistence>,
+    ) -> anyhow::Result<BTreeMap<String, crate::two_phase::TwoPhaseRedoEntry>> {
+        let Some(value) = persistence
+            .reader()
+            .get_persistence_global(PersistenceGlobalKey::TwoPhaseRedoRecords)
+            .await?
+        else {
+            return Ok(BTreeMap::new());
+        };
+        serde_json::from_value(value).context("2PC: Failed to parse durable redo records")
     }
 
-    fn handle_prepare_remote(
+    async fn write_two_phase_redo_records(
+        persistence: Arc<dyn Persistence>,
+        records: &BTreeMap<String, crate::two_phase::TwoPhaseRedoEntry>,
+    ) -> anyhow::Result<()> {
+        persistence
+            .write_persistence_global(
+                PersistenceGlobalKey::TwoPhaseRedoRecords,
+                serde_json::to_value(records).context("2PC: Failed to serialize redo records")?,
+            )
+            .await
+            .context("2PC: Failed to persist redo records")
+    }
+
+    async fn persist_two_phase_redo(
+        persistence: Arc<dyn Persistence>,
+        entry: crate::two_phase::TwoPhaseRedoEntry,
+    ) -> anyhow::Result<()> {
+        let mut records = Self::load_two_phase_redo_records(persistence.clone()).await?;
+        records.insert(entry.transaction_id.clone(), entry);
+        Self::write_two_phase_redo_records(persistence, &records).await
+    }
+
+    async fn delete_two_phase_redo(
+        persistence: Arc<dyn Persistence>,
+        transaction_id: &crate::two_phase::TwoPhaseTransactionId,
+    ) -> anyhow::Result<()> {
+        let mut records = Self::load_two_phase_redo_records(persistence.clone()).await?;
+        if records.remove(&transaction_id.0).is_some() {
+            Self::write_two_phase_redo_records(persistence, &records).await?;
+        }
+        Ok(())
+    }
+
+    async fn redo_entry_is_already_committed(
+        persistence_reader: Arc<dyn PersistenceReader>,
+        retention_validator: Arc<dyn RetentionValidator>,
+        entry: &crate::two_phase::TwoPhaseRedoEntry,
+        transaction: &crate::two_phase::ParticipantTransaction,
+        prepare_ts: Timestamp,
+    ) -> anyhow::Result<bool> {
+        if transaction.writes.is_empty() {
+            return Ok(false);
+        }
+        let expected: BTreeSet<_> = transaction
+            .writes
+            .iter()
+            .map(|write| InternalDocumentId::new(write.id.tablet_id, write.id.internal_id()))
+            .collect();
+        let mut seen = BTreeSet::new();
+        let mut stream = persistence_reader.load_documents(
+            TimestampRange::at(prepare_ts),
+            Order::Asc,
+            1024,
+            retention_validator,
+        );
+        while let Some(doc) = stream.try_next().await? {
+            if expected.contains(&doc.id) {
+                seen.insert(doc.id);
+            }
+        }
+        let already_committed = seen.len() == expected.len();
+        if already_committed {
+            tracing::info!(
+                "2PC Recovery: redo txn={} is already committed at ts={}, deleting redo",
+                entry.transaction_id,
+                u64::from(prepare_ts),
+            );
+        }
+        Ok(already_committed)
+    }
+
+    fn stage_participant_prepared_transaction(
         &mut self,
         transaction_id: crate::two_phase::TwoPhaseTransactionId,
         transaction: crate::two_phase::ParticipantTransaction,
         write_source: WriteSource,
         prepare_ts: Timestamp,
     ) -> anyhow::Result<crate::two_phase::PrepareResult> {
-        tracing::info!(
-            "2PC Remote Prepare: txn={}, {} writes, prepare_ts={}",
-            transaction_id,
-            transaction.writes.len(),
-            u64::from(prepare_ts),
-        );
-
         let mut table_mapping = self
             .snapshot_manager
             .read()
@@ -2509,6 +2606,151 @@ impl<RT: Runtime> Committer<RT> {
             write_source,
             Some(prepare_ts),
         )
+    }
+
+    async fn recover_two_phase_redo_records(&mut self) -> anyhow::Result<()> {
+        let records = Self::load_two_phase_redo_records(self.persistence.clone()).await?;
+        if records.is_empty() {
+            return Ok(());
+        }
+
+        tracing::info!(
+            "2PC Recovery: rebuilding {} prepared transaction(s) from durable redo",
+            records.len(),
+        );
+        for entry in records.values() {
+            let transaction_id = entry.transaction_id();
+            let prepare_ts = entry.prepare_ts()?;
+            let transaction = entry.participant_transaction().with_context(|| {
+                format!(
+                    "2PC Recovery: failed to decode participant transaction for txn={}",
+                    transaction_id
+                )
+            })?;
+            if entry.partition_id() != self.local_partition_for_two_phase() {
+                tracing::warn!(
+                    "2PC Recovery: ignoring redo txn={} for partition {}, local partition is {}",
+                    transaction_id,
+                    entry.partition_id().0,
+                    self.local_partition_for_two_phase().0,
+                );
+                continue;
+            }
+            if Self::redo_entry_is_already_committed(
+                self.persistence.reader(),
+                self.retention_validator.clone(),
+                entry,
+                &transaction,
+                prepare_ts,
+            )
+            .await?
+            {
+                Self::delete_two_phase_redo(self.persistence.clone(), &transaction_id).await?;
+                continue;
+            }
+
+            self.stage_participant_prepared_transaction(
+                transaction_id.clone(),
+                transaction,
+                entry.write_source(),
+                prepare_ts,
+            )
+            .with_context(|| {
+                format!("2PC Recovery: failed to stage prepared txn={transaction_id}")
+            })?;
+            tracing::info!(
+                "2PC Recovery: restored prepared txn={} at ts={}",
+                transaction_id,
+                u64::from(prepare_ts),
+            );
+        }
+        Ok(())
+    }
+
+    /// Prepare phase: validate OCC, assign timestamp, stage writes.
+    /// Does NOT publish — the transaction is held in prepared_transactions
+    /// until CommitPrepared or RollbackPrepared arrives.
+    async fn handle_prepare(
+        &mut self,
+        transaction_id: crate::two_phase::TwoPhaseTransactionId,
+        transaction: FinalTransaction,
+        write_source: WriteSource,
+    ) -> anyhow::Result<crate::two_phase::PrepareResult> {
+        tracing::info!(
+            "2PC Prepare: txn={}, {} writes",
+            transaction_id,
+            transaction.writes.coalesced_writes().count(),
+        );
+
+        let participant_transaction =
+            crate::two_phase::ParticipantTransaction::from_entire_final_transaction(&transaction)?;
+        let result = self.stage_prepared_transaction(
+            transaction_id.clone(),
+            *transaction.begin_timestamp,
+            transaction.reads.read_set(),
+            transaction.writes.coalesced_writes().cloned().collect(),
+            &transaction.table_mapping,
+            write_source.clone(),
+            None,
+        )?;
+        let redo = crate::two_phase::TwoPhaseRedoEntry::new(
+            &transaction_id,
+            result.prepare_ts,
+            self.local_partition_for_two_phase(),
+            participant_transaction,
+            &write_source,
+        )?;
+        if let Err(err) = Self::persist_two_phase_redo(self.persistence.clone(), redo).await {
+            if let Err(rollback_err) = self.handle_rollback_prepared(transaction_id.clone()) {
+                tracing::error!(
+                    "2PC Prepare: failed to rollback in-memory txn={} after redo write failure: \
+                     {rollback_err:#}",
+                    transaction_id,
+                );
+            }
+            return Err(err);
+        }
+        Ok(result)
+    }
+
+    async fn handle_prepare_remote(
+        &mut self,
+        transaction_id: crate::two_phase::TwoPhaseTransactionId,
+        transaction: crate::two_phase::ParticipantTransaction,
+        write_source: WriteSource,
+        prepare_ts: Timestamp,
+    ) -> anyhow::Result<crate::two_phase::PrepareResult> {
+        tracing::info!(
+            "2PC Remote Prepare: txn={}, {} writes, prepare_ts={}",
+            transaction_id,
+            transaction.writes.len(),
+            u64::from(prepare_ts),
+        );
+
+        let redo = crate::two_phase::TwoPhaseRedoEntry::new(
+            &transaction_id,
+            prepare_ts,
+            self.local_partition_for_two_phase(),
+            transaction.clone(),
+            &write_source,
+        )?;
+        let result = self.stage_participant_prepared_transaction(
+            transaction_id.clone(),
+            transaction,
+            write_source,
+            prepare_ts,
+        )?;
+        if let Err(err) = Self::persist_two_phase_redo(self.persistence.clone(), redo).await {
+            if let Err(rollback_err) = self.handle_rollback_prepared(transaction_id.clone()) {
+                tracing::error!(
+                    "2PC Prepare: failed to rollback in-memory txn={} after redo write failure: \
+                     {rollback_err:#}",
+                    transaction_id,
+                );
+            }
+            return Err(err);
+        }
+        Ok(result)
     }
 
     /// Commit a previously prepared transaction: write to persistence,
@@ -2917,6 +3159,7 @@ pub struct CommitterClient {
     snapshot_reader: Reader<SnapshotManager>,
     partition_map: Option<crate::partition::PartitionMap>,
     node_addresses: Option<crate::two_phase::NodeAddresses>,
+    two_phase_decision_log: Arc<dyn crate::two_phase::TwoPhaseDecisionLog>,
 }
 
 impl CommitterClient {
@@ -3013,6 +3256,10 @@ impl CommitterClient {
 
     pub(crate) fn node_addresses(&self) -> Option<&crate::two_phase::NodeAddresses> {
         self.node_addresses.as_ref()
+    }
+
+    pub(crate) fn two_phase_decision_log(&self) -> Arc<dyn crate::two_phase::TwoPhaseDecisionLog> {
+        self.two_phase_decision_log.clone()
     }
 
     async fn wait_for_remote_read_frontiers(

--- a/crates/database/src/database.rs
+++ b/crates/database/src/database.rs
@@ -987,6 +987,7 @@ impl<RT: Runtime> Database<RT> {
         replica_mode: bool,
         partition_map: Option<crate::partition::PartitionMap>,
         node_addresses: Option<crate::two_phase::NodeAddresses>,
+        two_phase_decision_log: Arc<dyn crate::two_phase::TwoPhaseDecisionLog>,
         timestamp_oracle: Option<Arc<dyn crate::timestamp_oracle::TimestampOracle>>,
         raft_state: Option<crate::raft_partition::RaftPartitionState>,
     ) -> anyhow::Result<Self> {
@@ -1101,6 +1102,7 @@ impl<RT: Runtime> Database<RT> {
             committer_distributed_log,
             partition_map,
             node_addresses,
+            two_phase_decision_log,
             timestamp_oracle,
             raft_state,
         );
@@ -2018,7 +2020,7 @@ impl<RT: Runtime> Database<RT> {
             create_checkpoint(self.reader.as_ref(), ts, self.retention_validator()).await?;
 
         let mut globals = BTreeMap::new();
-        for key in PersistenceGlobalKey::all_keys() {
+        for key in PersistenceGlobalKey::checkpoint_keys() {
             if let Some(value) = self.reader.get_persistence_global(key).await? {
                 globals.insert(String::from(key), value);
             }

--- a/crates/database/src/test_helpers/db_fixtures.rs
+++ b/crates/database/src/test_helpers/db_fixtures.rs
@@ -101,6 +101,7 @@ impl<RT: Runtime> DbFixtures<RT> {
             false,
             None,
             None,
+            Arc::new(crate::two_phase::NoopTwoPhaseDecisionLog),
             None,
             None,
         )

--- a/crates/database/src/tests/replication_tests.rs
+++ b/crates/database/src/tests/replication_tests.rs
@@ -43,6 +43,7 @@ async fn test_primary_commit_publishes_delta(rt: TestRuntime) -> anyhow::Result<
         false,
         None,
         None,
+        Arc::new(crate::two_phase::NoopTwoPhaseDecisionLog),
         None,
         None,
     )

--- a/crates/database/src/tests/write_scaling_tests.rs
+++ b/crates/database/src/tests/write_scaling_tests.rs
@@ -17,6 +17,10 @@ use common::{
     bootstrap_model::index::database_index::IndexedFields,
     interval::Interval,
     pause::PauseController,
+    persistence::{
+        Persistence,
+        PersistenceGlobalKey,
+    },
     query::{
         Order,
         Query,
@@ -86,9 +90,13 @@ use crate::{
         TimestampOracle,
     },
     two_phase::{
+        testing::InMemoryTwoPhaseDecisionLog,
         NodeAddresses,
+        NoopTwoPhaseDecisionLog,
         ParticipantTransaction,
         TwoPhaseCommitGrpcClient,
+        TwoPhaseDecision,
+        TwoPhaseDecisionLog,
         TwoPhaseTransactionId,
     },
     Database,
@@ -112,12 +120,32 @@ async fn create_node_with_options(
     node_addresses: Option<NodeAddresses>,
     timestamp_oracle: Option<Arc<dyn TimestampOracle>>,
 ) -> anyhow::Result<Database<TestRuntime>> {
+    create_node_with_options_and_decision_log(
+        rt,
+        distributed_log,
+        partition_map,
+        node_addresses,
+        timestamp_oracle,
+        Arc::new(NoopTwoPhaseDecisionLog),
+    )
+    .await
+}
+
+async fn create_node_with_options_and_decision_log(
+    rt: &TestRuntime,
+    distributed_log: Arc<InMemoryDistributedLog>,
+    partition_map: Option<PartitionMap>,
+    node_addresses: Option<NodeAddresses>,
+    timestamp_oracle: Option<Arc<dyn TimestampOracle>>,
+    two_phase_decision_log: Arc<dyn TwoPhaseDecisionLog>,
+) -> anyhow::Result<Database<TestRuntime>> {
     create_node_with_persistence(
         rt,
         Arc::new(TestPersistence::new()),
         distributed_log,
         partition_map,
         node_addresses,
+        two_phase_decision_log,
         timestamp_oracle,
     )
     .await
@@ -129,6 +157,7 @@ async fn create_node_with_persistence(
     distributed_log: Arc<InMemoryDistributedLog>,
     partition_map: Option<PartitionMap>,
     node_addresses: Option<NodeAddresses>,
+    two_phase_decision_log: Arc<dyn TwoPhaseDecisionLog>,
     timestamp_oracle: Option<Arc<dyn TimestampOracle>>,
 ) -> anyhow::Result<Database<TestRuntime>> {
     let searcher: Arc<dyn search::Searcher> = Arc::new(SearcherStub {});
@@ -146,6 +175,7 @@ async fn create_node_with_persistence(
         false,
         partition_map,
         node_addresses,
+        two_phase_decision_log,
         timestamp_oracle,
         None,
     )
@@ -214,7 +244,7 @@ impl TwoPhaseCommitService for TestTwoPhaseCommitGrpcService {
             .ok_or_else(|| Status::invalid_argument("Prepare missing transaction payload"))?;
         let transaction = ParticipantTransaction::try_from(transaction)
             .map_err(|e| Status::invalid_argument(format!("Invalid prepare payload: {e:#}")))?;
-        let prepare_ts = req
+        let prepare_ts: Timestamp = req
             .prepare_ts
             .try_into()
             .map_err(|e| Status::invalid_argument(format!("Invalid prepare timestamp: {e:#}")))?;
@@ -286,6 +316,42 @@ impl TwoPhaseCommitService for FailingPrepareGrpcService {
         Err(Status::failed_precondition(
             "rollback_prepared should not be called after a failed prepare",
         ))
+    }
+}
+
+struct FailingCommitAfterPrepareGrpcService;
+
+#[tonic::async_trait]
+impl TwoPhaseCommitService for FailingCommitAfterPrepareGrpcService {
+    async fn prepare(
+        &self,
+        request: Request<TwoPcPrepareRequest>,
+    ) -> Result<Response<TwoPcPrepareResponse>, Status> {
+        let req = request.into_inner();
+        let prepare_ts: Timestamp = req
+            .prepare_ts
+            .try_into()
+            .map_err(|e| Status::invalid_argument(format!("Invalid prepare timestamp: {e:#}")))?;
+
+        Ok(Response::new(TwoPcPrepareResponse {
+            prepare_ts: u64::from(prepare_ts),
+        }))
+    }
+
+    async fn commit_prepared(
+        &self,
+        _request: Request<TwoPcCommitRequest>,
+    ) -> Result<Response<TwoPcCommitResponse>, Status> {
+        Err(Status::unavailable(
+            "forced commit failure after durable decision",
+        ))
+    }
+
+    async fn rollback_prepared(
+        &self,
+        _request: Request<TwoPcRollbackRequest>,
+    ) -> Result<Response<TwoPcRollbackResponse>, Status> {
+        Ok(Response::new(TwoPcRollbackResponse {}))
     }
 }
 
@@ -868,6 +934,7 @@ async fn test_replication_frontier_persists_across_restart(rt: TestRuntime) -> a
         log.clone(),
         Some(partitioned_map(PartitionId(0))),
         None,
+        Arc::new(NoopTwoPhaseDecisionLog),
         None,
     )
     .await?;
@@ -909,6 +976,7 @@ async fn test_replication_frontier_persists_across_restart(rt: TestRuntime) -> a
         log,
         Some(partitioned_map(PartitionId(0))),
         None,
+        Arc::new(NoopTwoPhaseDecisionLog),
         None,
     )
     .await?;
@@ -917,6 +985,89 @@ async fn test_replication_frontier_persists_across_restart(rt: TestRuntime) -> a
         Some(persisted_frontier),
     );
 
+    Ok(())
+}
+
+#[convex_macro::test_runtime]
+async fn test_prepared_participant_recovers_from_redo_after_restart(
+    rt: TestRuntime,
+) -> anyhow::Result<()> {
+    let log = Arc::new(InMemoryDistributedLog::new());
+    let tp = Arc::new(TestPersistence::new());
+    let node = create_node_with_persistence(
+        &rt,
+        tp.clone(),
+        log.clone(),
+        Some(partitioned_map(PartitionId(1))),
+        None,
+        Arc::new(NoopTwoPhaseDecisionLog),
+        None,
+    )
+    .await?;
+
+    let mut tx = node.begin(Identity::system()).await?;
+    TestFacingModel::new(&mut tx)
+        .insert(
+            &"projects".parse()?,
+            assert_obj!("name" => "recovered-from-redo"),
+        )
+        .await?;
+    let final_tx = tx.finalize()?;
+    let write_indexes: Vec<_> = final_tx
+        .writes
+        .coalesced_writes()
+        .enumerate()
+        .map(|(index, _)| index)
+        .collect();
+    let write_source = WriteSource::new("prepared_redo_recovery_test");
+    let participant_tx = ParticipantTransaction::from_final_transaction(
+        &final_tx,
+        PartitionId(1),
+        &write_indexes,
+        &partitioned_map(PartitionId(1)),
+        &write_source,
+    )?;
+    let txn_id = TwoPhaseTransactionId::new();
+    let prepare_ts = node.committer_for_test().allocate_commit_ts().await?;
+    node.committer_for_test()
+        .prepare_remote(
+            txn_id.clone(),
+            participant_tx,
+            write_source.clone(),
+            prepare_ts,
+        )
+        .await?;
+    node.shutdown().await?;
+
+    let restarted = create_node_with_persistence(
+        &rt,
+        tp.clone(),
+        log,
+        Some(partitioned_map(PartitionId(1))),
+        None,
+        Arc::new(NoopTwoPhaseDecisionLog),
+        None,
+    )
+    .await?;
+    let committed_ts = restarted
+        .committer_for_test()
+        .commit_prepared(txn_id)
+        .await?;
+    assert_eq!(committed_ts, prepare_ts);
+
+    let projects = run_query(
+        restarted.clone(),
+        TableNamespace::root_component(),
+        Query::full_table_scan("projects".parse()?, Order::Asc),
+    )
+    .await?;
+    assert_eq!(projects.len(), 1);
+
+    let redo = tp
+        .reader()
+        .get_persistence_global(PersistenceGlobalKey::TwoPhaseRedoRecords)
+        .await?;
+    assert_eq!(redo, Some(serde_json::json!({})));
     Ok(())
 }
 
@@ -1276,6 +1427,20 @@ fn test_cross_partition_commit_uses_remote_prepare_over_grpc() -> anyhow::Result
             .apply_replica_delta(remote_seed_delta)
             .await?;
         insert_doc(&node_a, "messages", assert_obj!("text" => "seed")).await?;
+        let heartbeat_ts = node_b.bump_max_repeatable_ts().await?;
+        node_a
+            .committer_for_test()
+            .apply_replica_delta(CommitDelta {
+                ts: heartbeat_ts,
+                document_writes: Arc::new(Vec::new()),
+                document_updates: Vec::new(),
+                index_writes: Arc::new(Vec::new()),
+                write_source: WriteSource::new("cross_partition_commit_grpc_test"),
+                write_bytes: 0,
+                tablet_id_to_table_name: Default::default(),
+                source_partition: Some(PartitionId(1)),
+            })
+            .await?;
 
         let initial_delta_count = log.deltas().len();
 
@@ -1330,9 +1495,10 @@ fn test_failed_remote_prepare_rolls_back_local_participant() -> anyhow::Result<(
     let rt = td.rt();
     td.run_until(async move {
         let log = Arc::new(InMemoryDistributedLog::new());
+        let decision_log = Arc::new(InMemoryTwoPhaseDecisionLog::new());
         let tso: Arc<dyn TimestampOracle> = Arc::new(InMemoryTimestampOracle::new());
         let failing_server = start_two_pc_server(FailingPrepareGrpcService).await?;
-        let node_a = create_node_with_options(
+        let node_a = create_node_with_options_and_decision_log(
             &rt,
             log.clone(),
             Some(partitioned_map(PartitionId(0))),
@@ -1341,6 +1507,7 @@ fn test_failed_remote_prepare_rolls_back_local_participant() -> anyhow::Result<(
                 failing_server.addr()
             ))),
             Some(tso.clone()),
+            decision_log.clone(),
         )
         .await?;
         let _remote_participant = create_node_with_options(
@@ -1376,6 +1543,18 @@ fn test_failed_remote_prepare_rolls_back_local_participant() -> anyhow::Result<(
             format!("{err:#}").contains("forced prepare failure"),
             "expected remote prepare failure, got: {err:#}",
         );
+        let decisions = decision_log.decisions();
+        assert_eq!(decisions.len(), 1);
+        let decision = decisions
+            .values()
+            .next()
+            .expect("rollback decision should be durable");
+        match decision {
+            TwoPhaseDecision::RolledBack { participants, .. } => {
+                assert_eq!(participants, &vec![0]);
+            },
+            other => panic!("expected rollback decision, got {other:?}"),
+        }
 
         let mut retry_tx = node_a.begin(Identity::system()).await?;
         UserFacingModel::new(&mut retry_tx, TableNamespace::test_user())
@@ -1384,6 +1563,102 @@ fn test_failed_remote_prepare_rolls_back_local_participant() -> anyhow::Result<(
         node_a.commit(retry_tx).await?;
 
         failing_server.shutdown().await?;
+        Ok(())
+    })
+}
+
+#[test]
+fn test_commit_decision_survives_failed_participant_commit() -> anyhow::Result<()> {
+    let td = TestDriver::new_with_io();
+    let rt = td.rt();
+    td.run_until(async move {
+        let log = Arc::new(InMemoryDistributedLog::new());
+        let decision_log = Arc::new(InMemoryTwoPhaseDecisionLog::new());
+        let tso: Arc<dyn TimestampOracle> = Arc::new(InMemoryTimestampOracle::new());
+        let node_b = create_node_with_options(
+            &rt,
+            log.clone(),
+            Some(partitioned_map(PartitionId(1))),
+            None,
+            Some(tso.clone()),
+        )
+        .await?;
+        let server = start_two_pc_server(FailingCommitAfterPrepareGrpcService).await?;
+
+        let node_a = create_node_with_options_and_decision_log(
+            &rt,
+            log.clone(),
+            Some(partitioned_map(PartitionId(0))),
+            Some(NodeAddresses::from_config(&format!("1={}", server.addr()))),
+            Some(tso),
+            decision_log.clone(),
+        )
+        .await?;
+
+        insert_doc(&node_b, "projects", assert_obj!("name" => "seed")).await?;
+        let remote_seed_delta = log
+            .deltas()
+            .into_iter()
+            .last()
+            .expect("seed project should publish a delta");
+        node_a
+            .committer_for_test()
+            .apply_replica_delta(remote_seed_delta)
+            .await?;
+        insert_doc(&node_a, "messages", assert_obj!("text" => "seed")).await?;
+        let heartbeat_ts = node_b.bump_max_repeatable_ts().await?;
+        node_a
+            .committer_for_test()
+            .apply_replica_delta(CommitDelta {
+                ts: heartbeat_ts,
+                document_writes: Arc::new(Vec::new()),
+                document_updates: Vec::new(),
+                index_writes: Arc::new(Vec::new()),
+                write_source: WriteSource::new("commit_decision_recovery_test"),
+                write_bytes: 0,
+                tablet_id_to_table_name: Default::default(),
+                source_partition: Some(PartitionId(1)),
+            })
+            .await?;
+
+        let mut tx = node_a.begin(Identity::system()).await?;
+        let mut model = TestFacingModel::new(&mut tx);
+        model
+            .insert(
+                &"messages".parse()?,
+                assert_obj!("text" => "local-before-commit-failure"),
+            )
+            .await?;
+        model
+            .insert(
+                &"projects".parse()?,
+                assert_obj!("name" => "remote-before-commit-failure"),
+            )
+            .await?;
+
+        let err = node_a
+            .commit(tx)
+            .await
+            .expect_err("remote commit failure should leave durable decision for recovery");
+        assert!(
+            format!("{err:#}").contains("forced commit failure after durable decision"),
+            "expected forced commit failure, got: {err:#}",
+        );
+
+        let decisions = decision_log.decisions();
+        assert_eq!(decisions.len(), 1);
+        let decision = decisions
+            .values()
+            .next()
+            .expect("commit decision should remain for watcher recovery");
+        match decision {
+            TwoPhaseDecision::Committed { participants, .. } => {
+                assert_eq!(participants, &vec![0, 1]);
+            },
+            other => panic!("expected commit decision, got {other:?}"),
+        }
+
+        server.shutdown().await?;
         Ok(())
     })
 }

--- a/crates/database/src/two_phase.rs
+++ b/crates/database/src/two_phase.rs
@@ -15,9 +15,14 @@
 //!   - TiDB 1PC: https://pingcap.github.io/tidb-dev-guide/understand-tidb/1pc.html
 //!   - CockroachDB: https://www.cockroachlabs.com/blog/parallel-commits/
 
-use std::collections::BTreeMap;
+use std::{
+    collections::BTreeMap,
+    time::Duration,
+};
 
 use anyhow::Context;
+use async_nats::jetstream::kv::Store;
+use async_trait::async_trait;
 use common::{
     bootstrap_model::index::database_index::IndexedFields,
     document::DocumentUpdateWithPrevTs,
@@ -47,6 +52,7 @@ use pb::{
     },
     searchlight,
 };
+use prost::Message;
 use search::{
     query::{
         FuzzyDistance,
@@ -136,8 +142,101 @@ pub struct TwoPhaseRedoEntry {
     pub transaction_id: String,
     pub prepare_ts: u64,
     pub partition_id: u32,
-    pub num_document_writes: usize,
-    pub num_index_writes: usize,
+    pub write_source: Option<String>,
+    pub participant_transaction_hex: String,
+}
+
+impl TwoPhaseRedoEntry {
+    pub fn new(
+        transaction_id: &TwoPhaseTransactionId,
+        prepare_ts: Timestamp,
+        partition_id: PartitionId,
+        transaction: ParticipantTransaction,
+        write_source: &WriteSource,
+    ) -> anyhow::Result<Self> {
+        let proto = TwoPcParticipantTransactionProto::try_from(transaction)?;
+        let mut bytes = Vec::new();
+        proto
+            .encode(&mut bytes)
+            .context("2PC: Failed to encode participant transaction redo")?;
+        Ok(Self {
+            transaction_id: transaction_id.0.clone(),
+            prepare_ts: u64::from(prepare_ts),
+            partition_id: partition_id.0,
+            write_source: write_source.as_str().map(str::to_string),
+            participant_transaction_hex: hex::encode(bytes),
+        })
+    }
+
+    pub fn transaction_id(&self) -> TwoPhaseTransactionId {
+        TwoPhaseTransactionId(self.transaction_id.clone())
+    }
+
+    pub fn prepare_ts(&self) -> anyhow::Result<Timestamp> {
+        self.prepare_ts.try_into()
+    }
+
+    pub fn partition_id(&self) -> PartitionId {
+        PartitionId(self.partition_id)
+    }
+
+    pub fn write_source(&self) -> WriteSource {
+        WriteSource::from(self.write_source.clone())
+    }
+
+    pub fn participant_transaction(&self) -> anyhow::Result<ParticipantTransaction> {
+        let bytes = hex::decode(&self.participant_transaction_hex)
+            .context("2PC: Failed to decode participant transaction redo")?;
+        let proto = TwoPcParticipantTransactionProto::decode(bytes.as_slice())
+            .context("2PC: Failed to parse participant transaction redo")?;
+        ParticipantTransaction::try_from(proto)
+    }
+}
+
+#[cfg(any(test, feature = "testing"))]
+pub mod testing {
+    use std::sync::Arc;
+
+    use parking_lot::Mutex;
+
+    use super::*;
+
+    #[derive(Clone, Default)]
+    pub struct InMemoryTwoPhaseDecisionLog {
+        decisions: Arc<Mutex<BTreeMap<String, TwoPhaseDecision>>>,
+    }
+
+    impl InMemoryTwoPhaseDecisionLog {
+        pub fn new() -> Self {
+            Self::default()
+        }
+
+        pub fn decisions(&self) -> BTreeMap<String, TwoPhaseDecision> {
+            self.decisions.lock().clone()
+        }
+    }
+
+    #[async_trait]
+    impl TwoPhaseDecisionLog for InMemoryTwoPhaseDecisionLog {
+        async fn write_decision(
+            &self,
+            transaction_id: &TwoPhaseTransactionId,
+            decision: &TwoPhaseDecision,
+        ) -> anyhow::Result<()> {
+            self.decisions
+                .lock()
+                .insert(transaction_id.0.clone(), decision.clone());
+            Ok(())
+        }
+
+        async fn delete_decision(
+            &self,
+            transaction_id: &TwoPhaseTransactionId,
+        ) -> anyhow::Result<()> {
+            self.decisions.lock().remove(&transaction_id.0);
+            Ok(())
+        }
+    }
 }
 
 /// NATS KV key prefix for 2PC decision records.
@@ -146,8 +245,93 @@ pub const TWO_PHASE_KV_PREFIX: &str = "2pc_";
 /// NATS KV bucket for 2PC state.
 pub const TWO_PHASE_KV_BUCKET: &str = "convex_2pc";
 
+/// Retain resolved 2PC decision records long enough for watcher recovery.
+pub const TWO_PHASE_DECISION_TTL_SECS: u64 = 3600;
+
 /// Timeout for prepared transactions before the watcher rolls them back.
 pub const PREPARE_TIMEOUT_SECS: u64 = 30;
+
+pub fn two_phase_decision_key(transaction_id: &TwoPhaseTransactionId) -> String {
+    format!("{TWO_PHASE_KV_PREFIX}{}", transaction_id.0)
+}
+
+#[async_trait]
+pub trait TwoPhaseDecisionLog: Send + Sync + 'static {
+    async fn write_decision(
+        &self,
+        transaction_id: &TwoPhaseTransactionId,
+        decision: &TwoPhaseDecision,
+    ) -> anyhow::Result<()>;
+
+    async fn delete_decision(&self, transaction_id: &TwoPhaseTransactionId) -> anyhow::Result<()>;
+}
+
+pub struct NoopTwoPhaseDecisionLog;
+
+#[async_trait]
+impl TwoPhaseDecisionLog for NoopTwoPhaseDecisionLog {
+    async fn write_decision(
+        &self,
+        _transaction_id: &TwoPhaseTransactionId,
+        _decision: &TwoPhaseDecision,
+    ) -> anyhow::Result<()> {
+        Ok(())
+    }
+
+    async fn delete_decision(&self, _transaction_id: &TwoPhaseTransactionId) -> anyhow::Result<()> {
+        Ok(())
+    }
+}
+
+#[derive(Clone)]
+pub struct NatsTwoPhaseDecisionLog {
+    kv: Store,
+}
+
+impl NatsTwoPhaseDecisionLog {
+    pub async fn connect(nats_url: &str) -> anyhow::Result<Self> {
+        let _ = rustls::crypto::ring::default_provider().install_default();
+        let client = async_nats::connect(nats_url)
+            .await
+            .with_context(|| format!("2PC: Failed to connect to NATS at {nats_url}"))?;
+        let jetstream = async_nats::jetstream::new(client);
+        let kv = jetstream
+            .create_key_value(async_nats::jetstream::kv::Config {
+                bucket: TWO_PHASE_KV_BUCKET.to_string(),
+                history: 1,
+                max_age: Duration::from_secs(TWO_PHASE_DECISION_TTL_SECS),
+                ..Default::default()
+            })
+            .await
+            .context("2PC: Failed to create decision KV bucket")?;
+        Ok(Self { kv })
+    }
+}
+
+#[async_trait]
+impl TwoPhaseDecisionLog for NatsTwoPhaseDecisionLog {
+    async fn write_decision(
+        &self,
+        transaction_id: &TwoPhaseTransactionId,
+        decision: &TwoPhaseDecision,
+    ) -> anyhow::Result<()> {
+        let payload = serde_json::to_vec(decision)
+            .with_context(|| format!("2PC: Failed to serialize decision for {transaction_id}"))?;
+        self.kv
+            .put(two_phase_decision_key(transaction_id), payload.into())
+            .await
+            .with_context(|| format!("2PC: Failed to write decision for {transaction_id}"))?;
+        Ok(())
+    }
+
+    async fn delete_decision(&self, transaction_id: &TwoPhaseTransactionId) -> anyhow::Result<()> {
+        self.kv
+            .delete(two_phase_decision_key(transaction_id))
+            .await
+            .with_context(|| format!("2PC: Failed to delete decision for {transaction_id}"))?;
+        Ok(())
+    }
+}
 
 /// Partition-to-address mapping for gRPC communication.
 /// Each entry maps a partition ID to the gRPC address of its owner node.
@@ -277,6 +461,46 @@ impl ParticipantTransaction {
             begin_timestamp: transaction.begin_timestamp,
             tablet_metadata,
             reads,
+            writes: selected_writes,
+        })
+    }
+
+    pub fn from_entire_final_transaction(transaction: &FinalTransaction) -> anyhow::Result<Self> {
+        let selected_writes: Vec<_> = transaction.writes.coalesced_writes().cloned().collect();
+        let mut tablet_metadata = BTreeMap::new();
+        let mut record_tablet = |tablet_id: TabletId| -> anyhow::Result<()> {
+            if tablet_metadata.contains_key(&tablet_id) {
+                return Ok(());
+            }
+            let table_name = transaction.table_mapping.tablet_name(tablet_id)?;
+            let table_number = transaction.table_mapping.tablet_number(tablet_id)?;
+            let namespace = transaction.table_mapping.tablet_namespace(tablet_id)?;
+            tablet_metadata.insert(
+                tablet_id,
+                ParticipantTabletMetadata {
+                    tablet_id,
+                    namespace,
+                    table_number,
+                    table_name,
+                },
+            );
+            Ok(())
+        };
+
+        for (index_name, _) in transaction.reads.read_set().iter_indexed() {
+            record_tablet(*index_name.table())?;
+        }
+        for (index_name, _) in transaction.reads.read_set().iter_search() {
+            record_tablet(*index_name.table())?;
+        }
+        for write in &selected_writes {
+            record_tablet(write.id.tablet_id)?;
+        }
+
+        Ok(Self {
+            begin_timestamp: transaction.begin_timestamp,
+            tablet_metadata,
+            reads: transaction.reads.read_set().clone(),
             writes: selected_writes,
         })
     }

--- a/crates/database/src/two_phase_coordinator.rs
+++ b/crates/database/src/two_phase_coordinator.rs
@@ -28,6 +28,7 @@ use crate::{
         NodeAddresses,
         ParticipantTransaction,
         TwoPhaseCommitGrpcClient,
+        TwoPhaseDecision,
         TwoPhaseTransactionId,
     },
     write_log::WriteSource,
@@ -212,6 +213,27 @@ async fn commit_participant(
     }
 }
 
+async fn write_decision_record(
+    local_committer: &CommitterClient,
+    transaction_id: &TwoPhaseTransactionId,
+    decision: &TwoPhaseDecision,
+) -> anyhow::Result<()> {
+    local_committer
+        .two_phase_decision_log()
+        .write_decision(transaction_id, decision)
+        .await
+}
+
+async fn delete_decision_record(
+    local_committer: &CommitterClient,
+    transaction_id: &TwoPhaseTransactionId,
+) -> anyhow::Result<()> {
+    local_committer
+        .two_phase_decision_log()
+        .delete_decision(transaction_id)
+        .await
+}
+
 fn is_retryable_prepare_ts_error(err: &anyhow::Error) -> bool {
     err.chain()
         .any(|cause| cause.to_string().contains("2PC Prepare assigned ts="))
@@ -286,6 +308,22 @@ pub async fn coordinate_two_phase_commit(
                         participant,
                         txn_id,
                     );
+                    let retryable_prepare_ts_error =
+                        is_retryable_prepare_ts_error(&err) && attempt + 1 < MAX_PREPARE_TS_RETRIES;
+                    if !retryable_prepare_ts_error && !prepared_participants.is_empty() {
+                        let decision = TwoPhaseDecision::RolledBack {
+                            reason: err.to_string(),
+                            participants: prepared_participants.iter().map(|p| p.0).collect(),
+                        };
+                        write_decision_record(local_committer, &txn_id, &decision)
+                            .await
+                            .with_context(|| {
+                                format!(
+                                    "2PC Coordinator: failed to write rollback decision for \
+                                     txn={txn_id}"
+                                )
+                            })?;
+                    }
                     for prepared in prepared_participants.iter().rev().copied() {
                         if let Err(rollback_err) = rollback_participant(
                             local_committer,
@@ -305,7 +343,7 @@ pub async fn coordinate_two_phase_commit(
                         }
                     }
 
-                    if is_retryable_prepare_ts_error(&err) && attempt + 1 < MAX_PREPARE_TS_RETRIES {
+                    if retryable_prepare_ts_error {
                         metrics::log_two_phase_prepare_retry();
                         tracing::info!(
                             "2PC Coordinator: retrying txn={} with a newer prepare timestamp \
@@ -329,6 +367,16 @@ pub async fn coordinate_two_phase_commit(
         if retry_prepare {
             continue;
         }
+
+        let decision = TwoPhaseDecision::Committed {
+            commit_ts: u64::from(prepare_ts),
+            participants: prepared_participants.iter().map(|p| p.0).collect(),
+        };
+        write_decision_record(local_committer, &txn_id, &decision)
+            .await
+            .with_context(|| {
+                format!("2PC Coordinator: failed to write commit decision for txn={txn_id}")
+            })?;
 
         let mut commit_results = Vec::new();
         for participant in &prepared_participants {
@@ -367,6 +415,12 @@ pub async fn coordinate_two_phase_commit(
         );
         metrics::log_two_phase_prepare_attempts(prepare_attempts);
         metrics::log_two_phase_decision("commit");
+        if let Err(err) = delete_decision_record(local_committer, &txn_id).await {
+            tracing::warn!(
+                "2PC Coordinator: committed txn={} but failed to delete durable decision: {err:#}",
+                txn_id,
+            );
+        }
         timer.finish();
         return Ok(prepare_ts);
     }

--- a/crates/database/src/two_phase_watcher.rs
+++ b/crates/database/src/two_phase_watcher.rs
@@ -17,9 +17,11 @@ use common::runtime::Runtime;
 
 use crate::{
     committer::CommitterClient,
+    partition::PartitionId,
     two_phase::{
         TwoPhaseDecision,
         TwoPhaseTransactionId,
+        TWO_PHASE_DECISION_TTL_SECS,
         TWO_PHASE_KV_BUCKET,
         TWO_PHASE_KV_PREFIX,
     },
@@ -27,7 +29,12 @@ use crate::{
 
 /// Start the transaction watcher as a background task.
 /// Periodically scans NATS KV for unresolved 2PC transactions.
-pub fn start<RT: Runtime>(runtime: RT, committer: CommitterClient, nats_url: String) {
+pub fn start<RT: Runtime>(
+    runtime: RT,
+    committer: CommitterClient,
+    nats_url: String,
+    local_partition: PartitionId,
+) {
     runtime.spawn_background("two_phase_watcher", async move {
         let _ = rustls::crypto::ring::default_provider().install_default();
 
@@ -45,7 +52,7 @@ pub fn start<RT: Runtime>(runtime: RT, committer: CommitterClient, nats_url: Str
             .create_key_value(async_nats::jetstream::kv::Config {
                 bucket: TWO_PHASE_KV_BUCKET.to_string(),
                 history: 1,
-                max_age: Duration::from_secs(3600), // 1 hour TTL
+                max_age: Duration::from_secs(TWO_PHASE_DECISION_TTL_SECS),
                 ..Default::default()
             })
             .await
@@ -99,7 +106,10 @@ pub fn start<RT: Runtime>(runtime: RT, committer: CommitterClient, nats_url: Str
                 };
 
                 match decision {
-                    TwoPhaseDecision::Committed { .. } => {
+                    TwoPhaseDecision::Committed { participants, .. } => {
+                        if !participants.contains(&local_partition.0) {
+                            continue;
+                        }
                         // Transaction was committed but the coordinator may have
                         // crashed before sending CommitPrepared to all participants.
                         // Try to commit locally — if already committed, this is a no-op.
@@ -110,13 +120,14 @@ pub fn start<RT: Runtime>(runtime: RT, committer: CommitterClient, nats_url: Str
                                     txn_id,
                                     u64::from(ts),
                                 );
-                                // Clean up the decision record.
-                                let _ = kv.delete(&key).await;
                             },
                             Err(e) => {
                                 // "unknown transaction" means it was already committed.
                                 if e.to_string().contains("unknown transaction") {
-                                    let _ = kv.delete(&key).await;
+                                    tracing::debug!(
+                                        "2PC Watcher: committed txn={} already resolved locally",
+                                        txn_id,
+                                    );
                                 } else {
                                     tracing::debug!(
                                         "2PC Watcher: CommitPrepared for {txn_id} not ready: {e:#}"
@@ -125,12 +136,18 @@ pub fn start<RT: Runtime>(runtime: RT, committer: CommitterClient, nats_url: Str
                             },
                         }
                     },
-                    TwoPhaseDecision::RolledBack { .. } => {
+                    TwoPhaseDecision::RolledBack { participants, .. } => {
+                        if !participants.contains(&local_partition.0) {
+                            continue;
+                        }
                         // Transaction was rolled back but cleanup may be incomplete.
                         match committer.rollback_prepared(txn_id.clone()).await {
                             Ok(()) | Err(_) => {
-                                // Either rolled back or already gone — clean up.
-                                let _ = kv.delete(&key).await;
+                                tracing::debug!(
+                                    "2PC Watcher: rolled back txn={} locally or it was already \
+                                     gone",
+                                    txn_id,
+                                );
                             },
                         }
                     },

--- a/crates/local_backend/src/lib.rs
+++ b/crates/local_backend/src/lib.rs
@@ -221,6 +221,17 @@ pub async fn make_app(
         None
     };
 
+    let two_phase_decision_log: Arc<dyn database::two_phase::TwoPhaseDecisionLog> =
+        if config.partition_id.is_some() {
+            if let Some(nats_url) = &config.nats_url {
+                Arc::new(database::two_phase::NatsTwoPhaseDecisionLog::connect(nats_url).await?)
+            } else {
+                Arc::new(database::two_phase::NoopTwoPhaseDecisionLog)
+            }
+        } else {
+            Arc::new(database::two_phase::NoopTwoPhaseDecisionLog)
+        };
+
     let replica_mutation_forwarder = if config.replication_mode == "replica" {
         match config.primary_grpc_url.as_deref() {
             Some(primary_grpc_url) => Some(Arc::new(
@@ -259,6 +270,7 @@ pub async fn make_app(
             .node_addresses
             .as_deref()
             .map(database::two_phase::NodeAddresses::from_config),
+        two_phase_decision_log,
         timestamp_oracle,
         None, // raft_state: set after Raft node starts, not during Database::load
     )
@@ -693,12 +705,13 @@ pub async fn make_app(
     }
 
     // Start the 2PC Transaction Watcher for crash recovery.
-    if config.partition_id.is_some() {
+    if let Some(partition_id) = config.partition_id {
         if let Some(nats_url) = &config.nats_url {
             database::two_phase_watcher::start(
                 runtime.clone(),
                 database.committer_client(),
                 nats_url.clone(),
+                database::partition::PartitionId(partition_id),
             );
             tracing::info!("Started 2PC Transaction Watcher");
         }


### PR DESCRIPTION
## Summary
- persist participant 2PC redo records before acknowledging prepare, and rebuild prepared transactions on committer startup
- persist coordinator commit/rollback decisions in NATS KV before participant resolution
- make 2PC watcher participant-aware so one node cannot delete a global decision before other participants recover
- keep node-local redo out of checkpoints and clear redo on snapshot install

## Validation
- `cargo test -p database write_scaling_tests -- --nocapture`
- `cargo check -p database`
- `cargo check -p local_backend`
- `cargo test -p local_backend test_fresh_replica_bootstraps_from_checkpoint -- --nocapture`

Closes #101.
