### PR TITLE
fix: reject sync routes on non-authority nodes

### DIFF
--- a/crates/local_backend/src/public_api.rs
+++ b/crates/local_backend/src/public_api.rs
@@ -463,15 +463,12 @@ pub async fn public_function_post_with_path(
             "Path or function name not provided in path, e.g. /api/run/messages/list",
         ))
     };
-    println!("{path:?}");
-
     // messages/list -> ["messages", "list"]
     let mut path_parts = path
         .as_str()
         .split('/')
         .map(|p| urlencoding::decode(p).map_err(|_e| bad_request_error()))
         .try_collect::<Vec<_>>()?;
-    println!("{path_parts:?}");
     if path_parts.len() < 2 {
         return Err(bad_request_error().into());
     }
@@ -1790,17 +1787,52 @@ mod tests {
             Duration::from_secs(125),
             NoopRouteMapper,
         );
+        let admin_header = backend.admin_auth_header.0.encode();
 
-        for (method, uri) in [
-            (Method::POST, "/api/query_ts"),
-            (Method::POST, "/api/storage/upload?token=not-a-real-token"),
-            (Method::GET, "/http/anything"),
+        for (method, uri, body, include_admin_auth) in [
+            (Method::POST, "/api/query_ts", "{}", false),
+            (Method::POST, "/api/query_batch", r#"{"queries":[]}"#, false),
+            (
+                Method::POST,
+                "/api/action",
+                r#"{"path":"values:intAction","args":{}}"#,
+                false,
+            ),
+            (
+                Method::POST,
+                "/api/function",
+                r#"{"path":"values:intMutation","args":{}}"#,
+                true,
+            ),
+            (
+                Method::POST,
+                "/api/run/values/intMutation",
+                r#"{"args":{}}"#,
+                true,
+            ),
+            (
+                Method::POST,
+                "/api/storage/upload?token=not-a-real-token",
+                "",
+                false,
+            ),
+            (
+                Method::GET,
+                "/api/storage/00000000-0000-0000-0000-000000000000",
+                "",
+                false,
+            ),
+            (Method::GET, "/http/anything", "", false),
         ] {
-            let req = Request::builder()
+            let mut req = Request::builder()
                 .uri(uri)
                 .method(method)
                 .header("Host", "localhost")
-                .body(Body::empty())?;
+                .header("Content-Type", "application/json");
+            if include_admin_auth {
+                req = req.header("Authorization", admin_header.clone());
+            }
+            let req = req.body(Body::from(body))?;
             let (parts, body) = replica_app
                 .router()
                 .clone()

--- a/crates/local_backend/src/route_authority.rs
+++ b/crates/local_backend/src/route_authority.rs
@@ -9,6 +9,7 @@ use crate::{
     AdminRouterState,
     DeployRouterState,
     ImportExportRouterState,
+    RouterState,
 };
 
 pub(crate) const CLUSTER_COORDINATOR_PARTITION: PartitionId = PartitionId(0);
@@ -62,6 +63,20 @@ impl ClusterAuthorityContext for ActionCallbackRouterState {
 }
 
 impl ClusterAuthorityContext for ImportExportRouterState {
+    fn replica_mode(&self) -> bool {
+        self.replica_mode
+    }
+
+    fn partition_id(&self) -> Option<PartitionId> {
+        self.partition_id
+    }
+
+    fn raft_state(&self) -> Option<&RaftPartitionState> {
+        self.raft_state.as_ref()
+    }
+}
+
+impl ClusterAuthorityContext for RouterState {
     fn replica_mode(&self) -> bool {
         self.replica_mode
     }
@@ -180,6 +195,13 @@ pub(crate) const LOCAL_BACKEND_API_ROUTE_AUTHORITIES: &[RouteAuthorityRule] = &[
         RouteAuthorityClass::AnyNodeSafe,
         "CLI reads the target node before the deploy protocol push so each node can materialize \
          local modules",
+    ),
+    RouteAuthorityRule::exact(
+        "sync subscription setup",
+        "/sync",
+        RouteAuthorityClass::CoordinatorOwner,
+        "subscription setup creates global sync worker state and must run on the coordinator \
+         owner until follower-safe subscription routing exists",
     ),
     RouteAuthorityRule::prefix(
         "deploy protocol metadata operation",
@@ -396,7 +418,7 @@ fn unsupported_local_backend_cluster_surface_error(
     anyhow::anyhow!(ErrorMetadata::service_unavailable()).context(format!(
         "Local backend API route {surface} ({}) cannot execute locally on this clustered node: \
          {reason}. Route the request to the authoritative node, add an explicit forwarding path, \
-         or migrate the route to RouterState.",
+         or add a route-specific follower-safe read path.",
         class.label()
     ))
 }
@@ -502,6 +524,10 @@ mod tests {
         assert_eq!(
             class_for("/api/deploy/start_push"),
             Some(RouteAuthorityClass::ExplicitForwarding)
+        );
+        assert_eq!(
+            class_for("/api/sync"),
+            Some(RouteAuthorityClass::CoordinatorOwner)
         );
         assert_eq!(
             class_for("/api/actions/mutation"),

--- a/crates/local_backend/src/router.rs
+++ b/crates/local_backend/src/router.rs
@@ -227,6 +227,15 @@ async fn import_export_api_authority_middleware(
     Ok(next.run(req).await)
 }
 
+async fn sync_api_authority_middleware(
+    State(st): State<RouterState>,
+    req: axum::extract::Request,
+    next: axum::middleware::Next,
+) -> Result<impl IntoResponse, HttpResponseError> {
+    ensure_local_backend_api_authority(&st, "/sync")?;
+    Ok(next.run(req).await)
+}
+
 async fn snapshot_export_api_authority_middleware(
     State(st): State<ImportExportRouterState>,
     req: axum::extract::Request,
@@ -525,10 +534,39 @@ pub fn router(st: BackendAppState) -> Router {
         .split_for_parts();
     let public_openapi_spec = public_openapi.to_pretty_json().unwrap();
 
-    let migrated_api_routes = Router::new()
+    let router_state = RouterState {
+        api: Arc::new(
+            crate::query_forwarding_api::SelectiveQueryForwardingApi::new(
+                Arc::new(st.application.clone()),
+                st.application.database().clone(),
+                st.replica_mode,
+                st.partition_id,
+                st.node_addresses.clone(),
+                st.raft_state.clone(),
+                st.raft_peer_grpc_urls.clone(),
+            ),
+        ),
+        database: st.application.database().clone(),
+        runtime: st.application.runtime(),
+        replica_mode: st.replica_mode,
+        partition_id: st.partition_id,
+        node_addresses: st.node_addresses.clone(),
+        raft_state: st.raft_state.clone(),
+        raft_peer_grpc_urls: st.raft_peer_grpc_urls.clone(),
+        replica_mutation_forwarder: st.replica_mutation_forwarder.clone(),
+    };
+
+    let sync_routes = Router::new()
         .merge(browser_routes)
-        .merge(public_routes)
         .route("/sync", get(sync))
+        .layer(axum::middleware::from_fn_with_state(
+            router_state.clone(),
+            sync_api_authority_middleware,
+        ));
+
+    let migrated_api_routes = Router::new()
+        .merge(sync_routes)
+        .merge(public_routes)
         .route(
             "/public_openapi.json",
             axum::routing::get({
@@ -544,25 +582,7 @@ pub fn router(st: BackendAppState) -> Router {
         // Notably, any layers added here won't apply to common routes
         // added inside `serve_http`
         .nest("/http/", http_action_routes())
-        .with_state(RouterState {
-            api: Arc::new(crate::query_forwarding_api::SelectiveQueryForwardingApi::new(
-                Arc::new(st.application.clone()),
-                st.application.database().clone(),
-                st.replica_mode,
-                st.partition_id,
-                st.node_addresses.clone(),
-                st.raft_state.clone(),
-                st.raft_peer_grpc_urls.clone(),
-            )),
-            database: st.application.database().clone(),
-            runtime: st.application.runtime(),
-            replica_mode: st.replica_mode,
-            partition_id: st.partition_id,
-            node_addresses: st.node_addresses.clone(),
-            raft_state: st.raft_state.clone(),
-            raft_peer_grpc_urls: st.raft_peer_grpc_urls.clone(),
-            replica_mutation_forwarder: st.replica_mutation_forwarder.clone(),
-        });
+        .with_state(router_state);
 
     let version = SERVER_VERSION_STR.to_string();
 
@@ -1296,6 +1316,44 @@ mod tests {
         let bytes = body.collect().await?.to_bytes();
         let body = String::from_utf8_lossy(&bytes);
         assert_eq!(parts.status, StatusCode::OK, "{body}");
+
+        Ok(())
+    }
+
+    #[convex_macro::prod_rt_test]
+    async fn test_sync_routes_reject_non_authority_partition_before_websocket_upgrade(
+        rt: ProdRuntime,
+    ) -> anyhow::Result<()> {
+        let backend = setup_backend_for_test(rt).await?;
+
+        let mut partitioned_state = backend.st.clone();
+        partitioned_state.partition_id = Some(PartitionId(1));
+        let partitioned_app = ConvexHttpService::new(
+            router(partitioned_state),
+            "sync_authority_test",
+            SERVER_VERSION_STR.to_string(),
+            MAX_CONCURRENT_REQUESTS,
+            Duration::from_secs(125),
+            NoopRouteMapper,
+        );
+
+        for path in ["/api/sync", "/api/1.0.0/sync"] {
+            let req = Request::builder()
+                .uri(path)
+                .method("GET")
+                .header("Host", "localhost")
+                .body(Body::empty())?;
+            let (parts, body) = partitioned_app
+                .router()
+                .clone()
+                .oneshot(req)
+                .await?
+                .into_parts();
+            let bytes = body.collect().await?.to_bytes();
+            let body = String::from_utf8_lossy(&bytes);
+            assert_eq!(parts.status, StatusCode::SERVICE_UNAVAILABLE, "{body}");
+            assert!(body.contains("ServiceUnavailable"), "{body}");
+        }
 
         Ok(())
     }

--- a/docs/cluster-authority-routing.md
+++ b/docs/cluster-authority-routing.md
@@ -35,7 +35,7 @@ authority checks.
 | `/api/function`, `/api/run/*`                           | Coordinator owner because the function type is not known before dispatch.                                                                                                           |
 | `/api/query_ts`, `/api/query_batch` timestamp selection | Coordinator owner because latest timestamp selection must not be made from a stale follower/replica.                                                                                |
 | `/api/storage/*`                                        | Coordinator owner until file metadata and storage authorization have explicit clustered routing.                                                                                    |
-| `/api/sync`, `/{client_version}/sync`                   | Coordinator owner for subscription setup until follower-safe subscription ownership is implemented.                                                                                 |
+| `/api/sync`, `/api/{client_version}/sync`               | Coordinator owner for subscription setup until follower-safe subscription ownership is implemented. The router rejects non-authority nodes before accepting the WebSocket upgrade.   |
 
 ## Deploy `DeployRouterState` Routes
 


### PR DESCRIPTION
## Summary

- Add `RouterState` to the route-authority context so RouterState-backed routes can use the same coordinator/follower checks as the narrower route states.
- Mark sync subscription setup as coordinator-owned and wrap `/api/sync` plus `/api/{client_version}/sync` with a pre-upgrade authority guard.
- Expand migrated global route tests to cover query timestamp selection, query batch timestamp selection, public actions, any-function routes, storage upload/read, and HTTP actions.
- Remove stray debug `println!` calls from the `/api/run/*` public function path.

Refs #105

## Validation

- `cargo fmt -p local_backend`
- `git diff --check`
- `cargo test -p local_backend test_local_backend_api_route_authority_registry_classifies_core_surfaces -- --nocapture`
- `cargo test -p local_backend test_sync_routes_reject_non_authority_partition_before_websocket_upgrade -- --nocapture`
- `cargo test -p local_backend test_migrated_global_endpoints_reject_replica_mode -- --nocapture`
- `cargo test -p local_backend --lib -- --nocapture` (91/91 passed)
