### PR TITLE
fix: fail closed unsafe clustered request surfaces

### DIFF
--- a/crates/local_backend/src/public_api.rs
+++ b/crates/local_backend/src/public_api.rs
@@ -949,6 +949,7 @@ mod tests {
     use common::{
         components::{
             CanonicalizedComponentFunctionPath,
+            ComponentId,
             ComponentPath,
         },
         http::{
@@ -968,6 +969,7 @@ mod tests {
     };
     use headers::authorization::Credentials;
     use http::{
+        Method,
         Request,
         StatusCode,
     };
@@ -1630,6 +1632,186 @@ mod tests {
             msg.contains("replicas do not own global request surfaces"),
             "{msg}"
         );
+
+        Ok(())
+    }
+
+    #[convex_macro::prod_rt_test]
+    async fn test_selective_api_rejects_admin_and_subscription_surfaces_on_non_authority_partition(
+        rt: ProdRuntime,
+    ) -> anyhow::Result<()> {
+        let backend = setup_backend_for_test(rt.clone()).await?;
+        let api: Arc<dyn ApplicationApi> = Arc::new(SelectiveQueryForwardingApi::new(
+            Arc::new(backend.st.application.clone()),
+            backend.st.application.database().clone(),
+            false,
+            Some(PartitionId(1)),
+            None,
+            None,
+            None,
+        ));
+        let host = ResolvedHostname {
+            instance_name: backend.st.instance_name.clone(),
+            destination: RequestDestination::ConvexCloud,
+        };
+        let path = CanonicalizedComponentFunctionPath {
+            component: ComponentPath::root(),
+            udf_path: super::parse_udf_path("values:intQuery")?,
+        };
+
+        let admin_query_err = api
+            .execute_admin_query(
+                &host,
+                common::RequestId::new(),
+                Identity::system(),
+                path.clone(),
+                SerializedArgs::from_args(vec![json!({})])?,
+                FunctionCaller::HttpApi(ClientVersion::unknown()),
+                ExecuteQueryTimestamp::Latest,
+                None,
+            )
+            .await
+            .expect_err("non-authority partitions must not execute admin queries locally");
+        assert!(
+            format!("{admin_query_err:#}").contains("Admin query cannot execute locally"),
+            "{admin_query_err:#}"
+        );
+
+        let admin_mutation_err = api
+            .execute_admin_mutation(
+                &host,
+                common::RequestId::new(),
+                Identity::system(),
+                path,
+                SerializedArgs::from_args(vec![json!({})])?,
+                FunctionCaller::HttpApi(ClientVersion::unknown()),
+                None,
+                None,
+            )
+            .await
+            .expect_err("non-authority partitions must not execute admin mutations locally");
+        assert!(
+            format!("{admin_mutation_err:#}").contains("Admin mutation cannot execute locally"),
+            "{admin_mutation_err:#}"
+        );
+
+        let subscription_err = match api.subscription_client(&host).await {
+            Ok(_) => {
+                panic!("non-authority partitions must not create subscription clients locally")
+            },
+            Err(e) => e,
+        };
+        assert!(
+            format!("{subscription_err:#}").contains("Subscription setup cannot execute locally"),
+            "{subscription_err:#}"
+        );
+
+        Ok(())
+    }
+
+    #[convex_macro::prod_rt_test]
+    async fn test_selective_api_rejects_file_and_timestamp_surfaces_on_replica(
+        rt: ProdRuntime,
+    ) -> anyhow::Result<()> {
+        let backend = setup_backend_for_test(rt.clone()).await?;
+        let api: Arc<dyn ApplicationApi> = Arc::new(SelectiveQueryForwardingApi::new(
+            Arc::new(backend.st.application.clone()),
+            backend.st.application.database().clone(),
+            true,
+            None,
+            None,
+            None,
+            None,
+        ));
+        let host = ResolvedHostname {
+            instance_name: backend.st.instance_name.clone(),
+            destination: RequestDestination::ConvexCloud,
+        };
+
+        let timestamp_err = api
+            .latest_timestamp(&host, common::RequestId::new())
+            .await
+            .expect_err("replicas must not allocate latest query timestamps locally");
+        assert!(
+            format!("{timestamp_err:#}").contains("Latest timestamp cannot execute locally"),
+            "{timestamp_err:#}"
+        );
+
+        let file_auth_err = api
+            .check_store_file_authorization(
+                &host,
+                common::RequestId::new(),
+                "not-a-real-token",
+                Duration::from_secs(60),
+            )
+            .await
+            .expect_err("replicas must not validate file upload tokens locally");
+        assert!(
+            format!("{file_auth_err:#}")
+                .contains("File upload authorization cannot execute locally"),
+            "{file_auth_err:#}"
+        );
+
+        let file_read_err = match api
+            .get_file(
+                &host,
+                common::RequestId::new(),
+                "http://localhost".into(),
+                ComponentId::Root,
+                model::file_storage::FileStorageId::LegacyStorageId(
+                    "00000000-0000-0000-0000-000000000000".parse()?,
+                ),
+            )
+            .await
+        {
+            Ok(_) => panic!("replicas must not read file storage through local application state"),
+            Err(e) => e,
+        };
+        assert!(
+            format!("{file_read_err:#}").contains("File read cannot execute locally"),
+            "{file_read_err:#}"
+        );
+
+        Ok(())
+    }
+
+    #[convex_macro::prod_rt_test]
+    async fn test_migrated_global_endpoints_reject_replica_mode(
+        rt: ProdRuntime,
+    ) -> anyhow::Result<()> {
+        let backend = setup_backend_for_test(rt).await?;
+        let mut replica_state = backend.st.clone();
+        replica_state.replica_mode = true;
+        let replica_app = ConvexHttpService::new(
+            router(replica_state),
+            "backend_migrated_global_authority_test",
+            SERVER_VERSION_STR.to_string(),
+            MAX_CONCURRENT_REQUESTS,
+            Duration::from_secs(125),
+            NoopRouteMapper,
+        );
+
+        for (method, uri) in [
+            (Method::POST, "/api/query_ts"),
+            (Method::POST, "/api/storage/upload?token=not-a-real-token"),
+            (Method::GET, "/http/anything"),
+        ] {
+            let req = Request::builder()
+                .uri(uri)
+                .method(method)
+                .header("Host", "localhost")
+                .body(Body::empty())?;
+            let (parts, body) = replica_app
+                .router()
+                .clone()
+                .oneshot(req)
+                .await?
+                .into_parts();
+            let bytes = body.collect().await?.to_bytes();
+            let body = String::from_utf8_lossy(&bytes);
+            assert_eq!(parts.status, StatusCode::SERVICE_UNAVAILABLE, "{body}");
+            assert!(body.contains("ServiceUnavailable"), "{body}");
+        }
 
         Ok(())
     }

--- a/crates/local_backend/src/public_api.rs
+++ b/crates/local_backend/src/public_api.rs
@@ -947,6 +947,10 @@ mod tests {
     };
     use axum::body::Body;
     use common::{
+        components::{
+            CanonicalizedComponentFunctionPath,
+            ComponentPath,
+        },
         http::{
             ConvexHttpService,
             NoopRouteMapper,
@@ -962,6 +966,7 @@ mod tests {
         raft_partition::RaftPartitionState,
         two_phase::NodeAddresses,
     };
+    use headers::authorization::Credentials;
     use http::{
         Request,
         StatusCode,
@@ -1395,6 +1400,7 @@ mod tests {
         let api: Arc<dyn ApplicationApi> = Arc::new(SelectiveQueryForwardingApi::new(
             Arc::new(selective.st.application.clone()),
             selective.st.application.database().clone(),
+            false,
             Some(PartitionId(1)),
             Some(NodeAddresses::from_config(&format!("0={grpc_addr}"))),
             None,
@@ -1467,6 +1473,7 @@ mod tests {
         let api: Arc<dyn ApplicationApi> = Arc::new(SelectiveQueryForwardingApi::new(
             Arc::new(follower.st.application.clone()),
             follower.st.application.database().clone(),
+            false,
             Some(PartitionId(0)),
             None,
             Some(RaftPartitionState::new_for_test(
@@ -1497,6 +1504,133 @@ mod tests {
         assert_eq!(value["hello"], "authority follower forwarded query");
 
         let _ = shutdown_tx.send(());
+        Ok(())
+    }
+
+    #[convex_macro::prod_rt_test]
+    async fn test_selective_api_rejects_any_function_on_non_authority_partition(
+        rt: ProdRuntime,
+    ) -> anyhow::Result<()> {
+        let backend = setup_backend_for_test(rt.clone()).await?;
+        let api: Arc<dyn ApplicationApi> = Arc::new(SelectiveQueryForwardingApi::new(
+            Arc::new(backend.st.application.clone()),
+            backend.st.application.database().clone(),
+            false,
+            Some(PartitionId(1)),
+            None,
+            None,
+            None,
+        ));
+
+        let err = api
+            .execute_any_function(
+                &ResolvedHostname {
+                    instance_name: backend.st.instance_name.clone(),
+                    destination: RequestDestination::ConvexCloud,
+                },
+                common::RequestId::new(),
+                Identity::system(),
+                CanonicalizedComponentFunctionPath {
+                    component: ComponentPath::root(),
+                    udf_path: super::parse_udf_path("values:intMutation")?,
+                },
+                SerializedArgs::from_args(vec![json!({})])?,
+                FunctionCaller::HttpApi(ClientVersion::unknown()),
+            )
+            .await
+            .expect_err("non-authority partitions must not execute any-function locally");
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("Any function execution cannot execute locally"),
+            "{msg}"
+        );
+        assert!(
+            msg.contains("partition 1 is not the cluster coordinator partition 0"),
+            "{msg}"
+        );
+
+        Ok(())
+    }
+
+    #[convex_macro::prod_rt_test]
+    async fn test_public_function_endpoint_rejects_non_authority_partition(
+        rt: ProdRuntime,
+    ) -> anyhow::Result<()> {
+        let backend = setup_backend_for_test(rt).await?;
+        let mut partitioned_state = backend.st.clone();
+        partitioned_state.partition_id = Some(PartitionId(1));
+        let partitioned_app = ConvexHttpService::new(
+            router(partitioned_state),
+            "backend_any_function_authority_test",
+            SERVER_VERSION_STR.to_string(),
+            MAX_CONCURRENT_REQUESTS,
+            Duration::from_secs(125),
+            NoopRouteMapper,
+        );
+
+        let req = Request::builder()
+            .uri("/api/function")
+            .method("POST")
+            .header("Content-Type", "application/json")
+            .header("Host", "localhost")
+            .header("Authorization", backend.admin_auth_header.0.encode())
+            .body(Body::from(serde_json::to_vec(&json!({
+                "path": "values:intMutation",
+                "args": {},
+            }))?))?;
+        let (parts, body) = partitioned_app
+            .router()
+            .clone()
+            .oneshot(req)
+            .await?
+            .into_parts();
+        let bytes = body.collect().await?.to_bytes();
+        let body = String::from_utf8_lossy(&bytes);
+        assert_eq!(parts.status, StatusCode::SERVICE_UNAVAILABLE, "{body}");
+        assert!(body.contains("ServiceUnavailable"), "{body}");
+
+        Ok(())
+    }
+
+    #[convex_macro::prod_rt_test]
+    async fn test_selective_api_rejects_public_action_on_replica(
+        rt: ProdRuntime,
+    ) -> anyhow::Result<()> {
+        let backend = setup_backend_for_test(rt.clone()).await?;
+        let api: Arc<dyn ApplicationApi> = Arc::new(SelectiveQueryForwardingApi::new(
+            Arc::new(backend.st.application.clone()),
+            backend.st.application.database().clone(),
+            true,
+            None,
+            None,
+            None,
+            None,
+        ));
+
+        let err = api
+            .execute_public_action(
+                &ResolvedHostname {
+                    instance_name: backend.st.instance_name.clone(),
+                    destination: RequestDestination::ConvexCloud,
+                },
+                common::RequestId::new(),
+                Identity::system(),
+                "values:intAction".parse()?,
+                SerializedArgs::from_args(vec![json!({})])?,
+                FunctionCaller::HttpApi(ClientVersion::unknown()),
+            )
+            .await
+            .expect_err("replicas must not execute public actions locally");
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("Public action cannot execute locally"),
+            "{msg}"
+        );
+        assert!(
+            msg.contains("replicas do not own global request surfaces"),
+            "{msg}"
+        );
+
         Ok(())
     }
 

--- a/crates/local_backend/src/query_forwarding_api.rs
+++ b/crates/local_backend/src/query_forwarding_api.rs
@@ -65,6 +65,7 @@ const RECENT_QUERY_INTEREST_TTL: Duration = Duration::from_secs(60);
 pub struct SelectiveQueryForwardingApi {
     inner: Arc<dyn application::api::ApplicationApi>,
     database: Database<ProdRuntime>,
+    replica_mode: bool,
     partition_id: Option<PartitionId>,
     node_addresses: Option<NodeAddresses>,
     raft_state: Option<RaftPartitionState>,
@@ -75,6 +76,7 @@ impl SelectiveQueryForwardingApi {
     pub fn new(
         inner: Arc<dyn application::api::ApplicationApi>,
         database: Database<ProdRuntime>,
+        replica_mode: bool,
         partition_id: Option<PartitionId>,
         node_addresses: Option<NodeAddresses>,
         raft_state: Option<RaftPartitionState>,
@@ -83,6 +85,7 @@ impl SelectiveQueryForwardingApi {
         Self {
             inner,
             database,
+            replica_mode,
             partition_id,
             node_addresses,
             raft_state,
@@ -142,6 +145,46 @@ impl SelectiveQueryForwardingApi {
         {
             tracing::debug!("Failed to record recent query interest: {e:#}");
         }
+    }
+
+    fn unsupported_cluster_surface_error(&self, surface: &str, reason: String) -> anyhow::Error {
+        anyhow::anyhow!(ErrorMetadata::service_unavailable()).context(format!(
+            "{surface} cannot execute locally on this clustered node: {reason}. Route the request \
+             to the authoritative node or add an explicit forwarding path for this surface."
+        ))
+    }
+
+    fn ensure_cluster_coordinator_authority(&self, surface: &str) -> anyhow::Result<()> {
+        if !self.replica_mode && self.partition_id.is_none() {
+            return Ok(());
+        }
+        if self.replica_mode {
+            return Err(self.unsupported_cluster_surface_error(
+                surface,
+                "replicas do not own global request surfaces".to_string(),
+            ));
+        }
+        let Some(partition_id) = self.partition_id else {
+            return Ok(());
+        };
+        if partition_id != SELECTIVE_QUERY_AUTHORITY_PARTITION {
+            return Err(self.unsupported_cluster_surface_error(
+                surface,
+                format!(
+                    "partition {} is not the cluster coordinator partition {}",
+                    partition_id.0, SELECTIVE_QUERY_AUTHORITY_PARTITION.0
+                ),
+            ));
+        }
+        if let Some(raft_state) = self.raft_state.as_ref()
+            && !raft_state.is_leader()
+        {
+            return Err(self.unsupported_cluster_surface_error(
+                surface,
+                "the coordinator partition is running as a Raft follower".to_string(),
+            ));
+        }
+        Ok(())
     }
 }
 
@@ -208,6 +251,7 @@ impl application::api::ApplicationApi for SelectiveQueryForwardingApi {
         ts: application::api::ExecuteQueryTimestamp,
         journal: Option<SerializedQueryJournal>,
     ) -> anyhow::Result<application::RedactedQueryReturn> {
+        self.ensure_cluster_coordinator_authority("Admin query")?;
         self.inner
             .execute_admin_query(host, request_id, identity, path, args, caller, ts, journal)
             .await
@@ -253,6 +297,7 @@ impl application::api::ApplicationApi for SelectiveQueryForwardingApi {
     ) -> anyhow::Result<
         Result<application::RedactedMutationReturn, application::RedactedMutationError>,
     > {
+        self.ensure_cluster_coordinator_authority("Admin mutation")?;
         self.inner
             .execute_admin_mutation(
                 host,
@@ -277,6 +322,7 @@ impl application::api::ApplicationApi for SelectiveQueryForwardingApi {
         caller: FunctionCaller,
     ) -> anyhow::Result<Result<application::RedactedActionReturn, application::RedactedActionError>>
     {
+        self.ensure_cluster_coordinator_authority("Public action")?;
         self.inner
             .execute_public_action(host, request_id, identity, path, args, caller)
             .await
@@ -292,6 +338,7 @@ impl application::api::ApplicationApi for SelectiveQueryForwardingApi {
         caller: FunctionCaller,
     ) -> anyhow::Result<Result<application::RedactedActionReturn, application::RedactedActionError>>
     {
+        self.ensure_cluster_coordinator_authority("Admin action")?;
         self.inner
             .execute_admin_action(host, request_id, identity, path, args, caller)
             .await
@@ -306,6 +353,7 @@ impl application::api::ApplicationApi for SelectiveQueryForwardingApi {
         caller: FunctionCaller,
         response_streamer: HttpActionResponseStreamer,
     ) -> anyhow::Result<()> {
+        self.ensure_cluster_coordinator_authority("HTTP action")?;
         self.inner
             .execute_http_action(
                 host,
@@ -327,6 +375,7 @@ impl application::api::ApplicationApi for SelectiveQueryForwardingApi {
         args: SerializedArgs,
         caller: FunctionCaller,
     ) -> anyhow::Result<Result<application::FunctionReturn, application::FunctionError>> {
+        self.ensure_cluster_coordinator_authority("Any function execution")?;
         self.inner
             .execute_any_function(host, request_id, identity, path, args, caller)
             .await
@@ -337,6 +386,7 @@ impl application::api::ApplicationApi for SelectiveQueryForwardingApi {
         host: &ResolvedHostname,
         request_id: RequestId,
     ) -> anyhow::Result<RepeatableTimestamp> {
+        self.ensure_cluster_coordinator_authority("Latest timestamp")?;
         self.inner.latest_timestamp(host, request_id).await
     }
 
@@ -347,6 +397,7 @@ impl application::api::ApplicationApi for SelectiveQueryForwardingApi {
         token: &str,
         validity: Duration,
     ) -> anyhow::Result<ComponentId> {
+        self.ensure_cluster_coordinator_authority("File upload authorization")?;
         self.inner
             .check_store_file_authorization(host, request_id, token, validity)
             .await
@@ -363,6 +414,7 @@ impl application::api::ApplicationApi for SelectiveQueryForwardingApi {
         expected_sha256: Option<Sha256Digest>,
         body: BoxStream<'_, anyhow::Result<Bytes>>,
     ) -> anyhow::Result<PublicDocumentId> {
+        self.ensure_cluster_coordinator_authority("File upload")?;
         self.inner
             .store_file(
                 host,
@@ -386,6 +438,7 @@ impl application::api::ApplicationApi for SelectiveQueryForwardingApi {
         file_storage_id: FileStorageId,
         range: (Bound<u64>, Bound<u64>),
     ) -> anyhow::Result<FileStream> {
+        self.ensure_cluster_coordinator_authority("File range read")?;
         self.inner
             .get_file_range(host, request_id, origin, component, file_storage_id, range)
             .await
@@ -399,6 +452,7 @@ impl application::api::ApplicationApi for SelectiveQueryForwardingApi {
         component: ComponentId,
         file_storage_id: FileStorageId,
     ) -> anyhow::Result<FileStream> {
+        self.ensure_cluster_coordinator_authority("File read")?;
         self.inner
             .get_file(host, request_id, origin, component, file_storage_id)
             .await
@@ -408,6 +462,7 @@ impl application::api::ApplicationApi for SelectiveQueryForwardingApi {
         &self,
         host: &ResolvedHostname,
     ) -> anyhow::Result<Box<dyn SubscriptionClient>> {
+        self.ensure_cluster_coordinator_authority("Subscription setup")?;
         self.inner.subscription_client(host).await
     }
 

--- a/crates/local_backend/src/router.rs
+++ b/crates/local_backend/src/router.rs
@@ -9,7 +9,9 @@ use axum::{
     extract::{
         DefaultBodyLimit,
         FromRef,
+        State,
     },
+    response::IntoResponse,
     routing::{
         delete,
         get,
@@ -25,6 +27,7 @@ use common::{
             FromMtState,
             MtState,
         },
+        HttpResponseError,
     },
     knobs::{
         AIRBYTE_STREAMING_IMPORT_REQUEST_SIZE_LIMIT,
@@ -33,6 +36,8 @@ use common::{
         MAX_PUSH_BYTES,
     },
 };
+use database::partition::PartitionId;
+use errors::ErrorMetadata;
 use http::{
     Method,
     StatusCode,
@@ -167,6 +172,84 @@ use crate::{
     LocalAppState,
     RouterState,
 };
+
+const CLUSTER_COORDINATOR_PARTITION: PartitionId = PartitionId(0);
+
+fn legacy_api_route_is_any_node_safe(path: &str) -> bool {
+    matches!(
+        path,
+        "/api/dashboard_openapi.json"
+            | "/dashboard_openapi.json"
+            | "/api/v1/openapi.json"
+            | "/v1/openapi.json"
+            | "/api/get_config"
+            | "/get_config"
+            | "/api/get_config_hashes"
+            | "/get_config_hashes"
+    )
+}
+
+fn legacy_api_route_has_explicit_forwarding(path: &str) -> bool {
+    path.starts_with("/api/deploy2/") || path.starts_with("/deploy2/")
+}
+
+fn unsupported_legacy_cluster_surface_error(surface: &str, reason: String) -> anyhow::Error {
+    anyhow::anyhow!(ErrorMetadata::service_unavailable()).context(format!(
+        "Legacy API route {surface} cannot execute locally on this clustered node: {reason}. \
+         Route the request to the authoritative node or add an explicit forwarding path for this \
+         surface."
+    ))
+}
+
+fn ensure_legacy_cluster_coordinator_authority(
+    st: &LocalAppState,
+    surface: &str,
+) -> anyhow::Result<()> {
+    if legacy_api_route_is_any_node_safe(surface)
+        || legacy_api_route_has_explicit_forwarding(surface)
+    {
+        return Ok(());
+    }
+    if !st.replica_mode && st.partition_id.is_none() {
+        return Ok(());
+    }
+    if st.replica_mode {
+        return Err(unsupported_legacy_cluster_surface_error(
+            surface,
+            "replicas do not own global legacy request surfaces".to_string(),
+        ));
+    }
+    let Some(partition_id) = st.partition_id else {
+        return Ok(());
+    };
+    if partition_id != CLUSTER_COORDINATOR_PARTITION {
+        return Err(unsupported_legacy_cluster_surface_error(
+            surface,
+            format!(
+                "partition {} is not the cluster coordinator partition {}",
+                partition_id.0, CLUSTER_COORDINATOR_PARTITION.0
+            ),
+        ));
+    }
+    if let Some(raft_state) = st.raft_state.as_ref()
+        && !raft_state.is_leader()
+    {
+        return Err(unsupported_legacy_cluster_surface_error(
+            surface,
+            "the coordinator partition is running as a Raft follower".to_string(),
+        ));
+    }
+    Ok(())
+}
+
+async fn legacy_cluster_authority_middleware(
+    State(st): State<LocalAppState>,
+    req: axum::extract::Request,
+    next: axum::middleware::Next,
+) -> Result<impl IntoResponse, HttpResponseError> {
+    ensure_legacy_cluster_coordinator_authority(&st, req.uri().path())?;
+    Ok(next.run(req).await)
+}
 
 // Security addon for documenting authentication methods
 #[derive(Debug)]
@@ -375,7 +458,11 @@ pub fn router(st: LocalAppState) -> Router {
         .nest("/export", snapshot_export_routes)
         .nest("/logs", log_sink_routes())
         .nest("/streaming_import", streaming_import_routes())
-        .nest("/v1", platform_routes);
+        .nest("/v1", platform_routes)
+        .layer(axum::middleware::from_fn_with_state(
+            st.clone(),
+            legacy_cluster_authority_middleware,
+        ));
 
     // Endpoints migrated to use the RouterState trait instead of application.
     let (public_routes, public_openapi) = OpenApiRouter::with_openapi(PublicApiDoc::openapi())
@@ -646,15 +733,34 @@ pub fn cors() -> CorsLayer {
 
 #[cfg(test)]
 mod tests {
-    use std::fs;
+    use std::{
+        fs,
+        time::Duration,
+    };
 
     use anyhow::Context;
     use axum::body::Body;
     use axum_extra::headers::authorization::Credentials;
-    use http::Request;
+    use common::http::{
+        ConvexHttpService,
+        NoopRouteMapper,
+    };
+    use database::partition::PartitionId;
+    use http::{
+        Request,
+        StatusCode,
+    };
+    use http_body_util::BodyExt;
+    use metrics::SERVER_VERSION_STR;
     use runtime::prod::ProdRuntime;
+    use serde_json::json;
+    use tower::ServiceExt;
 
-    use crate::test_helpers::setup_backend_for_test;
+    use crate::{
+        router::router,
+        test_helpers::setup_backend_for_test,
+        MAX_CONCURRENT_REQUESTS,
+    };
 
     const DASHBOARD_SPEC_FILE: &str =
         "../../npm-packages/dashboard/dashboard-deployment-openapi.json";
@@ -718,6 +824,87 @@ mod tests {
                  test_api_specs_match`"
             );
         }
+        Ok(())
+    }
+
+    #[convex_macro::prod_rt_test]
+    async fn test_legacy_api_rejects_non_authority_partition(
+        rt: ProdRuntime,
+    ) -> anyhow::Result<()> {
+        let backend = setup_backend_for_test(rt).await?;
+        let mut partitioned_state = backend.st.clone();
+        partitioned_state.partition_id = Some(PartitionId(1));
+        let partitioned_app = ConvexHttpService::new(
+            router(partitioned_state),
+            "legacy_authority_test",
+            SERVER_VERSION_STR.to_string(),
+            MAX_CONCURRENT_REQUESTS,
+            Duration::from_secs(125),
+            NoopRouteMapper,
+        );
+
+        let req = Request::builder()
+            .uri("/api/push_config")
+            .method("POST")
+            .header("Host", "localhost")
+            .header("Content-Type", "application/json")
+            .body(Body::from("{}"))?;
+        let (parts, body) = partitioned_app
+            .router()
+            .clone()
+            .oneshot(req)
+            .await?
+            .into_parts();
+        let bytes = body.collect().await?.to_bytes();
+        let body = String::from_utf8_lossy(&bytes);
+        assert_eq!(parts.status, StatusCode::SERVICE_UNAVAILABLE, "{body}");
+        assert!(body.contains("ServiceUnavailable"), "{body}");
+
+        Ok(())
+    }
+
+    #[convex_macro::prod_rt_test]
+    async fn test_deploy2_routes_bypass_legacy_authority_middleware(
+        rt: ProdRuntime,
+    ) -> anyhow::Result<()> {
+        let backend = setup_backend_for_test(rt).await?;
+        let admin_header = backend.admin_auth_header.0.encode();
+        let admin_key = admin_header
+            .to_str()?
+            .strip_prefix("Convex ")
+            .context("admin auth header must use the Convex scheme")?
+            .to_string();
+
+        let mut partitioned_state = backend.st.clone();
+        partitioned_state.partition_id = Some(PartitionId(1));
+        let partitioned_app = ConvexHttpService::new(
+            router(partitioned_state),
+            "deploy2_authority_exemption_test",
+            SERVER_VERSION_STR.to_string(),
+            MAX_CONCURRENT_REQUESTS,
+            Duration::from_secs(125),
+            NoopRouteMapper,
+        );
+
+        let req = Request::builder()
+            .uri("/api/deploy2/report_push_completed")
+            .method("POST")
+            .header("Host", "localhost")
+            .header("Content-Type", "application/json")
+            .body(Body::from(serde_json::to_vec(&json!({
+                "adminKey": admin_key,
+                "spans": [],
+            }))?))?;
+        let (parts, body) = partitioned_app
+            .router()
+            .clone()
+            .oneshot(req)
+            .await?
+            .into_parts();
+        let bytes = body.collect().await?.to_bytes();
+        let body = String::from_utf8_lossy(&bytes);
+        assert_eq!(parts.status, StatusCode::OK, "{body}");
+
         Ok(())
     }
 }

--- a/crates/local_backend/src/router.rs
+++ b/crates/local_backend/src/router.rs
@@ -406,6 +406,7 @@ pub fn router(st: LocalAppState) -> Router {
             api: Arc::new(crate::query_forwarding_api::SelectiveQueryForwardingApi::new(
                 Arc::new(st.application.clone()),
                 st.application.database().clone(),
+                st.replica_mode,
                 st.partition_id,
                 st.node_addresses.clone(),
                 st.raft_state.clone(),

--- a/docs/cluster-authority-routing.md
+++ b/docs/cluster-authority-routing.md
@@ -1,0 +1,51 @@
+# Cluster Authority Routing
+
+This document records the request-authority rules for the horizontally scaled
+local backend. The goal is to make every externally reachable route explicit:
+serve locally only when it is safe, forward when an owner path exists, and fail
+closed otherwise.
+
+## Authority Classes
+
+| Class | Meaning | Current handling |
+| --- | --- | --- |
+| Any-node safe | The route is static, health-only, or purely local observability. | Serve locally. |
+| Partition owner | The route writes user data owned by one table partition. | Public mutations use the existing partition enforcement and mutation forwarding path. |
+| Coordinator owner | The route touches deployment-global metadata or APIs without partition-specific ownership. | Serve only on partition 0 / Raft leader; replicas and non-owner partitions reject with `ServiceUnavailable`. |
+| Explicit forwarding | The route has a purpose-built owner forwarding path. | The local handler may run on any node because it forwards first. |
+| Not yet safe | The route can mutate/read authoritative state but has no routing protocol. | Reject on non-authority nodes until forwarding is added. |
+
+## Migrated `RouterState` Routes
+
+These routes use `SelectiveQueryForwardingApi`, which centralizes clustered
+authority checks.
+
+| Route surface | Authority rule |
+| --- | --- |
+| `/api/query`, `/api/query_at_ts` | Public latest queries route to the selective query authority when necessary. Timestamped queries execute through the same API path after the timestamp is chosen. |
+| `/api/mutation` | Public mutations preserve the existing replica/Raft forwarding and partition enforcement path. Non-owner writes are rejected by the write path, not by a generic coordinator guard. |
+| `/api/action`, `/http/*` | Coordinator owner until action execution has explicit clustered routing. |
+| `/api/function`, `/api/run/*` | Coordinator owner because the function type is not known before dispatch. |
+| `/api/query_ts`, `/api/query_batch` timestamp selection | Coordinator owner because latest timestamp selection must not be made from a stale follower/replica. |
+| `/api/storage/*` | Coordinator owner until file metadata and storage authorization have explicit clustered routing. |
+| `/api/sync`, `/{client_version}/sync` | Coordinator owner for subscription setup until follower-safe subscription ownership is implemented. |
+
+## Legacy `LocalAppState` Routes
+
+Legacy `/api` routes bypass `ApplicationApi`, so they are protected by the
+legacy authority middleware in `router.rs`.
+
+| Route surface | Authority rule |
+| --- | --- |
+| `/api/deploy2/*` | Explicit forwarding. Deploy metadata handlers forward to partition 0 and then to the Raft leader where needed. `report_push_completed` is local observability. |
+| `/api/dashboard_openapi.json`, `/api/v1/openapi.json` | Any-node safe static schemas. |
+| `/api/get_config`, `/api/get_config_hashes` | Any-node safe deploy introspection. The current CLI reads target-node module/config hashes before the modern `deploy2` push so each node can materialize its local module view. |
+| Dashboard, platform, import/export, streaming import/export, log sinks, internal action callbacks, and mutating legacy CLI routes such as `/api/push_config` | Coordinator owner unless a narrower forwarding path is added. |
+
+## Adding A Route
+
+Every new local-backend route must choose one authority class before it is
+exposed in a clustered build. If the route touches deployment metadata, file
+metadata, subscriptions, function execution, imports, exports, or log sinks, do
+not default to local execution on followers or non-owner partitions. Add an
+explicit forwarding path or let the route fail closed on non-authority nodes.


### PR DESCRIPTION
## Summary
- Add cluster authority guards to `SelectiveQueryForwardingApi` for global or unsafe migrated request surfaces that do not have explicit clustered forwarding yet.
- Add legacy `/api` authority middleware for old `LocalAppState` routes, while preserving any-node static schema/config introspection and `deploy2` forwarding/materialization paths.
- Document the clustered request-authority matrix in `docs/cluster-authority-routing.md`.
- Add focused direct and HTTP-route tests for any-function, admin query/mutation, action, timestamp, storage, subscription, legacy route rejection, and the deploy2 exemption.

## Validation
- `cargo fmt -p local_backend`
- `git diff --check`
- `cargo test -p local_backend test_selective_api_rejects -- --nocapture`
- `cargo test -p local_backend test_migrated_global_endpoints_reject_replica_mode -- --nocapture`
- `cargo test -p local_backend test_legacy_api_rejects_non_authority_partition -- --nocapture`
- `cargo test -p local_backend test_deploy2_routes_bypass_legacy_authority_middleware -- --nocapture`
- `cargo test -p local_backend --lib -- --nocapture` passed `79/79`
- Manual Node B deploy canary with `npx convex deploy --admin-key ... --url http://127.0.0.1:3310` passed
- `docker build --progress=plain -t ghcr.io/martinkalema/convex-horizontal-scaling:backend-latest -f self-hosted/docker-build/Dockerfile.backend .`
- `bash self-hosted/docker/test.sh` passed `77/77` write-scaling tests and `10/10` Raft failover tests (`ALL SUITES PASSED`)

Refs #105
