### PR TITLE
chore: remove unmigrated local app state route guard

### DIFF
--- a/crates/local_backend/src/route_authority.rs
+++ b/crates/local_backend/src/route_authority.rs
@@ -9,7 +9,6 @@ use crate::{
     AdminRouterState,
     DeployRouterState,
     ImportExportRouterState,
-    LocalAppState,
 };
 
 pub(crate) const CLUSTER_COORDINATOR_PARTITION: PartitionId = PartitionId(0);
@@ -18,20 +17,6 @@ pub(crate) trait ClusterAuthorityContext {
     fn replica_mode(&self) -> bool;
     fn partition_id(&self) -> Option<PartitionId>;
     fn raft_state(&self) -> Option<&RaftPartitionState>;
-}
-
-impl ClusterAuthorityContext for LocalAppState {
-    fn replica_mode(&self) -> bool {
-        self.replica_mode
-    }
-
-    fn partition_id(&self) -> Option<PartitionId> {
-        self.partition_id
-    }
-
-    fn raft_state(&self) -> Option<&RaftPartitionState> {
-        self.raft_state.as_ref()
-    }
 }
 
 impl ClusterAuthorityContext for DeployRouterState {

--- a/crates/local_backend/src/router.rs
+++ b/crates/local_backend/src/router.rs
@@ -176,15 +176,6 @@ use crate::{
     RouterState,
 };
 
-async fn unmigrated_local_app_state_api_authority_middleware(
-    State(st): State<LocalAppState>,
-    req: axum::extract::Request,
-    next: axum::middleware::Next,
-) -> Result<impl IntoResponse, HttpResponseError> {
-    ensure_local_backend_api_authority(&st, req.uri().path())?;
-    Ok(next.run(req).await)
-}
-
 async fn deploy_api_authority_middleware(
     State(st): State<DeployRouterState>,
     req: axum::extract::Request,
@@ -530,10 +521,6 @@ pub fn router(st: LocalAppState) -> Router {
         .with_state(admin_state);
 
     let api_routes = Router::new()
-        .layer(axum::middleware::from_fn_with_state(
-            st.clone(),
-            unmigrated_local_app_state_api_authority_middleware,
-        ))
         .merge(observability_routes)
         .nest("/logs", log_sink_routes)
         .merge(snapshot_import_routes)
@@ -909,7 +896,7 @@ mod tests {
         partitioned_state.partition_id = Some(PartitionId(1));
         let partitioned_app = ConvexHttpService::new(
             router(partitioned_state),
-            "unmigrated_authority_test",
+            "deploy_api_authority_test",
             SERVER_VERSION_STR.to_string(),
             MAX_CONCURRENT_REQUESTS,
             Duration::from_secs(125),

--- a/docs/cluster-authority-routing.md
+++ b/docs/cluster-authority-routing.md
@@ -40,7 +40,7 @@ authority checks.
 ## Deploy `DeployRouterState` Routes
 
 Deploy and CLI config routes use a smaller cluster-aware `DeployRouterState`
-instead of the full `LocalAppState` route tree.
+instead of the broad application assembly state.
 
 | Route surface | Authority rule |
 | --- | --- |
@@ -51,7 +51,7 @@ instead of the full `LocalAppState` route tree.
 ## Admin `AdminRouterState` Routes
 
 Dashboard and platform admin routes use a smaller cluster-aware
-`AdminRouterState` instead of the full `LocalAppState` route tree.
+`AdminRouterState` instead of the broad application assembly state.
 
 | Route surface | Authority rule |
 | --- | --- |
@@ -62,7 +62,7 @@ Dashboard and platform admin routes use a smaller cluster-aware
 ## Log And Observability `AdminRouterState` Routes
 
 Log sink configuration and function-log observability routes use
-`AdminRouterState` instead of the full `LocalAppState` route tree.
+`AdminRouterState` instead of the broad application assembly state.
 
 | Route surface | Authority rule |
 | --- | --- |
@@ -73,7 +73,7 @@ Log sink configuration and function-log observability routes use
 ## Internal Action Callback `ActionCallbackRouterState` Routes
 
 Internal action callbacks use a dedicated `ActionCallbackRouterState` instead
-of the full `LocalAppState` route tree.
+of the broad application assembly state.
 
 | Route surface | Authority rule |
 | --- | --- |
@@ -82,7 +82,7 @@ of the full `LocalAppState` route tree.
 ## Import/Export `ImportExportRouterState` Routes
 
 Snapshot import/export and streaming import/export routes use a dedicated
-`ImportExportRouterState` instead of the full `LocalAppState` route tree.
+`ImportExportRouterState` instead of the broad application assembly state.
 
 | Route surface | Authority rule |
 | --- | --- |
@@ -93,9 +93,10 @@ Snapshot import/export and streaming import/export routes use a dedicated
 
 ## Final Router Shape
 
-`LocalAppState` remains the root object used to assemble the local backend and
-to serve local-process surfaces such as health checks, static assets, and
-server bootstrap wiring. It is no longer used as a broad `/api` route state.
+The application assembly state currently named `LocalAppState` remains only for
+constructing the local backend and serving local-process surfaces such as health
+checks, static assets, and server bootstrap wiring. It is no longer used as a
+broad `/api` route state.
 
 Every externally reachable clustered `/api` route is now mounted through an
 explicit smaller route state:

--- a/docs/cluster-authority-routing.md
+++ b/docs/cluster-authority-routing.md
@@ -20,7 +20,7 @@ routes choose an authority class in code, not only in prose.
 | Follower-safe read | The route is read-only and the node can prove its applied frontier is fresh enough for the requested timestamp. | Not generally available yet outside purpose-built read paths. |
 | Explicit forwarding | The route has a purpose-built owner forwarding path. | The local handler may run on any node because it forwards first. |
 | External side-effect owner | The route triggers external storage, import/export, or delivery side effects. | Needs a job/side-effect owner and idempotency model before it can run broadly. |
-| Not yet safe | The route can mutate/read authoritative state but has no routing protocol. | Reject on non-authority nodes until forwarding is added. |
+| Fail closed | The route can mutate/read authoritative state but has no routing protocol. | Reject on non-authority nodes until forwarding is added. |
 
 ## Migrated `RouterState` Routes
 
@@ -91,20 +91,29 @@ Snapshot import/export and streaming import/export routes use a dedicated
 | `/api/streaming_import/*` | Coordinator owner because streaming import writes schemas, tables, indexes, and bulk row mutations until per-table/partition fanout and idempotency are introduced. |
 | `/api/document_deltas`, `/api/list_snapshot`, `/api/json_schemas`, `/api/test_streaming_export_connection`, `/api/get_tables_and_columns`, `/api/get_table_column_names` | Coordinator owner until streaming export has a follower-safe snapshot/frontier proof or explicit export owner forwarding. |
 
-## Unmigrated `LocalAppState` Routes
+## Final Router Shape
 
-Unmigrated `/api` routes bypass `ApplicationApi`, so they are classified by
-`route_authority.rs` and protected by the unmigrated-route authority middleware
-in `router.rs`.
+`LocalAppState` remains the root object used to assemble the local backend and
+to serve local-process surfaces such as health checks, static assets, and
+server bootstrap wiring. It is no longer used as a broad `/api` route state.
 
-| Route surface | Authority rule |
+Every externally reachable clustered `/api` route is now mounted through an
+explicit smaller route state:
+
+| Route state | Route families |
 | --- | --- |
-| None after the route-family migrations above. The temporary guard remains only until the final cleanup removes the empty `LocalAppState` API route tree. |
+| `RouterState` | Public API, browser API, sync, HTTP actions, and storage public surfaces. |
+| `DeployRouterState` | Deploy and CLI config surfaces. |
+| `AdminRouterState` | Dashboard, platform admin, app metrics, log observability, and log sink surfaces. |
+| `ActionCallbackRouterState` | Internal node action callback surfaces. |
+| `ImportExportRouterState` | Snapshot and streaming import/export surfaces. |
 
 ## Adding A Route
 
 Every new local-backend route must choose one authority class before it is
 exposed in a clustered build. If the route touches deployment metadata, file
 metadata, subscriptions, function execution, imports, exports, or log sinks, do
-not default to local execution on followers or non-owner partitions. Add an
-explicit forwarding path or let the route fail closed on non-authority nodes.
+not default to local execution on followers or non-owner partitions. Mount the
+route on the narrowest explicit route state, add the matching authority
+middleware, and either provide an explicit forwarding path or let the route
+fail closed on non-authority nodes.


### PR DESCRIPTION
## Summary

- Remove the now-empty `LocalAppState` `/api` fallback authority middleware.
- Drop the `ClusterAuthorityContext` implementation for `LocalAppState` so clustered API authority checks only use explicit narrow route states.
- Update the cluster authority routing doc to describe the final router shape and route-addition rules.

Closes #118

## Validation

- `cargo fmt -p local_backend`
- `cargo check -p local_backend`
- `cargo test -p local_backend route_authority -- --nocapture`
- `cargo test -p local_backend authority -- --nocapture`
- `cargo test -p local_backend --lib -- --nocapture` (91/91 passed)
- `git diff --check`
- Rebuilt local backend image: `ghcr.io/martinkalema/convex-horizontal-scaling:backend-latest`
- Reset Docker cluster with `docker compose --profile cluster down -v --remove-orphans && docker compose --profile cluster up -d --pull never`
- `bash self-hosted/docker/test.sh` (77/77 write-scaling tests passed, 10/10 Raft failover tests passed)
