### PR TITLE
feat: migrate log observability routes to cluster-aware state

### DIFF
--- a/crates/local_backend/src/route_authority.rs
+++ b/crates/local_backend/src/route_authority.rs
@@ -557,6 +557,14 @@ mod tests {
             class_for("/api/logs/datadog_sink"),
             Some(RouteAuthorityClass::CoordinatorOwner)
         );
+        assert_eq!(
+            class_for("/api/stream_function_logs"),
+            Some(RouteAuthorityClass::CoordinatorOwner)
+        );
+        assert_eq!(
+            class_for("/api/app_metrics/function_concurrency"),
+            Some(RouteAuthorityClass::CoordinatorOwner)
+        );
         assert_eq!(class_for("/api/unregistered_route"), None);
     }
 

--- a/crates/local_backend/src/router.rs
+++ b/crates/local_backend/src/router.rs
@@ -203,6 +203,16 @@ async fn admin_api_authority_middleware(
     Ok(next.run(req).await)
 }
 
+async fn log_sink_api_authority_middleware(
+    State(st): State<AdminRouterState>,
+    req: axum::extract::Request,
+    next: axum::middleware::Next,
+) -> Result<impl IntoResponse, HttpResponseError> {
+    let nested_path = format!("/logs{}", req.uri().path());
+    ensure_local_backend_api_authority(&st, &nested_path)?;
+    Ok(next.run(req).await)
+}
+
 async fn platform_api_authority_middleware(
     State(st): State<AdminRouterState>,
     req: axum::extract::Request,
@@ -442,10 +452,22 @@ pub fn router(st: LocalAppState) -> Router {
         ))
         .with_state(deploy_state);
 
-    let cli_routes = Router::new()
+    let observability_routes = Router::new()
         .route("/stream_udf_execution", get(stream_udf_execution))
         .route("/stream_function_logs", get(stream_function_logs))
-        .layer(cli_cors());
+        .layer(cli_cors())
+        .layer(axum::middleware::from_fn_with_state(
+            admin_state.clone(),
+            admin_api_authority_middleware,
+        ))
+        .with_state(admin_state.clone());
+
+    let log_sink_routes = log_sink_routes()
+        .layer(axum::middleware::from_fn_with_state(
+            admin_state.clone(),
+            log_sink_api_authority_middleware,
+        ))
+        .with_state(admin_state.clone());
 
     let import_export_state = ImportExportRouterState::from(&st);
     let snapshot_import_routes = import_routes()
@@ -508,12 +530,12 @@ pub fn router(st: LocalAppState) -> Router {
         .with_state(admin_state);
 
     let api_routes = Router::new()
-        .merge(cli_routes)
-        .nest("/logs", log_sink_routes())
         .layer(axum::middleware::from_fn_with_state(
             st.clone(),
             unmigrated_local_app_state_api_authority_middleware,
         ))
+        .merge(observability_routes)
+        .nest("/logs", log_sink_routes)
         .merge(snapshot_import_routes)
         .merge(streaming_export_routes)
         .nest("/export", snapshot_export_routes)
@@ -1218,6 +1240,61 @@ mod tests {
             ("POST", "/api/export/request/zip", ""),
             ("GET", "/api/streaming_import/get_schema", ""),
             ("GET", "/api/document_deltas?cursor=0", ""),
+        ] {
+            let req = Request::builder()
+                .uri(path)
+                .method(method)
+                .header("Host", "localhost")
+                .header("Content-Type", "application/json")
+                .header("Authorization", admin_header.clone())
+                .body(Body::from(body))?;
+            let (parts, body) = partitioned_app
+                .router()
+                .clone()
+                .oneshot(req)
+                .await?
+                .into_parts();
+            let bytes = body.collect().await?.to_bytes();
+            let body = String::from_utf8_lossy(&bytes);
+            assert_eq!(
+                parts.status,
+                StatusCode::SERVICE_UNAVAILABLE,
+                "{path}: {body}"
+            );
+            assert!(body.contains("ServiceUnavailable"), "{path}: {body}");
+        }
+
+        Ok(())
+    }
+
+    #[convex_macro::prod_rt_test]
+    async fn test_log_observability_routes_reject_non_authority_partition(
+        rt: ProdRuntime,
+    ) -> anyhow::Result<()> {
+        let backend = setup_backend_for_test(rt).await?;
+        let admin_header = backend.admin_auth_header.0.encode();
+
+        let mut partitioned_state = backend.st.clone();
+        partitioned_state.partition_id = Some(PartitionId(1));
+        let partitioned_app = ConvexHttpService::new(
+            router(partitioned_state),
+            "log_observability_authority_test",
+            SERVER_VERSION_STR.to_string(),
+            MAX_CONCURRENT_REQUESTS,
+            Duration::from_secs(125),
+            NoopRouteMapper,
+        );
+
+        for (method, path, body) in [
+            ("POST", "/api/logs/datadog_sink", "{}"),
+            ("POST", "/api/v1/create_log_stream", "{}"),
+            ("GET", "/api/stream_udf_execution?cursor=0", ""),
+            ("GET", "/api/stream_function_logs?cursor=0", ""),
+            (
+                "GET",
+                "/api/app_metrics/function_concurrency?window=%7B%7D",
+                "",
+            ),
         ] {
             let req = Request::builder()
                 .uri(path)

--- a/docs/cluster-authority-routing.md
+++ b/docs/cluster-authority-routing.md
@@ -59,6 +59,17 @@ Dashboard and platform admin routes use a smaller cluster-aware
 | Dashboard admin routes, environment variables, canonical URLs, scheduled job cancellation, and app metrics | Coordinator owner because these routes read or write deployment-global metadata and function-log state. |
 | `/api/v1/*` platform admin routes, including deployment info/state, canonical URLs, environment variables, and platform log-stream configuration | Coordinator owner unless a narrower follower-safe read or forwarding path is added. |
 
+## Log And Observability `AdminRouterState` Routes
+
+Log sink configuration and function-log observability routes use
+`AdminRouterState` instead of the full `LocalAppState` route tree.
+
+| Route surface | Authority rule |
+| --- | --- |
+| Deprecated `/api/logs/*` log-sink routes | Coordinator owner because they mutate deployment-global log sink configuration and can trigger external delivery side effects. |
+| `/api/v1/*` platform log-stream routes such as `create_log_stream`, `update_log_stream`, `delete_log_stream`, and webhook secret rotation | Coordinator owner because they mutate deployment-global log-stream configuration. |
+| `/api/stream_udf_execution`, `/api/stream_function_logs`, and `/api/app_metrics/*` | Coordinator owner because these read deployment-global function-log and app-metrics state. They are not documented as local-node-only metrics; any future local-node metrics should be named and documented as local. |
+
 ## Internal Action Callback `ActionCallbackRouterState` Routes
 
 Internal action callbacks use a dedicated `ActionCallbackRouterState` instead
@@ -88,7 +99,7 @@ in `router.rs`.
 
 | Route surface | Authority rule |
 | --- | --- |
-| Deprecated `/api/logs/*` log-sink routes | Coordinator owner unless a narrower forwarding path is added. |
+| None after the route-family migrations above. The temporary guard remains only until the final cleanup removes the empty `LocalAppState` API route tree. |
 
 ## Adding A Route
 


### PR DESCRIPTION
## Summary
- Move top-level CLI function-log streaming routes onto explicit `AdminRouterState` authority middleware.
- Move deprecated `/api/logs/*` log-sink routes onto explicit nested AdminRouterState authority middleware.
- Keep platform log-stream routes and app metrics documented as coordinator-owned cluster-global observability surfaces.
- Add wrong-node coverage for deprecated log sinks, platform log-stream config, top-level function log streams, and app metrics.
- Update authority docs and shrink the remaining `LocalAppState` route bucket to the final cleanup state.

## Validation
- `cargo fmt -p local_backend`
- `git diff --check`
- `cargo check -p local_backend`
- `cargo test -p local_backend test_log_observability_routes_reject_non_authority_partition -- --nocapture`
- `cargo test -p local_backend route_authority -- --nocapture` passed `3/3`
- `cargo test -p local_backend log_sinks -- --nocapture` passed `27/27`
- `cargo test -p local_backend --lib -- --nocapture` passed `91/91`
- `docker build --progress=plain -t ghcr.io/martinkalema/convex-horizontal-scaling:backend-latest -f self-hosted/docker-build/Dockerfile.backend .`
- Clean cluster `bash self-hosted/docker/test.sh` passed `77/77` write-scaling and `10/10` Raft failover (`ALL SUITES PASSED`)

Closes #117