### PR TITLE
feat: migrate admin routes to cluster-aware state

### DIFF
--- a/crates/local_backend/src/app_metrics.rs
+++ b/crates/local_backend/src/app_metrics.rs
@@ -22,8 +22,8 @@ use serde::Deserialize;
 use sync_types::UdfPath;
 
 use crate::{
-    authentication::ExtractIdentity,
-    LocalAppState,
+    authentication::ExtractAdminIdentity as ExtractIdentity,
+    AdminRouterState,
 };
 
 #[derive(Deserialize)]
@@ -38,7 +38,7 @@ pub(crate) struct UdfRateQueryArgs {
 }
 
 pub(crate) async fn udf_rate(
-    MtState(st): MtState<LocalAppState>,
+    MtState(st): MtState<AdminRouterState>,
     ExtractIdentity(identity): ExtractIdentity,
     Query(UdfRateQueryArgs {
         component_path,
@@ -68,7 +68,7 @@ pub(crate) struct TopKQueryArgs {
 }
 
 pub(crate) async fn failure_percentage_top_k(
-    MtState(st): MtState<LocalAppState>,
+    MtState(st): MtState<AdminRouterState>,
     ExtractIdentity(identity): ExtractIdentity,
     Query(TopKQueryArgs { window, k }): Query<TopKQueryArgs>,
 ) -> Result<impl IntoResponse, HttpResponseError> {
@@ -86,7 +86,7 @@ pub(crate) async fn failure_percentage_top_k(
 }
 
 pub(crate) async fn cache_hit_percentage_top_k(
-    MtState(st): MtState<LocalAppState>,
+    MtState(st): MtState<AdminRouterState>,
     ExtractIdentity(identity): ExtractIdentity,
     Query(TopKQueryArgs { window, k }): Query<TopKQueryArgs>,
 ) -> Result<impl IntoResponse, HttpResponseError> {
@@ -104,7 +104,7 @@ pub(crate) async fn cache_hit_percentage_top_k(
 }
 
 pub(crate) async fn function_call_count_top_k(
-    MtState(st): MtState<LocalAppState>,
+    MtState(st): MtState<AdminRouterState>,
     ExtractIdentity(identity): ExtractIdentity,
     Query(TopKQueryArgs { window, k }): Query<TopKQueryArgs>,
 ) -> Result<impl IntoResponse, HttpResponseError> {
@@ -131,7 +131,7 @@ pub(crate) struct CacheHitPercentageQueryArgs {
     udf_type: Option<String>,
 }
 pub(crate) async fn cache_hit_percentage(
-    MtState(st): MtState<LocalAppState>,
+    MtState(st): MtState<AdminRouterState>,
     ExtractIdentity(identity): ExtractIdentity,
     Query(query_args): Query<CacheHitPercentageQueryArgs>,
 ) -> Result<impl IntoResponse, HttpResponseError> {
@@ -161,7 +161,7 @@ pub(crate) struct LatencyPercentilesQueryArgs {
     udf_type: Option<String>,
 }
 pub(crate) async fn latency_percentiles(
-    MtState(st): MtState<LocalAppState>,
+    MtState(st): MtState<AdminRouterState>,
     ExtractIdentity(identity): ExtractIdentity,
     Query(query_args): Query<LatencyPercentilesQueryArgs>,
 ) -> Result<impl IntoResponse, HttpResponseError> {
@@ -191,7 +191,7 @@ pub(crate) struct TableRateQueryArgs {
     window: String,
 }
 pub(crate) async fn table_rate(
-    MtState(st): MtState<LocalAppState>,
+    MtState(st): MtState<AdminRouterState>,
     ExtractIdentity(identity): ExtractIdentity,
     Query(query_args): Query<TableRateQueryArgs>,
 ) -> Result<impl IntoResponse, HttpResponseError> {
@@ -245,7 +245,7 @@ pub(crate) struct ScheduledJobLagArgs {
     window: String,
 }
 pub(crate) async fn scheduled_job_lag(
-    MtState(st): MtState<LocalAppState>,
+    MtState(st): MtState<AdminRouterState>,
     ExtractIdentity(identity): ExtractIdentity,
     Query(query_args): Query<ScheduledJobLagArgs>,
 ) -> Result<impl IntoResponse, HttpResponseError> {
@@ -264,7 +264,7 @@ pub(crate) struct FunctionConcurrencyArgs {
     window: String,
 }
 pub(crate) async fn function_concurrency(
-    MtState(st): MtState<LocalAppState>,
+    MtState(st): MtState<AdminRouterState>,
     ExtractIdentity(identity): ExtractIdentity,
     Query(query_args): Query<FunctionConcurrencyArgs>,
 ) -> Result<impl IntoResponse, HttpResponseError> {

--- a/crates/local_backend/src/authentication.rs
+++ b/crates/local_backend/src/authentication.rs
@@ -32,6 +32,7 @@ use sync_types::{
 };
 
 use crate::{
+    AdminRouterState,
     LocalAppState,
     RouterState,
 };
@@ -128,6 +129,37 @@ where
 
 impl From<ExtractIdentity> for Identity {
     fn from(identity: ExtractIdentity) -> Self {
+        identity.0
+    }
+}
+
+pub struct ExtractAdminIdentity(pub Identity);
+
+impl<S> FromRequestParts<S> for ExtractAdminIdentity
+where
+    AdminRouterState: FromMtState<S>,
+    S: Send + Sync + Clone + 'static,
+{
+    type Rejection = HttpResponseError;
+
+    async fn from_request_parts(
+        parts: &mut axum::http::request::Parts,
+        st: &S,
+    ) -> Result<Self, Self::Rejection> {
+        let token: AuthenticationToken =
+            parts.extract::<ExtractAuthenticationToken>().await?.into();
+        let st = AdminRouterState::from_request_parts(parts, st).await?;
+
+        Ok(Self(
+            st.application
+                .authenticate(token, st.application.runtime().system_time())
+                .await?,
+        ))
+    }
+}
+
+impl From<ExtractAdminIdentity> for Identity {
+    fn from(identity: ExtractAdminIdentity) -> Self {
         identity.0
     }
 }

--- a/crates/local_backend/src/canonical_urls.rs
+++ b/crates/local_backend/src/canonical_urls.rs
@@ -33,8 +33,8 @@ use crate::{
         must_be_admin,
         must_be_admin_with_write_access,
     },
-    authentication::ExtractIdentity,
-    LocalAppState,
+    authentication::ExtractAdminIdentity as ExtractIdentity,
+    AdminRouterState,
 };
 
 #[derive(Deserialize, ToSchema)]
@@ -66,7 +66,7 @@ pub struct UpdateCanonicalUrlRequest {
     ),
 )]
 pub async fn update_canonical_url(
-    State(st): State<LocalAppState>,
+    State(st): State<AdminRouterState>,
     ExtractIdentity(identity): ExtractIdentity,
     Json(request): Json<UpdateCanonicalUrlRequest>,
 ) -> Result<impl IntoResponse, HttpResponseError> {
@@ -128,7 +128,7 @@ pub struct GetCanonicalUrlsResponse {
     ),
 )]
 pub async fn get_canonical_urls(
-    MtState(st): MtState<LocalAppState>,
+    MtState(st): MtState<AdminRouterState>,
     ExtractIdentity(identity): ExtractIdentity,
 ) -> Result<impl IntoResponse, HttpResponseError> {
     must_be_admin(&identity)?;
@@ -164,7 +164,7 @@ pub async fn get_canonical_urls(
 
 pub fn platform_router<S>() -> OpenApiRouter<S>
 where
-    LocalAppState: FromRef<S>,
+    AdminRouterState: FromRef<S>,
     S: Clone + Send + Sync + 'static,
 {
     OpenApiRouter::new().routes(utoipa_axum::routes!(

--- a/crates/local_backend/src/dashboard.rs
+++ b/crates/local_backend/src/dashboard.rs
@@ -53,7 +53,7 @@ use crate::{
         must_be_admin_from_key,
         must_be_admin_with_write_access,
     },
-    authentication::ExtractIdentity,
+    authentication::ExtractAdminIdentity as ExtractIdentity,
     public_api::{
         export_value,
         UdfResponse,
@@ -63,8 +63,8 @@ use crate::{
         delete_scheduled_functions_table,
     },
     schema::IndexMetadataResponse,
+    AdminRouterState,
     DeployRouterState,
-    LocalAppState,
 };
 
 #[derive(Deserialize, ToSchema)]
@@ -98,7 +98,7 @@ pub struct ShapesArgs {
     responses((status = 200, body = serde_json::Value)),
 )]
 pub async fn shapes2(
-    MtState(st): MtState<LocalAppState>,
+    MtState(st): MtState<AdminRouterState>,
     ExtractIdentity(identity): ExtractIdentity,
     Query(ShapesArgs { component }): Query<ShapesArgs>,
 ) -> Result<impl IntoResponse, HttpResponseError> {
@@ -139,7 +139,7 @@ pub async fn shapes2(
     responses((status = 200)),
 )]
 pub async fn delete_tables(
-    MtState(st): MtState<LocalAppState>,
+    MtState(st): MtState<AdminRouterState>,
     ExtractIdentity(identity): ExtractIdentity,
     Json(DeleteTableArgs {
         table_names,
@@ -170,7 +170,7 @@ pub async fn delete_tables(
     responses((status = 200)),
 )]
 pub async fn delete_component(
-    MtState(st): MtState<LocalAppState>,
+    MtState(st): MtState<AdminRouterState>,
     ExtractIdentity(identity): ExtractIdentity,
     Json(DeleteComponentArgs { component_id }): Json<DeleteComponentArgs>,
 ) -> Result<impl IntoResponse, HttpResponseError> {
@@ -207,7 +207,7 @@ struct GetIndexesResponse {
     responses((status = 200, body = GetIndexesResponse)),
 )]
 pub async fn get_indexes(
-    MtState(st): MtState<LocalAppState>,
+    MtState(st): MtState<AdminRouterState>,
     ExtractIdentity(identity): ExtractIdentity,
     Query(GetIndexesArgs { component_id }): Query<GetIndexesArgs>,
 ) -> Result<impl IntoResponse, HttpResponseError> {
@@ -245,7 +245,7 @@ pub struct GetSourceCodeArgs {
     responses((status = 200, body = String)),
 )]
 pub async fn get_source_code(
-    MtState(st): MtState<LocalAppState>,
+    MtState(st): MtState<AdminRouterState>,
     ExtractIdentity(identity): ExtractIdentity,
     Query(GetSourceCodeArgs { path, component }): Query<GetSourceCodeArgs>,
 ) -> Result<impl IntoResponse, HttpResponseError> {
@@ -274,7 +274,7 @@ pub async fn get_source_code(
 )]
 #[debug_handler]
 pub async fn check_admin_key(
-    State(_st): State<LocalAppState>,
+    State(_st): State<AdminRouterState>,
     ExtractIdentity(identity): ExtractIdentity,
 ) -> Result<impl IntoResponse, HttpResponseError> {
     must_be_admin_with_write_access(&identity)?;
@@ -342,14 +342,14 @@ pub async fn run_test_function(
     Ok(Json(response))
 }
 
-pub fn local_only_dashboard_router() -> OpenApiRouter<crate::LocalAppState> {
+pub fn local_only_dashboard_router() -> OpenApiRouter<crate::AdminRouterState> {
     OpenApiRouter::new().routes(utoipa_axum::routes!(check_admin_key))
 }
 
 // Routes with the same handlers for the local backend + closed source backend
 pub fn common_dashboard_api_router<S>() -> OpenApiRouter<S>
 where
-    LocalAppState: FromMtState<S>,
+    AdminRouterState: FromMtState<S>,
     S: Clone + Send + Sync + 'static,
 {
     OpenApiRouter::new()

--- a/crates/local_backend/src/deployment_info.rs
+++ b/crates/local_backend/src/deployment_info.rs
@@ -24,8 +24,8 @@ use utoipa_axum::router::OpenApiRouter;
 
 use crate::{
     admin::must_be_admin,
-    authentication::ExtractIdentity,
-    LocalAppState,
+    authentication::ExtractAdminIdentity as ExtractIdentity,
+    AdminRouterState,
 };
 
 #[derive(Serialize, ToSchema)]
@@ -64,7 +64,7 @@ pub enum DeploymentInfoResponse {
     ),
 )]
 pub async fn get_deployment_info(
-    MtState(st): MtState<LocalAppState>,
+    MtState(st): MtState<AdminRouterState>,
     ExtractIdentity(identity): ExtractIdentity,
 ) -> Result<impl IntoResponse, HttpResponseError> {
     must_be_admin(&identity)?;
@@ -93,7 +93,7 @@ pub async fn get_deployment_info(
 
 pub fn platform_router<S>() -> OpenApiRouter<S>
 where
-    LocalAppState: FromRef<S>,
+    AdminRouterState: FromRef<S>,
     S: Clone + Send + Sync + 'static,
 {
     OpenApiRouter::new().routes(utoipa_axum::routes!(get_deployment_info))

--- a/crates/local_backend/src/deployment_state.rs
+++ b/crates/local_backend/src/deployment_state.rs
@@ -16,8 +16,8 @@ use utoipa_axum::router::OpenApiRouter;
 
 use crate::{
     admin::must_be_admin_with_write_access,
-    authentication::ExtractIdentity,
-    LocalAppState,
+    authentication::ExtractAdminIdentity as ExtractIdentity,
+    AdminRouterState,
 };
 
 /// Pause deployment
@@ -41,7 +41,7 @@ use crate::{
     ),
 )]
 pub async fn pause_deployment(
-    MtState(st): MtState<LocalAppState>,
+    MtState(st): MtState<AdminRouterState>,
     ExtractIdentity(identity): ExtractIdentity,
 ) -> Result<impl IntoResponse, HttpResponseError> {
     must_be_admin_with_write_access(&identity)?;
@@ -84,7 +84,7 @@ pub async fn pause_deployment(
     ),
 )]
 pub async fn unpause_deployment(
-    MtState(st): MtState<LocalAppState>,
+    MtState(st): MtState<AdminRouterState>,
     ExtractIdentity(identity): ExtractIdentity,
 ) -> Result<impl IntoResponse, HttpResponseError> {
     must_be_admin_with_write_access(&identity)?;
@@ -111,7 +111,7 @@ pub async fn unpause_deployment(
 
 pub fn platform_router<S>() -> OpenApiRouter<S>
 where
-    LocalAppState: FromRef<S>,
+    AdminRouterState: FromRef<S>,
     S: Clone + Send + Sync + 'static,
 {
     OpenApiRouter::new()

--- a/crates/local_backend/src/environment_variables.rs
+++ b/crates/local_backend/src/environment_variables.rs
@@ -34,8 +34,8 @@ use crate::{
         must_be_admin,
         must_be_admin_with_write_access,
     },
-    authentication::ExtractIdentity,
-    LocalAppState,
+    authentication::ExtractAdminIdentity as ExtractIdentity,
+    AdminRouterState,
 };
 
 #[derive(Deserialize, ToSchema)]
@@ -88,7 +88,7 @@ pub struct UpdateEnvVarsRequest {
     ),
 )]
 pub async fn update_environment_variables(
-    State(st): State<LocalAppState>,
+    State(st): State<AdminRouterState>,
     ExtractIdentity(identity): ExtractIdentity,
     Json(UpdateEnvVarsRequest { changes }): Json<UpdateEnvVarsRequest>,
 ) -> Result<impl IntoResponse, HttpResponseError> {
@@ -139,7 +139,7 @@ pub struct ListEnvVarsResponse {
     ),
 )]
 pub async fn list_environment_variables(
-    MtState(st): MtState<LocalAppState>,
+    MtState(st): MtState<AdminRouterState>,
     ExtractIdentity(identity): ExtractIdentity,
 ) -> Result<impl IntoResponse, HttpResponseError> {
     must_be_admin(&identity)?;
@@ -165,7 +165,7 @@ fn validate_env_var(name: &String, value: &String) -> anyhow::Result<Environment
 
 pub fn platform_router<S>() -> OpenApiRouter<S>
 where
-    LocalAppState: FromRef<S>,
+    AdminRouterState: FromRef<S>,
     S: Clone + Send + Sync + 'static,
 {
     OpenApiRouter::new().routes(utoipa_axum::routes!(

--- a/crates/local_backend/src/lib.rs
+++ b/crates/local_backend/src/lib.rs
@@ -198,6 +198,39 @@ impl From<&LocalAppState> for DeployRouterState {
     }
 }
 
+#[derive(Clone)]
+pub struct AdminRouterState {
+    pub origin: ConvexOrigin,
+    pub site_origin: ConvexSite,
+    pub instance_name: String,
+    pub application: Application<ProdRuntime>,
+    pub zombify_rx: async_broadcast::Receiver<()>,
+    pub replica_mode: bool,
+    pub partition_id: Option<database::partition::PartitionId>,
+    pub raft_state: Option<database::raft_partition::RaftPartitionState>,
+}
+
+impl From<&LocalAppState> for AdminRouterState {
+    fn from(st: &LocalAppState) -> Self {
+        Self {
+            origin: st.origin.clone(),
+            site_origin: st.site_origin.clone(),
+            instance_name: st.instance_name.clone(),
+            application: st.application.clone(),
+            zombify_rx: st.zombify_rx.clone(),
+            replica_mode: st.replica_mode,
+            partition_id: st.partition_id,
+            raft_state: st.raft_state.clone(),
+        }
+    }
+}
+
+impl axum::extract::FromRef<LocalAppState> for AdminRouterState {
+    fn from_ref(st: &LocalAppState) -> Self {
+        Self::from(st)
+    }
+}
+
 #[derive(Serialize)]
 pub struct EmptyResponse {}
 

--- a/crates/local_backend/src/log_sinks.rs
+++ b/crates/local_backend/src/log_sinks.rs
@@ -66,8 +66,8 @@ use crate::{
         must_be_admin,
         must_be_admin_with_write_access,
     },
-    authentication::ExtractIdentity,
-    LocalAppState,
+    authentication::ExtractAdminIdentity as ExtractIdentity,
+    AdminRouterState,
 };
 
 /// Status of a log stream
@@ -145,7 +145,7 @@ impl TryFrom<DatadogSinkPostArgs> for DatadogConfig {
 }
 
 pub async fn add_datadog_sink(
-    MtState(st): MtState<LocalAppState>,
+    MtState(st): MtState<AdminRouterState>,
     ExtractIdentity(identity): ExtractIdentity,
     Json(args): Json<DatadogSinkPostArgs>,
 ) -> Result<impl IntoResponse, HttpResponseError> {
@@ -163,7 +163,7 @@ pub async fn add_datadog_sink(
 }
 
 pub async fn regenerate_webhook_secret(
-    MtState(st): MtState<LocalAppState>,
+    MtState(st): MtState<AdminRouterState>,
     ExtractIdentity(identity): ExtractIdentity,
 ) -> Result<impl IntoResponse, HttpResponseError> {
     tracing::info!(
@@ -206,7 +206,7 @@ pub struct WebhookSinkPostArgs {
 }
 
 pub async fn add_webhook_sink(
-    MtState(st): MtState<LocalAppState>,
+    MtState(st): MtState<AdminRouterState>,
     ExtractIdentity(identity): ExtractIdentity,
     Json(args): Json<WebhookSinkPostArgs>,
 ) -> Result<impl IntoResponse, HttpResponseError> {
@@ -287,7 +287,7 @@ impl TryFrom<AxiomSinkPostArgs> for AxiomConfig {
 }
 
 pub async fn add_axiom_sink(
-    MtState(st): MtState<LocalAppState>,
+    MtState(st): MtState<AdminRouterState>,
     ExtractIdentity(identity): ExtractIdentity,
     Json(args): Json<AxiomSinkPostArgs>,
 ) -> Result<impl IntoResponse, HttpResponseError> {
@@ -321,7 +321,7 @@ async fn add_axiom_sink_inner(
 }
 
 pub async fn add_sentry_sink(
-    MtState(st): MtState<LocalAppState>,
+    MtState(st): MtState<AdminRouterState>,
     ExtractIdentity(identity): ExtractIdentity,
     Json(args): Json<SerializedSentryConfig>,
 ) -> Result<impl IntoResponse, HttpResponseError> {
@@ -343,7 +343,7 @@ pub struct LogSinkDeleteArgs {
 }
 
 pub async fn delete_log_sink(
-    MtState(st): MtState<LocalAppState>,
+    MtState(st): MtState<AdminRouterState>,
     ExtractIdentity(identity): ExtractIdentity,
     Json(LogSinkDeleteArgs { sink_type }): Json<LogSinkDeleteArgs>,
 ) -> Result<impl IntoResponse, HttpResponseError> {
@@ -400,7 +400,7 @@ impl From<LogStreamType> for SinkType {
     ),
 )]
 pub async fn delete_log_stream(
-    MtState(st): MtState<LocalAppState>,
+    MtState(st): MtState<AdminRouterState>,
     ExtractIdentity(identity): ExtractIdentity,
     Path(id): Path<String>,
 ) -> Result<impl IntoResponse, HttpResponseError> {
@@ -640,7 +640,7 @@ async fn ensure_log_sink_does_not_exist(
     ),
 )]
 pub async fn create_log_stream(
-    MtState(st): MtState<LocalAppState>,
+    MtState(st): MtState<AdminRouterState>,
     ExtractIdentity(identity): ExtractIdentity,
     Json(args): Json<CreateLogStreamArgs>,
 ) -> Result<impl IntoResponse, HttpResponseError> {
@@ -781,7 +781,7 @@ pub enum RotateLogStreamSecretResponse {
     ),
 )]
 pub async fn rotate_webhook_secret(
-    MtState(st): MtState<LocalAppState>,
+    MtState(st): MtState<AdminRouterState>,
     ExtractIdentity(identity): ExtractIdentity,
     Path(id): Path<String>,
 ) -> Result<impl IntoResponse, HttpResponseError> {
@@ -998,7 +998,7 @@ fn log_sink_to_log_stream_config(sink: LogSinkWithId) -> Option<LogStreamConfig>
     ),
 )]
 pub async fn list_log_streams(
-    MtState(st): MtState<LocalAppState>,
+    MtState(st): MtState<AdminRouterState>,
     ExtractIdentity(identity): ExtractIdentity,
 ) -> Result<impl IntoResponse, HttpResponseError> {
     must_be_admin(&identity)?;
@@ -1032,7 +1032,7 @@ pub async fn list_log_streams(
     ),
 )]
 pub async fn get_log_stream(
-    MtState(st): MtState<LocalAppState>,
+    MtState(st): MtState<AdminRouterState>,
     ExtractIdentity(identity): ExtractIdentity,
     Path(id): Path<String>,
 ) -> Result<impl IntoResponse, HttpResponseError> {
@@ -1178,7 +1178,7 @@ pub enum UpdateLogStreamArgs {
     ),
 )]
 pub async fn update_log_stream(
-    MtState(st): MtState<LocalAppState>,
+    MtState(st): MtState<AdminRouterState>,
     ExtractIdentity(identity): ExtractIdentity,
     Path(id): Path<String>,
     Json(args): Json<UpdateLogStreamArgs>,
@@ -1406,7 +1406,7 @@ pub async fn update_log_stream(
 
 pub fn platform_router<S>() -> OpenApiRouter<S>
 where
-    LocalAppState: FromRef<S>,
+    AdminRouterState: FromRef<S>,
     S: Clone + Send + Sync + 'static,
 {
     OpenApiRouter::new()

--- a/crates/local_backend/src/logs.rs
+++ b/crates/local_backend/src/logs.rs
@@ -31,12 +31,12 @@ use futures::FutureExt;
 use serde_json::Value as JsonValue;
 
 use crate::{
-    authentication::ExtractIdentity,
-    LocalAppState,
+    authentication::ExtractAdminIdentity as ExtractIdentity,
+    AdminRouterState,
 };
 
 pub async fn stream_udf_execution(
-    MtState(st): MtState<LocalAppState>,
+    MtState(st): MtState<AdminRouterState>,
     ExtractIdentity(identity): ExtractIdentity,
     Query(query_args): Query<StreamUdfExecutionQueryArgs>,
 ) -> Result<impl IntoResponse, HttpResponseError> {
@@ -79,7 +79,7 @@ pub async fn stream_udf_execution(
 // If (session_id, client_request_counter) is provided, the results will be
 // filtered to events from the root execution of the corresponding request.
 pub async fn stream_function_logs(
-    MtState(st): MtState<LocalAppState>,
+    MtState(st): MtState<AdminRouterState>,
     ExtractIdentity(identity): ExtractIdentity,
     ExtractClientVersion(client_version): ExtractClientVersion,
     Query(query_args): Query<StreamFunctionLogs>,

--- a/crates/local_backend/src/route_authority.rs
+++ b/crates/local_backend/src/route_authority.rs
@@ -5,6 +5,7 @@ use database::{
 use errors::ErrorMetadata;
 
 use crate::{
+    AdminRouterState,
     DeployRouterState,
     LocalAppState,
 };
@@ -32,6 +33,20 @@ impl ClusterAuthorityContext for LocalAppState {
 }
 
 impl ClusterAuthorityContext for DeployRouterState {
+    fn replica_mode(&self) -> bool {
+        self.replica_mode
+    }
+
+    fn partition_id(&self) -> Option<PartitionId> {
+        self.partition_id
+    }
+
+    fn raft_state(&self) -> Option<&RaftPartitionState> {
+        self.raft_state.as_ref()
+    }
+}
+
+impl ClusterAuthorityContext for AdminRouterState {
     fn replica_mode(&self) -> bool {
         self.replica_mode
     }

--- a/crates/local_backend/src/router.rs
+++ b/crates/local_backend/src/router.rs
@@ -168,6 +168,7 @@ use crate::{
         replace_tables,
     },
     subs::sync,
+    AdminRouterState,
     DeployRouterState,
     LocalAppState,
     RouterState,
@@ -188,6 +189,25 @@ async fn deploy_api_authority_middleware(
     next: axum::middleware::Next,
 ) -> Result<impl IntoResponse, HttpResponseError> {
     ensure_local_backend_api_authority(&st, req.uri().path())?;
+    Ok(next.run(req).await)
+}
+
+async fn admin_api_authority_middleware(
+    State(st): State<AdminRouterState>,
+    req: axum::extract::Request,
+    next: axum::middleware::Next,
+) -> Result<impl IntoResponse, HttpResponseError> {
+    ensure_local_backend_api_authority(&st, req.uri().path())?;
+    Ok(next.run(req).await)
+}
+
+async fn platform_api_authority_middleware(
+    State(st): State<AdminRouterState>,
+    req: axum::extract::Request,
+    next: axum::middleware::Next,
+) -> Result<impl IntoResponse, HttpResponseError> {
+    let nested_path = format!("/v1{}", req.uri().path());
+    ensure_local_backend_api_authority(&st, &nested_path)?;
     Ok(next.run(req).await)
 }
 
@@ -311,7 +331,7 @@ pub fn router(st: LocalAppState) -> Router {
     // routes are added by common_dashboard_routes below
     let (_, common_dashboard_openapi_spec) =
         OpenApiRouter::with_openapi(DashboardApiDoc::openapi())
-            .merge(common_dashboard_api_router())
+            .merge(common_dashboard_api_router::<AdminRouterState>())
             .split_for_parts();
     let (local_only_dashboard_routes, local_only_openapi_spec) =
         OpenApiRouter::with_openapi(DashboardApiDoc::openapi())
@@ -321,7 +341,8 @@ pub fn router(st: LocalAppState) -> Router {
     let mut dashboard_openapi_spec = common_dashboard_openapi_spec;
     dashboard_openapi_spec.merge(local_only_openapi_spec);
     let dashboard_openapi_json = dashboard_openapi_spec.to_pretty_json().unwrap();
-    let dashboard_routes = common_dashboard_routes()
+    let admin_state = AdminRouterState::from(&st);
+    let dashboard_routes = common_dashboard_routes::<AdminRouterState>()
         .merge(local_only_dashboard_routes)
         // Environment variable routes
         .route("/update_environment_variables", post(update_environment_variables))
@@ -334,7 +355,12 @@ pub fn router(st: LocalAppState) -> Router {
         .route("/dashboard_openapi.json", axum::routing::get({
             move || async { dashboard_openapi_json }
         }))
-        .layer(ServiceBuilder::new());
+        .layer(ServiceBuilder::new())
+        .layer(axum::middleware::from_fn_with_state(
+            admin_state.clone(),
+            admin_api_authority_middleware,
+        ))
+        .with_state(admin_state.clone());
 
     let deploy_push_routes = Router::new()
         .route("/push_config", post(push_config))
@@ -389,31 +415,38 @@ pub fn router(st: LocalAppState) -> Router {
 
     let (platform_routes, platform_openapi) =
         OpenApiRouter::with_openapi(PlatformApiDoc::openapi())
-            .merge(platform_router())
-            .merge(crate::deployment_info::platform_router())
-            .merge(crate::canonical_urls::platform_router())
-            .merge(crate::log_sinks::platform_router())
-            .merge(crate::deployment_state::platform_router())
+            .merge(platform_router::<AdminRouterState>())
+            .merge(crate::deployment_info::platform_router::<AdminRouterState>())
+            .merge(crate::canonical_urls::platform_router::<AdminRouterState>())
+            .merge(crate::log_sinks::platform_router::<AdminRouterState>())
+            .merge(crate::deployment_state::platform_router::<AdminRouterState>())
             .split_for_parts();
     let platform_openapi_spec = platform_openapi.to_pretty_json().unwrap();
-    let platform_routes = Router::new().merge(platform_routes).route(
-        "/openapi.json",
-        axum::routing::get(move || async { platform_openapi_spec }),
-    );
+    let platform_routes = Router::new()
+        .merge(platform_routes)
+        .route(
+            "/openapi.json",
+            axum::routing::get(move || async { platform_openapi_spec }),
+        )
+        .layer(axum::middleware::from_fn_with_state(
+            admin_state.clone(),
+            platform_api_authority_middleware,
+        ))
+        .with_state(admin_state);
 
     let api_routes = Router::new()
         .merge(cli_routes)
-        .merge(dashboard_routes)
         .merge(streaming_export_routes())
         .nest("/actions", action_callback_routes(st.clone()))
         .nest("/export", snapshot_export_routes)
         .nest("/logs", log_sink_routes())
         .nest("/streaming_import", streaming_import_routes())
-        .nest("/v1", platform_routes)
         .layer(axum::middleware::from_fn_with_state(
             st.clone(),
             unmigrated_local_app_state_api_authority_middleware,
         ))
+        .merge(dashboard_routes)
+        .nest("/v1", platform_routes)
         .merge(deploy_routes);
 
     // Endpoints migrated to use the RouterState trait instead of application.
@@ -537,7 +570,7 @@ pub fn http_action_routes() -> Router<RouterState> {
 
 pub fn app_metrics_routes<S>() -> Router<S>
 where
-    LocalAppState: FromMtState<S>,
+    AdminRouterState: FromMtState<S>,
     S: Clone + Send + Sync + 'static,
 {
     Router::new()
@@ -560,7 +593,7 @@ where
 // Routes with the same handlers for the local backend + closed source backend
 pub fn common_dashboard_routes<S>() -> Router<S>
 where
-    LocalAppState: FromMtState<S>,
+    AdminRouterState: FromMtState<S>,
     S: Clone + Send + Sync + 'static,
 {
     let (dashboard_routes_from_openapi, _dashboard_openapi_spec) =
@@ -652,7 +685,7 @@ where
 // applied to `crates_private/usher/src/proxy.rs`.
 pub fn log_sink_routes<S>() -> Router<S>
 where
-    LocalAppState: FromMtState<S>,
+    AdminRouterState: FromMtState<S>,
     S: Clone + Send + Sync + 'static,
 {
     Router::new()
@@ -879,6 +912,152 @@ mod tests {
 
         let req = Request::builder()
             .uri("/api/schema_state/not-a-real-schema-id")
+            .method("GET")
+            .header("Host", "localhost")
+            .header("Authorization", admin_header)
+            .body(Body::empty())?;
+        let (parts, body) = partitioned_app
+            .router()
+            .clone()
+            .oneshot(req)
+            .await?
+            .into_parts();
+        let bytes = body.collect().await?.to_bytes();
+        let body = String::from_utf8_lossy(&bytes);
+        assert_eq!(parts.status, StatusCode::SERVICE_UNAVAILABLE, "{body}");
+        assert!(body.contains("ServiceUnavailable"), "{body}");
+
+        Ok(())
+    }
+
+    #[convex_macro::prod_rt_test]
+    async fn test_dashboard_static_schema_allows_non_authority_partition(
+        rt: ProdRuntime,
+    ) -> anyhow::Result<()> {
+        let backend = setup_backend_for_test(rt).await?;
+
+        let mut partitioned_state = backend.st.clone();
+        partitioned_state.partition_id = Some(PartitionId(1));
+        let partitioned_app = ConvexHttpService::new(
+            router(partitioned_state),
+            "dashboard_schema_authority_test",
+            SERVER_VERSION_STR.to_string(),
+            MAX_CONCURRENT_REQUESTS,
+            Duration::from_secs(125),
+            NoopRouteMapper,
+        );
+
+        let req = Request::builder()
+            .uri("/api/dashboard_openapi.json")
+            .method("GET")
+            .header("Host", "localhost")
+            .body(Body::empty())?;
+        let (parts, body) = partitioned_app
+            .router()
+            .clone()
+            .oneshot(req)
+            .await?
+            .into_parts();
+        let bytes = body.collect().await?.to_bytes();
+        let body = String::from_utf8_lossy(&bytes);
+        assert_eq!(parts.status, StatusCode::OK, "{body}");
+
+        Ok(())
+    }
+
+    #[convex_macro::prod_rt_test]
+    async fn test_dashboard_admin_route_rejects_non_authority_partition(
+        rt: ProdRuntime,
+    ) -> anyhow::Result<()> {
+        let backend = setup_backend_for_test(rt).await?;
+        let admin_header = backend.admin_auth_header.0.encode();
+
+        let mut partitioned_state = backend.st.clone();
+        partitioned_state.partition_id = Some(PartitionId(1));
+        let partitioned_app = ConvexHttpService::new(
+            router(partitioned_state),
+            "dashboard_admin_authority_test",
+            SERVER_VERSION_STR.to_string(),
+            MAX_CONCURRENT_REQUESTS,
+            Duration::from_secs(125),
+            NoopRouteMapper,
+        );
+
+        let req = Request::builder()
+            .uri("/api/list_environment_variables")
+            .method("GET")
+            .header("Host", "localhost")
+            .header("Authorization", admin_header)
+            .body(Body::empty())?;
+        let (parts, body) = partitioned_app
+            .router()
+            .clone()
+            .oneshot(req)
+            .await?
+            .into_parts();
+        let bytes = body.collect().await?.to_bytes();
+        let body = String::from_utf8_lossy(&bytes);
+        assert_eq!(parts.status, StatusCode::SERVICE_UNAVAILABLE, "{body}");
+        assert!(body.contains("ServiceUnavailable"), "{body}");
+
+        Ok(())
+    }
+
+    #[convex_macro::prod_rt_test]
+    async fn test_platform_static_schema_allows_non_authority_partition(
+        rt: ProdRuntime,
+    ) -> anyhow::Result<()> {
+        let backend = setup_backend_for_test(rt).await?;
+
+        let mut partitioned_state = backend.st.clone();
+        partitioned_state.partition_id = Some(PartitionId(1));
+        let partitioned_app = ConvexHttpService::new(
+            router(partitioned_state),
+            "platform_schema_authority_test",
+            SERVER_VERSION_STR.to_string(),
+            MAX_CONCURRENT_REQUESTS,
+            Duration::from_secs(125),
+            NoopRouteMapper,
+        );
+
+        let req = Request::builder()
+            .uri("/api/v1/openapi.json")
+            .method("GET")
+            .header("Host", "localhost")
+            .body(Body::empty())?;
+        let (parts, body) = partitioned_app
+            .router()
+            .clone()
+            .oneshot(req)
+            .await?
+            .into_parts();
+        let bytes = body.collect().await?.to_bytes();
+        let body = String::from_utf8_lossy(&bytes);
+        assert_eq!(parts.status, StatusCode::OK, "{body}");
+
+        Ok(())
+    }
+
+    #[convex_macro::prod_rt_test]
+    async fn test_platform_admin_route_rejects_non_authority_partition(
+        rt: ProdRuntime,
+    ) -> anyhow::Result<()> {
+        let backend = setup_backend_for_test(rt).await?;
+        let admin_header = backend.admin_auth_header.0.encode();
+
+        let mut partitioned_state = backend.st.clone();
+        partitioned_state.partition_id = Some(PartitionId(1));
+        let partitioned_app = ConvexHttpService::new(
+            router(partitioned_state),
+            "platform_admin_authority_test",
+            SERVER_VERSION_STR.to_string(),
+            MAX_CONCURRENT_REQUESTS,
+            Duration::from_secs(125),
+            NoopRouteMapper,
+        );
+
+        let req = Request::builder()
+            .uri("/api/v1/deployment_info")
             .method("GET")
             .header("Host", "localhost")
             .header("Authorization", admin_header)

--- a/crates/local_backend/src/scheduling.rs
+++ b/crates/local_backend/src/scheduling.rs
@@ -34,9 +34,9 @@ use value::TableNamespace;
 
 use crate::{
     admin::must_be_admin_with_write_access,
-    authentication::ExtractIdentity,
+    authentication::ExtractAdminIdentity as ExtractIdentity,
     parse::parse_document_id,
-    LocalAppState,
+    AdminRouterState,
 };
 
 #[derive(Deserialize)]
@@ -58,7 +58,7 @@ pub struct CancelAllJobsRequest {
 
 #[debug_handler]
 pub async fn cancel_all_jobs(
-    State(st): State<LocalAppState>,
+    State(st): State<AdminRouterState>,
     ExtractIdentity(identity): ExtractIdentity,
     Json(CancelAllJobsRequest {
         component_id,
@@ -117,7 +117,7 @@ pub struct CancelJobRequest {
 
 #[debug_handler]
 pub async fn cancel_job(
-    State(st): State<LocalAppState>,
+    State(st): State<AdminRouterState>,
     ExtractIdentity(identity): ExtractIdentity,
     Json(cancel_job_request): Json<CancelJobRequest>,
 ) -> Result<impl IntoResponse, HttpResponseError> {
@@ -158,7 +158,7 @@ pub struct DeleteScheduledFunctionsTableRequest {
     responses((status = 200))
 )]
 pub async fn delete_scheduled_functions_table(
-    MtState(st): MtState<LocalAppState>,
+    MtState(st): MtState<AdminRouterState>,
     ExtractIdentity(identity): ExtractIdentity,
     Json(DeleteScheduledFunctionsTableRequest { component_id }): Json<
         DeleteScheduledFunctionsTableRequest,

--- a/docs/cluster-authority-routing.md
+++ b/docs/cluster-authority-routing.md
@@ -48,6 +48,17 @@ instead of the full `LocalAppState` route tree.
 | `/api/get_config`, `/api/get_config_hashes` | Any-node safe deploy introspection. The current CLI reads target-node module/config hashes before the modern `deploy2` push so each node can materialize its local module view. |
 | `/api/push_config`, `/api/prepare_schema`, `/api/run_test_function`, `/api/schema_state/*` | Coordinator owner unless a narrower forwarding path is added. |
 
+## Admin `AdminRouterState` Routes
+
+Dashboard and platform admin routes use a smaller cluster-aware
+`AdminRouterState` instead of the full `LocalAppState` route tree.
+
+| Route surface | Authority rule |
+| --- | --- |
+| `/api/dashboard_openapi.json`, `/api/v1/openapi.json` | Any-node safe static schemas. |
+| Dashboard admin routes, environment variables, canonical URLs, scheduled job cancellation, and app metrics | Coordinator owner because these routes read or write deployment-global metadata and function-log state. |
+| `/api/v1/*` platform admin routes, including deployment info/state, canonical URLs, environment variables, and platform log-stream configuration | Coordinator owner unless a narrower follower-safe read or forwarding path is added. |
+
 ## Unmigrated `LocalAppState` Routes
 
 Unmigrated `/api` routes bypass `ApplicationApi`, so they are classified by
@@ -56,8 +67,7 @@ in `router.rs`.
 
 | Route surface | Authority rule |
 | --- | --- |
-| `/api/dashboard_openapi.json`, `/api/v1/openapi.json` | Any-node safe static schemas. |
-| Dashboard, platform, import/export, streaming import/export, log sinks, and internal action callbacks | Coordinator owner unless a narrower forwarding path is added. |
+| Import/export, streaming import/export, deprecated `/api/logs/*` log-sink routes, and internal action callbacks | Coordinator owner unless a narrower forwarding path is added. |
 
 ## Adding A Route
 


### PR DESCRIPTION
## Summary
- Add `AdminRouterState` for dashboard, platform admin, app metrics, log streaming, and log-stream configuration handlers.
- Move dashboard and `/api/v1` platform routes out from under the remaining `LocalAppState` middleware and mount them behind admin-specific authority middleware.
- Keep static dashboard/platform OpenAPI schemas any-node safe while coordinator-gating dashboard/platform admin routes on non-owner partitions.
- Update route-authority docs to show the new admin route slice and shrink the remaining `LocalAppState` bucket.

## Validation
- `cargo fmt -p local_backend`
- `git diff --check`
- `cargo test -p local_backend authority -- --nocapture` passed `15/15`
- `cargo check -p local_backend`
- `cargo test -p local_backend test_api_specs_match -- --nocapture`
- `cargo test -p local_backend --lib -- --nocapture` passed `88/88`
- `docker build --progress=plain -t ghcr.io/martinkalema/convex-horizontal-scaling:backend-latest -f self-hosted/docker-build/Dockerfile.backend .`
- Clean cluster `bash self-hosted/docker/test.sh` passed `77/77` write-scaling tests and `10/10` Raft failover tests (`ALL SUITES PASSED`)

Refs #114
Stacked on #120 / #113.