### PR TITLE
feat: migrate deploy routes to cluster-aware state

### DIFF
--- a/crates/local_backend/src/dashboard.rs
+++ b/crates/local_backend/src/dashboard.rs
@@ -63,6 +63,7 @@ use crate::{
         delete_scheduled_functions_table,
     },
     schema::IndexMetadataResponse,
+    DeployRouterState,
     LocalAppState,
 };
 
@@ -303,7 +304,7 @@ pub struct RunTestFunctionArgs {
 )]
 #[debug_handler]
 pub async fn run_test_function(
-    State(st): State<LocalAppState>,
+    State(st): State<DeployRouterState>,
     ExtractRequestId(request_id): ExtractRequestId,
     ExtractClientVersion(client_version): ExtractClientVersion,
     Json(req): Json<RunTestFunctionArgs>,

--- a/crates/local_backend/src/deploy_config.rs
+++ b/crates/local_backend/src/deploy_config.rs
@@ -55,8 +55,8 @@ use crate::{
         must_be_admin_from_key,
         must_be_admin_with_write_access,
     },
+    DeployRouterState,
     EmptyResponse,
-    LocalAppState,
 };
 
 #[derive(Deserialize)]
@@ -186,7 +186,7 @@ pub struct ModuleHashJson {
 }
 
 pub async fn get_config(
-    MtState(st): MtState<LocalAppState>,
+    MtState(st): MtState<DeployRouterState>,
     Json(req): Json<GetConfigRequest>,
 ) -> Result<impl IntoResponse, HttpResponseError> {
     let identity = must_be_admin_from_key(
@@ -215,7 +215,7 @@ pub async fn get_config(
 }
 
 pub async fn get_config_hashes(
-    MtState(st): MtState<LocalAppState>,
+    MtState(st): MtState<DeployRouterState>,
     Json(req): Json<GetConfigRequest>,
 ) -> Result<impl IntoResponse, HttpResponseError> {
     let identity = must_be_admin_from_key(
@@ -257,7 +257,7 @@ pub async fn get_config_hashes(
 
 #[debug_handler]
 pub async fn push_config(
-    State(st): State<LocalAppState>,
+    State(st): State<DeployRouterState>,
     Json(req): Json<ConfigJson>,
 ) -> Result<impl IntoResponse, HttpResponseError> {
     push_config_handler(&st.application, req)

--- a/crates/local_backend/src/deploy_config2.rs
+++ b/crates/local_backend/src/deploy_config2.rs
@@ -82,12 +82,12 @@ use crate::{
         must_be_admin_from_key,
         must_be_admin_from_key_with_write_access,
     },
-    LocalAppState,
+    DeployRouterState,
 };
 
 const INTERNAL_BACKEND_HTTP_PORT: u16 = 3210;
 
-async fn raft_leader_origin(st: &LocalAppState) -> anyhow::Result<Option<String>> {
+async fn raft_leader_origin(st: &DeployRouterState) -> anyhow::Result<Option<String>> {
     let Some(raft_state) = st.raft_state.as_ref() else {
         return Ok(None);
     };
@@ -110,14 +110,14 @@ async fn raft_leader_origin(st: &LocalAppState) -> anyhow::Result<Option<String>
     Ok(None)
 }
 
-async fn deploy_target_origin(st: &LocalAppState) -> anyhow::Result<Option<String>> {
+async fn deploy_target_origin(st: &DeployRouterState) -> anyhow::Result<Option<String>> {
     if let Some(origin) = metadata_owner_origin(st)? {
         return Ok(Some(origin));
     }
     raft_leader_origin(st).await
 }
 
-fn metadata_owner_origin(st: &LocalAppState) -> anyhow::Result<Option<String>> {
+fn metadata_owner_origin(st: &DeployRouterState) -> anyhow::Result<Option<String>> {
     let Some(local_partition) = st.partition_id else {
         return Ok(None);
     };
@@ -172,7 +172,7 @@ async fn metadata_owner_instance_name(owner_origin: &str) -> anyhow::Result<Stri
 }
 
 fn issue_owner_admin_key(
-    st: &LocalAppState,
+    st: &DeployRouterState,
     owner_instance_name: &str,
     identity: &Identity,
 ) -> anyhow::Result<String> {
@@ -200,7 +200,7 @@ fn issue_owner_admin_key(
 }
 
 async fn maybe_forward_deploy_request<Req, Resp>(
-    st: &LocalAppState,
+    st: &DeployRouterState,
     path: &str,
     req: &mut Req,
     needs_write_access: bool,
@@ -390,7 +390,7 @@ pub struct AnalyzedComponent {
 
 #[debug_handler]
 pub async fn start_push(
-    State(st): State<LocalAppState>,
+    State(st): State<DeployRouterState>,
     Json(mut req): Json<StartPushRequest>,
 ) -> Result<impl IntoResponse, HttpResponseError> {
     if let Some(forwarded) =
@@ -422,7 +422,7 @@ pub async fn start_push(
 // what will be the effects of a large push without starting work that can take
 // a long time on large instances.
 pub async fn evaluate_push(
-    MtState(st): MtState<LocalAppState>,
+    MtState(st): MtState<DeployRouterState>,
     Json(mut req): Json<StartPushRequest>,
 ) -> Result<impl IntoResponse, HttpResponseError> {
     if let Some(forwarded) =
@@ -469,7 +469,7 @@ impl AdminKeyCarrier for WaitForSchemaRequest {
 }
 
 pub async fn wait_for_schema(
-    MtState(st): MtState<LocalAppState>,
+    MtState(st): MtState<DeployRouterState>,
     Json(mut req): Json<WaitForSchemaRequest>,
 ) -> Result<impl IntoResponse, HttpResponseError> {
     if let Some(forwarded) =
@@ -516,7 +516,7 @@ impl AdminKeyCarrier for FinishPushRequest {
 
 /// Internal version that returns the commit timestamp for use by conductor
 pub async fn finish_push_internal(
-    st: &LocalAppState,
+    st: &DeployRouterState,
     req: FinishPushRequest,
 ) -> anyhow::Result<(SerializedFinishPushDiff, Option<common::types::Timestamp>)> {
     let identity = must_be_admin_from_key_with_write_access(
@@ -553,7 +553,7 @@ pub struct SerializedFinishPushResponse {
 }
 
 pub async fn finish_push(
-    MtState(st): MtState<LocalAppState>,
+    MtState(st): MtState<DeployRouterState>,
     Json(mut req): Json<FinishPushRequest>,
 ) -> Result<impl IntoResponse, HttpResponseError> {
     if let Some(forwarded) = maybe_forward_deploy_request::<
@@ -586,7 +586,7 @@ pub struct ReportPushCompletedRequest {
 }
 
 pub async fn report_push_completed(
-    st: LocalAppState,
+    st: DeployRouterState,
     req: ReportPushCompletedRequest,
 ) -> anyhow::Result<Vec<SpanRecord>> {
     let _identity = must_be_admin_from_key_with_write_access(
@@ -605,7 +605,7 @@ pub async fn report_push_completed(
 
 #[debug_handler]
 pub async fn report_push_completed_handler(
-    State(st): State<LocalAppState>,
+    State(st): State<DeployRouterState>,
     Json(req): Json<ReportPushCompletedRequest>,
 ) -> Result<impl IntoResponse, HttpResponseError> {
     let spans = report_push_completed(st, req).await?;

--- a/crates/local_backend/src/lib.rs
+++ b/crates/local_backend/src/lib.rs
@@ -171,6 +171,33 @@ pub struct RouterState {
     pub replica_mutation_forwarder: Option<Arc<mutation_forwarder::MutationForwarderGrpcClient>>,
 }
 
+#[derive(Clone)]
+pub struct DeployRouterState {
+    pub instance_name: String,
+    pub instance_secret: InstanceSecret,
+    pub application: Application<ProdRuntime>,
+    pub replica_mode: bool,
+    pub partition_id: Option<database::partition::PartitionId>,
+    pub node_addresses: Option<database::two_phase::NodeAddresses>,
+    pub raft_state: Option<database::raft_partition::RaftPartitionState>,
+    pub raft_peer_http_origins: Option<BTreeMap<u64, String>>,
+}
+
+impl From<&LocalAppState> for DeployRouterState {
+    fn from(st: &LocalAppState) -> Self {
+        Self {
+            instance_name: st.instance_name.clone(),
+            instance_secret: st.instance_secret,
+            application: st.application.clone(),
+            replica_mode: st.replica_mode,
+            partition_id: st.partition_id,
+            node_addresses: st.node_addresses.clone(),
+            raft_state: st.raft_state.clone(),
+            raft_peer_http_origins: st.raft_peer_http_origins.clone(),
+        }
+    }
+}
+
 #[derive(Serialize)]
 pub struct EmptyResponse {}
 

--- a/crates/local_backend/src/route_authority.rs
+++ b/crates/local_backend/src/route_authority.rs
@@ -1,9 +1,49 @@
-use database::partition::PartitionId;
+use database::{
+    partition::PartitionId,
+    raft_partition::RaftPartitionState,
+};
 use errors::ErrorMetadata;
 
-use crate::LocalAppState;
+use crate::{
+    DeployRouterState,
+    LocalAppState,
+};
 
 pub(crate) const CLUSTER_COORDINATOR_PARTITION: PartitionId = PartitionId(0);
+
+pub(crate) trait ClusterAuthorityContext {
+    fn replica_mode(&self) -> bool;
+    fn partition_id(&self) -> Option<PartitionId>;
+    fn raft_state(&self) -> Option<&RaftPartitionState>;
+}
+
+impl ClusterAuthorityContext for LocalAppState {
+    fn replica_mode(&self) -> bool {
+        self.replica_mode
+    }
+
+    fn partition_id(&self) -> Option<PartitionId> {
+        self.partition_id
+    }
+
+    fn raft_state(&self) -> Option<&RaftPartitionState> {
+        self.raft_state.as_ref()
+    }
+}
+
+impl ClusterAuthorityContext for DeployRouterState {
+    fn replica_mode(&self) -> bool {
+        self.replica_mode
+    }
+
+    fn partition_id(&self) -> Option<PartitionId> {
+        self.partition_id
+    }
+
+    fn raft_state(&self) -> Option<&RaftPartitionState> {
+        self.raft_state.as_ref()
+    }
+}
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum RouteAuthorityClass {
@@ -89,9 +129,9 @@ const ANY_NODE_STATIC_SCHEMA: &str = "static schema or deploy-introspection rout
 const EXPLICIT_DEPLOY_FORWARDING: &str =
     "deploy2 handlers forward to the metadata owner and Raft leader before mutating state";
 const COORDINATOR_GLOBAL_STATE: &str =
-    "unmigrated route touches deployment-global state and must run on partition 0 / Raft leader";
+    "route touches deployment-global state and must run on partition 0 / Raft leader";
 
-pub(crate) const UNMIGRATED_LOCAL_APP_STATE_API_ROUTE_AUTHORITIES: &[RouteAuthorityRule] = &[
+pub(crate) const LOCAL_BACKEND_API_ROUTE_AUTHORITIES: &[RouteAuthorityRule] = &[
     RouteAuthorityRule::exact(
         "dashboard OpenAPI schema",
         "/dashboard_openapi.json",
@@ -159,7 +199,7 @@ pub(crate) const UNMIGRATED_LOCAL_APP_STATE_API_ROUTE_AUTHORITIES: &[RouteAuthor
         COORDINATOR_GLOBAL_STATE,
     ),
     RouteAuthorityRule::exact(
-        "unmigrated deploy config push",
+        "deploy config push",
         "/push_config",
         RouteAuthorityClass::CoordinatorOwner,
         COORDINATOR_GLOBAL_STATE,
@@ -328,54 +368,52 @@ pub(crate) const UNMIGRATED_LOCAL_APP_STATE_API_ROUTE_AUTHORITIES: &[RouteAuthor
     ),
 ];
 
-pub(crate) fn normalize_unmigrated_api_path(path: &str) -> &str {
+pub(crate) fn normalize_local_backend_api_path(path: &str) -> &str {
     path.strip_prefix("/api")
         .filter(|stripped| stripped.starts_with('/'))
         .unwrap_or(path)
 }
 
-pub(crate) fn classify_unmigrated_local_app_state_api_route(
-    path: &str,
-) -> Option<&'static RouteAuthorityRule> {
-    let normalized_path = normalize_unmigrated_api_path(path);
-    UNMIGRATED_LOCAL_APP_STATE_API_ROUTE_AUTHORITIES
+pub(crate) fn classify_local_backend_api_route(path: &str) -> Option<&'static RouteAuthorityRule> {
+    let normalized_path = normalize_local_backend_api_path(path);
+    LOCAL_BACKEND_API_ROUTE_AUTHORITIES
         .iter()
         .find(|rule| rule.matcher.matches(normalized_path))
 }
 
-fn unsupported_unmigrated_cluster_surface_error(
+fn unsupported_local_backend_cluster_surface_error(
     surface: &str,
     class: RouteAuthorityClass,
     reason: String,
 ) -> anyhow::Error {
     anyhow::anyhow!(ErrorMetadata::service_unavailable()).context(format!(
-        "Unmigrated LocalAppState API route {surface} ({}) cannot execute locally on this \
-         clustered node: {reason}. Route the request to the authoritative node, add an explicit \
-         forwarding path, or migrate the route to RouterState.",
+        "Local backend API route {surface} ({}) cannot execute locally on this clustered node: \
+         {reason}. Route the request to the authoritative node, add an explicit forwarding path, \
+         or migrate the route to RouterState.",
         class.label()
     ))
 }
 
 fn ensure_cluster_coordinator_authority(
-    st: &LocalAppState,
+    st: &impl ClusterAuthorityContext,
     surface: &str,
     class: RouteAuthorityClass,
 ) -> anyhow::Result<()> {
-    if !st.replica_mode && st.partition_id.is_none() {
+    if !st.replica_mode() && st.partition_id().is_none() {
         return Ok(());
     }
-    if st.replica_mode {
-        return Err(unsupported_unmigrated_cluster_surface_error(
+    if st.replica_mode() {
+        return Err(unsupported_local_backend_cluster_surface_error(
             surface,
             class,
             "replicas do not own deployment-global request surfaces".to_string(),
         ));
     }
-    let Some(partition_id) = st.partition_id else {
+    let Some(partition_id) = st.partition_id() else {
         return Ok(());
     };
     if partition_id != CLUSTER_COORDINATOR_PARTITION {
-        return Err(unsupported_unmigrated_cluster_surface_error(
+        return Err(unsupported_local_backend_cluster_surface_error(
             surface,
             class,
             format!(
@@ -384,10 +422,10 @@ fn ensure_cluster_coordinator_authority(
             ),
         ));
     }
-    if let Some(raft_state) = st.raft_state.as_ref()
+    if let Some(raft_state) = st.raft_state()
         && !raft_state.is_leader()
     {
-        return Err(unsupported_unmigrated_cluster_surface_error(
+        return Err(unsupported_local_backend_cluster_surface_error(
             surface,
             class,
             "the coordinator partition is running as a Raft follower".to_string(),
@@ -396,11 +434,11 @@ fn ensure_cluster_coordinator_authority(
     Ok(())
 }
 
-pub(crate) fn ensure_unmigrated_local_app_state_api_authority(
-    st: &LocalAppState,
+pub(crate) fn ensure_local_backend_api_authority(
+    st: &impl ClusterAuthorityContext,
     path: &str,
 ) -> anyhow::Result<()> {
-    let (surface, class) = if let Some(rule) = classify_unmigrated_local_app_state_api_route(path) {
+    let (surface, class) = if let Some(rule) = classify_local_backend_api_route(path) {
         (rule.surface, rule.class)
     } else {
         (path, RouteAuthorityClass::FailClosed)
@@ -414,7 +452,7 @@ pub(crate) fn ensure_unmigrated_local_app_state_api_authority(
         | RouteAuthorityClass::PartitionLeader
         | RouteAuthorityClass::FollowerSafeRead
         | RouteAuthorityClass::ExternalSideEffectOwner
-        | RouteAuthorityClass::FailClosed => Err(unsupported_unmigrated_cluster_surface_error(
+        | RouteAuthorityClass::FailClosed => Err(unsupported_local_backend_cluster_surface_error(
             surface,
             class,
             format!("the {class:?} authority class has no local execution strategy yet"),
@@ -425,31 +463,31 @@ pub(crate) fn ensure_unmigrated_local_app_state_api_authority(
 #[cfg(test)]
 mod tests {
     use super::{
-        classify_unmigrated_local_app_state_api_route,
-        normalize_unmigrated_api_path,
+        classify_local_backend_api_route,
+        normalize_local_backend_api_path,
         RouteAuthorityClass,
-        UNMIGRATED_LOCAL_APP_STATE_API_ROUTE_AUTHORITIES,
+        LOCAL_BACKEND_API_ROUTE_AUTHORITIES,
     };
 
     fn class_for(path: &str) -> Option<RouteAuthorityClass> {
-        classify_unmigrated_local_app_state_api_route(path).map(|rule| rule.class)
+        classify_local_backend_api_route(path).map(|rule| rule.class)
     }
 
     #[test]
     fn test_normalizes_nested_api_prefix() {
         assert_eq!(
-            normalize_unmigrated_api_path("/api/push_config"),
+            normalize_local_backend_api_path("/api/push_config"),
             "/push_config"
         );
         assert_eq!(
-            normalize_unmigrated_api_path("/push_config"),
+            normalize_local_backend_api_path("/push_config"),
             "/push_config"
         );
-        assert_eq!(normalize_unmigrated_api_path("/apiary"), "/apiary");
+        assert_eq!(normalize_local_backend_api_path("/apiary"), "/apiary");
     }
 
     #[test]
-    fn test_unmigrated_api_route_authority_registry_classifies_core_surfaces() {
+    fn test_local_backend_api_route_authority_registry_classifies_core_surfaces() {
         assert_eq!(
             class_for("/api/get_config_hashes"),
             Some(RouteAuthorityClass::AnyNodeSafe)
@@ -478,8 +516,8 @@ mod tests {
     }
 
     #[test]
-    fn test_unmigrated_api_route_authority_rules_are_documented() {
-        assert!(UNMIGRATED_LOCAL_APP_STATE_API_ROUTE_AUTHORITIES
+    fn test_local_backend_api_route_authority_rules_are_documented() {
+        assert!(LOCAL_BACKEND_API_ROUTE_AUTHORITIES
             .iter()
             .all(|rule| !rule.surface.is_empty() && !rule.rationale.is_empty()));
     }

--- a/crates/local_backend/src/router.rs
+++ b/crates/local_backend/src/router.rs
@@ -119,7 +119,7 @@ use crate::{
         vector_search,
     },
     public_api::public_api_router,
-    route_authority::ensure_unmigrated_local_app_state_api_authority,
+    route_authority::ensure_local_backend_api_authority,
     scheduling::{
         cancel_all_jobs,
         cancel_job,
@@ -168,6 +168,7 @@ use crate::{
         replace_tables,
     },
     subs::sync,
+    DeployRouterState,
     LocalAppState,
     RouterState,
 };
@@ -177,7 +178,16 @@ async fn unmigrated_local_app_state_api_authority_middleware(
     req: axum::extract::Request,
     next: axum::middleware::Next,
 ) -> Result<impl IntoResponse, HttpResponseError> {
-    ensure_unmigrated_local_app_state_api_authority(&st, req.uri().path())?;
+    ensure_local_backend_api_authority(&st, req.uri().path())?;
+    Ok(next.run(req).await)
+}
+
+async fn deploy_api_authority_middleware(
+    State(st): State<DeployRouterState>,
+    req: axum::extract::Request,
+    next: axum::middleware::Next,
+) -> Result<impl IntoResponse, HttpResponseError> {
+    ensure_local_backend_api_authority(&st, req.uri().path())?;
     Ok(next.run(req).await)
 }
 
@@ -326,7 +336,7 @@ pub fn router(st: LocalAppState) -> Router {
         }))
         .layer(ServiceBuilder::new());
 
-    let cli_routes = Router::new()
+    let deploy_push_routes = Router::new()
         .route("/push_config", post(push_config))
         .route("/prepare_schema", post(prepare_schema))
         .route("/deploy2/start_push", post(deploy_config2::start_push))
@@ -351,10 +361,21 @@ pub fn router(st: LocalAppState) -> Router {
                 }))
                 .layer(RequestDecompressionLayer::new())
                 .layer(DefaultBodyLimit::max(*MAX_PUSH_BYTES)),
-        )
+        );
+    let deploy_state = DeployRouterState::from(&st);
+    let deploy_routes = Router::new()
+        .merge(deploy_push_routes)
         .route("/get_config", post(get_config))
         .route("/get_config_hashes", post(get_config_hashes))
         .route("/schema_state/{schema_id}", get(schema_state))
+        .layer(cli_cors())
+        .layer(axum::middleware::from_fn_with_state(
+            deploy_state.clone(),
+            deploy_api_authority_middleware,
+        ))
+        .with_state(deploy_state);
+
+    let cli_routes = Router::new()
         .route("/stream_udf_execution", get(stream_udf_execution))
         .route("/stream_function_logs", get(stream_function_logs))
         .merge(import_routes())
@@ -392,7 +413,8 @@ pub fn router(st: LocalAppState) -> Router {
         .layer(axum::middleware::from_fn_with_state(
             st.clone(),
             unmigrated_local_app_state_api_authority_middleware,
-        ));
+        ))
+        .merge(deploy_routes);
 
     // Endpoints migrated to use the RouterState trait instead of application.
     let (public_routes, public_openapi) = OpenApiRouter::with_openapi(PublicApiDoc::openapi())
@@ -758,7 +780,7 @@ mod tests {
     }
 
     #[convex_macro::prod_rt_test]
-    async fn test_unmigrated_api_rejects_non_authority_partition(
+    async fn test_deploy_api_rejects_non_authority_partition(
         rt: ProdRuntime,
     ) -> anyhow::Result<()> {
         let backend = setup_backend_for_test(rt).await?;
@@ -794,7 +816,89 @@ mod tests {
     }
 
     #[convex_macro::prod_rt_test]
-    async fn test_deploy2_routes_bypass_unmigrated_authority_middleware(
+    async fn test_deploy_config_hashes_allow_non_authority_partition(
+        rt: ProdRuntime,
+    ) -> anyhow::Result<()> {
+        let backend = setup_backend_for_test(rt).await?;
+        let admin_header = backend.admin_auth_header.0.encode();
+        let admin_key = admin_header
+            .to_str()?
+            .strip_prefix("Convex ")
+            .context("admin auth header must use the Convex scheme")?
+            .to_string();
+
+        let mut partitioned_state = backend.st.clone();
+        partitioned_state.partition_id = Some(PartitionId(1));
+        let partitioned_app = ConvexHttpService::new(
+            router(partitioned_state),
+            "deploy_config_hashes_authority_test",
+            SERVER_VERSION_STR.to_string(),
+            MAX_CONCURRENT_REQUESTS,
+            Duration::from_secs(125),
+            NoopRouteMapper,
+        );
+
+        let req = Request::builder()
+            .uri("/api/get_config_hashes")
+            .method("POST")
+            .header("Host", "localhost")
+            .header("Content-Type", "application/json")
+            .body(Body::from(serde_json::to_vec(&json!({
+                "adminKey": admin_key,
+            }))?))?;
+        let (parts, body) = partitioned_app
+            .router()
+            .clone()
+            .oneshot(req)
+            .await?
+            .into_parts();
+        let bytes = body.collect().await?.to_bytes();
+        let body = String::from_utf8_lossy(&bytes);
+        assert_eq!(parts.status, StatusCode::OK, "{body}");
+
+        Ok(())
+    }
+
+    #[convex_macro::prod_rt_test]
+    async fn test_schema_state_rejects_non_authority_partition(
+        rt: ProdRuntime,
+    ) -> anyhow::Result<()> {
+        let backend = setup_backend_for_test(rt).await?;
+        let admin_header = backend.admin_auth_header.0.encode();
+
+        let mut partitioned_state = backend.st.clone();
+        partitioned_state.partition_id = Some(PartitionId(1));
+        let partitioned_app = ConvexHttpService::new(
+            router(partitioned_state),
+            "schema_state_authority_test",
+            SERVER_VERSION_STR.to_string(),
+            MAX_CONCURRENT_REQUESTS,
+            Duration::from_secs(125),
+            NoopRouteMapper,
+        );
+
+        let req = Request::builder()
+            .uri("/api/schema_state/not-a-real-schema-id")
+            .method("GET")
+            .header("Host", "localhost")
+            .header("Authorization", admin_header)
+            .body(Body::empty())?;
+        let (parts, body) = partitioned_app
+            .router()
+            .clone()
+            .oneshot(req)
+            .await?
+            .into_parts();
+        let bytes = body.collect().await?.to_bytes();
+        let body = String::from_utf8_lossy(&bytes);
+        assert_eq!(parts.status, StatusCode::SERVICE_UNAVAILABLE, "{body}");
+        assert!(body.contains("ServiceUnavailable"), "{body}");
+
+        Ok(())
+    }
+
+    #[convex_macro::prod_rt_test]
+    async fn test_deploy2_routes_use_explicit_forwarding_authority(
         rt: ProdRuntime,
     ) -> anyhow::Result<()> {
         let backend = setup_backend_for_test(rt).await?;

--- a/crates/local_backend/src/schema.rs
+++ b/crates/local_backend/src/schema.rs
@@ -2,8 +2,12 @@ use anyhow::Context;
 use application::deploy_config::ModuleJson;
 use axum::{
     debug_handler,
-    extract::State,
+    extract::{
+        FromRequestParts,
+        State,
+    },
     response::IntoResponse,
+    RequestPartsExt,
 };
 use common::{
     bootstrap_model::{
@@ -38,6 +42,7 @@ use common::{
         },
         HttpResponseError,
     },
+    runtime::Runtime,
     types::IndexDiff,
 };
 use database::{
@@ -65,9 +70,28 @@ use crate::{
         must_be_admin,
         must_be_admin_from_key_with_write_access,
     },
-    authentication::ExtractIdentity,
-    LocalAppState,
+    authentication::ExtractAuthenticationToken,
+    DeployRouterState,
 };
+
+pub struct ExtractDeployIdentity(pub keybroker::Identity);
+
+impl FromRequestParts<DeployRouterState> for ExtractDeployIdentity {
+    type Rejection = HttpResponseError;
+
+    async fn from_request_parts(
+        parts: &mut axum::http::request::Parts,
+        st: &DeployRouterState,
+    ) -> Result<Self, Self::Rejection> {
+        let token: sync_types::AuthenticationToken =
+            parts.extract::<ExtractAuthenticationToken>().await?.into();
+        Ok(Self(
+            st.application
+                .authenticate(token, st.application.runtime().system_time())
+                .await?,
+        ))
+    }
+}
 
 #[derive(Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -239,7 +263,7 @@ impl PrepareSchemaResponse {
 
 #[debug_handler]
 pub async fn prepare_schema(
-    State(st): State<LocalAppState>,
+    State(st): State<DeployRouterState>,
     Json(req): Json<PrepareSchemaArgs>,
 ) -> Result<Json<PrepareSchemaResponse>, HttpResponseError> {
     let (response, _) = prepare_schema_handler(st, req).await?;
@@ -247,7 +271,7 @@ pub async fn prepare_schema(
 }
 
 pub async fn prepare_schema_handler(
-    st: LocalAppState,
+    st: DeployRouterState,
     req: PrepareSchemaArgs,
 ) -> Result<(Json<PrepareSchemaResponse>, bool), HttpResponseError> {
     let bundle = req.bundle.try_into()?;
@@ -350,9 +374,9 @@ impl From<SchemaState> for SchemaStateJson {
 
 /// Gets the current state of the indexes and schema.
 pub async fn schema_state(
-    MtState(st): MtState<LocalAppState>,
+    MtState(st): MtState<DeployRouterState>,
     Path(schema_id): Path<String>,
-    ExtractIdentity(identity): ExtractIdentity,
+    ExtractDeployIdentity(identity): ExtractDeployIdentity,
 ) -> Result<impl IntoResponse, HttpResponseError> {
     must_be_admin(&identity)?;
     let mut tx = st.application.begin(identity.clone()).await?;

--- a/docs/cluster-authority-routing.md
+++ b/docs/cluster-authority-routing.md
@@ -7,7 +7,7 @@ closed otherwise.
 
 ## Authority Classes
 
-The code-level registry for unmigrated local-backend routes lives in
+The code-level registry for local-backend route authority lives in
 `crates/local_backend/src/route_authority.rs`. It is intentionally typed so new
 routes choose an authority class in code, not only in prose.
 
@@ -37,6 +37,17 @@ authority checks.
 | `/api/storage/*` | Coordinator owner until file metadata and storage authorization have explicit clustered routing. |
 | `/api/sync`, `/{client_version}/sync` | Coordinator owner for subscription setup until follower-safe subscription ownership is implemented. |
 
+## Deploy `DeployRouterState` Routes
+
+Deploy and CLI config routes use a smaller cluster-aware `DeployRouterState`
+instead of the full `LocalAppState` route tree.
+
+| Route surface | Authority rule |
+| --- | --- |
+| `/api/deploy2/*` | Explicit forwarding. Deploy metadata handlers forward to partition 0 and then to the Raft leader where needed. `report_push_completed` is local observability. |
+| `/api/get_config`, `/api/get_config_hashes` | Any-node safe deploy introspection. The current CLI reads target-node module/config hashes before the modern `deploy2` push so each node can materialize its local module view. |
+| `/api/push_config`, `/api/prepare_schema`, `/api/run_test_function`, `/api/schema_state/*` | Coordinator owner unless a narrower forwarding path is added. |
+
 ## Unmigrated `LocalAppState` Routes
 
 Unmigrated `/api` routes bypass `ApplicationApi`, so they are classified by
@@ -45,10 +56,8 @@ in `router.rs`.
 
 | Route surface | Authority rule |
 | --- | --- |
-| `/api/deploy2/*` | Explicit forwarding. Deploy metadata handlers forward to partition 0 and then to the Raft leader where needed. `report_push_completed` is local observability. |
 | `/api/dashboard_openapi.json`, `/api/v1/openapi.json` | Any-node safe static schemas. |
-| `/api/get_config`, `/api/get_config_hashes` | Any-node safe deploy introspection. The current CLI reads target-node module/config hashes before the modern `deploy2` push so each node can materialize its local module view. |
-| Dashboard, platform, import/export, streaming import/export, log sinks, internal action callbacks, and mutating old CLI routes such as `/api/push_config` | Coordinator owner unless a narrower forwarding path is added. |
+| Dashboard, platform, import/export, streaming import/export, log sinks, and internal action callbacks | Coordinator owner unless a narrower forwarding path is added. |
 
 ## Adding A Route
 


### PR DESCRIPTION
## Summary
- Add `DeployRouterState` for deploy/config/schema/test-function routes instead of serving them from the broad `LocalAppState` route tree.
- Mount deploy routes behind their own authority middleware while keeping deploy2 explicit forwarding and config-hash introspection behavior intact.
- Move deploy config, deploy2, schema prepare/schema_state, and run_test_function handlers onto deploy-specific state.
- Generalize the route authority registry from unmigrated-only naming to local-backend API authority, and document the new deploy route section.

## Validation
- `cargo fmt -p local_backend`
- `git diff --check`
- `cargo test -p local_backend route_authority -- --nocapture`
- `cargo test -p local_backend deploy -- --nocapture`
- `cargo test -p local_backend schema_state -- --nocapture`
- `cargo check -p local_backend`
- `cargo test -p local_backend --lib -- --nocapture` passed `84/84`
- `docker build --progress=plain -t ghcr.io/martinkalema/convex-horizontal-scaling:backend-latest -f self-hosted/docker-build/Dockerfile.backend .`
- Manual Node B deploy canary: `npx convex deploy --admin-key ... --url http://127.0.0.1:3310` passed
- `bash self-hosted/docker/test.sh` passed `77/77` write-scaling tests and `10/10` Raft failover tests (`ALL SUITES PASSED`)

Refs #113
Stacked on #119 / #112.