### PR TITLE
refactor: add route authority registry

### DIFF
--- a/crates/local_backend/src/lib.rs
+++ b/crates/local_backend/src/lib.rs
@@ -107,6 +107,7 @@ pub mod parse;
 pub mod proxy;
 pub mod public_api;
 pub mod query_forwarding_api;
+pub mod route_authority;
 pub mod router;
 pub mod scheduling;
 pub mod schema;

--- a/crates/local_backend/src/route_authority.rs
+++ b/crates/local_backend/src/route_authority.rs
@@ -1,0 +1,486 @@
+use database::partition::PartitionId;
+use errors::ErrorMetadata;
+
+use crate::LocalAppState;
+
+pub(crate) const CLUSTER_COORDINATOR_PARTITION: PartitionId = PartitionId(0);
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum RouteAuthorityClass {
+    AnyNodeSafe,
+    PartitionOwner,
+    PartitionLeader,
+    CoordinatorOwner,
+    FollowerSafeRead,
+    ExplicitForwarding,
+    ExternalSideEffectOwner,
+    FailClosed,
+}
+
+impl RouteAuthorityClass {
+    fn label(self) -> &'static str {
+        match self {
+            Self::AnyNodeSafe => "any-node safe",
+            Self::PartitionOwner => "partition owner",
+            Self::PartitionLeader => "partition leader",
+            Self::CoordinatorOwner => "coordinator owner",
+            Self::FollowerSafeRead => "follower-safe read",
+            Self::ExplicitForwarding => "explicit forwarding",
+            Self::ExternalSideEffectOwner => "external side-effect owner",
+            Self::FailClosed => "fail closed",
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum RouteMatcher {
+    Exact(&'static str),
+    Prefix(&'static str),
+}
+
+impl RouteMatcher {
+    fn matches(self, path: &str) -> bool {
+        match self {
+            Self::Exact(expected) => path == expected,
+            Self::Prefix(prefix) => path.starts_with(prefix),
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) struct RouteAuthorityRule {
+    pub(crate) surface: &'static str,
+    matcher: RouteMatcher,
+    pub(crate) class: RouteAuthorityClass,
+    pub(crate) rationale: &'static str,
+}
+
+impl RouteAuthorityRule {
+    const fn exact(
+        surface: &'static str,
+        path: &'static str,
+        class: RouteAuthorityClass,
+        rationale: &'static str,
+    ) -> Self {
+        Self {
+            surface,
+            matcher: RouteMatcher::Exact(path),
+            class,
+            rationale,
+        }
+    }
+
+    const fn prefix(
+        surface: &'static str,
+        prefix: &'static str,
+        class: RouteAuthorityClass,
+        rationale: &'static str,
+    ) -> Self {
+        Self {
+            surface,
+            matcher: RouteMatcher::Prefix(prefix),
+            class,
+            rationale,
+        }
+    }
+}
+
+const ANY_NODE_STATIC_SCHEMA: &str = "static schema or deploy-introspection route";
+const EXPLICIT_DEPLOY_FORWARDING: &str =
+    "deploy2 handlers forward to the metadata owner and Raft leader before mutating state";
+const COORDINATOR_GLOBAL_STATE: &str =
+    "unmigrated route touches deployment-global state and must run on partition 0 / Raft leader";
+
+pub(crate) const UNMIGRATED_LOCAL_APP_STATE_API_ROUTE_AUTHORITIES: &[RouteAuthorityRule] = &[
+    RouteAuthorityRule::exact(
+        "dashboard OpenAPI schema",
+        "/dashboard_openapi.json",
+        RouteAuthorityClass::AnyNodeSafe,
+        ANY_NODE_STATIC_SCHEMA,
+    ),
+    RouteAuthorityRule::exact(
+        "platform OpenAPI schema",
+        "/v1/openapi.json",
+        RouteAuthorityClass::AnyNodeSafe,
+        ANY_NODE_STATIC_SCHEMA,
+    ),
+    RouteAuthorityRule::exact(
+        "deploy config read",
+        "/get_config",
+        RouteAuthorityClass::AnyNodeSafe,
+        "CLI reads the target node before deploy2 push so each node can materialize local modules",
+    ),
+    RouteAuthorityRule::exact(
+        "deploy config hash read",
+        "/get_config_hashes",
+        RouteAuthorityClass::AnyNodeSafe,
+        "CLI reads the target node before deploy2 push so each node can materialize local modules",
+    ),
+    RouteAuthorityRule::prefix(
+        "deploy2 metadata operation",
+        "/deploy2/",
+        RouteAuthorityClass::ExplicitForwarding,
+        EXPLICIT_DEPLOY_FORWARDING,
+    ),
+    RouteAuthorityRule::prefix(
+        "internal action callback",
+        "/actions/",
+        RouteAuthorityClass::CoordinatorOwner,
+        COORDINATOR_GLOBAL_STATE,
+    ),
+    RouteAuthorityRule::prefix(
+        "snapshot export",
+        "/export/",
+        RouteAuthorityClass::CoordinatorOwner,
+        COORDINATOR_GLOBAL_STATE,
+    ),
+    RouteAuthorityRule::prefix(
+        "log sink route",
+        "/logs/",
+        RouteAuthorityClass::CoordinatorOwner,
+        COORDINATOR_GLOBAL_STATE,
+    ),
+    RouteAuthorityRule::prefix(
+        "streaming import",
+        "/streaming_import/",
+        RouteAuthorityClass::CoordinatorOwner,
+        COORDINATOR_GLOBAL_STATE,
+    ),
+    RouteAuthorityRule::prefix(
+        "dashboard app metrics",
+        "/app_metrics/",
+        RouteAuthorityClass::CoordinatorOwner,
+        COORDINATOR_GLOBAL_STATE,
+    ),
+    RouteAuthorityRule::prefix(
+        "platform API",
+        "/v1/",
+        RouteAuthorityClass::CoordinatorOwner,
+        COORDINATOR_GLOBAL_STATE,
+    ),
+    RouteAuthorityRule::exact(
+        "unmigrated deploy config push",
+        "/push_config",
+        RouteAuthorityClass::CoordinatorOwner,
+        COORDINATOR_GLOBAL_STATE,
+    ),
+    RouteAuthorityRule::exact(
+        "schema prepare",
+        "/prepare_schema",
+        RouteAuthorityClass::CoordinatorOwner,
+        COORDINATOR_GLOBAL_STATE,
+    ),
+    RouteAuthorityRule::exact(
+        "dashboard test function runner",
+        "/run_test_function",
+        RouteAuthorityClass::CoordinatorOwner,
+        COORDINATOR_GLOBAL_STATE,
+    ),
+    RouteAuthorityRule::prefix(
+        "schema state read",
+        "/schema_state/",
+        RouteAuthorityClass::CoordinatorOwner,
+        COORDINATOR_GLOBAL_STATE,
+    ),
+    RouteAuthorityRule::exact(
+        "UDF execution stream",
+        "/stream_udf_execution",
+        RouteAuthorityClass::CoordinatorOwner,
+        COORDINATOR_GLOBAL_STATE,
+    ),
+    RouteAuthorityRule::exact(
+        "function log stream",
+        "/stream_function_logs",
+        RouteAuthorityClass::CoordinatorOwner,
+        COORDINATOR_GLOBAL_STATE,
+    ),
+    RouteAuthorityRule::exact(
+        "dashboard check admin key",
+        "/check_admin_key",
+        RouteAuthorityClass::CoordinatorOwner,
+        COORDINATOR_GLOBAL_STATE,
+    ),
+    RouteAuthorityRule::exact(
+        "dashboard shapes",
+        "/shapes2",
+        RouteAuthorityClass::CoordinatorOwner,
+        COORDINATOR_GLOBAL_STATE,
+    ),
+    RouteAuthorityRule::exact(
+        "dashboard indexes",
+        "/get_indexes",
+        RouteAuthorityClass::CoordinatorOwner,
+        COORDINATOR_GLOBAL_STATE,
+    ),
+    RouteAuthorityRule::exact(
+        "dashboard delete tables",
+        "/delete_tables",
+        RouteAuthorityClass::CoordinatorOwner,
+        COORDINATOR_GLOBAL_STATE,
+    ),
+    RouteAuthorityRule::exact(
+        "dashboard delete component",
+        "/delete_component",
+        RouteAuthorityClass::CoordinatorOwner,
+        COORDINATOR_GLOBAL_STATE,
+    ),
+    RouteAuthorityRule::exact(
+        "dashboard source code",
+        "/get_source_code",
+        RouteAuthorityClass::CoordinatorOwner,
+        COORDINATOR_GLOBAL_STATE,
+    ),
+    RouteAuthorityRule::exact(
+        "scheduled function table delete",
+        "/delete_scheduled_functions_table",
+        RouteAuthorityClass::CoordinatorOwner,
+        COORDINATOR_GLOBAL_STATE,
+    ),
+    RouteAuthorityRule::exact(
+        "environment variable update",
+        "/update_environment_variables",
+        RouteAuthorityClass::CoordinatorOwner,
+        COORDINATOR_GLOBAL_STATE,
+    ),
+    RouteAuthorityRule::exact(
+        "environment variable list",
+        "/list_environment_variables",
+        RouteAuthorityClass::CoordinatorOwner,
+        COORDINATOR_GLOBAL_STATE,
+    ),
+    RouteAuthorityRule::exact(
+        "canonical URL update",
+        "/update_canonical_url",
+        RouteAuthorityClass::CoordinatorOwner,
+        COORDINATOR_GLOBAL_STATE,
+    ),
+    RouteAuthorityRule::exact(
+        "cancel all scheduled jobs",
+        "/cancel_all_jobs",
+        RouteAuthorityClass::CoordinatorOwner,
+        COORDINATOR_GLOBAL_STATE,
+    ),
+    RouteAuthorityRule::exact(
+        "cancel scheduled job",
+        "/cancel_job",
+        RouteAuthorityClass::CoordinatorOwner,
+        COORDINATOR_GLOBAL_STATE,
+    ),
+    RouteAuthorityRule::exact(
+        "snapshot import",
+        "/import",
+        RouteAuthorityClass::CoordinatorOwner,
+        COORDINATOR_GLOBAL_STATE,
+    ),
+    RouteAuthorityRule::prefix(
+        "snapshot import upload",
+        "/import/",
+        RouteAuthorityClass::CoordinatorOwner,
+        COORDINATOR_GLOBAL_STATE,
+    ),
+    RouteAuthorityRule::exact(
+        "perform snapshot import",
+        "/perform_import",
+        RouteAuthorityClass::CoordinatorOwner,
+        COORDINATOR_GLOBAL_STATE,
+    ),
+    RouteAuthorityRule::exact(
+        "cancel snapshot import",
+        "/cancel_import",
+        RouteAuthorityClass::CoordinatorOwner,
+        COORDINATOR_GLOBAL_STATE,
+    ),
+    RouteAuthorityRule::exact(
+        "streaming export document deltas",
+        "/document_deltas",
+        RouteAuthorityClass::CoordinatorOwner,
+        COORDINATOR_GLOBAL_STATE,
+    ),
+    RouteAuthorityRule::exact(
+        "streaming export snapshot list",
+        "/list_snapshot",
+        RouteAuthorityClass::CoordinatorOwner,
+        COORDINATOR_GLOBAL_STATE,
+    ),
+    RouteAuthorityRule::exact(
+        "streaming export JSON schemas",
+        "/json_schemas",
+        RouteAuthorityClass::CoordinatorOwner,
+        COORDINATOR_GLOBAL_STATE,
+    ),
+    RouteAuthorityRule::exact(
+        "streaming export connection test",
+        "/test_streaming_export_connection",
+        RouteAuthorityClass::CoordinatorOwner,
+        COORDINATOR_GLOBAL_STATE,
+    ),
+    RouteAuthorityRule::exact(
+        "streaming export tables and columns",
+        "/get_tables_and_columns",
+        RouteAuthorityClass::CoordinatorOwner,
+        COORDINATOR_GLOBAL_STATE,
+    ),
+    RouteAuthorityRule::exact(
+        "streaming export table column names",
+        "/get_table_column_names",
+        RouteAuthorityClass::CoordinatorOwner,
+        COORDINATOR_GLOBAL_STATE,
+    ),
+];
+
+pub(crate) fn normalize_unmigrated_api_path(path: &str) -> &str {
+    path.strip_prefix("/api")
+        .filter(|stripped| stripped.starts_with('/'))
+        .unwrap_or(path)
+}
+
+pub(crate) fn classify_unmigrated_local_app_state_api_route(
+    path: &str,
+) -> Option<&'static RouteAuthorityRule> {
+    let normalized_path = normalize_unmigrated_api_path(path);
+    UNMIGRATED_LOCAL_APP_STATE_API_ROUTE_AUTHORITIES
+        .iter()
+        .find(|rule| rule.matcher.matches(normalized_path))
+}
+
+fn unsupported_unmigrated_cluster_surface_error(
+    surface: &str,
+    class: RouteAuthorityClass,
+    reason: String,
+) -> anyhow::Error {
+    anyhow::anyhow!(ErrorMetadata::service_unavailable()).context(format!(
+        "Unmigrated LocalAppState API route {surface} ({}) cannot execute locally on this \
+         clustered node: {reason}. Route the request to the authoritative node, add an explicit \
+         forwarding path, or migrate the route to RouterState.",
+        class.label()
+    ))
+}
+
+fn ensure_cluster_coordinator_authority(
+    st: &LocalAppState,
+    surface: &str,
+    class: RouteAuthorityClass,
+) -> anyhow::Result<()> {
+    if !st.replica_mode && st.partition_id.is_none() {
+        return Ok(());
+    }
+    if st.replica_mode {
+        return Err(unsupported_unmigrated_cluster_surface_error(
+            surface,
+            class,
+            "replicas do not own deployment-global request surfaces".to_string(),
+        ));
+    }
+    let Some(partition_id) = st.partition_id else {
+        return Ok(());
+    };
+    if partition_id != CLUSTER_COORDINATOR_PARTITION {
+        return Err(unsupported_unmigrated_cluster_surface_error(
+            surface,
+            class,
+            format!(
+                "partition {} is not the cluster coordinator partition {}",
+                partition_id.0, CLUSTER_COORDINATOR_PARTITION.0
+            ),
+        ));
+    }
+    if let Some(raft_state) = st.raft_state.as_ref()
+        && !raft_state.is_leader()
+    {
+        return Err(unsupported_unmigrated_cluster_surface_error(
+            surface,
+            class,
+            "the coordinator partition is running as a Raft follower".to_string(),
+        ));
+    }
+    Ok(())
+}
+
+pub(crate) fn ensure_unmigrated_local_app_state_api_authority(
+    st: &LocalAppState,
+    path: &str,
+) -> anyhow::Result<()> {
+    let (surface, class) = if let Some(rule) = classify_unmigrated_local_app_state_api_route(path) {
+        (rule.surface, rule.class)
+    } else {
+        (path, RouteAuthorityClass::FailClosed)
+    };
+    match class {
+        RouteAuthorityClass::AnyNodeSafe | RouteAuthorityClass::ExplicitForwarding => Ok(()),
+        RouteAuthorityClass::CoordinatorOwner => {
+            ensure_cluster_coordinator_authority(st, surface, class)
+        },
+        RouteAuthorityClass::PartitionOwner
+        | RouteAuthorityClass::PartitionLeader
+        | RouteAuthorityClass::FollowerSafeRead
+        | RouteAuthorityClass::ExternalSideEffectOwner
+        | RouteAuthorityClass::FailClosed => Err(unsupported_unmigrated_cluster_surface_error(
+            surface,
+            class,
+            format!("the {class:?} authority class has no local execution strategy yet"),
+        )),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        classify_unmigrated_local_app_state_api_route,
+        normalize_unmigrated_api_path,
+        RouteAuthorityClass,
+        UNMIGRATED_LOCAL_APP_STATE_API_ROUTE_AUTHORITIES,
+    };
+
+    fn class_for(path: &str) -> Option<RouteAuthorityClass> {
+        classify_unmigrated_local_app_state_api_route(path).map(|rule| rule.class)
+    }
+
+    #[test]
+    fn test_normalizes_nested_api_prefix() {
+        assert_eq!(
+            normalize_unmigrated_api_path("/api/push_config"),
+            "/push_config"
+        );
+        assert_eq!(
+            normalize_unmigrated_api_path("/push_config"),
+            "/push_config"
+        );
+        assert_eq!(normalize_unmigrated_api_path("/apiary"), "/apiary");
+    }
+
+    #[test]
+    fn test_unmigrated_api_route_authority_registry_classifies_core_surfaces() {
+        assert_eq!(
+            class_for("/api/get_config_hashes"),
+            Some(RouteAuthorityClass::AnyNodeSafe)
+        );
+        assert_eq!(
+            class_for("/api/deploy2/start_push"),
+            Some(RouteAuthorityClass::ExplicitForwarding)
+        );
+        assert_eq!(
+            class_for("/api/push_config"),
+            Some(RouteAuthorityClass::CoordinatorOwner)
+        );
+        assert_eq!(
+            class_for("/api/actions/mutation"),
+            Some(RouteAuthorityClass::CoordinatorOwner)
+        );
+        assert_eq!(
+            class_for("/api/streaming_import/replace_tables"),
+            Some(RouteAuthorityClass::CoordinatorOwner)
+        );
+        assert_eq!(
+            class_for("/api/logs/datadog_sink"),
+            Some(RouteAuthorityClass::CoordinatorOwner)
+        );
+        assert_eq!(class_for("/api/unregistered_route"), None);
+    }
+
+    #[test]
+    fn test_unmigrated_api_route_authority_rules_are_documented() {
+        assert!(UNMIGRATED_LOCAL_APP_STATE_API_ROUTE_AUTHORITIES
+            .iter()
+            .all(|rule| !rule.surface.is_empty() && !rule.rationale.is_empty()));
+    }
+}

--- a/crates/local_backend/src/router.rs
+++ b/crates/local_backend/src/router.rs
@@ -36,8 +36,6 @@ use common::{
         MAX_PUSH_BYTES,
     },
 };
-use database::partition::PartitionId;
-use errors::ErrorMetadata;
 use http::{
     Method,
     StatusCode,
@@ -121,6 +119,7 @@ use crate::{
         vector_search,
     },
     public_api::public_api_router,
+    route_authority::ensure_unmigrated_local_app_state_api_authority,
     scheduling::{
         cancel_all_jobs,
         cancel_job,
@@ -173,81 +172,12 @@ use crate::{
     RouterState,
 };
 
-const CLUSTER_COORDINATOR_PARTITION: PartitionId = PartitionId(0);
-
-fn legacy_api_route_is_any_node_safe(path: &str) -> bool {
-    matches!(
-        path,
-        "/api/dashboard_openapi.json"
-            | "/dashboard_openapi.json"
-            | "/api/v1/openapi.json"
-            | "/v1/openapi.json"
-            | "/api/get_config"
-            | "/get_config"
-            | "/api/get_config_hashes"
-            | "/get_config_hashes"
-    )
-}
-
-fn legacy_api_route_has_explicit_forwarding(path: &str) -> bool {
-    path.starts_with("/api/deploy2/") || path.starts_with("/deploy2/")
-}
-
-fn unsupported_legacy_cluster_surface_error(surface: &str, reason: String) -> anyhow::Error {
-    anyhow::anyhow!(ErrorMetadata::service_unavailable()).context(format!(
-        "Legacy API route {surface} cannot execute locally on this clustered node: {reason}. \
-         Route the request to the authoritative node or add an explicit forwarding path for this \
-         surface."
-    ))
-}
-
-fn ensure_legacy_cluster_coordinator_authority(
-    st: &LocalAppState,
-    surface: &str,
-) -> anyhow::Result<()> {
-    if legacy_api_route_is_any_node_safe(surface)
-        || legacy_api_route_has_explicit_forwarding(surface)
-    {
-        return Ok(());
-    }
-    if !st.replica_mode && st.partition_id.is_none() {
-        return Ok(());
-    }
-    if st.replica_mode {
-        return Err(unsupported_legacy_cluster_surface_error(
-            surface,
-            "replicas do not own global legacy request surfaces".to_string(),
-        ));
-    }
-    let Some(partition_id) = st.partition_id else {
-        return Ok(());
-    };
-    if partition_id != CLUSTER_COORDINATOR_PARTITION {
-        return Err(unsupported_legacy_cluster_surface_error(
-            surface,
-            format!(
-                "partition {} is not the cluster coordinator partition {}",
-                partition_id.0, CLUSTER_COORDINATOR_PARTITION.0
-            ),
-        ));
-    }
-    if let Some(raft_state) = st.raft_state.as_ref()
-        && !raft_state.is_leader()
-    {
-        return Err(unsupported_legacy_cluster_surface_error(
-            surface,
-            "the coordinator partition is running as a Raft follower".to_string(),
-        ));
-    }
-    Ok(())
-}
-
-async fn legacy_cluster_authority_middleware(
+async fn unmigrated_local_app_state_api_authority_middleware(
     State(st): State<LocalAppState>,
     req: axum::extract::Request,
     next: axum::middleware::Next,
 ) -> Result<impl IntoResponse, HttpResponseError> {
-    ensure_legacy_cluster_coordinator_authority(&st, req.uri().path())?;
+    ensure_unmigrated_local_app_state_api_authority(&st, req.uri().path())?;
     Ok(next.run(req).await)
 }
 
@@ -461,7 +391,7 @@ pub fn router(st: LocalAppState) -> Router {
         .nest("/v1", platform_routes)
         .layer(axum::middleware::from_fn_with_state(
             st.clone(),
-            legacy_cluster_authority_middleware,
+            unmigrated_local_app_state_api_authority_middleware,
         ));
 
     // Endpoints migrated to use the RouterState trait instead of application.
@@ -828,7 +758,7 @@ mod tests {
     }
 
     #[convex_macro::prod_rt_test]
-    async fn test_legacy_api_rejects_non_authority_partition(
+    async fn test_unmigrated_api_rejects_non_authority_partition(
         rt: ProdRuntime,
     ) -> anyhow::Result<()> {
         let backend = setup_backend_for_test(rt).await?;
@@ -836,7 +766,7 @@ mod tests {
         partitioned_state.partition_id = Some(PartitionId(1));
         let partitioned_app = ConvexHttpService::new(
             router(partitioned_state),
-            "legacy_authority_test",
+            "unmigrated_authority_test",
             SERVER_VERSION_STR.to_string(),
             MAX_CONCURRENT_REQUESTS,
             Duration::from_secs(125),
@@ -864,7 +794,7 @@ mod tests {
     }
 
     #[convex_macro::prod_rt_test]
-    async fn test_deploy2_routes_bypass_legacy_authority_middleware(
+    async fn test_deploy2_routes_bypass_unmigrated_authority_middleware(
         rt: ProdRuntime,
     ) -> anyhow::Result<()> {
         let backend = setup_backend_for_test(rt).await?;

--- a/docs/cluster-authority-routing.md
+++ b/docs/cluster-authority-routing.md
@@ -7,12 +7,19 @@ closed otherwise.
 
 ## Authority Classes
 
+The code-level registry for unmigrated local-backend routes lives in
+`crates/local_backend/src/route_authority.rs`. It is intentionally typed so new
+routes choose an authority class in code, not only in prose.
+
 | Class | Meaning | Current handling |
 | --- | --- | --- |
 | Any-node safe | The route is static, health-only, or purely local observability. | Serve locally. |
 | Partition owner | The route writes user data owned by one table partition. | Public mutations use the existing partition enforcement and mutation forwarding path. |
+| Partition leader | The route writes Raft-protected partition state. | Serve only on that partition's Raft leader or through leader forwarding. |
 | Coordinator owner | The route touches deployment-global metadata or APIs without partition-specific ownership. | Serve only on partition 0 / Raft leader; replicas and non-owner partitions reject with `ServiceUnavailable`. |
+| Follower-safe read | The route is read-only and the node can prove its applied frontier is fresh enough for the requested timestamp. | Not generally available yet outside purpose-built read paths. |
 | Explicit forwarding | The route has a purpose-built owner forwarding path. | The local handler may run on any node because it forwards first. |
+| External side-effect owner | The route triggers external storage, import/export, or delivery side effects. | Needs a job/side-effect owner and idempotency model before it can run broadly. |
 | Not yet safe | The route can mutate/read authoritative state but has no routing protocol. | Reject on non-authority nodes until forwarding is added. |
 
 ## Migrated `RouterState` Routes
@@ -30,17 +37,18 @@ authority checks.
 | `/api/storage/*` | Coordinator owner until file metadata and storage authorization have explicit clustered routing. |
 | `/api/sync`, `/{client_version}/sync` | Coordinator owner for subscription setup until follower-safe subscription ownership is implemented. |
 
-## Legacy `LocalAppState` Routes
+## Unmigrated `LocalAppState` Routes
 
-Legacy `/api` routes bypass `ApplicationApi`, so they are protected by the
-legacy authority middleware in `router.rs`.
+Unmigrated `/api` routes bypass `ApplicationApi`, so they are classified by
+`route_authority.rs` and protected by the unmigrated-route authority middleware
+in `router.rs`.
 
 | Route surface | Authority rule |
 | --- | --- |
 | `/api/deploy2/*` | Explicit forwarding. Deploy metadata handlers forward to partition 0 and then to the Raft leader where needed. `report_push_completed` is local observability. |
 | `/api/dashboard_openapi.json`, `/api/v1/openapi.json` | Any-node safe static schemas. |
 | `/api/get_config`, `/api/get_config_hashes` | Any-node safe deploy introspection. The current CLI reads target-node module/config hashes before the modern `deploy2` push so each node can materialize its local module view. |
-| Dashboard, platform, import/export, streaming import/export, log sinks, internal action callbacks, and mutating legacy CLI routes such as `/api/push_config` | Coordinator owner unless a narrower forwarding path is added. |
+| Dashboard, platform, import/export, streaming import/export, log sinks, internal action callbacks, and mutating old CLI routes such as `/api/push_config` | Coordinator owner unless a narrower forwarding path is added. |
 
 ## Adding A Route
 


### PR DESCRIPTION
## Summary
- Add a typed `route_authority` module for unmigrated `LocalAppState` API route classification.
- Replace the ad hoc router allowlist with registry-driven enforcement while preserving #105 behavior.
- Rename the route guard path away from `legacy_*` language toward `unmigrated LocalAppState` wording.
- Update `docs/cluster-authority-routing.md` to point at the code registry and describe the full authority model.

## Validation
- `cargo fmt -p local_backend`
- `cargo test -p local_backend route_authority -- --nocapture`
- `cargo test -p local_backend test_unmigrated_api_rejects_non_authority_partition -- --nocapture`
- `cargo test -p local_backend test_deploy2_routes_bypass_unmigrated_authority_middleware -- --nocapture`
- `cargo check -p local_backend`
- `cargo test -p local_backend --lib -- --nocapture` passed `82/82`
- `git diff --check`

Refs #112
Stacked on #110 / #105.
