### PR TITLE
fix: keep TSO allocations within reserved ranges

### DIFF
--- a/crates/database/src/committer.rs
+++ b/crates/database/src/committer.rs
@@ -3103,6 +3103,7 @@ impl<RT: Runtime> Committer<RT> {
 
     fn next_commit_ts(&mut self) -> anyhow::Result<Timestamp> {
         let _timer = next_commit_ts_seconds();
+        let local_floor = self.local_commit_floor()?;
 
         // When a global TSO is configured (TiDB PD pattern), draw timestamps
         // from it instead of the local clock. This ensures globally unique,
@@ -3114,40 +3115,34 @@ impl<RT: Runtime> Committer<RT> {
             let ts = block_in_place(|| {
                 let rt = tokio::runtime::Handle::current();
                 if rt.runtime_flavor() == tokio::runtime::RuntimeFlavor::CurrentThread {
-                    futures::executor::block_on(tso.next_ts())
+                    futures::executor::block_on(tso.next_ts_at_or_after(local_floor))
                 } else {
-                    rt.block_on(tso.next_ts())
+                    rt.block_on(tso.next_ts_at_or_after(local_floor))
                 }
             })?;
-            // Still enforce local monotonicity against snapshot and last_assigned.
-            let log_floor = self.log.max_ts().succ()?;
-            let latest_ts = self.snapshot_manager.read().latest_ts();
-            let max = cmp::max(
+            anyhow::ensure!(
+                ts >= local_floor,
+                "TSO returned ts={} below requested local floor {}",
                 ts,
-                cmp::max(
-                    log_floor,
-                    cmp::max(latest_ts.succ()?, self.last_assigned_ts.succ()?),
-                ),
+                local_floor,
             );
-            self.last_assigned_ts = max;
-            return Ok(max);
+            self.last_assigned_ts = ts;
+            return Ok(ts);
         }
 
         // Single-node mode: existing behavior (local clock + monotonic counter).
-        let log_floor = self.log.max_ts().succ()?;
-        let latest_ts = self.snapshot_manager.read().latest_ts();
-        let max = cmp::max(
-            log_floor,
-            cmp::max(
-                latest_ts.succ()?,
-                cmp::max(
-                    self.runtime.generate_timestamp()?,
-                    self.last_assigned_ts.succ()?,
-                ),
-            ),
-        );
+        let max = cmp::max(local_floor, self.runtime.generate_timestamp()?);
         self.last_assigned_ts = max;
         Ok(max)
+    }
+
+    fn local_commit_floor(&self) -> anyhow::Result<Timestamp> {
+        let log_floor = self.log.max_ts().succ()?;
+        let latest_ts = self.snapshot_manager.read().latest_ts();
+        Ok(cmp::max(
+            log_floor,
+            cmp::max(latest_ts.succ()?, self.last_assigned_ts.succ()?),
+        ))
     }
 
     fn next_max_repeatable_ts(&mut self) -> anyhow::Result<Timestamp> {

--- a/crates/database/src/tests/write_scaling_tests.rs
+++ b/crates/database/src/tests/write_scaling_tests.rs
@@ -40,6 +40,7 @@ use common::{
     },
 };
 use keybroker::Identity;
+use parking_lot::Mutex;
 use pb::replication::{
     two_phase_commit_service_server::{
         TwoPhaseCommitService,
@@ -359,7 +360,7 @@ struct FailingTimestampOracle;
 
 #[async_trait]
 impl TimestampOracle for FailingTimestampOracle {
-    async fn next_ts(&self) -> anyhow::Result<Timestamp> {
+    async fn next_ts_at_or_after(&self, _min_ts: Timestamp) -> anyhow::Result<Timestamp> {
         anyhow::bail!("TSO unavailable during idle heartbeat test");
     }
 
@@ -369,6 +370,58 @@ impl TimestampOracle for FailingTimestampOracle {
 
     async fn advance_committed_ts(&self, _ts: Timestamp) -> anyhow::Result<()> {
         anyhow::bail!("TSO unavailable during idle heartbeat test");
+    }
+}
+
+struct RecordingTimestampOracle {
+    state: Mutex<RecordingTimestampOracleState>,
+}
+
+struct RecordingTimestampOracleState {
+    last_assigned: Timestamp,
+    max_committed: Timestamp,
+    requested_floors: Vec<Timestamp>,
+}
+
+impl RecordingTimestampOracle {
+    fn new() -> Self {
+        Self {
+            state: Mutex::new(RecordingTimestampOracleState {
+                last_assigned: Timestamp::MIN,
+                max_committed: Timestamp::MIN,
+                requested_floors: Vec::new(),
+            }),
+        }
+    }
+
+    fn requested_floors(&self) -> Vec<Timestamp> {
+        self.state.lock().requested_floors.clone()
+    }
+}
+
+#[async_trait]
+impl TimestampOracle for RecordingTimestampOracle {
+    async fn next_ts_at_or_after(&self, min_ts: Timestamp) -> anyhow::Result<Timestamp> {
+        let mut state = self.state.lock();
+        state.requested_floors.push(min_ts);
+        let next = std::cmp::max(
+            min_ts,
+            std::cmp::max(state.last_assigned.succ()?, state.max_committed.succ()?),
+        );
+        state.last_assigned = next;
+        Ok(next)
+    }
+
+    async fn max_committed_ts(&self) -> anyhow::Result<Timestamp> {
+        Ok(self.state.lock().max_committed)
+    }
+
+    async fn advance_committed_ts(&self, ts: Timestamp) -> anyhow::Result<()> {
+        let mut state = self.state.lock();
+        if ts > state.max_committed {
+            state.max_committed = ts;
+        }
+        Ok(())
     }
 }
 
@@ -1659,6 +1712,59 @@ fn test_commit_decision_survives_failed_participant_commit() -> anyhow::Result<(
         }
 
         server.shutdown().await?;
+        Ok(())
+    })
+}
+
+#[test]
+fn test_tso_request_includes_local_replica_floor() -> anyhow::Result<()> {
+    let td = TestDriver::new_with_io();
+    let rt = td.rt();
+    td.run_until(async move {
+        let log = Arc::new(InMemoryDistributedLog::new());
+        let tso = Arc::new(RecordingTimestampOracle::new());
+        let node = create_node_with_options(
+            &rt,
+            log,
+            Some(partitioned_map(PartitionId(0))),
+            None,
+            Some(tso.clone()),
+        )
+        .await?;
+
+        let replica_floor = Timestamp::try_from(
+            u64::from(*node.now_ts_for_reads())
+                .checked_add(10_000)
+                .context("test timestamp overflow")?,
+        )?;
+        node.committer_for_test()
+            .apply_replica_delta(CommitDelta {
+                ts: replica_floor,
+                document_writes: Arc::new(Vec::new()),
+                document_updates: Vec::new(),
+                index_writes: Arc::new(Vec::new()),
+                write_source: WriteSource::new("tso_local_floor_test"),
+                write_bytes: 0,
+                tablet_id_to_table_name: Default::default(),
+                source_partition: Some(PartitionId(1)),
+            })
+            .await?;
+
+        let expected_floor = replica_floor.succ()?;
+        let commit_ts = insert_doc(&node, "messages", assert_obj!("text" => "after-floor")).await?;
+        let requested_floors = tso.requested_floors();
+
+        assert!(
+            commit_ts >= expected_floor,
+            "commit_ts={commit_ts} should be at or above local floor {expected_floor}",
+        );
+        assert_eq!(
+            requested_floors.last().copied(),
+            Some(expected_floor),
+            "TSO must reserve at the committer's local floor instead of returning a lower value \
+             and letting the committer bump it outside the reserved range",
+        );
+
         Ok(())
     })
 }

--- a/crates/database/src/timestamp_oracle.rs
+++ b/crates/database/src/timestamp_oracle.rs
@@ -31,7 +31,8 @@ use parking_lot::Mutex;
 
 /// Trait for assigning globally unique, monotonically increasing timestamps.
 ///
-/// Each Committer calls `next_ts()` before committing a transaction.
+/// Each Committer calls `next_ts_at_or_after()` before committing a
+/// transaction.
 /// The implementation must guarantee that no two calls — across any node
 /// in the cluster — ever return the same timestamp.
 #[async_trait]
@@ -39,7 +40,17 @@ pub trait TimestampOracle: Send + Sync + 'static {
     /// Get the next globally unique timestamp.
     /// Must be monotonically increasing within each node.
     /// Must not overlap with timestamps from other nodes.
-    async fn next_ts(&self) -> anyhow::Result<Timestamp>;
+    async fn next_ts(&self) -> anyhow::Result<Timestamp> {
+        self.next_ts_at_or_after(Timestamp::MIN).await
+    }
+
+    /// Get the next globally unique timestamp at or above `min_ts`.
+    ///
+    /// `min_ts` is the caller's local safety floor, usually derived from the
+    /// local write log, restored snapshot, and last assigned timestamp. Global
+    /// TSOs must include this floor in their reservation, rather than allowing
+    /// callers to bump a returned timestamp outside the reserved range.
+    async fn next_ts_at_or_after(&self, min_ts: Timestamp) -> anyhow::Result<Timestamp>;
 
     /// Get the current maximum committed timestamp across all nodes.
     /// Used for read-after-write consistency.
@@ -76,11 +87,11 @@ impl<RT: Runtime> LocalTimestampOracle<RT> {
 
 #[async_trait]
 impl<RT: Runtime> TimestampOracle for LocalTimestampOracle<RT> {
-    async fn next_ts(&self) -> anyhow::Result<Timestamp> {
+    async fn next_ts_at_or_after(&self, min_ts: Timestamp) -> anyhow::Result<Timestamp> {
         let mut state = self.state.lock();
         let system_ts = self.runtime.generate_timestamp()?;
         let next = std::cmp::max(
-            system_ts,
+            std::cmp::max(system_ts, min_ts),
             std::cmp::max(state.last_assigned.succ()?, state.max_committed.succ()?),
         );
         state.last_assigned = next;
@@ -226,7 +237,9 @@ impl BatchTimestampOracle {
             );
 
             let new_lower = batch_lower_bound(current_value, min_next);
-            let new_upper = new_lower + self.batch_size;
+            let new_upper = new_lower
+                .checked_add(self.batch_size)
+                .context("TSO: Reserved batch upper bound overflow")?;
             let new_value = new_upper.to_be_bytes().to_vec();
 
             // Atomic compare-and-swap: only succeeds if no other node
@@ -255,9 +268,10 @@ impl BatchTimestampOracle {
 
 #[async_trait]
 impl TimestampOracle for BatchTimestampOracle {
-    async fn next_ts(&self) -> anyhow::Result<Timestamp> {
+    async fn next_ts_at_or_after(&self, min_ts: Timestamp) -> anyhow::Result<Timestamp> {
         let committed_floor = self.max_committed_ts().await?;
-        let min_next = u64::from(committed_floor.succ()?);
+        let min_next_ts = std::cmp::max(min_ts, committed_floor.succ()?);
+        let min_next = u64::from(min_next_ts);
 
         loop {
             let candidate = {
@@ -398,9 +412,12 @@ pub mod testing {
 
     #[async_trait]
     impl TimestampOracle for InMemoryTimestampOracle {
-        async fn next_ts(&self) -> anyhow::Result<Timestamp> {
+        async fn next_ts_at_or_after(&self, min_ts: Timestamp) -> anyhow::Result<Timestamp> {
             let mut state = self.state.lock();
-            let next = std::cmp::max(state.last_assigned.succ()?, state.max_committed.succ()?);
+            let next = std::cmp::max(
+                min_ts,
+                std::cmp::max(state.last_assigned.succ()?, state.max_committed.succ()?),
+            );
             state.last_assigned = next;
             Ok(next)
         }
@@ -435,7 +452,7 @@ mod tests {
     }
 
     #[test]
-    fn reserved_batch_fast_forwards_to_committed_floor() {
+    fn reserved_batch_fast_forwards_to_requested_floor() {
         let (ts, next_current) =
             next_ts_from_reserved_batch(100, 200, 150).expect("candidate within batch");
         assert_eq!(ts, 150);
@@ -449,7 +466,7 @@ mod tests {
     }
 
     #[test]
-    fn reserve_batch_starts_above_committed_floor_when_counter_lags() {
+    fn reserve_batch_starts_above_requested_floor_when_counter_lags() {
         assert_eq!(batch_lower_bound(1000, 1001), 1001);
         assert_eq!(batch_lower_bound(1000, 1500), 1500);
         assert_eq!(batch_lower_bound(2000, 1500), 2000);


### PR DESCRIPTION
## Summary

Closes #103.

This fixes the TSO reserved-range invariant by making commit timestamp allocation floor-aware before the timestamp oracle returns a value.

## Root Cause

`Committer::next_commit_ts` previously called the global TSO first, then locally bumped the returned timestamp above the write log, snapshot, or last-assigned floor. With batch TSO reservations, that meant a recovered or caught-up node could commit at a timestamp that was never explicitly covered by its globally reserved range.

## Changes

- Add `TimestampOracle::next_ts_at_or_after(min_ts)` so callers can supply their local safety floor.
- Update `BatchTimestampOracle` to fast-forward inside an existing reserved batch or reserve a new batch beginning at/above the requested floor.
- Update `Committer` to compute its local commit floor first and request a globally reserved timestamp at or above that floor.
- Add a regression test proving replica-applied high timestamps are sent to the TSO as the reservation floor before the next local write.

## Validation

- `cargo fmt -p database`
- `cargo test -p database test_tso_request_includes_local_replica_floor -- --nocapture`
- `cargo test -p database timestamp_oracle -- --nocapture`
- `cargo test -p database write_scaling_tests -- --nocapture`
- `cargo test -p database replication_tests -- --nocapture`
- `cargo test -p database replica::tests -- --nocapture`
- `cargo check -p local_backend`
- `cargo test -p local_backend test_fresh_replica_bootstraps_from_checkpoint -- --nocapture`
- `cargo test -p local_backend test_http_mutation_forwards_when_replica_mode -- --nocapture`
- `cargo test -p local_backend --lib -- --nocapture`
- Rebuilt backend Docker image: `docker build --progress=plain -t ghcr.io/martinkalema/convex-horizontal-scaling:backend-latest -f self-hosted/docker-build/Dockerfile.backend .`
- Restarted local cluster on rebuilt image: `docker compose --profile cluster down --remove-orphans && docker compose --profile cluster up -d --pull never`
- Full Docker harness: `bash self-hosted/docker/test.sh`
  - Write-scaling suite: 77/77 passed
  - Raft failover suite: 10/10 passed
  - Result: all suites passed
