### PR TITLE
feat: migrate import export routes to cluster-aware state

### DIFF
--- a/crates/local_backend/src/authentication.rs
+++ b/crates/local_backend/src/authentication.rs
@@ -33,6 +33,7 @@ use sync_types::{
 
 use crate::{
     AdminRouterState,
+    ImportExportRouterState,
     LocalAppState,
     RouterState,
 };
@@ -160,6 +161,37 @@ where
 
 impl From<ExtractAdminIdentity> for Identity {
     fn from(identity: ExtractAdminIdentity) -> Self {
+        identity.0
+    }
+}
+
+pub struct ExtractImportExportIdentity(pub Identity);
+
+impl<S> FromRequestParts<S> for ExtractImportExportIdentity
+where
+    ImportExportRouterState: FromMtState<S>,
+    S: Send + Sync + Clone + 'static,
+{
+    type Rejection = HttpResponseError;
+
+    async fn from_request_parts(
+        parts: &mut axum::http::request::Parts,
+        st: &S,
+    ) -> Result<Self, Self::Rejection> {
+        let token: AuthenticationToken =
+            parts.extract::<ExtractAuthenticationToken>().await?.into();
+        let st = ImportExportRouterState::from_request_parts(parts, st).await?;
+
+        Ok(Self(
+            st.application
+                .authenticate(token, st.application.runtime().system_time())
+                .await?,
+        ))
+    }
+}
+
+impl From<ExtractImportExportIdentity> for Identity {
+    fn from(identity: ExtractImportExportIdentity) -> Self {
         identity.0
     }
 }

--- a/crates/local_backend/src/lib.rs
+++ b/crates/local_backend/src/lib.rs
@@ -250,6 +250,25 @@ impl From<&LocalAppState> for ActionCallbackRouterState {
     }
 }
 
+#[derive(Clone)]
+pub struct ImportExportRouterState {
+    pub application: Application<ProdRuntime>,
+    pub replica_mode: bool,
+    pub partition_id: Option<database::partition::PartitionId>,
+    pub raft_state: Option<database::raft_partition::RaftPartitionState>,
+}
+
+impl From<&LocalAppState> for ImportExportRouterState {
+    fn from(st: &LocalAppState) -> Self {
+        Self {
+            application: st.application.clone(),
+            replica_mode: st.replica_mode,
+            partition_id: st.partition_id,
+            raft_state: st.raft_state.clone(),
+        }
+    }
+}
+
 #[derive(Serialize)]
 pub struct EmptyResponse {}
 

--- a/crates/local_backend/src/route_authority.rs
+++ b/crates/local_backend/src/route_authority.rs
@@ -8,6 +8,7 @@ use crate::{
     ActionCallbackRouterState,
     AdminRouterState,
     DeployRouterState,
+    ImportExportRouterState,
     LocalAppState,
 };
 
@@ -62,6 +63,20 @@ impl ClusterAuthorityContext for AdminRouterState {
 }
 
 impl ClusterAuthorityContext for ActionCallbackRouterState {
+    fn replica_mode(&self) -> bool {
+        self.replica_mode
+    }
+
+    fn partition_id(&self) -> Option<PartitionId> {
+        self.partition_id
+    }
+
+    fn raft_state(&self) -> Option<&RaftPartitionState> {
+        self.raft_state.as_ref()
+    }
+}
+
+impl ClusterAuthorityContext for ImportExportRouterState {
     fn replica_mode(&self) -> bool {
         self.replica_mode
     }

--- a/crates/local_backend/src/router.rs
+++ b/crates/local_backend/src/router.rs
@@ -171,6 +171,7 @@ use crate::{
     ActionCallbackRouterState,
     AdminRouterState,
     DeployRouterState,
+    ImportExportRouterState,
     LocalAppState,
     RouterState,
 };
@@ -218,6 +219,35 @@ async fn action_callback_api_authority_middleware(
     next: axum::middleware::Next,
 ) -> Result<impl IntoResponse, HttpResponseError> {
     let nested_path = format!("/actions{}", req.uri().path());
+    ensure_local_backend_api_authority(&st, &nested_path)?;
+    Ok(next.run(req).await)
+}
+
+async fn import_export_api_authority_middleware(
+    State(st): State<ImportExportRouterState>,
+    req: axum::extract::Request,
+    next: axum::middleware::Next,
+) -> Result<impl IntoResponse, HttpResponseError> {
+    ensure_local_backend_api_authority(&st, req.uri().path())?;
+    Ok(next.run(req).await)
+}
+
+async fn snapshot_export_api_authority_middleware(
+    State(st): State<ImportExportRouterState>,
+    req: axum::extract::Request,
+    next: axum::middleware::Next,
+) -> Result<impl IntoResponse, HttpResponseError> {
+    let nested_path = format!("/export{}", req.uri().path());
+    ensure_local_backend_api_authority(&st, &nested_path)?;
+    Ok(next.run(req).await)
+}
+
+async fn streaming_import_api_authority_middleware(
+    State(st): State<ImportExportRouterState>,
+    req: axum::extract::Request,
+    next: axum::middleware::Next,
+) -> Result<impl IntoResponse, HttpResponseError> {
+    let nested_path = format!("/streaming_import{}", req.uri().path());
     ensure_local_backend_api_authority(&st, &nested_path)?;
     Ok(next.run(req).await)
 }
@@ -415,8 +445,39 @@ pub fn router(st: LocalAppState) -> Router {
     let cli_routes = Router::new()
         .route("/stream_udf_execution", get(stream_udf_execution))
         .route("/stream_function_logs", get(stream_function_logs))
-        .merge(import_routes())
         .layer(cli_cors());
+
+    let import_export_state = ImportExportRouterState::from(&st);
+    let snapshot_import_routes = import_routes()
+        .layer(cli_cors())
+        .layer(axum::middleware::from_fn_with_state(
+            import_export_state.clone(),
+            import_export_api_authority_middleware,
+        ))
+        .with_state(import_export_state.clone());
+    let streaming_export_routes = streaming_export_routes()
+        .layer(axum::middleware::from_fn_with_state(
+            import_export_state.clone(),
+            import_export_api_authority_middleware,
+        ))
+        .with_state(import_export_state.clone());
+    let snapshot_export_routes = Router::new()
+        .route("/request/zip", post(request_zip_export))
+        .route("/zip/{id}", get(get_zip_export))
+        .route("/set_expiration/{snapshot_id}", post(set_export_expiration))
+        .route("/cancel/{snapshot_id}", post(cancel_export))
+        .layer(axum::middleware::from_fn_with_state(
+            import_export_state.clone(),
+            snapshot_export_api_authority_middleware,
+        ))
+        .with_state(import_export_state.clone());
+    let streaming_import_routes = streaming_import_routes()
+        .layer(axum::middleware::from_fn_with_state(
+            import_export_state.clone(),
+            streaming_import_api_authority_middleware,
+        ))
+        .with_state(import_export_state.clone());
+
     let action_callback_state = ActionCallbackRouterState::from(&st);
     let action_callback_routes = action_callback_routes(action_callback_state.clone())
         .layer(axum::middleware::from_fn_with_state(
@@ -424,12 +485,6 @@ pub fn router(st: LocalAppState) -> Router {
             action_callback_api_authority_middleware,
         ))
         .with_state(action_callback_state);
-
-    let snapshot_export_routes = Router::new()
-        .route("/request/zip", post(request_zip_export))
-        .route("/zip/{id}", get(get_zip_export))
-        .route("/set_expiration/{snapshot_id}", post(set_export_expiration))
-        .route("/cancel/{snapshot_id}", post(cancel_export));
 
     let (platform_routes, platform_openapi) =
         OpenApiRouter::with_openapi(PlatformApiDoc::openapi())
@@ -454,14 +509,15 @@ pub fn router(st: LocalAppState) -> Router {
 
     let api_routes = Router::new()
         .merge(cli_routes)
-        .merge(streaming_export_routes())
-        .nest("/export", snapshot_export_routes)
         .nest("/logs", log_sink_routes())
-        .nest("/streaming_import", streaming_import_routes())
         .layer(axum::middleware::from_fn_with_state(
             st.clone(),
             unmigrated_local_app_state_api_authority_middleware,
         ))
+        .merge(snapshot_import_routes)
+        .merge(streaming_export_routes)
+        .nest("/export", snapshot_export_routes)
+        .nest("/streaming_import", streaming_import_routes)
         .nest("/actions", action_callback_routes)
         .merge(dashboard_routes)
         .nest("/v1", platform_routes)
@@ -566,11 +622,7 @@ pub fn action_callback_routes(
         ))
 }
 
-pub fn import_routes<S>() -> Router<S>
-where
-    LocalAppState: FromMtState<S>,
-    S: Clone + Send + Sync + 'static,
-{
+pub fn import_routes() -> Router<ImportExportRouterState> {
     Router::new()
         .route("/import", post(import))
         .route("/import/start_upload", post(import_start_upload))
@@ -652,11 +704,7 @@ where
 // IMPORTANT NOTE: Those routes are proxied by Usher. Any changes to the router,
 // such as adding or removing a route, or changing limits, also need to be
 // applied to `crates_private/usher/src/proxy.rs`.
-pub fn streaming_import_routes<S>() -> Router<S>
-where
-    LocalAppState: FromMtState<S>,
-    S: Clone + Send + Sync + 'static,
-{
+pub fn streaming_import_routes() -> Router<ImportExportRouterState> {
     Router::new()
         .route(
             "/import_airbyte_records",
@@ -680,11 +728,7 @@ where
 // IMPORTANT NOTE: Those routes are proxied by Usher. Any changes to the router,
 // such as adding or removing a route, or changing limits, also need to be
 // applied to `crates_private/usher/src/proxy.rs`.
-pub fn streaming_export_routes<S>() -> Router<S>
-where
-    LocalAppState: FromMtState<S>,
-    S: Clone + Send + Sync + 'static,
-{
+pub fn streaming_export_routes() -> Router<ImportExportRouterState> {
     Router::new()
         .route("/document_deltas", get(document_deltas_get))
         .route("/document_deltas", post(document_deltas_post))
@@ -1132,6 +1176,56 @@ mod tests {
                 .header("Content-Type", "application/json")
                 .header("Convex-Action-Callback-Token", callback_token.clone())
                 .body(Body::from("{}"))?;
+            let (parts, body) = partitioned_app
+                .router()
+                .clone()
+                .oneshot(req)
+                .await?
+                .into_parts();
+            let bytes = body.collect().await?.to_bytes();
+            let body = String::from_utf8_lossy(&bytes);
+            assert_eq!(
+                parts.status,
+                StatusCode::SERVICE_UNAVAILABLE,
+                "{path}: {body}"
+            );
+            assert!(body.contains("ServiceUnavailable"), "{path}: {body}");
+        }
+
+        Ok(())
+    }
+
+    #[convex_macro::prod_rt_test]
+    async fn test_import_export_routes_reject_non_authority_partition(
+        rt: ProdRuntime,
+    ) -> anyhow::Result<()> {
+        let backend = setup_backend_for_test(rt).await?;
+        let admin_header = backend.admin_auth_header.0.encode();
+
+        let mut partitioned_state = backend.st.clone();
+        partitioned_state.partition_id = Some(PartitionId(1));
+        let partitioned_app = ConvexHttpService::new(
+            router(partitioned_state),
+            "import_export_authority_test",
+            SERVER_VERSION_STR.to_string(),
+            MAX_CONCURRENT_REQUESTS,
+            Duration::from_secs(125),
+            NoopRouteMapper,
+        );
+
+        for (method, path, body) in [
+            ("POST", "/api/import/start_upload", ""),
+            ("POST", "/api/export/request/zip", ""),
+            ("GET", "/api/streaming_import/get_schema", ""),
+            ("GET", "/api/document_deltas?cursor=0", ""),
+        ] {
+            let req = Request::builder()
+                .uri(path)
+                .method(method)
+                .header("Host", "localhost")
+                .header("Content-Type", "application/json")
+                .header("Authorization", admin_header.clone())
+                .body(Body::from(body))?;
             let (parts, body) = partitioned_app
                 .router()
                 .clone()

--- a/crates/local_backend/src/snapshot_export.rs
+++ b/crates/local_backend/src/snapshot_export.rs
@@ -42,9 +42,9 @@ use value::PublicDocumentId;
 
 use crate::{
     admin::must_be_admin_with_write_access,
-    authentication::ExtractIdentity,
+    authentication::ExtractImportExportIdentity,
     custom_headers::ContentDispositionAttachment,
-    LocalAppState,
+    ImportExportRouterState,
 };
 
 // Export GETs are immutable. Browser can cache for a long time.
@@ -60,8 +60,8 @@ pub struct RequestZipExport {
 
 #[fastrace::trace]
 pub async fn request_zip_export(
-    MtState(st): MtState<LocalAppState>,
-    ExtractIdentity(identity): ExtractIdentity,
+    MtState(st): MtState<ImportExportRouterState>,
+    ExtractImportExportIdentity(identity): ExtractImportExportIdentity,
     Query(RequestZipExport {
         include_storage,
         component,
@@ -88,8 +88,8 @@ pub struct ZipExportRequest {
 }
 
 pub async fn get_zip_export(
-    MtState(st): MtState<LocalAppState>,
-    ExtractIdentity(identity): ExtractIdentity,
+    MtState(st): MtState<ImportExportRouterState>,
+    ExtractImportExportIdentity(identity): ExtractImportExportIdentity,
     Path(ZipExportRequest { id }): Path<ZipExportRequest>,
 ) -> Result<impl IntoResponse, HttpResponseError> {
     must_be_admin_with_write_access(&identity)?;
@@ -129,8 +129,8 @@ pub struct SetExportExpirationPathArgs {
 
 #[fastrace::trace]
 pub async fn set_export_expiration(
-    MtState(st): MtState<LocalAppState>,
-    ExtractIdentity(identity): ExtractIdentity,
+    MtState(st): MtState<ImportExportRouterState>,
+    ExtractImportExportIdentity(identity): ExtractImportExportIdentity,
     Path(SetExportExpirationPathArgs { snapshot_id }): Path<SetExportExpirationPathArgs>,
     Json(SetExportExpirationRequest { expiration_ts_ns }): Json<SetExportExpirationRequest>,
 ) -> Result<StatusCode, HttpResponseError> {
@@ -153,8 +153,8 @@ pub async fn set_export_expiration(
 
 #[fastrace::trace]
 pub async fn cancel_export(
-    MtState(st): MtState<LocalAppState>,
-    ExtractIdentity(identity): ExtractIdentity,
+    MtState(st): MtState<ImportExportRouterState>,
+    ExtractImportExportIdentity(identity): ExtractImportExportIdentity,
     Path(SetExportExpirationPathArgs { snapshot_id }): Path<SetExportExpirationPathArgs>,
 ) -> Result<StatusCode, HttpResponseError> {
     // This route is accessed directly from the admin dashboard

--- a/crates/local_backend/src/snapshot_import.rs
+++ b/crates/local_backend/src/snapshot_import.rs
@@ -44,8 +44,8 @@ use value::{
 
 use crate::{
     admin::must_be_admin_with_write_access,
-    authentication::ExtractIdentity,
-    LocalAppState,
+    authentication::ExtractImportExportIdentity,
+    ImportExportRouterState,
 };
 
 #[derive(Deserialize)]
@@ -126,8 +126,8 @@ fn parse_format_arg(
 }
 
 pub async fn import(
-    MtState(st): MtState<LocalAppState>,
-    ExtractIdentity(identity): ExtractIdentity,
+    MtState(st): MtState<ImportExportRouterState>,
+    ExtractImportExportIdentity(identity): ExtractImportExportIdentity,
     Query(ImportQueryArgs {
         table_name,
         component_path,
@@ -162,8 +162,8 @@ pub struct StartUploadResponse {
 }
 
 pub async fn import_start_upload(
-    MtState(st): MtState<LocalAppState>,
-    ExtractIdentity(identity): ExtractIdentity,
+    MtState(st): MtState<ImportExportRouterState>,
+    ExtractImportExportIdentity(identity): ExtractImportExportIdentity,
 ) -> Result<impl IntoResponse, HttpResponseError> {
     must_be_admin_with_write_access(&identity)?;
     let token = st
@@ -176,8 +176,8 @@ pub async fn import_start_upload(
 }
 
 pub async fn import_upload_part(
-    MtState(st): MtState<LocalAppState>,
-    ExtractIdentity(identity): ExtractIdentity,
+    MtState(st): MtState<ImportExportRouterState>,
+    ExtractImportExportIdentity(identity): ExtractImportExportIdentity,
     Query(ImportUploadPartArgs {
         upload_token,
         part_number,
@@ -213,8 +213,8 @@ pub struct ImportFinishUploadResponse {
 }
 
 pub async fn import_finish_upload(
-    MtState(st): MtState<LocalAppState>,
-    ExtractIdentity(identity): ExtractIdentity,
+    MtState(st): MtState<ImportExportRouterState>,
+    ExtractImportExportIdentity(identity): ExtractImportExportIdentity,
     Json(ImportFinishUploadArgs {
         import:
             ImportQueryArgs {
@@ -256,8 +256,8 @@ pub struct PerformImportArgs {
 }
 
 pub async fn perform_import(
-    MtState(st): MtState<LocalAppState>,
-    ExtractIdentity(identity): ExtractIdentity,
+    MtState(st): MtState<ImportExportRouterState>,
+    ExtractImportExportIdentity(identity): ExtractImportExportIdentity,
     Json(PerformImportArgs { import_id }): Json<PerformImportArgs>,
 ) -> Result<impl IntoResponse, HttpResponseError> {
     must_be_admin_with_write_access(&identity)?;
@@ -276,8 +276,8 @@ pub struct CancelImportArgs {
 }
 
 pub async fn cancel_import(
-    MtState(st): MtState<LocalAppState>,
-    ExtractIdentity(identity): ExtractIdentity,
+    MtState(st): MtState<ImportExportRouterState>,
+    ExtractImportExportIdentity(identity): ExtractImportExportIdentity,
     Json(CancelImportArgs { import_id }): Json<CancelImportArgs>,
 ) -> Result<impl IntoResponse, HttpResponseError> {
     let import_id = PublicDocumentId::decode(&import_id).context(ErrorMetadata::bad_request(

--- a/crates/local_backend/src/streaming_export.rs
+++ b/crates/local_backend/src/streaming_export.rs
@@ -90,30 +90,30 @@ use value::{
 
 use crate::{
     admin::must_be_admin,
-    authentication::ExtractIdentity,
-    LocalAppState,
+    authentication::ExtractImportExportIdentity,
+    ImportExportRouterState,
 };
 
 #[fastrace::trace]
 pub async fn document_deltas_get(
-    MtState(st): MtState<LocalAppState>,
+    MtState(st): MtState<ImportExportRouterState>,
     Query(args): Query<DocumentDeltasArgs>,
-    ExtractIdentity(identity): ExtractIdentity,
+    ExtractImportExportIdentity(identity): ExtractImportExportIdentity,
 ) -> Result<impl IntoResponse, HttpResponseError> {
     _document_deltas(st, args, identity).await
 }
 
 #[fastrace::trace]
 pub async fn document_deltas_post(
-    MtState(st): MtState<LocalAppState>,
-    ExtractIdentity(identity): ExtractIdentity,
+    MtState(st): MtState<ImportExportRouterState>,
+    ExtractImportExportIdentity(identity): ExtractImportExportIdentity,
     Json(args): Json<DocumentDeltasArgs>,
 ) -> Result<impl IntoResponse, HttpResponseError> {
     _document_deltas(st, args, identity).await
 }
 
 pub async fn _document_deltas(
-    st: LocalAppState,
+    st: ImportExportRouterState,
     args: DocumentDeltasArgs,
     identity: Identity,
 ) -> Result<impl IntoResponse, HttpResponseError> {
@@ -192,24 +192,24 @@ pub async fn _document_deltas(
 
 #[fastrace::trace]
 pub async fn list_snapshot_get(
-    MtState(st): MtState<LocalAppState>,
+    MtState(st): MtState<ImportExportRouterState>,
     Query(query_args): Query<ListSnapshotArgs>,
-    ExtractIdentity(identity): ExtractIdentity,
+    ExtractImportExportIdentity(identity): ExtractImportExportIdentity,
 ) -> Result<impl IntoResponse, HttpResponseError> {
     _list_snapshot(st, query_args, identity).await
 }
 
 #[fastrace::trace]
 pub async fn list_snapshot_post(
-    MtState(st): MtState<LocalAppState>,
-    ExtractIdentity(identity): ExtractIdentity,
+    MtState(st): MtState<ImportExportRouterState>,
+    ExtractImportExportIdentity(identity): ExtractImportExportIdentity,
     Json(args): Json<ListSnapshotArgs>,
 ) -> Result<impl IntoResponse, HttpResponseError> {
     _list_snapshot(st, args, identity).await
 }
 
 async fn _list_snapshot(
-    st: LocalAppState,
+    st: ImportExportRouterState,
     args: ListSnapshotArgs,
     identity: Identity,
 ) -> Result<impl IntoResponse, HttpResponseError> {
@@ -307,8 +307,8 @@ async fn _list_snapshot(
 
 /// Confirms that streaming export is enabled
 pub async fn test_streaming_export_connection(
-    MtState(st): MtState<LocalAppState>,
-    ExtractIdentity(identity): ExtractIdentity,
+    MtState(st): MtState<ImportExportRouterState>,
+    ExtractImportExportIdentity(identity): ExtractImportExportIdentity,
 ) -> Result<impl IntoResponse, HttpResponseError> {
     st.application
         .ensure_streaming_export_enabled(identity.clone())
@@ -325,8 +325,8 @@ pub async fn test_streaming_export_connection(
 /// TODO(nicolas): Remove this endpoint (replaced by
 /// get_table_column_names)
 pub async fn get_tables_and_columns(
-    MtState(st): MtState<LocalAppState>,
-    ExtractIdentity(identity): ExtractIdentity,
+    MtState(st): MtState<ImportExportRouterState>,
+    ExtractImportExportIdentity(identity): ExtractImportExportIdentity,
 ) -> Result<impl IntoResponse, HttpResponseError> {
     st.application
         .ensure_streaming_export_enabled(identity.clone())
@@ -358,8 +358,8 @@ pub async fn get_tables_and_columns(
 /// It’s ok for the list of columns to be incomplete since Fivetran can handle
 /// extra fields during an export.
 pub async fn get_table_column_names(
-    MtState(st): MtState<LocalAppState>,
-    ExtractIdentity(identity): ExtractIdentity,
+    MtState(st): MtState<ImportExportRouterState>,
+    ExtractImportExportIdentity(identity): ExtractImportExportIdentity,
 ) -> Result<impl IntoResponse, HttpResponseError> {
     st.application
         .ensure_streaming_export_enabled(identity.clone())
@@ -458,9 +458,9 @@ pub struct JsonSchemaArgs {
 /// component, { "waitlist": { "users": { "type": "object", "properties": { ...
 /// } } } }
 pub async fn json_schemas(
-    MtState(st): MtState<LocalAppState>,
+    MtState(st): MtState<ImportExportRouterState>,
     Query(query_args): Query<JsonSchemaArgs>,
-    ExtractIdentity(identity): ExtractIdentity,
+    ExtractImportExportIdentity(identity): ExtractImportExportIdentity,
 ) -> Result<impl IntoResponse, HttpResponseError> {
     st.application
         .ensure_streaming_export_enabled(identity.clone())

--- a/crates/local_backend/src/streaming_import.rs
+++ b/crates/local_backend/src/streaming_import.rs
@@ -53,8 +53,8 @@ use crate::{
         must_be_admin,
         must_be_admin_with_write_access,
     },
-    authentication::ExtractIdentity,
-    LocalAppState,
+    authentication::ExtractImportExportIdentity,
+    ImportExportRouterState,
 };
 
 #[derive(Deserialize)]
@@ -65,8 +65,8 @@ pub struct AirbyteImportArgs {
 }
 
 pub async fn import_airbyte_records(
-    MtState(st): MtState<LocalAppState>,
-    ExtractIdentity(identity): ExtractIdentity,
+    MtState(st): MtState<ImportExportRouterState>,
+    ExtractImportExportIdentity(identity): ExtractImportExportIdentity,
     Json(AirbyteImportArgs { tables, messages }): Json<AirbyteImportArgs>,
 ) -> Result<impl IntoResponse, HttpResponseError> {
     must_be_admin_with_write_access(&identity)?;
@@ -93,8 +93,8 @@ pub async fn import_airbyte_records(
 }
 
 pub async fn apply_fivetran_operations(
-    MtState(st): MtState<LocalAppState>,
-    ExtractIdentity(identity): ExtractIdentity,
+    MtState(st): MtState<ImportExportRouterState>,
+    ExtractImportExportIdentity(identity): ExtractImportExportIdentity,
     Json(rows): Json<Vec<BatchWriteRow>>,
 ) -> Result<impl IntoResponse, HttpResponseError> {
     must_be_admin_with_write_access(&identity)?;
@@ -112,8 +112,8 @@ pub async fn apply_fivetran_operations(
 }
 
 pub async fn get_schema(
-    MtState(st): MtState<LocalAppState>,
-    ExtractIdentity(identity): ExtractIdentity,
+    MtState(st): MtState<ImportExportRouterState>,
+    ExtractImportExportIdentity(identity): ExtractImportExportIdentity,
 ) -> Result<impl IntoResponse, HttpResponseError> {
     must_be_admin_with_write_access(&identity)?;
     let schema = st
@@ -127,8 +127,8 @@ pub async fn get_schema(
 }
 
 pub async fn fivetran_create_table(
-    MtState(st): MtState<LocalAppState>,
-    ExtractIdentity(identity): ExtractIdentity,
+    MtState(st): MtState<ImportExportRouterState>,
+    ExtractImportExportIdentity(identity): ExtractImportExportIdentity,
     Json(CreateTableArgs { table_definition }): Json<CreateTableArgs>,
 ) -> Result<StatusCode, HttpResponseError> {
     must_be_admin_with_write_access(&identity)?;
@@ -147,8 +147,8 @@ pub struct ClearTableArgs {
 }
 
 pub async fn clear_tables(
-    MtState(st): MtState<LocalAppState>,
-    ExtractIdentity(identity): ExtractIdentity,
+    MtState(st): MtState<ImportExportRouterState>,
+    ExtractImportExportIdentity(identity): ExtractImportExportIdentity,
     Json(ClearTableArgs { table_names }): Json<ClearTableArgs>,
 ) -> Result<impl IntoResponse, HttpResponseError> {
     must_be_admin_with_write_access(&identity)?;
@@ -195,8 +195,8 @@ pub async fn clear_tables(
 /// (and `fivetran.deleted` when using soft deletes) to efficiently find the
 /// rows to delete.
 pub async fn fivetran_truncate_table(
-    MtState(st): MtState<LocalAppState>,
-    ExtractIdentity(identity): ExtractIdentity,
+    MtState(st): MtState<ImportExportRouterState>,
+    ExtractImportExportIdentity(identity): ExtractImportExportIdentity,
     Json(TruncateTableArgs {
         table_name,
         delete_before,
@@ -249,8 +249,8 @@ pub struct ReplaceTableArgs {
 }
 
 pub async fn replace_tables(
-    MtState(_st): MtState<LocalAppState>,
-    ExtractIdentity(_identity): ExtractIdentity,
+    MtState(_st): MtState<ImportExportRouterState>,
+    ExtractImportExportIdentity(_identity): ExtractImportExportIdentity,
     Json(ReplaceTableArgs { _table_names: _ }): Json<ReplaceTableArgs>,
 ) -> Result<impl IntoResponse, HttpResponseError> {
     // Disabled until we figure out how to make schema validation and indexes
@@ -271,8 +271,8 @@ pub struct AddIndexesArgs {
 }
 
 pub async fn add_primary_key_indexes(
-    MtState(st): MtState<LocalAppState>,
-    ExtractIdentity(identity): ExtractIdentity,
+    MtState(st): MtState<ImportExportRouterState>,
+    ExtractImportExportIdentity(identity): ExtractImportExportIdentity,
     Json(AddIndexesArgs { indexes }): Json<AddIndexesArgs>,
 ) -> Result<impl IntoResponse, HttpResponseError> {
     must_be_admin_with_write_access(&identity)?;
@@ -308,8 +308,8 @@ pub struct IndexesReadyResponse {
 }
 
 pub async fn primary_key_indexes_ready(
-    MtState(st): MtState<LocalAppState>,
-    ExtractIdentity(identity): ExtractIdentity,
+    MtState(st): MtState<ImportExportRouterState>,
+    ExtractImportExportIdentity(identity): ExtractImportExportIdentity,
     Json(IndexesReadyArgs { tables }): Json<IndexesReadyArgs>,
 ) -> Result<impl IntoResponse, HttpResponseError> {
     must_be_admin(&identity)?;

--- a/docs/cluster-authority-routing.md
+++ b/docs/cluster-authority-routing.md
@@ -68,6 +68,18 @@ of the full `LocalAppState` route tree.
 | --- | --- |
 | `/api/actions/*` internal query, mutation, action, scheduling, vector search, function-handle, and storage callbacks | Coordinator owner until callback reads and side effects have a narrower partition/index/storage ownership model or explicit forwarding path. |
 
+## Import/Export `ImportExportRouterState` Routes
+
+Snapshot import/export and streaming import/export routes use a dedicated
+`ImportExportRouterState` instead of the full `LocalAppState` route tree.
+
+| Route surface | Authority rule |
+| --- | --- |
+| `/api/import`, `/api/import/*`, `/api/perform_import`, `/api/cancel_import` | Coordinator owner because snapshot imports mutate deployment-global schema/table state and object-upload job state. |
+| `/api/export/*` | Coordinator owner because snapshot export jobs, expiration changes, cancellation, and archive retrieval need a consistent deployment-global export owner. |
+| `/api/streaming_import/*` | Coordinator owner because streaming import writes schemas, tables, indexes, and bulk row mutations until per-table/partition fanout and idempotency are introduced. |
+| `/api/document_deltas`, `/api/list_snapshot`, `/api/json_schemas`, `/api/test_streaming_export_connection`, `/api/get_tables_and_columns`, `/api/get_table_column_names` | Coordinator owner until streaming export has a follower-safe snapshot/frontier proof or explicit export owner forwarding. |
+
 ## Unmigrated `LocalAppState` Routes
 
 Unmigrated `/api` routes bypass `ApplicationApi`, so they are classified by
@@ -76,7 +88,7 @@ in `router.rs`.
 
 | Route surface | Authority rule |
 | --- | --- |
-| Import/export, streaming import/export, and deprecated `/api/logs/*` log-sink routes | Coordinator owner unless a narrower forwarding path is added. |
+| Deprecated `/api/logs/*` log-sink routes | Coordinator owner unless a narrower forwarding path is added. |
 
 ## Adding A Route
 


### PR DESCRIPTION
## Summary
- Add `ImportExportRouterState` for snapshot import/export and streaming import/export routes.
- Add a dedicated import/export identity extractor so these handlers no longer depend on full `LocalAppState`.
- Move snapshot import, snapshot export, streaming import, and streaming export route groups behind typed coordinator-authority middleware.
- Add wrong-node coverage across representative snapshot import, snapshot export, streaming import, and streaming export routes.
- Update cluster authority routing docs and shrink the remaining `LocalAppState` route bucket.

## Validation
- `cargo fmt -p local_backend`
- `git diff --check`
- `cargo check -p local_backend`
- `cargo test -p local_backend test_import_export_routes_reject_non_authority_partition -- --nocapture`
- `cargo test -p local_backend route_authority -- --nocapture` passed `3/3`
- `cargo test -p local_backend streaming_export -- --nocapture` passed `13/13`
- `cargo test -p local_backend snapshot_import -- --nocapture` passed with no matching local-backend tests
- `cargo test -p local_backend --lib -- --nocapture` passed `90/90`
- `docker build --progress=plain -t ghcr.io/martinkalema/convex-horizontal-scaling:backend-latest -f self-hosted/docker-build/Dockerfile.backend .`
- Clean cluster `bash self-hosted/docker/test.sh` passed `77/77` write-scaling and `10/10` Raft failover (`ALL SUITES PASSED`)

Closes #116