### PR TITLE
feat: add placement version guard for 2pc prepare

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 The first horizontal scaling implementation for the [Convex open-source backend](https://github.com/get-convex/convex-backend) — reads, writes, and automatic failover.
 
-Convex is a reactive database: real-time subscriptions, in-memory snapshots, OCC with automatic retry, TypeScript function execution. No distributed database — CockroachDB, TiDB, Vitess, YugabyteDB, or Spanner — has all of these. We made it scale horizontally without losing any of them.
+Convex is a reactive database: real-time subscriptions, in-memory snapshots, OCC with automatic retry, TypeScript function execution. No distributed database — CockroachDB, TiDB, Vitess, YugabyteDB, Spanner, or FoundationDB — has all of these together. This fork's goal is to scale those properties horizontally while keeping partitions, leaders, placement versions, and routing out of developer-facing APIs.
 
 ## The Problem
 
@@ -32,6 +32,9 @@ We took the best engineering from five distributed databases and combined them:
 The combination — real-time subscriptions + in-memory OCC + partitioned multi-writer + delta replication + 2PC — doesn't exist in any of those systems. CockroachDB doesn't have subscriptions. TiDB doesn't have in-memory snapshots. Vitess doesn't have OCC. We kept Convex's unique architecture and grafted distributed database patterns onto it.
 
 Full details: [docs/what-we-built.md](docs/what-we-built.md)
+
+Project-wide design goals, including the rule that topology must not leak into
+developer APIs: [docs/project-goals.md](docs/project-goals.md)
 
 Issue journal for regressions, fixes, and validation history:
 [docs/issue-journal.md](docs/issue-journal.md)
@@ -320,6 +323,7 @@ Full test details: [docs/write-scaling-tests.md](docs/write-scaling-tests.md)
 
 | Document | Contents |
 | --- | --- |
+| [Project Goals](docs/project-goals.md) | Preserve Convex semantics while preventing topology leaks into developer APIs |
 | [Production Deployment](docs/production-deployment.md) | Kubernetes (GKE, EKS), bare VMs (EC2), load balancing, persistent storage, peer discovery |
 | [Raft Integration](docs/raft-integration.md) | tikv/raft-rs integration design — Raft loop, storage, transport, state machine, leader lifecycle |
 | [What We Built](docs/what-we-built.md) | What we took from each distributed database and what's new |

--- a/crates/database/src/committer.rs
+++ b/crates/database/src/committer.rs
@@ -3277,6 +3277,26 @@ impl CommitterClient {
         self.node_addresses.as_ref()
     }
 
+    pub fn placement_version(&self) -> crate::partition::PlacementVersion {
+        self.partition_map
+            .as_ref()
+            .map(|partition_map| partition_map.placement_version())
+            .unwrap_or(crate::partition::PlacementVersion::STATIC)
+    }
+
+    pub fn ensure_placement_version(
+        &self,
+        requested: crate::partition::PlacementVersion,
+    ) -> anyhow::Result<()> {
+        let local = self.placement_version();
+        anyhow::ensure!(
+            local == requested,
+            "Placement version mismatch: request used {requested}, local node is on {local}. \
+             Refresh placement metadata before retrying the write."
+        );
+        Ok(())
+    }
+
     pub(crate) fn two_phase_decision_log(&self) -> Arc<dyn crate::two_phase::TwoPhaseDecisionLog> {
         self.two_phase_decision_log.clone()
     }

--- a/crates/database/src/partition.rs
+++ b/crates/database/src/partition.rs
@@ -48,6 +48,39 @@ impl fmt::Display for PartitionId {
     }
 }
 
+/// Monotonically identifies the placement metadata version used for routing.
+///
+/// Version 0 is the static, startup-configured map. Dynamic placement updates
+/// must bump this value whenever ownership changes.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct PlacementVersion(pub u64);
+
+impl PlacementVersion {
+    pub const STATIC: Self = Self(0);
+
+    pub fn new(version: u64) -> Self {
+        Self(version)
+    }
+}
+
+impl From<PlacementVersion> for u64 {
+    fn from(version: PlacementVersion) -> Self {
+        version.0
+    }
+}
+
+impl From<u64> for PlacementVersion {
+    fn from(version: u64) -> Self {
+        Self(version)
+    }
+}
+
+impl fmt::Display for PlacementVersion {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "placement-version-{}", self.0)
+    }
+}
+
 /// Maps table names to partitions.
 ///
 /// System tables (starting with `_`) are always on partition 0.
@@ -61,6 +94,8 @@ pub struct PartitionMap {
     local_partition: PartitionId,
     /// Total number of partitions in the cluster.
     num_partitions: u32,
+    /// Version of the placement metadata used to build this map.
+    placement_version: PlacementVersion,
 }
 
 impl PartitionMap {
@@ -71,6 +106,21 @@ impl PartitionMap {
     /// Tables not listed default to partition 0.
     /// System tables (starting with `_`) are always partition 0 regardless.
     pub fn from_config(config: &str, local_partition: PartitionId, num_partitions: u32) -> Self {
+        Self::from_config_with_version(
+            config,
+            local_partition,
+            num_partitions,
+            PlacementVersion::STATIC,
+        )
+    }
+
+    /// Create a partition map from a config string and placement version.
+    pub fn from_config_with_version(
+        config: &str,
+        local_partition: PartitionId,
+        num_partitions: u32,
+        placement_version: PlacementVersion,
+    ) -> Self {
         let mut assignments = BTreeMap::new();
         if !config.is_empty() {
             for pair in config.split(',') {
@@ -90,6 +140,7 @@ impl PartitionMap {
             assignments,
             local_partition,
             num_partitions,
+            placement_version,
         }
     }
 
@@ -100,6 +151,7 @@ impl PartitionMap {
             assignments: BTreeMap::new(),
             local_partition: PartitionId::DEFAULT,
             num_partitions: 1,
+            placement_version: PlacementVersion::STATIC,
         }
     }
 
@@ -141,6 +193,11 @@ impl PartitionMap {
     /// Get the total number of partitions.
     pub fn num_partitions(&self) -> u32 {
         self.num_partitions
+    }
+
+    /// Get the placement metadata version.
+    pub fn placement_version(&self) -> PlacementVersion {
+        self.placement_version
     }
 
     /// Get all partition IDs in the cluster.
@@ -265,6 +322,23 @@ mod tests {
         let map = PartitionMap::from_config("a=1,b=2", PartitionId(0), 3);
         let all = map.all_partitions();
         assert_eq!(all, vec![PartitionId(0), PartitionId(1), PartitionId(2)]);
+    }
+
+    #[test]
+    fn test_placement_version_defaults_to_static() {
+        let map = PartitionMap::from_config("a=1", PartitionId(0), 2);
+        assert_eq!(map.placement_version(), PlacementVersion::STATIC);
+    }
+
+    #[test]
+    fn test_placement_version_from_config() {
+        let map = PartitionMap::from_config_with_version(
+            "a=1",
+            PartitionId(0),
+            2,
+            PlacementVersion::new(42),
+        );
+        assert_eq!(map.placement_version(), PlacementVersion::new(42));
     }
 
     #[test]

--- a/crates/database/src/tests/write_scaling_tests.rs
+++ b/crates/database/src/tests/write_scaling_tests.rs
@@ -84,6 +84,7 @@ use crate::{
     partition::{
         PartitionId,
         PartitionMap,
+        PlacementVersion,
     },
     tests::run_query,
     timestamp_oracle::{
@@ -191,6 +192,18 @@ fn partitioned_map(local_partition: PartitionId) -> PartitionMap {
     PartitionMap::from_config("messages=0,projects=1", local_partition, 2)
 }
 
+fn partitioned_map_with_version(
+    local_partition: PartitionId,
+    placement_version: PlacementVersion,
+) -> PartitionMap {
+    PartitionMap::from_config_with_version(
+        "messages=0,projects=1",
+        local_partition,
+        2,
+        placement_version,
+    )
+}
+
 fn partitioned_map_with_tasks(local_partition: PartitionId) -> PartitionMap {
     PartitionMap::from_config("messages=0,projects=1,tasks=1", local_partition, 2)
 }
@@ -249,6 +262,9 @@ impl TwoPhaseCommitService for TestTwoPhaseCommitGrpcService {
             .prepare_ts
             .try_into()
             .map_err(|e| Status::invalid_argument(format!("Invalid prepare timestamp: {e:#}")))?;
+        self.committer
+            .ensure_placement_version(PlacementVersion::from(req.placement_version))
+            .map_err(|e| Status::failed_precondition(format!("Prepare rejected: {e:#}")))?;
 
         let result = self
             .committer
@@ -1410,10 +1426,17 @@ fn test_remote_prepare_over_grpc_is_idempotent() -> anyhow::Result<()> {
                 participant_tx.clone(),
                 write_source.clone(),
                 prepare_ts,
+                partition_map.placement_version(),
             )
             .await?;
         let second = client
-            .prepare(&txn_id, participant_tx, write_source, prepare_ts)
+            .prepare(
+                &txn_id,
+                participant_tx,
+                write_source,
+                prepare_ts,
+                partition_map.placement_version(),
+            )
             .await?;
 
         assert_eq!(first.prepare_ts, prepare_ts);
@@ -1434,6 +1457,68 @@ fn test_remote_prepare_over_grpc_is_idempotent() -> anyhow::Result<()> {
             "duplicate prepare should still publish exactly one committed delta",
         );
         assert_eq!(committed_deltas[0].source_partition, Some(PartitionId(1)));
+
+        server.shutdown().await?;
+        Ok(())
+    })
+}
+
+#[test]
+fn test_remote_prepare_rejects_stale_placement_version() -> anyhow::Result<()> {
+    let td = TestDriver::new_with_io();
+    let rt = td.rt();
+    td.run_until(async move {
+        let log = Arc::new(InMemoryDistributedLog::new());
+        let tso: Arc<dyn TimestampOracle> = Arc::new(InMemoryTimestampOracle::new());
+        let node_b_map = partitioned_map_with_version(PartitionId(1), PlacementVersion::new(2));
+        let node_b = create_node_with_options(&rt, log, Some(node_b_map), None, Some(tso)).await?;
+
+        let server = start_two_pc_server(TestTwoPhaseCommitGrpcService::new(
+            node_b.committer_for_test(),
+        ))
+        .await?;
+        let client = TwoPhaseCommitGrpcClient::connect(server.addr()).await?;
+
+        let mut tx = node_b.begin(Identity::system()).await?;
+        TestFacingModel::new(&mut tx)
+            .insert(
+                &"projects".parse()?,
+                assert_obj!("name" => "stale-placement"),
+            )
+            .await?;
+        let final_tx = tx.finalize()?;
+        let write_indexes: Vec<_> = final_tx
+            .writes
+            .coalesced_writes()
+            .enumerate()
+            .map(|(index, _)| index)
+            .collect();
+        let write_source = WriteSource::new("stale_placement_version_test");
+        let stale_map = partitioned_map_with_version(PartitionId(1), PlacementVersion::new(1));
+        let participant_tx = ParticipantTransaction::from_final_transaction(
+            &final_tx,
+            PartitionId(1),
+            &write_indexes,
+            &stale_map,
+            &write_source,
+        )?;
+
+        let txn_id = TwoPhaseTransactionId::new();
+        let prepare_ts = node_b.committer_for_test().allocate_commit_ts().await?;
+        let err = client
+            .prepare(
+                &txn_id,
+                participant_tx,
+                write_source,
+                prepare_ts,
+                stale_map.placement_version(),
+            )
+            .await
+            .unwrap_err();
+        assert!(
+            format!("{err:#}").contains("Placement version mismatch"),
+            "expected stale placement rejection, got {err:#}",
+        );
 
         server.shutdown().await?;
         Ok(())

--- a/crates/database/src/two_phase.rs
+++ b/crates/database/src/two_phase.rs
@@ -808,12 +808,14 @@ impl TwoPhaseCommitGrpcClient {
         transaction: ParticipantTransaction,
         write_source: WriteSource,
         prepare_ts: Timestamp,
+        placement_version: crate::partition::PlacementVersion,
     ) -> anyhow::Result<PrepareResult> {
         let request = TwoPcPrepareRequest {
             transaction_id: transaction_id.0.clone(),
             transaction: Some(transaction.try_into()?),
             write_source: write_source.as_str().unwrap_or_default().to_string(),
             prepare_ts: u64::from(prepare_ts),
+            placement_version: u64::from(placement_version),
         };
         let response = self
             .client

--- a/crates/database/src/two_phase_coordinator.rs
+++ b/crates/database/src/two_phase_coordinator.rs
@@ -147,6 +147,7 @@ async fn prepare_participant(
                 participant_tx,
                 write_source.clone(),
                 prepare_ts,
+                partition_map.placement_version(),
             )
             .await?
     };

--- a/crates/local_backend/src/config.rs
+++ b/crates/local_backend/src/config.rs
@@ -167,6 +167,11 @@ pub struct LocalConfig {
     #[clap(long, env = "PARTITION_MAP")]
     pub partition_map: Option<String>,
 
+    /// Placement map version. Bump this whenever PARTITION_MAP ownership
+    /// changes.
+    #[clap(long, env = "PARTITION_MAP_VERSION")]
+    pub partition_map_version: Option<u64>,
+
     /// Total number of partitions in the cluster.
     #[clap(long, env = "NUM_PARTITIONS")]
     pub num_partitions: Option<u32>,

--- a/crates/local_backend/src/lib.rs
+++ b/crates/local_backend/src/lib.rs
@@ -358,10 +358,13 @@ pub async fn make_app(
         config.partition_id.map(|id| {
             let partition_map_str = config.partition_map.as_deref().unwrap_or("");
             let num_partitions = config.num_partitions.unwrap_or(1);
-            database::partition::PartitionMap::from_config(
+            database::partition::PartitionMap::from_config_with_version(
                 partition_map_str,
                 database::partition::PartitionId(id),
                 num_partitions,
+                database::partition::PlacementVersion::new(
+                    config.partition_map_version.unwrap_or_default(),
+                ),
             )
         }),
         config

--- a/crates/local_backend/src/two_phase_service.rs
+++ b/crates/local_backend/src/two_phase_service.rs
@@ -10,6 +10,7 @@
 use std::collections::BTreeMap;
 
 use database::{
+    partition::PlacementVersion,
     raft_partition::RaftPartitionState,
     two_phase::{
         ParticipantTransaction,
@@ -114,10 +115,20 @@ impl TwoPhaseCommitService for TwoPhaseCommitGrpcService {
             .prepare_ts
             .try_into()
             .map_err(|e| Status::invalid_argument(format!("Invalid prepare timestamp: {e:#}")))?;
+        let placement_version = PlacementVersion::from(req.placement_version);
+        self.committer
+            .ensure_placement_version(placement_version)
+            .map_err(|e| Status::failed_precondition(format!("Prepare rejected: {e:#}")))?;
 
         if let Some(client) = self.leader_client().await? {
             let result = client
-                .prepare(&txn_id, transaction, req.write_source.into(), prepare_ts)
+                .prepare(
+                    &txn_id,
+                    transaction,
+                    req.write_source.into(),
+                    prepare_ts,
+                    placement_version,
+                )
                 .await
                 .map_err(|e| Status::internal(format!("Leader Prepare failed: {e:#}")))?;
             return Ok(Response::new(TwoPcPrepareResponse {

--- a/crates/pb/protos/replication.proto
+++ b/crates/pb/protos/replication.proto
@@ -138,6 +138,11 @@ message TwoPcPrepareRequest {
 
   // Globally assigned prepare/commit timestamp chosen by the coordinator.
   uint64 prepare_ts = 4;
+
+  // Placement metadata version used by the coordinator to route this prepare.
+  // Participants reject mismatched versions so stale ownership maps cannot
+  // prepare writes on the wrong partition during rebalancing.
+  uint64 placement_version = 5;
 }
 
 message TwoPcPrepareResponse {

--- a/docs/dynamic-placement.md
+++ b/docs/dynamic-placement.md
@@ -13,6 +13,11 @@ The table owner map is represented by `PartitionMap` in
 map. Operators may now set `PARTITION_MAP_VERSION` and must bump it whenever
 table ownership changes.
 
+Placement metadata is control-plane state, not an application API. Nodes,
+routers, and operators may reason about placement versions and ownership, but
+queries, mutations, actions, and subscriptions should continue to target one
+logical Convex database without shard or partition hints.
+
 Cross-partition 2PC `Prepare` requests carry the coordinator's placement
 version. The participant compares it with its local `PartitionMap` version and
 rejects mismatches before staging writes. This prevents a stale coordinator from

--- a/docs/dynamic-placement.md
+++ b/docs/dynamic-placement.md
@@ -1,0 +1,47 @@
+# Dynamic Placement Control Plane
+
+Issue #104 is the path from startup-configured partitions to online placement
+changes. The current implementation is still static: nodes read
+`PARTITION_ID`, `PARTITION_MAP`, `NUM_PARTITIONS`, and `NODE_ADDRESSES` at
+startup. This document records the safety contract added before online
+rebalancing is introduced.
+
+## Current State
+
+The table owner map is represented by `PartitionMap` in
+`crates/database/src/partition.rs`. Version `0` means the legacy static startup
+map. Operators may now set `PARTITION_MAP_VERSION` and must bump it whenever
+table ownership changes.
+
+Cross-partition 2PC `Prepare` requests carry the coordinator's placement
+version. The participant compares it with its local `PartitionMap` version and
+rejects mismatches before staging writes. This prevents a stale coordinator from
+preparing writes against an old owner while the cluster is rolling to a new
+placement map.
+
+`CommitPrepared` and `RollbackPrepared` intentionally do not reject on placement
+version. Once a participant has prepared a transaction, finishing or aborting
+that exact transaction must remain possible even if placement metadata changes.
+
+## Operator Rule
+
+When changing `PARTITION_MAP`, roll all nodes with the same
+`PARTITION_MAP_VERSION`. If one node is stale, cross-partition writes involving
+that node fail fast with a placement-version mismatch instead of silently
+preparing against the wrong owner.
+
+## Remaining #104 Work
+
+- Store placement metadata in a replicated system table instead of env vars.
+- Add an authority/lease model for who may publish a new placement version.
+- Add node membership metadata so new partitions can be added without editing
+  every node config by hand.
+- Add an online movement workflow: freeze source writes for the moved range or
+  table, copy/catch up data, publish the new placement version, then unfreeze.
+- Add stale-map refresh behavior so clients/nodes retry after loading the newer
+  placement version.
+- Add operational procedures for add-node, remove-node, and rebalance.
+
+Large distributed databases use the same shape at a larger scale: placement is
+metadata with an owner, routers carry or observe a metadata version/epoch, stale
+routers refresh, and data movement is separate from request routing.

--- a/docs/horizontal-scaling-proposal.md
+++ b/docs/horizontal-scaling-proposal.md
@@ -416,7 +416,21 @@ impl PartitionedPersistence {
 | **Subscription API** | `subscribe()` returns `Subscription` with invalidation notification. Identical API. |
 | **Persistence trait** | Same interface, just multiple instances. |
 | **Client SDK** | Clients still connect via WebSocket, still get real-time updates. Routing is transparent. |
-| **Developer-facing function model** | Queries, mutations, actions all work identically. Developers don't see partitions. |
+| **Developer-facing function model** | Queries, mutations, actions all work identically. Developers don't see partitions, leaders, placement versions, resolver shards, or routing epochs. |
+
+### No Topology Leaks
+
+The public API must continue to look like one logical Convex database. Internal
+systems may use partitions, Raft groups, ownership leases, placement versions,
+resolver shards, and selective delivery, but application code should not need
+to pass topology hints or avoid otherwise-valid transactions because records
+land on different partitions.
+
+Operator-visible topology is allowed and expected: metrics, placement tools,
+runbooks, and administrative dashboards should show where data lives and which
+node owns it. Developer-visible topology requirements are the line we should
+not cross. Performance guidance may say that related tables or ranges are
+faster when co-located, but correctness must remain a system responsibility.
 
 ---
 

--- a/docs/project-goals.md
+++ b/docs/project-goals.md
@@ -1,0 +1,69 @@
+# Project Goals
+
+This fork is not only trying to run the Convex backend on more machines. The
+goal is to preserve the product shape that makes Convex different while adding
+horizontal scale and high availability.
+
+## Preserve Convex's Core Attributes
+
+Scaling work is incomplete if it improves throughput by weakening the
+properties that make Convex feel like Convex:
+
+- serializable transactions with optimistic conflict detection and automatic
+  retry;
+- consistent snapshots for queries, mutations, exports, and subscriptions;
+- reactive invalidation that keeps clients current without application-managed
+  cache invalidation;
+- the TypeScript function model where application code talks to one logical
+  database.
+
+FoundationDB, Spanner, CockroachDB, TiDB, Vitess, and YugabyteDB prove that
+parts of this problem can be distributed. They do not, by themselves, provide
+Convex's full combination of arbitrary TypeScript functions, automatic read-set
+tracking, consistent snapshots, exact reactive invalidation, and transparent
+horizontal write scaling.
+
+## Do Not Leak Topology Into Developer APIs
+
+Internal topology includes partitions, ranges, shards, Raft leaders, placement
+versions, ownership leases, NATS subjects, resolver shards, replication
+frontiers, and subscription invalidation workers. Application developers should
+not need to reason about those details to write normal Convex queries,
+mutations, actions, or subscriptions.
+
+The following are topology leaks and should be treated as design failures
+unless the project explicitly accepts the trade-off:
+
+- requiring shard, partition, range, or placement hints in `ctx.db.query`,
+  `ctx.db.get`, `ctx.db.insert`, `ctx.db.patch`, or mutation APIs;
+- making a transaction invalid only because records live on different
+  partitions;
+- requiring application code to choose strong-vs-stale read modes for basic
+  correctness;
+- exposing placement versions or partition ownership to client logic;
+- requiring subscription code to register with a specific shard or invalidation
+  worker;
+- documenting "put these tables together or correctness breaks" as an
+  application contract.
+
+The system may expose topology to operators through metrics, runbooks,
+placement tooling, debugging APIs, and administrative dashboards. Operator
+visibility is good. Developer-visible topology requirements are the problem.
+
+## Accept Performance Reality Without Moving Correctness To Users
+
+Cross-partition work may be slower than single-partition work. That can be
+documented as performance guidance, and operators may use placement tools to
+co-locate related tables or ranges. It must not become a correctness
+precondition for application developers.
+
+The public API should still look like one logical Convex database. Placement,
+routing, conflict checking, replication, and invalidation are system
+responsibilities.
+
+## Fail Closed Before Weakening Semantics
+
+If a route, subscription path, write path, placement transition, or failover
+case cannot prove the same Convex semantics in a clustered deployment, it should
+fail closed, forward to an authority, or remain coordinator-owned until the
+distributed design is complete.


### PR DESCRIPTION
## Summary
- Add `PlacementVersion` to `PartitionMap` and wire `PARTITION_MAP_VERSION` through local backend config.
- Carry placement version on 2PC `Prepare` requests and reject mismatched versions before staging participant writes.
- Document the current static placement state and the remaining dynamic placement/rebalance work.

## Why
This is the first safety slice for #104. Before we can move table/range ownership online, participants need a hard fence against stale coordinators preparing writes with an old ownership map.

## Tests
- `cargo fmt -p database -p local_backend -p pb`
- `env PROTOC=/Users/martin/Desktop/convex-horizontal-scaling/crates/pb_build/protoc/protoc-macos-universal cargo test -p database placement_version -- --nocapture`
- `env PROTOC=/Users/martin/Desktop/convex-horizontal-scaling/crates/pb_build/protoc/protoc-macos-universal cargo test -p database test_remote_prepare_over_grpc_is_idempotent -- --nocapture`
- `env PROTOC=/Users/martin/Desktop/convex-horizontal-scaling/crates/pb_build/protoc/protoc-macos-universal cargo test -p database test_cross_partition_commit_uses_remote_prepare_over_grpc -- --nocapture`
- `env PROTOC=/Users/martin/Desktop/convex-horizontal-scaling/crates/pb_build/protoc/protoc-macos-universal cargo test -p local_backend --lib -- --nocapture`
- `env PROTOC=/Users/martin/Desktop/convex-horizontal-scaling/crates/pb_build/protoc/protoc-macos-universal cargo test -p database --lib -- --nocapture`
- `git diff --check`
- `docker build --progress=plain -t ghcr.io/martinkalema/convex-horizontal-scaling:backend-latest -f self-hosted/docker-build/Dockerfile.backend .`
- `docker compose --profile cluster up -d --wait --force-recreate --pull never`
- verified node image ID matched branch-built image `sha256:a541647a9ec44a5a883eb8c9ddfeb5e71292696dab67da03d56fb48b234d0490`
- `bash self-hosted/docker/test.sh` -> 77/77 write-scaling, 10/10 Raft failover, all suites passed

Refs #104.
