### PR TITLE
feat: migrate action callbacks to cluster-aware state

### DIFF
--- a/crates/local_backend/src/lib.rs
+++ b/crates/local_backend/src/lib.rs
@@ -231,6 +231,25 @@ impl axum::extract::FromRef<LocalAppState> for AdminRouterState {
     }
 }
 
+#[derive(Clone)]
+pub struct ActionCallbackRouterState {
+    pub application: Application<ProdRuntime>,
+    pub replica_mode: bool,
+    pub partition_id: Option<database::partition::PartitionId>,
+    pub raft_state: Option<database::raft_partition::RaftPartitionState>,
+}
+
+impl From<&LocalAppState> for ActionCallbackRouterState {
+    fn from(st: &LocalAppState) -> Self {
+        Self {
+            application: st.application.clone(),
+            replica_mode: st.replica_mode,
+            partition_id: st.partition_id,
+            raft_state: st.raft_state.clone(),
+        }
+    }
+}
+
 #[derive(Serialize)]
 pub struct EmptyResponse {}
 

--- a/crates/local_backend/src/node_action_callbacks.rs
+++ b/crates/local_backend/src/node_action_callbacks.rs
@@ -5,7 +5,10 @@ use std::{
 
 use anyhow::Context;
 use axum::{
-    extract::FromRequestParts,
+    extract::{
+        FromRequestParts,
+        State,
+    },
     response::IntoResponse,
     RequestPartsExt,
 };
@@ -76,7 +79,7 @@ use crate::{
         export_value,
         UdfResponse,
     },
-    LocalAppState,
+    ActionCallbackRouterState,
 };
 
 #[derive(Deserialize, Debug)]
@@ -96,7 +99,7 @@ pub struct NodeCallbackUdfPostRequest {
 /// other Convex functions (i.e. actions calling into mutations)
 #[fastrace::trace]
 pub async fn internal_query_post(
-    MtState(st): MtState<LocalAppState>,
+    MtState(st): MtState<ActionCallbackRouterState>,
     ExtractActionIdentity {
         identity,
         component_id,
@@ -150,7 +153,7 @@ pub async fn internal_query_post(
 /// other Convex functions (i.e. actions calling into mutations)
 #[fastrace::trace]
 pub async fn internal_mutation_post(
-    MtState(st): MtState<LocalAppState>,
+    MtState(st): MtState<ActionCallbackRouterState>,
     ExtractActionIdentity {
         identity,
         component_id,
@@ -209,7 +212,7 @@ pub async fn internal_mutation_post(
 /// other Convex functions (i.e. actions calling into actions)
 #[fastrace::trace]
 pub async fn internal_action_post(
-    MtState(st): MtState<LocalAppState>,
+    MtState(st): MtState<ActionCallbackRouterState>,
     ExtractActionIdentity {
         identity,
         component_id,
@@ -277,7 +280,7 @@ pub struct ScheduleJobResponse {
 }
 
 pub async fn schedule_job(
-    MtState(st): MtState<LocalAppState>,
+    MtState(st): MtState<ActionCallbackRouterState>,
     ExtractActionIdentity {
         identity,
         component_id,
@@ -327,7 +330,7 @@ pub struct CancelDeveloperJobRequest {
 }
 
 pub async fn cancel_developer_job(
-    MtState(st): MtState<LocalAppState>,
+    MtState(st): MtState<ActionCallbackRouterState>,
     ExtractActionIdentity {
         identity,
         component_id: _,
@@ -359,7 +362,7 @@ pub struct CreateFunctionHandleResponse {
 }
 
 pub async fn create_function_handle(
-    MtState(st): MtState<LocalAppState>,
+    MtState(st): MtState<ActionCallbackRouterState>,
     ExtractActionIdentity {
         identity,
         component_id,
@@ -390,7 +393,7 @@ pub async fn create_function_handle(
 }
 
 pub async fn vector_search(
-    MtState(st): MtState<LocalAppState>,
+    MtState(st): MtState<ActionCallbackRouterState>,
     ExtractActionIdentity {
         identity,
         component_id,
@@ -448,7 +451,7 @@ pub async fn vector_search(
 }
 
 pub async fn storage_generate_upload_url(
-    MtState(st): MtState<LocalAppState>,
+    MtState(st): MtState<ActionCallbackRouterState>,
     ExtractActionIdentity {
         identity,
         component_id,
@@ -468,7 +471,7 @@ pub struct GetParams {
 }
 
 pub async fn storage_get_url(
-    MtState(st): MtState<LocalAppState>,
+    MtState(st): MtState<ActionCallbackRouterState>,
     ExtractActionIdentity {
         identity,
         component_id,
@@ -485,7 +488,7 @@ pub async fn storage_get_url(
 }
 
 pub async fn storage_get_metadata(
-    MtState(st): MtState<LocalAppState>,
+    MtState(st): MtState<ActionCallbackRouterState>,
     ExtractActionIdentity {
         identity,
         component_id,
@@ -521,7 +524,7 @@ pub async fn storage_get_metadata(
 }
 
 pub async fn storage_delete(
-    MtState(st): MtState<LocalAppState>,
+    MtState(st): MtState<ActionCallbackRouterState>,
     ExtractActionIdentity {
         identity,
         component_id,
@@ -539,7 +542,7 @@ pub async fn storage_delete(
 pub static CONVEX_ACTIONS_CALLBACK_TOKEN: &str = "Convex-Action-Callback-Token";
 
 async fn check_actions_token(
-    st: &LocalAppState,
+    st: &ActionCallbackRouterState,
     headers: &HeaderMap,
 ) -> anyhow::Result<(SystemTime, ComponentId)> {
     let value = headers
@@ -569,14 +572,11 @@ fn get_encoded_span(headers: &HeaderMap) -> anyhow::Result<EncodedSpan> {
     ))
 }
 
-pub async fn action_callbacks_middleware<S>(
-    MtState(st): MtState<LocalAppState>,
+pub async fn action_callbacks_middleware(
+    State(st): State<ActionCallbackRouterState>,
     req: axum::extract::Request,
     next: axum::middleware::Next,
-) -> Result<impl IntoResponse, HttpResponseError>
-where
-    LocalAppState: FromMtState<S>,
-{
+) -> Result<impl IntoResponse, HttpResponseError> {
     // Validate we have an valid token in order to call any methods in this
     // actions_callback router.
     check_actions_token(&st, req.headers()).await?;
@@ -597,7 +597,7 @@ pub struct ExtractActionIdentity {
 
 impl<S> FromRequestParts<S> for ExtractActionIdentity
 where
-    LocalAppState: FromMtState<S>,
+    ActionCallbackRouterState: FromMtState<S>,
     S: Send + Sync + Clone + 'static,
 {
     type Rejection = HttpResponseError;
@@ -606,7 +606,7 @@ where
         parts: &mut axum::http::request::Parts,
         st: &S,
     ) -> Result<Self, Self::Rejection> {
-        let st = LocalAppState::from_request_parts(parts, st).await?;
+        let st = ActionCallbackRouterState::from_request_parts(parts, st).await?;
         let token: AuthenticationToken =
             parts.extract::<ExtractAuthenticationToken>().await?.into();
 

--- a/crates/local_backend/src/route_authority.rs
+++ b/crates/local_backend/src/route_authority.rs
@@ -5,6 +5,7 @@ use database::{
 use errors::ErrorMetadata;
 
 use crate::{
+    ActionCallbackRouterState,
     AdminRouterState,
     DeployRouterState,
     LocalAppState,
@@ -47,6 +48,20 @@ impl ClusterAuthorityContext for DeployRouterState {
 }
 
 impl ClusterAuthorityContext for AdminRouterState {
+    fn replica_mode(&self) -> bool {
+        self.replica_mode
+    }
+
+    fn partition_id(&self) -> Option<PartitionId> {
+        self.partition_id
+    }
+
+    fn raft_state(&self) -> Option<&RaftPartitionState> {
+        self.raft_state.as_ref()
+    }
+}
+
+impl ClusterAuthorityContext for ActionCallbackRouterState {
     fn replica_mode(&self) -> bool {
         self.replica_mode
     }

--- a/crates/local_backend/src/router.rs
+++ b/crates/local_backend/src/router.rs
@@ -168,6 +168,7 @@ use crate::{
         replace_tables,
     },
     subs::sync,
+    ActionCallbackRouterState,
     AdminRouterState,
     DeployRouterState,
     LocalAppState,
@@ -207,6 +208,16 @@ async fn platform_api_authority_middleware(
     next: axum::middleware::Next,
 ) -> Result<impl IntoResponse, HttpResponseError> {
     let nested_path = format!("/v1{}", req.uri().path());
+    ensure_local_backend_api_authority(&st, &nested_path)?;
+    Ok(next.run(req).await)
+}
+
+async fn action_callback_api_authority_middleware(
+    State(st): State<ActionCallbackRouterState>,
+    req: axum::extract::Request,
+    next: axum::middleware::Next,
+) -> Result<impl IntoResponse, HttpResponseError> {
+    let nested_path = format!("/actions{}", req.uri().path());
     ensure_local_backend_api_authority(&st, &nested_path)?;
     Ok(next.run(req).await)
 }
@@ -406,6 +417,13 @@ pub fn router(st: LocalAppState) -> Router {
         .route("/stream_function_logs", get(stream_function_logs))
         .merge(import_routes())
         .layer(cli_cors());
+    let action_callback_state = ActionCallbackRouterState::from(&st);
+    let action_callback_routes = action_callback_routes(action_callback_state.clone())
+        .layer(axum::middleware::from_fn_with_state(
+            action_callback_state.clone(),
+            action_callback_api_authority_middleware,
+        ))
+        .with_state(action_callback_state);
 
     let snapshot_export_routes = Router::new()
         .route("/request/zip", post(request_zip_export))
@@ -437,7 +455,6 @@ pub fn router(st: LocalAppState) -> Router {
     let api_routes = Router::new()
         .merge(cli_routes)
         .merge(streaming_export_routes())
-        .nest("/actions", action_callback_routes(st.clone()))
         .nest("/export", snapshot_export_routes)
         .nest("/logs", log_sink_routes())
         .nest("/streaming_import", streaming_import_routes())
@@ -445,6 +462,7 @@ pub fn router(st: LocalAppState) -> Router {
             st.clone(),
             unmigrated_local_app_state_api_authority_middleware,
         ))
+        .nest("/actions", action_callback_routes)
         .merge(dashboard_routes)
         .nest("/v1", platform_routes)
         .merge(deploy_routes);
@@ -524,11 +542,9 @@ pub fn storage_api_routes() -> Router<RouterState> {
 // IMPORTANT NOTE: Those routes are proxied by Usher. Any changes to the router,
 // such as adding or removing a route, or changing limits, also need to be
 // applied to `crates_private/usher/src/proxy.rs`.
-pub fn action_callback_routes<S>(state: S) -> Router<S>
-where
-    LocalAppState: FromMtState<S>,
-    S: Send + Sync + Clone + 'static,
-{
+pub fn action_callback_routes(
+    state: ActionCallbackRouterState,
+) -> Router<ActionCallbackRouterState> {
     Router::new()
         .route("/query", post(internal_query_post))
         .route("/mutation", post(internal_mutation_post))
@@ -544,7 +560,10 @@ where
         .route("/storage_delete", post(storage_delete))
         // All routes above this line get the increased limit
         .layer(DefaultBodyLimit::max(*MAX_BACKEND_RPC_REQUEST_SIZE))
-        .layer(axum::middleware::from_fn_with_state(state, action_callbacks_middleware::<S>))
+        .layer(axum::middleware::from_fn_with_state(
+            state,
+            action_callbacks_middleware,
+        ))
 }
 
 pub fn import_routes<S>() -> Router<S>
@@ -726,9 +745,12 @@ mod tests {
     use anyhow::Context;
     use axum::body::Body;
     use axum_extra::headers::authorization::Credentials;
-    use common::http::{
-        ConvexHttpService,
-        NoopRouteMapper,
+    use common::{
+        components::ComponentId,
+        http::{
+            ConvexHttpService,
+            NoopRouteMapper,
+        },
     };
     use database::partition::PartitionId;
     use http::{
@@ -1072,6 +1094,59 @@ mod tests {
         let body = String::from_utf8_lossy(&bytes);
         assert_eq!(parts.status, StatusCode::SERVICE_UNAVAILABLE, "{body}");
         assert!(body.contains("ServiceUnavailable"), "{body}");
+
+        Ok(())
+    }
+
+    #[convex_macro::prod_rt_test]
+    async fn test_action_callbacks_reject_non_authority_partition(
+        rt: ProdRuntime,
+    ) -> anyhow::Result<()> {
+        let backend = setup_backend_for_test(rt).await?;
+        let callback_token = backend
+            .st
+            .application
+            .key_broker()
+            .issue_action_token(ComponentId::test_user());
+
+        let mut partitioned_state = backend.st.clone();
+        partitioned_state.partition_id = Some(PartitionId(1));
+        let partitioned_app = ConvexHttpService::new(
+            router(partitioned_state),
+            "action_callback_authority_test",
+            SERVER_VERSION_STR.to_string(),
+            MAX_CONCURRENT_REQUESTS,
+            Duration::from_secs(125),
+            NoopRouteMapper,
+        );
+
+        for path in [
+            "/api/actions/mutation",
+            "/api/actions/schedule_job",
+            "/api/actions/storage_delete",
+        ] {
+            let req = Request::builder()
+                .uri(path)
+                .method("POST")
+                .header("Host", "localhost")
+                .header("Content-Type", "application/json")
+                .header("Convex-Action-Callback-Token", callback_token.clone())
+                .body(Body::from("{}"))?;
+            let (parts, body) = partitioned_app
+                .router()
+                .clone()
+                .oneshot(req)
+                .await?
+                .into_parts();
+            let bytes = body.collect().await?.to_bytes();
+            let body = String::from_utf8_lossy(&bytes);
+            assert_eq!(
+                parts.status,
+                StatusCode::SERVICE_UNAVAILABLE,
+                "{path}: {body}"
+            );
+            assert!(body.contains("ServiceUnavailable"), "{path}: {body}");
+        }
 
         Ok(())
     }

--- a/docs/cluster-authority-routing.md
+++ b/docs/cluster-authority-routing.md
@@ -59,6 +59,15 @@ Dashboard and platform admin routes use a smaller cluster-aware
 | Dashboard admin routes, environment variables, canonical URLs, scheduled job cancellation, and app metrics | Coordinator owner because these routes read or write deployment-global metadata and function-log state. |
 | `/api/v1/*` platform admin routes, including deployment info/state, canonical URLs, environment variables, and platform log-stream configuration | Coordinator owner unless a narrower follower-safe read or forwarding path is added. |
 
+## Internal Action Callback `ActionCallbackRouterState` Routes
+
+Internal action callbacks use a dedicated `ActionCallbackRouterState` instead
+of the full `LocalAppState` route tree.
+
+| Route surface | Authority rule |
+| --- | --- |
+| `/api/actions/*` internal query, mutation, action, scheduling, vector search, function-handle, and storage callbacks | Coordinator owner until callback reads and side effects have a narrower partition/index/storage ownership model or explicit forwarding path. |
+
 ## Unmigrated `LocalAppState` Routes
 
 Unmigrated `/api` routes bypass `ApplicationApi`, so they are classified by
@@ -67,7 +76,7 @@ in `router.rs`.
 
 | Route surface | Authority rule |
 | --- | --- |
-| Import/export, streaming import/export, deprecated `/api/logs/*` log-sink routes, and internal action callbacks | Coordinator owner unless a narrower forwarding path is added. |
+| Import/export, streaming import/export, and deprecated `/api/logs/*` log-sink routes | Coordinator owner unless a narrower forwarding path is added. |
 
 ## Adding A Route
 


### PR DESCRIPTION
## Summary
- Add `ActionCallbackRouterState` for `/api/actions/*` internal runtime callbacks.
- Move callback handlers, action-token middleware, and action identity extraction off `LocalAppState`.
- Mount `/api/actions/*` behind callback-specific authority middleware while keeping action callback token validation intact.
- Add wrong-node coverage for mutation, scheduling, and storage callback surfaces.
- Update route authority docs and shrink the remaining `LocalAppState` route bucket.

## Validation
- `cargo fmt -p local_backend`
- `git diff --check`
- `cargo check -p local_backend`
- `cargo test -p local_backend action_callback -- --nocapture`
- `cargo test -p local_backend test_cancel_recursive_scheduled_job -- --nocapture`
- `cargo test -p local_backend authority -- --nocapture` passed `16/16`
- `cargo test -p local_backend --lib -- --nocapture` passed `89/89`
- `docker build --progress=plain -t ghcr.io/martinkalema/convex-horizontal-scaling:backend-latest -f self-hosted/docker-build/Dockerfile.backend .`
- Clean cluster `bash self-hosted/docker/test.sh` passed `77/77` write-scaling and `10/10` Raft failover (`ALL SUITES PASSED`)

Refs #115