### PR TITLE
fix: harden NATS replication acknowledgements

### DIFF
--- a/crates/database/src/commit_delta.rs
+++ b/crates/database/src/commit_delta.rs
@@ -76,6 +76,54 @@ pub struct CommitDelta {
     pub source_partition: Option<PartitionId>,
 }
 
+#[async_trait]
+pub trait ReplicationAck: Send + 'static {
+    async fn ack(self: Box<Self>) -> anyhow::Result<()>;
+
+    async fn nak(self: Box<Self>) -> anyhow::Result<()>;
+
+    async fn term(self: Box<Self>) -> anyhow::Result<()>;
+}
+
+pub struct ReplicationMessage {
+    pub delta: CommitDelta,
+    ack: Box<dyn ReplicationAck>,
+}
+
+impl ReplicationMessage {
+    pub fn new(delta: CommitDelta, ack: Box<dyn ReplicationAck>) -> Self {
+        Self { delta, ack }
+    }
+
+    pub fn noop_ack(delta: CommitDelta) -> Self {
+        Self {
+            delta,
+            ack: Box::new(NoopReplicationAck),
+        }
+    }
+
+    pub fn into_parts(self) -> (CommitDelta, Box<dyn ReplicationAck>) {
+        (self.delta, self.ack)
+    }
+}
+
+pub struct NoopReplicationAck;
+
+#[async_trait]
+impl ReplicationAck for NoopReplicationAck {
+    async fn ack(self: Box<Self>) -> anyhow::Result<()> {
+        Ok(())
+    }
+
+    async fn nak(self: Box<Self>) -> anyhow::Result<()> {
+        Ok(())
+    }
+
+    async fn term(self: Box<Self>) -> anyhow::Result<()> {
+        Ok(())
+    }
+}
+
 /// Abstraction over the transport that carries [`CommitDelta`]s between
 /// the Primary node and Replica nodes.
 ///
@@ -94,7 +142,7 @@ pub trait DistributedLog: Send + Sync + 'static {
     async fn subscribe(
         &self,
         from_ts: Timestamp,
-    ) -> anyhow::Result<BoxStream<'static, anyhow::Result<CommitDelta>>>;
+    ) -> anyhow::Result<BoxStream<'static, anyhow::Result<ReplicationMessage>>>;
 
     /// Subscribe to deltas starting after `from_ts`, optionally restricting
     /// delivery to specific source partitions.
@@ -105,7 +153,7 @@ pub trait DistributedLog: Send + Sync + 'static {
         &self,
         from_ts: Timestamp,
         _source_partitions: Option<Vec<PartitionId>>,
-    ) -> anyhow::Result<BoxStream<'static, anyhow::Result<CommitDelta>>> {
+    ) -> anyhow::Result<BoxStream<'static, anyhow::Result<ReplicationMessage>>> {
         self.subscribe(from_ts).await
     }
 }
@@ -123,7 +171,7 @@ impl DistributedLog for NoopDistributedLog {
     async fn subscribe(
         &self,
         _from_ts: Timestamp,
-    ) -> anyhow::Result<BoxStream<'static, anyhow::Result<CommitDelta>>> {
+    ) -> anyhow::Result<BoxStream<'static, anyhow::Result<ReplicationMessage>>> {
         Ok(Box::pin(futures::stream::pending()))
     }
 }
@@ -151,6 +199,7 @@ pub mod testing {
     use super::{
         CommitDelta,
         DistributedLog,
+        ReplicationMessage,
     };
 
     /// In-memory [`DistributedLog`] for testing. Stores deltas in a Vec and
@@ -186,7 +235,7 @@ pub mod testing {
         async fn subscribe(
             &self,
             from_ts: Timestamp,
-        ) -> anyhow::Result<BoxStream<'static, anyhow::Result<CommitDelta>>> {
+        ) -> anyhow::Result<BoxStream<'static, anyhow::Result<ReplicationMessage>>> {
             let existing: Vec<CommitDelta> = self
                 .deltas
                 .lock()
@@ -198,12 +247,19 @@ pub mod testing {
             let receiver = self.sender.subscribe();
             let broadcast_stream =
                 BroadcastStream::new(receiver).filter_map(move |result| match result {
-                    Ok(delta) if delta.ts > from_ts => Some(Ok(delta)),
+                    Ok(delta) if delta.ts > from_ts => {
+                        Some(Ok(ReplicationMessage::noop_ack(delta)))
+                    },
                     Ok(_) => None,
                     Err(e) => Some(Err(anyhow::anyhow!("broadcast lag: {e}"))),
                 });
 
-            let existing_stream = futures::stream::iter(existing.into_iter().map(Ok));
+            let existing_stream = futures::stream::iter(
+                existing
+                    .into_iter()
+                    .map(ReplicationMessage::noop_ack)
+                    .map(Ok),
+            );
             let combined = existing_stream.chain(broadcast_stream);
             Ok(Box::pin(combined))
         }

--- a/crates/database/src/committer.rs
+++ b/crates/database/src/committer.rs
@@ -630,7 +630,19 @@ impl<RT: Runtime> Committer<RT> {
                                     err,
                                 );
                             }
-                            self.publish_commit_delta(published_commit.delta);
+                            if let Err(err) = Self::publish_commit_delta(
+                                self.distributed_log.clone(),
+                                published_commit.delta,
+                            )
+                            .await
+                            {
+                                return Self::fail_committed_write(
+                                    result,
+                                    commit_ts,
+                                    "publish committed write to replication log",
+                                    err,
+                                );
+                            }
                             let _ = result.send(Ok(commit_ts));
 
                             // When we next get free cycles and there is no ongoing bump,
@@ -884,7 +896,19 @@ impl<RT: Runtime> Committer<RT> {
                                     err,
                                 );
                             }
-                            self.publish_commit_delta(published_commit.delta);
+                            if let Err(err) = Self::publish_commit_delta(
+                                self.distributed_log.clone(),
+                                published_commit.delta,
+                            )
+                            .await
+                            {
+                                return Self::fail_committed_write(
+                                    result,
+                                    commit_ts,
+                                    "publish prepared write to replication log",
+                                    err,
+                                );
+                            }
                             if let Err(err) = Self::delete_two_phase_redo(
                                 self.persistence.clone(),
                                 &redo_transaction_id,
@@ -1707,17 +1731,17 @@ impl<RT: Runtime> Committer<RT> {
         anyhow::bail!(message)
     }
 
-    fn publish_commit_delta(&self, delta: CommitDelta) {
-        let distributed_log = self.distributed_log.clone();
+    async fn publish_commit_delta(
+        distributed_log: Arc<dyn DistributedLog>,
+        delta: CommitDelta,
+    ) -> anyhow::Result<()> {
         let delta_ts = delta.ts;
-        tokio_spawn("publish_commit_delta", async move {
-            if let Err(e) = distributed_log.publish(delta).await {
-                tracing::error!(
-                    "Failed to publish commit delta at ts={}: {e:#}",
-                    u64::from(delta_ts)
-                );
-            }
-        });
+        distributed_log.publish(delta).await.with_context(|| {
+            format!(
+                "Failed to publish commit delta at ts={}",
+                u64::from(delta_ts)
+            )
+        })
     }
 
     fn propose_commit_to_raft(&self, delta: &CommitDelta) -> anyhow::Result<RaftCommitWaiter> {

--- a/crates/database/src/nats_distributed_log.rs
+++ b/crates/database/src/nats_distributed_log.rs
@@ -13,6 +13,8 @@ use async_nats::jetstream::{
     self,
     consumer::PullConsumer,
     stream::Stream as JsStream,
+    AckKind,
+    Message as JetStreamMessage,
 };
 use async_trait::async_trait;
 use common::{
@@ -33,6 +35,8 @@ use crate::{
     commit_delta::{
         CommitDelta,
         DistributedLog,
+        ReplicationAck,
+        ReplicationMessage,
     },
     metrics,
     partition::PartitionId,
@@ -80,7 +84,7 @@ impl NatsDistributedLog {
         &self,
         from_ts: Timestamp,
         filter_subjects: Option<Vec<String>>,
-    ) -> anyhow::Result<BoxStream<'static, anyhow::Result<CommitDelta>>> {
+    ) -> anyhow::Result<BoxStream<'static, anyhow::Result<ReplicationMessage>>> {
         // Create a durable consumer so it survives reconnections.
         // DeliverPolicy::All replays all messages from the stream beginning,
         // and we filter out messages at or before from_ts ourselves.
@@ -159,24 +163,39 @@ impl NatsDistributedLog {
                                 tracing::debug!("Failed to parse JetStream message info: {e}");
                             },
                         }
-                        if let Err(e) = msg.ack().await {
-                            tracing::warn!("Failed to ack NATS message: {e:?}");
-                        }
                         let envelope: DeltaEnvelope = match serde_json::from_slice(&msg.payload) {
                             Ok(e) => e,
                             Err(e) => {
                                 tracing::error!("Failed to deserialize delta from NATS: {e}");
+                                if let Err(ack_err) = msg.ack_with(AckKind::Term).await {
+                                    tracing::warn!(
+                                        "Failed to terminate poison NATS message after \
+                                         deserialize error: {ack_err:?}"
+                                    );
+                                }
                                 return Some(Err(anyhow::anyhow!(
                                     "Failed to deserialize delta: {e}"
                                 )));
                             },
                         };
                         if envelope.ts <= from_ts_u64 {
+                            if let Err(e) = msg.ack().await {
+                                return Some(Err(anyhow::anyhow!(
+                                    "Failed to ack skipped NATS delta at ts={}: {e:#}",
+                                    envelope.ts
+                                )));
+                            }
                             return None;
                         }
                         // Skip deltas published by this node to avoid double-applying.
                         if !envelope.source_node.is_empty() && envelope.source_node == node_name {
                             tracing::debug!("Skipping self-published delta at ts={}", envelope.ts,);
+                            if let Err(e) = msg.ack().await {
+                                return Some(Err(anyhow::anyhow!(
+                                    "Failed to ack self-published NATS delta at ts={}: {e:#}",
+                                    envelope.ts
+                                )));
+                            }
                             return None;
                         }
                         tracing::debug!(
@@ -184,7 +203,23 @@ impl NatsDistributedLog {
                             envelope.ts,
                             envelope.source_node,
                         );
-                        Some(envelope.to_delta())
+                        let delta = match envelope.to_delta() {
+                            Ok(delta) => delta,
+                            Err(e) => {
+                                tracing::error!("Failed to decode NATS delta envelope: {e:#}");
+                                if let Err(ack_err) = msg.ack_with(AckKind::Term).await {
+                                    tracing::warn!(
+                                        "Failed to terminate poison NATS message after delta \
+                                         decode error: {ack_err:?}"
+                                    );
+                                }
+                                return Some(Err(e));
+                            },
+                        };
+                        Some(Ok(ReplicationMessage::new(
+                            delta,
+                            Box::new(NatsReplicationAck { msg }),
+                        )))
                     },
                     Err(e) => {
                         tracing::error!("NATS message error: {e}");
@@ -201,7 +236,7 @@ impl NatsDistributedLog {
         &self,
         from_ts: Timestamp,
         source_partitions: Option<Vec<PartitionId>>,
-    ) -> anyhow::Result<BoxStream<'static, anyhow::Result<CommitDelta>>> {
+    ) -> anyhow::Result<BoxStream<'static, anyhow::Result<ReplicationMessage>>> {
         let filter_subjects = source_partitions.map(|partitions| {
             partitions
                 .into_iter()
@@ -215,7 +250,7 @@ impl NatsDistributedLog {
         &self,
         from_ts: Timestamp,
         node_name: &str,
-    ) -> anyhow::Result<BoxStream<'static, anyhow::Result<CommitDelta>>> {
+    ) -> anyhow::Result<BoxStream<'static, anyhow::Result<ReplicationMessage>>> {
         self.subscribe_subjects(
             from_ts,
             Some(vec![SelectiveDeliveryRegistry::node_subject(node_name)]),
@@ -227,7 +262,7 @@ impl NatsDistributedLog {
         &self,
         from_ts: Timestamp,
         node_name: &str,
-    ) -> anyhow::Result<BoxStream<'static, anyhow::Result<CommitDelta>>> {
+    ) -> anyhow::Result<BoxStream<'static, anyhow::Result<ReplicationMessage>>> {
         self.subscribe_subjects(
             from_ts,
             Some(vec![
@@ -303,6 +338,34 @@ impl NatsDistributedLog {
             publish_subject,
             selective_registry,
         })
+    }
+}
+
+struct NatsReplicationAck {
+    msg: JetStreamMessage,
+}
+
+#[async_trait]
+impl ReplicationAck for NatsReplicationAck {
+    async fn ack(self: Box<Self>) -> anyhow::Result<()> {
+        self.msg
+            .ack()
+            .await
+            .map_err(|e| anyhow::anyhow!("Failed to ack NATS replication message: {e}"))
+    }
+
+    async fn nak(self: Box<Self>) -> anyhow::Result<()> {
+        self.msg
+            .ack_with(AckKind::Nak(None))
+            .await
+            .map_err(|e| anyhow::anyhow!("Failed to NAK NATS replication message: {e}"))
+    }
+
+    async fn term(self: Box<Self>) -> anyhow::Result<()> {
+        self.msg
+            .ack_with(AckKind::Term)
+            .await
+            .map_err(|e| anyhow::anyhow!("Failed to terminate NATS replication message: {e}"))
     }
 }
 
@@ -493,7 +556,7 @@ impl DistributedLog for NatsDistributedLog {
     async fn subscribe(
         &self,
         from_ts: Timestamp,
-    ) -> anyhow::Result<BoxStream<'static, anyhow::Result<CommitDelta>>> {
+    ) -> anyhow::Result<BoxStream<'static, anyhow::Result<ReplicationMessage>>> {
         self.subscribe_inner(from_ts, None).await
     }
 
@@ -501,7 +564,7 @@ impl DistributedLog for NatsDistributedLog {
         &self,
         from_ts: Timestamp,
         source_partitions: Option<Vec<PartitionId>>,
-    ) -> anyhow::Result<BoxStream<'static, anyhow::Result<CommitDelta>>> {
+    ) -> anyhow::Result<BoxStream<'static, anyhow::Result<ReplicationMessage>>> {
         self.subscribe_inner(from_ts, source_partitions).await
     }
 }

--- a/crates/database/src/replica.rs
+++ b/crates/database/src/replica.rs
@@ -15,9 +15,65 @@ use common::runtime::{
 use futures::StreamExt;
 
 use crate::{
-    commit_delta::DistributedLog,
+    commit_delta::{
+        CommitDelta,
+        DistributedLog,
+        ReplicationMessage,
+    },
     committer::CommitterClient,
 };
+
+pub async fn apply_replication_message(
+    committer: &CommitterClient,
+    message: ReplicationMessage,
+) -> anyhow::Result<(common::types::Timestamp, usize)> {
+    let committer = committer.clone();
+    apply_replication_message_with(message, move |delta| async move {
+        committer.apply_replica_delta(delta).await
+    })
+    .await
+}
+
+async fn apply_replication_message_with<F, Fut>(
+    message: ReplicationMessage,
+    apply: F,
+) -> anyhow::Result<(common::types::Timestamp, usize)>
+where
+    F: FnOnce(CommitDelta) -> Fut,
+    Fut: std::future::Future<Output = anyhow::Result<common::types::Timestamp>>,
+{
+    let (delta, ack) = message.into_parts();
+    let ts = delta.ts;
+    let num_updates = delta.document_updates.len();
+
+    match apply(delta).await {
+        Ok(applied_ts) => {
+            ack.ack().await.with_context(|| {
+                format!(
+                    "Failed to ack applied replica delta at ts={}",
+                    u64::from(applied_ts),
+                )
+            })?;
+            Ok((applied_ts, num_updates))
+        },
+        Err(e) => {
+            tracing::error!(
+                "Failed to apply replica delta at ts={}: {e:#}",
+                u64::from(ts),
+            );
+            if let Err(ack_err) = ack.nak().await {
+                tracing::warn!(
+                    "Failed to NAK unapplied replica delta at ts={}: {ack_err:#}",
+                    u64::from(ts),
+                );
+            }
+            anyhow::bail!(
+                "Failed to apply replica delta at ts={}: {e:#}",
+                u64::from(ts)
+            );
+        },
+    }
+}
 
 /// Consumes [`CommitDelta`]s from a [`DistributedLog`] and feeds them
 /// through the Committer's apply loop via
@@ -63,28 +119,129 @@ impl ReplicaDeltaConsumer {
         tracing::info!("ReplicaDeltaConsumer subscribed, waiting for deltas...");
 
         while let Some(result) = stream.next().await {
-            let delta = result.context("Error reading from distributed log")?;
-            let ts = delta.ts;
-            let num_updates = delta.document_updates.len();
-
-            match committer.apply_replica_delta(delta).await {
-                Ok(applied_ts) => {
-                    tracing::info!(
-                        "Applied replica delta: ts={}, {} updates",
-                        u64::from(applied_ts),
-                        num_updates,
-                    );
-                },
-                Err(e) => {
-                    tracing::error!(
-                        "Failed to apply replica delta at ts={}: {e:#}",
-                        u64::from(ts),
-                    );
-                },
-            }
+            let message = result.context("Error reading from distributed log")?;
+            let (applied_ts, num_updates) = apply_replication_message(&committer, message).await?;
+            tracing::info!(
+                "Applied replica delta: ts={}, {} updates",
+                u64::from(applied_ts),
+                num_updates,
+            );
         }
 
         tracing::warn!("ReplicaDeltaConsumer stream ended — no more deltas");
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        collections::BTreeMap,
+        sync::{
+            atomic::{
+                AtomicUsize,
+                Ordering,
+            },
+            Arc,
+        },
+    };
+
+    use async_trait::async_trait;
+    use common::types::Timestamp;
+
+    use super::apply_replication_message_with;
+    use crate::{
+        commit_delta::{
+            CommitDelta,
+            ReplicationAck,
+            ReplicationMessage,
+        },
+        write_log::WriteSource,
+    };
+
+    #[derive(Default)]
+    struct AckCounts {
+        ack: AtomicUsize,
+        nak: AtomicUsize,
+        term: AtomicUsize,
+    }
+
+    struct RecordingAck {
+        counts: Arc<AckCounts>,
+    }
+
+    #[async_trait]
+    impl ReplicationAck for RecordingAck {
+        async fn ack(self: Box<Self>) -> anyhow::Result<()> {
+            self.counts.ack.fetch_add(1, Ordering::SeqCst);
+            Ok(())
+        }
+
+        async fn nak(self: Box<Self>) -> anyhow::Result<()> {
+            self.counts.nak.fetch_add(1, Ordering::SeqCst);
+            Ok(())
+        }
+
+        async fn term(self: Box<Self>) -> anyhow::Result<()> {
+            self.counts.term.fetch_add(1, Ordering::SeqCst);
+            Ok(())
+        }
+    }
+
+    fn test_message(ts: Timestamp, counts: Arc<AckCounts>) -> ReplicationMessage {
+        ReplicationMessage::new(
+            CommitDelta {
+                ts,
+                document_writes: Arc::new(Vec::new()),
+                document_updates: Vec::new(),
+                index_writes: Arc::new(Vec::new()),
+                write_source: WriteSource::unknown(),
+                write_bytes: 0,
+                tablet_id_to_table_name: BTreeMap::new(),
+                source_partition: None,
+            },
+            Box::new(RecordingAck { counts }),
+        )
+    }
+
+    #[tokio::test]
+    async fn apply_replication_message_acks_after_success() -> anyhow::Result<()> {
+        let counts = Arc::new(AckCounts::default());
+        let ts = Timestamp::try_from(42u64)?;
+        let (applied_ts, num_updates) =
+            apply_replication_message_with(test_message(ts, counts.clone()), |delta| async move {
+                Ok(delta.ts)
+            })
+            .await?;
+
+        assert_eq!(applied_ts, ts);
+        assert_eq!(num_updates, 0);
+        assert_eq!(counts.ack.load(Ordering::SeqCst), 1);
+        assert_eq!(counts.nak.load(Ordering::SeqCst), 0);
+        assert_eq!(counts.term.load(Ordering::SeqCst), 0);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn apply_replication_message_naks_after_apply_failure() -> anyhow::Result<()> {
+        let counts = Arc::new(AckCounts::default());
+        let ts = Timestamp::try_from(42u64)?;
+        let err =
+            apply_replication_message_with(test_message(ts, counts.clone()), |_delta| async move {
+                anyhow::bail!("forced apply failure")
+            })
+            .await
+            .unwrap_err();
+
+        let message = format!("{err:#}");
+        assert!(
+            message.contains("Failed to apply replica delta"),
+            "{message}"
+        );
+        assert!(message.contains("forced apply failure"), "{message}");
+        assert_eq!(counts.ack.load(Ordering::SeqCst), 0);
+        assert_eq!(counts.nak.load(Ordering::SeqCst), 1);
+        assert_eq!(counts.term.load(Ordering::SeqCst), 0);
         Ok(())
     }
 }

--- a/crates/database/src/replica.rs
+++ b/crates/database/src/replica.rs
@@ -244,4 +244,30 @@ mod tests {
         assert_eq!(counts.term.load(Ordering::SeqCst), 0);
         Ok(())
     }
+
+    #[tokio::test]
+    async fn apply_failure_naks_then_redelivered_message_can_ack() -> anyhow::Result<()> {
+        let counts = Arc::new(AckCounts::default());
+        let ts = Timestamp::try_from(42u64)?;
+
+        let first_attempt =
+            apply_replication_message_with(test_message(ts, counts.clone()), |_delta| async move {
+                anyhow::bail!("transient apply failure")
+            })
+            .await;
+        assert!(first_attempt.is_err());
+        assert_eq!(counts.ack.load(Ordering::SeqCst), 0);
+        assert_eq!(counts.nak.load(Ordering::SeqCst), 1);
+
+        let (applied_ts, _) =
+            apply_replication_message_with(test_message(ts, counts.clone()), |delta| async move {
+                Ok(delta.ts)
+            })
+            .await?;
+        assert_eq!(applied_ts, ts);
+        assert_eq!(counts.ack.load(Ordering::SeqCst), 1);
+        assert_eq!(counts.nak.load(Ordering::SeqCst), 1);
+        assert_eq!(counts.term.load(Ordering::SeqCst), 0);
+        Ok(())
+    }
 }

--- a/crates/database/src/tests/replication_tests.rs
+++ b/crates/database/src/tests/replication_tests.rs
@@ -1,45 +1,50 @@
 use std::sync::Arc;
 
+use async_trait::async_trait;
 use common::{
     assert_obj,
     runtime::{
         new_unlimited_rate_limiter,
         testing::TestRuntime,
-        Runtime,
     },
     shutdown::ShutdownSignal,
     testing::TestPersistence,
+    types::Timestamp,
 };
+use futures::stream::BoxStream;
 use keybroker::Identity;
 use search::searcher::SearcherStub;
 use storage::LocalDirStorage;
 use value::TableName;
 
 use crate::{
-    commit_delta::testing::InMemoryDistributedLog,
+    commit_delta::{
+        testing::InMemoryDistributedLog,
+        CommitDelta,
+        DistributedLog,
+        ReplicationMessage,
+    },
     Database,
     TestFacingModel,
 };
 
-/// Test that a commit on the Primary publishes a CommitDelta to the
-/// distributed log with the correct document updates.
-#[convex_macro::test_runtime]
-async fn test_primary_commit_publishes_delta(rt: TestRuntime) -> anyhow::Result<()> {
-    let distributed_log = Arc::new(InMemoryDistributedLog::new());
-
+async fn load_test_primary(
+    rt: &TestRuntime,
+    distributed_log: Arc<dyn DistributedLog>,
+) -> anyhow::Result<Database<TestRuntime>> {
     let tp = Arc::new(TestPersistence::new());
     let searcher: Arc<dyn search::Searcher> = Arc::new(SearcherStub {});
     let (deleted_tablet_sender, _) = tokio::sync::mpsc::channel(100);
     let primary = Database::load(
-        tp.clone(),
+        tp,
         rt.clone(),
-        searcher.clone(),
-        ShutdownSignal::panic(),
+        searcher,
+        ShutdownSignal::no_op(),
         Default::default(),
         None,
         Arc::new(new_unlimited_rate_limiter(rt.clone())),
         deleted_tablet_sender,
-        distributed_log.clone(),
+        distributed_log,
         false,
         None,
         None,
@@ -51,6 +56,31 @@ async fn test_primary_commit_publishes_delta(rt: TestRuntime) -> anyhow::Result<
     primary.set_search_storage(Arc::new(LocalDirStorage::new(rt.clone())?));
     let handle = primary.start_search_and_vector_bootstrap();
     handle.join().await?;
+    Ok(primary)
+}
+
+struct FailingPublishDistributedLog;
+
+#[async_trait]
+impl DistributedLog for FailingPublishDistributedLog {
+    async fn publish(&self, _delta: CommitDelta) -> anyhow::Result<()> {
+        anyhow::bail!("forced replication publish failure")
+    }
+
+    async fn subscribe(
+        &self,
+        _from_ts: Timestamp,
+    ) -> anyhow::Result<BoxStream<'static, anyhow::Result<ReplicationMessage>>> {
+        Ok(Box::pin(futures::stream::pending()))
+    }
+}
+
+/// Test that a commit on the Primary publishes a CommitDelta to the
+/// distributed log with the correct document updates.
+#[convex_macro::test_runtime]
+async fn test_primary_commit_publishes_delta(rt: TestRuntime) -> anyhow::Result<()> {
+    let distributed_log = Arc::new(InMemoryDistributedLog::new());
+    let primary = load_test_primary(&rt, distributed_log.clone()).await?;
 
     // Commit a document on the Primary.
     let table_name: TableName = "test_table".parse()?;
@@ -59,9 +89,6 @@ async fn test_primary_commit_publishes_delta(rt: TestRuntime) -> anyhow::Result<
         .insert(&table_name, assert_obj!("field" => "value"))
         .await?;
     primary.commit(tx).await?;
-
-    // Give the async publish task a moment to complete.
-    rt.wait(std::time::Duration::from_millis(100)).await;
 
     // Verify the delta was published.
     let deltas = distributed_log.deltas();
@@ -75,6 +102,30 @@ async fn test_primary_commit_publishes_delta(rt: TestRuntime) -> anyhow::Result<
         .iter()
         .any(|d| d.document_updates.iter().any(|u| u.new_document.is_some()));
     assert!(has_doc_update, "Expected a delta with a document insert");
+
+    Ok(())
+}
+
+#[convex_macro::test_runtime]
+async fn test_commit_fails_when_replication_publish_fails(rt: TestRuntime) -> anyhow::Result<()> {
+    let primary = load_test_primary(&rt, Arc::new(FailingPublishDistributedLog)).await?;
+
+    let table_name: TableName = "test_table".parse()?;
+    let mut tx = primary.begin(Identity::system()).await?;
+    TestFacingModel::new(&mut tx)
+        .insert(&table_name, assert_obj!("field" => "value"))
+        .await?;
+
+    let err = primary.commit(tx).await.unwrap_err();
+    let message = format!("{err:#}");
+    assert!(
+        message.contains("publish committed write to replication log"),
+        "{message}"
+    );
+    assert!(
+        message.contains("forced replication publish failure"),
+        "{message}"
+    );
 
     Ok(())
 }

--- a/crates/local_backend/src/lib.rs
+++ b/crates/local_backend/src/lib.rs
@@ -541,19 +541,30 @@ pub async fn make_app(
                         );
                         while let Some(result) = futures::StreamExt::next(&mut stream).await {
                             match result {
-                                Ok(delta) => {
+                                Ok(message) => {
+                                    let (delta, ack) = message.into_parts();
                                     database::log_selective_delivery_shadow_receive();
                                     tracing::debug!(
                                         "Selective-delivery shadow delta observed for {} at ts={}",
                                         shadow_node_name,
                                         u64::from(delta.ts),
                                     );
+                                    if let Err(e) = ack.ack().await {
+                                        tracing::warn!(
+                                            "Selective-delivery shadow consumer failed to ack for \
+                                             {} at ts={}: {e:#}",
+                                            shadow_node_name,
+                                            u64::from(delta.ts),
+                                        );
+                                        break;
+                                    }
                                 },
                                 Err(e) => {
                                     tracing::warn!(
                                         "Selective-delivery shadow consumer error for {}: {e:#}",
                                         shadow_node_name,
                                     );
+                                    break;
                                 },
                             }
                         }
@@ -674,25 +685,30 @@ pub async fn make_app(
                         tracing::info!("ReplicaDeltaConsumer subscribed, processing deltas...");
                         while let Some(result) = futures::StreamExt::next(&mut stream).await {
                             match result {
-                                Ok(delta) => {
+                                Ok(message) => {
                                     if use_selective_node_targeting {
                                         database::log_selective_delivery_shadow_receive();
                                     }
-                                    let ts = delta.ts;
-                                    let n = delta.document_updates.len();
-                                    match committer.apply_replica_delta(delta).await {
-                                        Ok(_) => tracing::info!(
+                                    match database::replica::apply_replication_message(
+                                        &committer, message,
+                                    )
+                                    .await
+                                    {
+                                        Ok((ts, n)) => tracing::info!(
                                             "Applied replica delta: ts={}, {} updates",
                                             u64::from(ts),
                                             n
                                         ),
-                                        Err(e) => tracing::error!(
-                                            "Failed to apply delta at ts={}: {e:#}",
-                                            u64::from(ts)
-                                        ),
+                                        Err(e) => {
+                                            tracing::error!("Failed to apply NATS delta: {e:#}");
+                                            break;
+                                        },
                                     }
                                 },
-                                Err(e) => tracing::error!("Error reading NATS delta: {e:#}"),
+                                Err(e) => {
+                                    tracing::error!("Error reading NATS delta: {e:#}");
+                                    break;
+                                },
                             }
                         }
                         tracing::warn!("ReplicaDeltaConsumer stream ended");


### PR DESCRIPTION
## Summary
- make distributed-log subscribers receive a delta plus an explicit ACK handle
- defer JetStream ACK until after replica apply succeeds; NAK apply failures and TERM poison decode failures
- make committed-write replication publish part of the commit completion path instead of a detached best-effort task
- add regression coverage for publish failures and ACK/NAK-after-apply behavior

Closes #102

## Validation
- `cargo test -p database replica::tests -- --nocapture`
- `cargo test -p database replication_tests -- --nocapture`
- `cargo check -p local_backend`
- `cargo test -p local_backend test_http_mutation_forwards_when_replica_mode -- --nocapture`
- `cargo test -p local_backend test_fresh_replica_bootstraps_from_checkpoint -- --nocapture`
- `cargo test -p database write_scaling_tests -- --nocapture`
- `cargo test -p local_backend --lib -- --nocapture`
- rebuilt `ghcr.io/martinkalema/convex-horizontal-scaling:backend-latest` from this branch
- clean Docker cluster with `docker compose --profile cluster up -d --pull never`
- `bash self-hosted/docker/test.sh` passed 77/77 write-scaling and 10/10 Raft failover tests