### PR TITLE
feat: load placement metadata from nats

### DIFF
--- a/crates/database/src/partition.rs
+++ b/crates/database/src/partition.rs
@@ -31,6 +31,12 @@ use std::{
     },
 };
 
+use anyhow::Context;
+use async_trait::async_trait;
+use serde::{
+    Deserialize,
+    Serialize,
+};
 use value::TableName;
 
 use crate::write_log::WriteSource;
@@ -176,6 +182,23 @@ impl PlacementMetadata {
         }
     }
 
+    pub fn from_table_assignments(
+        source: PlacementMetadataSource,
+        version: PlacementVersion,
+        num_partitions: u32,
+        assignments: BTreeMap<TableName, PartitionId>,
+    ) -> Self {
+        Self {
+            source,
+            version,
+            num_partitions,
+            rules: assignments
+                .into_iter()
+                .map(|(table, owner)| (PlacementTarget::Table(table), owner))
+                .collect(),
+        }
+    }
+
     pub fn source(&self) -> PlacementMetadataSource {
         self.source
     }
@@ -213,6 +236,128 @@ impl PlacementMetadata {
             local_partition,
             num_partitions: self.num_partitions,
             placement_version: self.version,
+        }
+    }
+}
+
+#[derive(Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct SerializedPlacementMetadata {
+    version: u64,
+    num_partitions: u32,
+    table_assignments: BTreeMap<String, u32>,
+}
+
+impl From<&PlacementMetadata> for SerializedPlacementMetadata {
+    fn from(metadata: &PlacementMetadata) -> Self {
+        Self {
+            version: u64::from(metadata.version()),
+            num_partitions: metadata.num_partitions(),
+            table_assignments: metadata
+                .table_assignments()
+                .into_iter()
+                .map(|(table, partition)| (table.to_string(), partition.0))
+                .collect(),
+        }
+    }
+}
+
+impl TryFrom<SerializedPlacementMetadata> for PlacementMetadata {
+    type Error = anyhow::Error;
+
+    fn try_from(serialized: SerializedPlacementMetadata) -> anyhow::Result<Self> {
+        let assignments = serialized
+            .table_assignments
+            .into_iter()
+            .map(|(table, partition)| Ok((table.parse::<TableName>()?, PartitionId(partition))))
+            .collect::<anyhow::Result<_>>()?;
+        Ok(PlacementMetadata::from_table_assignments(
+            PlacementMetadataSource::Replicated,
+            PlacementVersion::new(serialized.version),
+            serialized.num_partitions,
+            assignments,
+        ))
+    }
+}
+
+const PLACEMENT_KV_BUCKET: &str = "convex_placement";
+const PLACEMENT_CURRENT_KEY: &str = "current";
+
+#[async_trait]
+pub trait PlacementMetadataStore: Send + Sync + 'static {
+    async fn load(&self) -> anyhow::Result<Option<PlacementMetadata>>;
+    async fn ensure_initialized(
+        &self,
+        bootstrap_metadata: PlacementMetadata,
+    ) -> anyhow::Result<PlacementMetadata>;
+}
+
+pub struct NatsPlacementMetadataStore {
+    kv: async_nats::jetstream::kv::Store,
+}
+
+impl NatsPlacementMetadataStore {
+    pub async fn connect(nats_url: &str) -> anyhow::Result<Self> {
+        let _ = rustls::crypto::ring::default_provider().install_default();
+        let client = async_nats::connect(nats_url).await.with_context(|| {
+            format!("Placement metadata: failed to connect to NATS at {nats_url}")
+        })?;
+        let jetstream = async_nats::jetstream::new(client);
+        let kv = jetstream
+            .create_key_value(async_nats::jetstream::kv::Config {
+                bucket: PLACEMENT_KV_BUCKET.to_string(),
+                history: 8,
+                ..Default::default()
+            })
+            .await
+            .context("Placement metadata: failed to create KV bucket")?;
+        Ok(Self { kv })
+    }
+
+    fn encode(metadata: &PlacementMetadata) -> anyhow::Result<Vec<u8>> {
+        serde_json::to_vec(&SerializedPlacementMetadata::from(metadata))
+            .context("Placement metadata: failed to serialize metadata")
+    }
+
+    fn decode(bytes: &[u8]) -> anyhow::Result<PlacementMetadata> {
+        let serialized: SerializedPlacementMetadata = serde_json::from_slice(bytes)
+            .context("Placement metadata: failed to parse metadata")?;
+        serialized.try_into()
+    }
+}
+
+#[async_trait]
+impl PlacementMetadataStore for NatsPlacementMetadataStore {
+    async fn load(&self) -> anyhow::Result<Option<PlacementMetadata>> {
+        let Some(entry) = self
+            .kv
+            .entry(PLACEMENT_CURRENT_KEY)
+            .await
+            .context("Placement metadata: failed to read current metadata")?
+        else {
+            return Ok(None);
+        };
+        Ok(Some(Self::decode(&entry.value)?))
+    }
+
+    async fn ensure_initialized(
+        &self,
+        bootstrap_metadata: PlacementMetadata,
+    ) -> anyhow::Result<PlacementMetadata> {
+        if let Some(metadata) = self.load().await? {
+            return Ok(metadata);
+        }
+
+        let payload = Self::encode(&bootstrap_metadata)?;
+        match self.kv.create(PLACEMENT_CURRENT_KEY, payload.into()).await {
+            Ok(_) => self
+                .load()
+                .await?
+                .context("Placement metadata: current metadata missing after initialize"),
+            Err(_) => self
+                .load()
+                .await?
+                .context("Placement metadata: current metadata missing after initialize race"),
         }
     }
 }
@@ -655,6 +800,28 @@ mod tests {
             .to_string()
             .contains("Refusing to refresh placement metadata"));
         assert_eq!(state.placement_version(), PlacementVersion::new(3));
+        Ok(())
+    }
+
+    #[test]
+    fn test_placement_metadata_serialization_loads_as_replicated() -> anyhow::Result<()> {
+        let metadata = PlacementMetadata::from_static_config(StaticPlacementConfig {
+            table_assignments: "messages=0,projects=1",
+            num_partitions: 2,
+            placement_version: PlacementVersion::new(9),
+        });
+
+        let bytes = NatsPlacementMetadataStore::encode(&metadata)?;
+        let decoded = NatsPlacementMetadataStore::decode(&bytes)?;
+
+        assert_eq!(decoded.source(), PlacementMetadataSource::Replicated);
+        assert_eq!(decoded.version(), PlacementVersion::new(9));
+        assert_eq!(
+            decoded
+                .table_assignments()
+                .get(&"projects".parse().unwrap()),
+            Some(&PartitionId(1)),
+        );
         Ok(())
     }
 

--- a/crates/database/src/tests/write_scaling_tests.rs
+++ b/crates/database/src/tests/write_scaling_tests.rs
@@ -84,7 +84,9 @@ use crate::{
     partition::{
         PartitionId,
         PartitionMap,
+        PlacementMetadata,
         PlacementVersion,
+        StaticPlacementConfig,
     },
     tests::run_query,
     timestamp_oracle::{
@@ -1521,6 +1523,41 @@ fn test_remote_prepare_rejects_stale_placement_version() -> anyhow::Result<()> {
         );
 
         server.shutdown().await?;
+        Ok(())
+    })
+}
+
+#[test]
+fn test_committer_client_refreshes_placement_metadata() -> anyhow::Result<()> {
+    let td = TestDriver::new();
+    let rt = td.rt();
+    td.run_until(async move {
+        let log = Arc::new(InMemoryDistributedLog::new());
+        let node = create_node(
+            &rt,
+            log,
+            Some(partitioned_map_with_version(
+                PartitionId(1),
+                PlacementVersion::new(1),
+            )),
+        )
+        .await?;
+        let committer = node.committer_for_test();
+
+        committer.ensure_placement_version(PlacementVersion::new(1))?;
+        assert!(committer
+            .ensure_placement_version(PlacementVersion::new(2))
+            .is_err());
+
+        committer.refresh_placement_metadata(PlacementMetadata::from_static_config(
+            StaticPlacementConfig {
+                table_assignments: "messages=1,projects=0",
+                num_partitions: 2,
+                placement_version: PlacementVersion::new(2),
+            },
+        ))?;
+
+        committer.ensure_placement_version(PlacementVersion::new(2))?;
         Ok(())
     })
 }

--- a/crates/local_backend/src/lib.rs
+++ b/crates/local_backend/src/lib.rs
@@ -140,6 +140,7 @@ pub struct BackendAppState {
     pub raft_peer_http_origins: Option<BTreeMap<u64, String>>,
     pub raft_peer_grpc_urls: Option<BTreeMap<u64, String>>,
     pub replica_mutation_forwarder: Option<Arc<mutation_forwarder::MutationForwarderGrpcClient>>,
+    pub placement_metadata_store: Option<Arc<dyn database::partition::PlacementMetadataStore>>,
     /// Raft partition mailbox for receiving Raft messages from peers.
     /// None if Raft is not enabled.
     pub raft_mailbox_tx:
@@ -340,6 +341,19 @@ pub async fn make_app(
     } else {
         None
     };
+    let static_placement_metadata = config.partition_id.map(|_| {
+        let partition_map_str = config.partition_map.as_deref().unwrap_or("");
+        let num_partitions = config.num_partitions.unwrap_or(1);
+        database::partition::PlacementMetadata::from_static_config(
+            database::partition::StaticPlacementConfig {
+                table_assignments: partition_map_str,
+                num_partitions,
+                placement_version: database::partition::PlacementVersion::new(
+                    config.partition_map_version.unwrap_or_default(),
+                ),
+            },
+        )
+    });
 
     let database = Database::load(
         persistence.clone(),
@@ -356,18 +370,10 @@ pub async fn make_app(
         distributed_log.clone(),
         config.replication_mode == "replica",
         config.partition_id.map(|id| {
-            let partition_map_str = config.partition_map.as_deref().unwrap_or("");
-            let num_partitions = config.num_partitions.unwrap_or(1);
-            database::partition::PlacementMetadata::from_static_config(
-                database::partition::StaticPlacementConfig {
-                    table_assignments: partition_map_str,
-                    num_partitions,
-                    placement_version: database::partition::PlacementVersion::new(
-                        config.partition_map_version.unwrap_or_default(),
-                    ),
-                },
-            )
-            .into_partition_map(database::partition::PartitionId(id))
+            static_placement_metadata
+                .as_ref()
+                .expect("partitioned startup should have placement metadata")
+                .into_partition_map(database::partition::PartitionId(id))
         }),
         config
             .node_addresses
@@ -378,6 +384,22 @@ pub async fn make_app(
         None, // raft_state: set after Raft node starts, not during Database::load
     )
     .await?;
+
+    let placement_metadata_store: Option<Arc<dyn database::partition::PlacementMetadataStore>> =
+        if let (Some(bootstrap_metadata), Some(nats_url)) = (
+            static_placement_metadata.clone(),
+            config.nats_url.as_deref(),
+        ) {
+            let store: Arc<dyn database::partition::PlacementMetadataStore> =
+                Arc::new(database::partition::NatsPlacementMetadataStore::connect(nats_url).await?);
+            let authoritative_metadata = store.ensure_initialized(bootstrap_metadata).await?;
+            database
+                .committer_client()
+                .refresh_placement_metadata(authoritative_metadata)?;
+            Some(store)
+        } else {
+            None
+        };
 
     if config.replication_mode == "replica" && persistence_was_fresh {
         let checkpoint_path = config.checkpoint_storage_path.as_ref().ok_or_else(|| {
@@ -1018,6 +1040,7 @@ pub async fn make_app(
         raft_peer_http_origins,
         raft_peer_grpc_urls,
         replica_mutation_forwarder,
+        placement_metadata_store,
         raft_mailbox_tx,
     };
 

--- a/crates/local_backend/src/main.rs
+++ b/crates/local_backend/src/main.rs
@@ -145,6 +145,7 @@ async fn run_server_inner(runtime: ProdRuntime, config: LocalConfig) -> anyhow::
             st.application.database().committer_client(),
             st.raft_state.clone(),
             st.raft_peer_grpc_urls.clone(),
+            st.placement_metadata_store.clone(),
         );
 
         // Add Raft transport server if Raft is enabled.

--- a/crates/local_backend/src/two_phase_service.rs
+++ b/crates/local_backend/src/two_phase_service.rs
@@ -7,10 +7,16 @@
 //! The coordinator uses the database-layer gRPC client to reach remote
 //! partitions.
 
-use std::collections::BTreeMap;
+use std::{
+    collections::BTreeMap,
+    sync::Arc,
+};
 
 use database::{
-    partition::PlacementVersion,
+    partition::{
+        PlacementMetadataStore,
+        PlacementVersion,
+    },
     raft_partition::RaftPartitionState,
     two_phase::{
         ParticipantTransaction,
@@ -44,6 +50,7 @@ pub struct TwoPhaseCommitGrpcService {
     committer: CommitterClient,
     raft_state: Option<RaftPartitionState>,
     raft_peer_grpc_urls: Option<BTreeMap<u64, String>>,
+    placement_metadata_store: Option<Arc<dyn PlacementMetadataStore>>,
 }
 
 impl TwoPhaseCommitGrpcService {
@@ -51,11 +58,13 @@ impl TwoPhaseCommitGrpcService {
         committer: CommitterClient,
         raft_state: Option<RaftPartitionState>,
         raft_peer_grpc_urls: Option<BTreeMap<u64, String>>,
+        placement_metadata_store: Option<Arc<dyn PlacementMetadataStore>>,
     ) -> Self {
         Self {
             committer,
             raft_state,
             raft_peer_grpc_urls,
+            placement_metadata_store,
         }
     }
 
@@ -96,6 +105,47 @@ impl TwoPhaseCommitGrpcService {
             })?;
         Ok(Some(client))
     }
+
+    async fn refresh_placement_metadata(&self) -> Result<(), Status> {
+        let Some(store) = self.placement_metadata_store.as_ref() else {
+            return Ok(());
+        };
+        let Some(metadata) = store.load().await.map_err(|e| {
+            Status::unavailable(format!(
+                "Failed to refresh placement metadata before Prepare retry: {e:#}"
+            ))
+        })?
+        else {
+            return Ok(());
+        };
+        self.committer
+            .refresh_placement_metadata(metadata)
+            .map_err(|e| {
+                Status::failed_precondition(format!(
+                    "Refreshed placement metadata but local state is still invalid: {e:#}"
+                ))
+            })
+    }
+
+    async fn ensure_placement_version(
+        &self,
+        placement_version: PlacementVersion,
+    ) -> Result<(), Status> {
+        match self.committer.ensure_placement_version(placement_version) {
+            Ok(()) => Ok(()),
+            Err(original_err) => {
+                self.refresh_placement_metadata().await?;
+                self.committer
+                    .ensure_placement_version(placement_version)
+                    .map_err(|e| {
+                        Status::failed_precondition(format!(
+                            "Prepare rejected after placement metadata refresh: {e:#}. Original \
+                             rejection: {original_err:#}"
+                        ))
+                    })
+            },
+        }
+    }
 }
 
 #[tonic::async_trait]
@@ -116,9 +166,7 @@ impl TwoPhaseCommitService for TwoPhaseCommitGrpcService {
             .try_into()
             .map_err(|e| Status::invalid_argument(format!("Invalid prepare timestamp: {e:#}")))?;
         let placement_version = PlacementVersion::from(req.placement_version);
-        self.committer
-            .ensure_placement_version(placement_version)
-            .map_err(|e| Status::failed_precondition(format!("Prepare rejected: {e:#}")))?;
+        self.ensure_placement_version(placement_version).await?;
 
         if let Some(client) = self.leader_client().await? {
             let result = client

--- a/docs/dynamic-placement.md
+++ b/docs/dynamic-placement.md
@@ -25,6 +25,12 @@ The current metadata source is still static process config. Version `0` means
 the startup-configured map. Operators may now set `PARTITION_MAP_VERSION` and
 must bump it whenever table ownership changes.
 
+When NATS is configured, startup now initializes or loads the shared
+`convex_placement/current` NATS KV record and refreshes `PlacementState` from
+that authoritative control-plane record. The static env map remains the
+bootstrap fallback so `Database::load` can start before any external placement
+source is available.
+
 Placement metadata is control-plane state, not an application API. Nodes,
 routers, and operators may reason about placement versions and ownership, but
 queries, mutations, actions, and subscriptions should continue to target one
@@ -51,8 +57,8 @@ preparing against the wrong owner.
 
 - Store placement metadata in a replicated system table instead of env vars.
 - Add an authority/lease model for who may publish a new placement version.
-- Plug `PlacementState` into that authoritative source so nodes refresh newer
-  placement metadata when they observe a stale-version rejection.
+- Decide whether NATS KV remains the placement authority long term or becomes a
+  bootstrap/transport layer for a replicated placement system table.
 - Add node membership metadata so new partitions can be added without editing
   every node config by hand.
 - Add an online movement workflow: freeze source writes for the moved range or


### PR DESCRIPTION
## Summary
- add a NATS KV-backed placement metadata store at `convex_placement/current`
- keep static env placement as the bootstrap fallback for `Database::load`
- refresh `PlacementState` from the shared placement record during local backend startup
- let 2PC participants reload placement metadata once before rejecting a prepare-version mismatch
- add a focused regression test for `CommitterClient::refresh_placement_metadata`
- document the current NATS authority and remaining system-table/lease decision

## Validation
- `cargo fmt -p database -p local_backend`
- `cargo test -p database test_committer_client_refreshes_placement_metadata --lib -- --nocapture`
- `cargo test -p database placement_metadata --lib -- --nocapture`
- `cargo test -p database partition --lib -- --nocapture`
- `cargo check -p local_backend`
- `git diff --check`

Refs #130
