### PR TITLE
fix: allocate table numbers globally in clusters

### DIFF
--- a/crates/application/src/test_helpers.rs
+++ b/crates/application/src/test_helpers.rs
@@ -224,6 +224,7 @@ impl<RT: Runtime> ApplicationTestExt<RT> for Application<RT> {
             None,
             Arc::new(database::two_phase::NoopTwoPhaseDecisionLog),
             None,
+            Arc::new(database::LocalTableNumberAllocator),
             None,
         )
         .await?;

--- a/crates/database/src/bootstrap_model/table.rs
+++ b/crates/database/src/bootstrap_model/table.rs
@@ -339,7 +339,14 @@ impl<'a, RT: Runtime> TableModel<'a, RT> {
             candidate_table_number = candidate_table_number.increment()?;
         }
 
-        Ok(candidate_table_number)
+        if is_system {
+            Ok(candidate_table_number)
+        } else {
+            self.tx
+                .table_number_allocator
+                .next_user_table_number(candidate_table_number)
+                .await
+        }
     }
 
     /// Checks for table number conflicts when activating a table, e.g. snapshot

--- a/crates/database/src/committer.rs
+++ b/crates/database/src/committer.rs
@@ -2286,29 +2286,16 @@ impl<RT: Runtime> Committer<RT> {
 
         // Phase 1: Apply _tables updates (creates new tables).
         //
-        // Each node assigns table numbers independently (like CockroachDB's
-        // non-transactional descriptor ID allocator or TiDB's PD global ID).
-        // When replicating a _tables entry from another node, the remote
-        // table number may collide with a different local table. We reassign
-        // the table number to a locally-unique value, preserving only the
-        // table name and TabletId (derived from document_id) for remapping.
+        // Clustered deployments allocate user table numbers from a global
+        // allocator, so public document IDs embedded in document values are
+        // portable across nodes. Replica apply must therefore preserve the
+        // source TableMetadata.number exactly. If a local table with the same
+        // name already exists with a different number, fail loudly instead of
+        // silently rewriting IDs into a different table-number namespace.
         if !tables_updates.is_empty() {
-            use value::{
-                DocumentObject,
-                TableNumber,
-            };
+            use value::DocumentObject;
 
             let remap = build_remap(&snapshot, &delta.tablet_id_to_table_name);
-            let mapping = snapshot.table_registry.table_mapping();
-
-            // Find the next available user table number by scanning local tables.
-            // User table numbers start above NUM_RESERVED_SYSTEM_TABLE_NUMBERS (10000).
-            let max_local_number: u32 = mapping
-                .iter()
-                .map(|(_, _, num, _)| u32::from(num))
-                .max()
-                .unwrap_or(10000);
-            let mut next_number = max_local_number + 1;
 
             for update in &tables_updates {
                 let primary_tablet = update.id.tablet_id;
@@ -2344,40 +2331,43 @@ impl<RT: Runtime> Committer<RT> {
                 let metadata: TableMetadata = new_doc.value().0.clone().try_into()?;
 
                 // If the table already exists locally by name, skip this update.
-                // Each node may have independently created the same table.
+                // Each node may have independently created the same table, but
+                // the table number must now be globally stable.
                 if snapshot
                     .table_registry
                     .table_exists(metadata.namespace, &metadata.name)
                 {
-                    tracing::debug!(
-                        "Skipping _tables update for '{}': already exists locally",
+                    let existing = snapshot
+                        .table_registry
+                        .table_mapping()
+                        .namespace(metadata.namespace)
+                        .id(&metadata.name)?;
+                    anyhow::ensure!(
+                        existing.table_number == metadata.number,
+                        "Replicated table '{}' has table number {} but local table uses {}",
                         metadata.name,
+                        u32::from(metadata.number),
+                        u32::from(existing.table_number),
+                    );
+                    tracing::debug!(
+                        "Skipping _tables update for '{}': already exists locally with stable \
+                         table number {}",
+                        metadata.name,
+                        u32::from(metadata.number),
                     );
                     continue;
                 }
 
-                // Reassign the table number to avoid collisions with local tables.
-                // This is the same pattern as CockroachDB's descriptor ID allocator:
-                // each node picks the next available number locally.
-                let local_number = TableNumber::try_from(next_number)?;
-                next_number += 1;
-                let local_metadata = TableMetadata::new_with_state(
-                    metadata.namespace,
-                    metadata.name.clone(),
-                    local_number,
-                    metadata.state,
-                );
-                let local_value: DocumentObject = local_metadata.try_into()?;
+                let local_value: DocumentObject = metadata.clone().try_into()?;
 
                 tracing::info!(
-                    "Creating replicated table '{}' with local number {} (remote was {})",
+                    "Creating replicated table '{}' with stable table number {}",
                     metadata.name,
-                    u32::from(local_number),
                     u32::from(metadata.number),
                 );
 
                 // Build a new ResolvedDocument with the remapped tablet ID and
-                // the locally-assigned table number.
+                // the globally-stable table number from the source metadata.
                 let remapped_id = ResolvedDocumentId {
                     tablet_id: local_tablet,
                     document_id: update.id.document_id,

--- a/crates/database/src/database.rs
+++ b/crates/database/src/database.rs
@@ -215,6 +215,7 @@ use crate::{
         ErasedSystemIndex,
         SystemTable,
     },
+    table_number_allocator::TableNumberAllocator,
     table_registry::TableRegistry,
     table_summary::{
         self,
@@ -298,6 +299,7 @@ pub struct Database<RT: Runtime> {
     pub search_storage: Arc<OnceLock<Arc<dyn Storage>>>,
     shared_index_cache: Option<SharedIndexCache>,
     virtual_system_mapping: VirtualSystemMapping,
+    table_number_allocator: Arc<dyn TableNumberAllocator>,
     pub bootstrap_metadata: BootstrapMetadata,
     // Caches of snapshot TableMapping and by_id index ids, which are used repeatedly by
     // /api/list_snapshot.
@@ -989,6 +991,7 @@ impl<RT: Runtime> Database<RT> {
         node_addresses: Option<crate::two_phase::NodeAddresses>,
         two_phase_decision_log: Arc<dyn crate::two_phase::TwoPhaseDecisionLog>,
         timestamp_oracle: Option<Arc<dyn crate::timestamp_oracle::TimestampOracle>>,
+        table_number_allocator: Arc<dyn TableNumberAllocator>,
         raft_state: Option<crate::raft_partition::RaftPartitionState>,
     ) -> anyhow::Result<Self> {
         let _load_database_timer = metrics::load_database_timer();
@@ -1127,6 +1130,7 @@ impl<RT: Runtime> Database<RT> {
             search_storage: Arc::new(OnceLock::new()),
             shared_index_cache,
             virtual_system_mapping,
+            table_number_allocator,
             bootstrap_metadata,
             table_mapping_snapshot_cache,
             by_id_indexes_snapshot_cache,
@@ -1953,7 +1957,7 @@ impl<RT: Runtime> Database<RT> {
             )),
         );
         let count_snapshot = Arc::new(snapshot.table_summaries);
-        let tx = Transaction::new(
+        let tx = Transaction::new_with_table_number_allocator(
             identity,
             id_generator,
             creation_time,
@@ -1966,6 +1970,7 @@ impl<RT: Runtime> Database<RT> {
             usage_tracker,
             self.retention_manager.clone(),
             self.virtual_system_mapping.clone(),
+            self.table_number_allocator.clone(),
         );
         Ok(tx)
     }

--- a/crates/database/src/lib.rs
+++ b/crates/database/src/lib.rs
@@ -44,6 +44,7 @@ pub mod streaming_export_selection;
 pub mod subscription;
 pub mod system_query;
 pub mod system_tables;
+mod table_number_allocator;
 mod table_registry;
 pub mod table_summary;
 mod table_usage;
@@ -100,6 +101,11 @@ pub use reads::{
     OVER_LIMIT_HELP,
 };
 pub use schema_registry::SchemaRegistry;
+pub use table_number_allocator::{
+    LocalTableNumberAllocator,
+    NatsTableNumberAllocator,
+    TableNumberAllocator,
+};
 pub use table_registry::TableRegistry;
 pub use token::{
     SerializedToken,

--- a/crates/database/src/table_number_allocator.rs
+++ b/crates/database/src/table_number_allocator.rs
@@ -1,0 +1,186 @@
+//! Table number allocation for user tables.
+//!
+//! In single-node mode Convex can choose the next available table number from
+//! the local `_tables` snapshot. In clustered mode public document IDs need to
+//! be portable across nodes, so table numbers must come from one global
+//! allocator instead of each node assigning from its own local namespace.
+
+use std::time::Duration;
+
+use anyhow::Context;
+use async_trait::async_trait;
+use value::TableNumber;
+
+use crate::bootstrap_model::table::NUM_RESERVED_SYSTEM_TABLE_NUMBERS;
+
+#[async_trait]
+pub trait TableNumberAllocator: Send + Sync + 'static {
+    async fn next_user_table_number(&self, local_floor: TableNumber)
+        -> anyhow::Result<TableNumber>;
+}
+
+#[derive(Clone, Copy, Debug, Default)]
+pub struct LocalTableNumberAllocator;
+
+#[async_trait]
+impl TableNumberAllocator for LocalTableNumberAllocator {
+    async fn next_user_table_number(
+        &self,
+        local_floor: TableNumber,
+    ) -> anyhow::Result<TableNumber> {
+        Ok(local_floor)
+    }
+}
+
+#[derive(Clone)]
+pub struct NatsTableNumberAllocator {
+    kv: async_nats::jetstream::kv::Store,
+}
+
+const TABLE_NUMBER_KV_BUCKET: &str = "convex_table_numbers";
+const USER_TABLE_NUMBER_COUNTER_KEY: &str = "user_table_number_counter";
+
+fn first_user_table_number() -> anyhow::Result<TableNumber> {
+    TableNumber::try_from(NUM_RESERVED_SYSTEM_TABLE_NUMBERS)?.increment()
+}
+
+impl NatsTableNumberAllocator {
+    pub async fn connect(nats_url: &str) -> anyhow::Result<Self> {
+        let _ = rustls::crypto::ring::default_provider().install_default();
+        let client = async_nats::connect(nats_url)
+            .await
+            .with_context(|| format!("TableNumberAllocator: Failed to connect to {nats_url}"))?;
+        let jetstream = async_nats::jetstream::new(client);
+        let kv = jetstream
+            .create_key_value(async_nats::jetstream::kv::Config {
+                bucket: TABLE_NUMBER_KV_BUCKET.to_string(),
+                history: 1,
+                ..Default::default()
+            })
+            .await
+            .context("TableNumberAllocator: Failed to create KV bucket")?;
+
+        let initial = u32::from(first_user_table_number()?);
+        match kv
+            .create(
+                USER_TABLE_NUMBER_COUNTER_KEY,
+                initial.to_be_bytes().to_vec().into(),
+            )
+            .await
+        {
+            Ok(_) => tracing::info!("TableNumberAllocator: initialized counter at {initial}"),
+            Err(_) => tracing::info!("TableNumberAllocator: counter already exists"),
+        }
+
+        Ok(Self { kv })
+    }
+}
+
+#[async_trait]
+impl TableNumberAllocator for NatsTableNumberAllocator {
+    async fn next_user_table_number(
+        &self,
+        local_floor: TableNumber,
+    ) -> anyhow::Result<TableNumber> {
+        let local_floor = u32::from(local_floor);
+
+        for attempt in 0..10 {
+            let entry = self
+                .kv
+                .entry(USER_TABLE_NUMBER_COUNTER_KEY)
+                .await
+                .context("TableNumberAllocator: Failed to read counter")?
+                .context("TableNumberAllocator: Counter key not found")?;
+            let counter = u32::from_be_bytes(
+                entry
+                    .value
+                    .as_ref()
+                    .try_into()
+                    .context("TableNumberAllocator: Invalid counter value")?,
+            );
+            let candidate = counter.max(local_floor);
+            let next = candidate
+                .checked_add(1)
+                .context("TableNumberAllocator: table number overflow")?;
+
+            match self
+                .kv
+                .update(
+                    USER_TABLE_NUMBER_COUNTER_KEY,
+                    next.to_be_bytes().to_vec().into(),
+                    entry.revision,
+                )
+                .await
+            {
+                Ok(_) => {
+                    tracing::info!(
+                        "TableNumberAllocator: allocated user table number {candidate} on attempt \
+                         {attempt}"
+                    );
+                    return TableNumber::try_from(candidate);
+                },
+                Err(_) => {
+                    tracing::debug!(
+                        "TableNumberAllocator: CAS conflict on attempt {attempt}, retrying"
+                    );
+                    tokio::time::sleep(Duration::from_millis(1 << attempt)).await;
+                },
+            }
+        }
+
+        anyhow::bail!("TableNumberAllocator: Failed to allocate after 10 attempts")
+    }
+}
+
+#[cfg(test)]
+pub mod testing {
+    use std::sync::atomic::{
+        AtomicU32,
+        Ordering,
+    };
+
+    use async_trait::async_trait;
+    use value::TableNumber;
+
+    use crate::{
+        bootstrap_model::table::NUM_RESERVED_SYSTEM_TABLE_NUMBERS,
+        table_number_allocator::TableNumberAllocator,
+    };
+
+    #[derive(Debug)]
+    pub struct InMemoryTableNumberAllocator {
+        next: AtomicU32,
+    }
+
+    impl Default for InMemoryTableNumberAllocator {
+        fn default() -> Self {
+            Self {
+                next: AtomicU32::new(NUM_RESERVED_SYSTEM_TABLE_NUMBERS + 1),
+            }
+        }
+    }
+
+    #[async_trait]
+    impl TableNumberAllocator for InMemoryTableNumberAllocator {
+        async fn next_user_table_number(
+            &self,
+            local_floor: TableNumber,
+        ) -> anyhow::Result<TableNumber> {
+            let local_floor = u32::from(local_floor);
+            loop {
+                let current = self.next.load(Ordering::SeqCst);
+                let candidate = current.max(local_floor);
+                let next = candidate.checked_add(1).ok_or_else(|| {
+                    anyhow::anyhow!("TableNumberAllocator: table number overflow")
+                })?;
+                match self
+                    .next
+                    .compare_exchange(current, next, Ordering::SeqCst, Ordering::SeqCst)
+                {
+                    Ok(_) => return TableNumber::try_from(candidate),
+                    Err(_) => continue,
+                }
+            }
+        }
+    }
+}

--- a/crates/database/src/test_helpers/db_fixtures.rs
+++ b/crates/database/src/test_helpers/db_fixtures.rs
@@ -103,6 +103,7 @@ impl<RT: Runtime> DbFixtures<RT> {
             None,
             Arc::new(crate::two_phase::NoopTwoPhaseDecisionLog),
             None,
+            Arc::new(crate::LocalTableNumberAllocator),
             None,
         )
         .await?;

--- a/crates/database/src/tests/replication_tests.rs
+++ b/crates/database/src/tests/replication_tests.rs
@@ -50,6 +50,7 @@ async fn load_test_primary(
         None,
         Arc::new(crate::two_phase::NoopTwoPhaseDecisionLog),
         None,
+        Arc::new(crate::LocalTableNumberAllocator),
         None,
     )
     .await?;

--- a/crates/database/src/tests/write_scaling_tests.rs
+++ b/crates/database/src/tests/write_scaling_tests.rs
@@ -1383,10 +1383,15 @@ async fn test_replica_preserves_global_table_numbers_for_embedded_ids(
         .await?;
 
     let mut tx = node_b.begin(Identity::system()).await?;
+    let replica_user_id =
+        tx.resolve_developer_id(&user_public_id, TableNamespace::root_component())?;
     assert_eq!(
-        tx.resolve_developer_id(&user_public_id, TableNamespace::root_component())?,
-        user_id,
+        replica_user_id, user_id,
         "replica must resolve the source node's public user ID without table-number translation",
+    );
+    assert!(
+        tx.get(replica_user_id).await?.is_some(),
+        "replica should support a client round-trip lookup with the source public ID",
     );
     drop(tx);
 

--- a/crates/database/src/tests/write_scaling_tests.rs
+++ b/crates/database/src/tests/write_scaling_tests.rs
@@ -67,6 +67,7 @@ use tonic::{
     Status,
 };
 use value::{
+    PublicDocumentId,
     ResolvedDocumentId,
     TableName,
     TableNamespace,
@@ -87,6 +88,10 @@ use crate::{
         PlacementMetadata,
         PlacementVersion,
         StaticPlacementConfig,
+    },
+    table_number_allocator::{
+        testing::InMemoryTableNumberAllocator,
+        TableNumberAllocator,
     },
     tests::run_query,
     timestamp_oracle::{
@@ -135,6 +140,25 @@ async fn create_node_with_options(
     .await
 }
 
+async fn create_node_with_table_number_allocator(
+    rt: &TestRuntime,
+    distributed_log: Arc<InMemoryDistributedLog>,
+    partition_map: Option<PartitionMap>,
+    table_number_allocator: Arc<dyn TableNumberAllocator>,
+) -> anyhow::Result<Database<TestRuntime>> {
+    create_node_with_persistence_and_table_number_allocator(
+        rt,
+        Arc::new(TestPersistence::new()),
+        distributed_log,
+        partition_map,
+        None,
+        Arc::new(NoopTwoPhaseDecisionLog),
+        None,
+        table_number_allocator,
+    )
+    .await
+}
+
 async fn create_node_with_options_and_decision_log(
     rt: &TestRuntime,
     distributed_log: Arc<InMemoryDistributedLog>,
@@ -164,6 +188,29 @@ async fn create_node_with_persistence(
     two_phase_decision_log: Arc<dyn TwoPhaseDecisionLog>,
     timestamp_oracle: Option<Arc<dyn TimestampOracle>>,
 ) -> anyhow::Result<Database<TestRuntime>> {
+    create_node_with_persistence_and_table_number_allocator(
+        rt,
+        tp,
+        distributed_log,
+        partition_map,
+        node_addresses,
+        two_phase_decision_log,
+        timestamp_oracle,
+        Arc::new(crate::LocalTableNumberAllocator),
+    )
+    .await
+}
+
+async fn create_node_with_persistence_and_table_number_allocator(
+    rt: &TestRuntime,
+    tp: Arc<TestPersistence>,
+    distributed_log: Arc<InMemoryDistributedLog>,
+    partition_map: Option<PartitionMap>,
+    node_addresses: Option<NodeAddresses>,
+    two_phase_decision_log: Arc<dyn TwoPhaseDecisionLog>,
+    timestamp_oracle: Option<Arc<dyn TimestampOracle>>,
+    table_number_allocator: Arc<dyn TableNumberAllocator>,
+) -> anyhow::Result<Database<TestRuntime>> {
     let searcher: Arc<dyn search::Searcher> = Arc::new(SearcherStub {});
     let (deleted_tablet_sender, _) = tokio::sync::mpsc::channel(100);
     let db = Database::load(
@@ -181,6 +228,7 @@ async fn create_node_with_persistence(
         node_addresses,
         two_phase_decision_log,
         timestamp_oracle,
+        table_number_allocator,
         None,
     )
     .await?;
@@ -208,6 +256,10 @@ fn partitioned_map_with_version(
 
 fn partitioned_map_with_tasks(local_partition: PartitionId) -> PartitionMap {
     PartitionMap::from_config("messages=0,projects=1,tasks=1", local_partition, 2)
+}
+
+fn partitioned_map_with_users_and_tasks(local_partition: PartitionId) -> PartitionMap {
+    PartitionMap::from_config("users=0,tasks=1", local_partition, 2)
 }
 
 async fn insert_doc_get_id(
@@ -1241,16 +1293,19 @@ async fn test_replica_table_number_allocation_waits_for_prior_publish(
     rt: TestRuntime,
 ) -> anyhow::Result<()> {
     let log = Arc::new(InMemoryDistributedLog::new());
-    let node_a = create_node(
+    let table_numbers = Arc::new(InMemoryTableNumberAllocator::default());
+    let node_a = create_node_with_table_number_allocator(
         &rt,
         log.clone(),
         Some(partitioned_map_with_tasks(PartitionId(0))),
+        table_numbers.clone(),
     )
     .await?;
-    let node_b = create_node(
+    let node_b = create_node_with_table_number_allocator(
         &rt,
         log.clone(),
         Some(partitioned_map_with_tasks(PartitionId(1))),
+        table_numbers,
     )
     .await?;
 
@@ -1295,21 +1350,97 @@ async fn test_replica_table_number_allocation_waits_for_prior_publish(
 }
 
 #[convex_macro::test_runtime]
+async fn test_replica_preserves_global_table_numbers_for_embedded_ids(
+    rt: TestRuntime,
+) -> anyhow::Result<()> {
+    let log = Arc::new(InMemoryDistributedLog::new());
+    let table_numbers = Arc::new(InMemoryTableNumberAllocator::default());
+    let node_a = create_node_with_table_number_allocator(
+        &rt,
+        log.clone(),
+        Some(partitioned_map_with_users_and_tasks(PartitionId(0))),
+        table_numbers.clone(),
+    )
+    .await?;
+    let node_b = create_node_with_table_number_allocator(
+        &rt,
+        log.clone(),
+        Some(partitioned_map_with_users_and_tasks(PartitionId(1))),
+        table_numbers,
+    )
+    .await?;
+
+    let user_id = insert_doc_get_id(&node_a, "users", assert_obj!("name" => "Ada")).await?;
+    let user_public_id = PublicDocumentId::from(user_id);
+    let user_delta = log
+        .deltas()
+        .into_iter()
+        .last()
+        .expect("user insert should publish a delta");
+    node_b
+        .committer_for_test()
+        .apply_replica_delta(user_delta)
+        .await?;
+
+    let mut tx = node_b.begin(Identity::system()).await?;
+    assert_eq!(
+        tx.resolve_developer_id(&user_public_id, TableNamespace::root_component())?,
+        user_id,
+        "replica must resolve the source node's public user ID without table-number translation",
+    );
+    drop(tx);
+
+    insert_doc(
+        &node_b,
+        "tasks",
+        assert_obj!("title" => "ship", "userId" => user_public_id.encode()),
+    )
+    .await?;
+    let task_delta = log
+        .deltas()
+        .into_iter()
+        .last()
+        .expect("task insert should publish a delta");
+    node_a
+        .committer_for_test()
+        .apply_replica_delta(task_delta)
+        .await?;
+
+    let tasks = run_query(
+        node_a,
+        TableNamespace::root_component(),
+        Query::full_table_scan("tasks".parse()?, Order::Asc),
+    )
+    .await?;
+    assert_eq!(tasks.len(), 1);
+    assert_eq!(
+        tasks[0].value().0.get("userId"),
+        assert_obj!("userId" => user_public_id.encode()).get("userId"),
+        "embedded user ID should stay in the source table-number namespace",
+    );
+
+    Ok(())
+}
+
+#[convex_macro::test_runtime]
 async fn test_replica_delta_does_not_erase_pending_local_table_creation(
     rt: TestRuntime,
     pause: PauseController,
 ) -> anyhow::Result<()> {
     let log = Arc::new(InMemoryDistributedLog::new());
-    let node_a = create_node(
+    let table_numbers = Arc::new(InMemoryTableNumberAllocator::default());
+    let node_a = create_node_with_table_number_allocator(
         &rt,
         log.clone(),
         Some(partitioned_map_with_tasks(PartitionId(0))),
+        table_numbers.clone(),
     )
     .await?;
-    let node_b = create_node(
+    let node_b = create_node_with_table_number_allocator(
         &rt,
         log.clone(),
         Some(partitioned_map_with_tasks(PartitionId(1))),
+        table_numbers,
     )
     .await?;
 

--- a/crates/database/src/transaction.rs
+++ b/crates/database/src/transaction.rs
@@ -125,6 +125,10 @@ use crate::{
     reads::TransactionReadSet,
     schema_registry::SchemaRegistry,
     snapshot_manager::Snapshot,
+    table_number_allocator::{
+        LocalTableNumberAllocator,
+        TableNumberAllocator,
+    },
     table_summary::table_summary_bootstrapping_error,
     token::Token,
     transaction_id_generator::TransactionIdGenerator,
@@ -181,6 +185,7 @@ pub struct Transaction<RT: Runtime> {
 
     pub usage_tracker: FunctionUsageTracker,
     pub(crate) virtual_system_mapping: VirtualSystemMapping,
+    pub(crate) table_number_allocator: Arc<dyn TableNumberAllocator>,
 
     #[cfg(any(test, feature = "testing"))]
     index_size_override: Option<usize>,
@@ -223,6 +228,38 @@ impl<RT: Runtime> Transaction<RT> {
         retention_validator: Arc<dyn RetentionValidator>,
         virtual_system_mapping: VirtualSystemMapping,
     ) -> Self {
+        Self::new_with_table_number_allocator(
+            identity,
+            id_generator,
+            creation_time,
+            index,
+            metadata,
+            schema_registry,
+            component_registry,
+            count,
+            runtime,
+            usage_tracker,
+            retention_validator,
+            virtual_system_mapping,
+            Arc::new(LocalTableNumberAllocator),
+        )
+    }
+
+    pub fn new_with_table_number_allocator(
+        identity: Identity,
+        id_generator: TransactionIdGenerator,
+        creation_time: CreationTime,
+        index: TransactionIndex,
+        metadata: TableRegistry,
+        schema_registry: SchemaRegistry,
+        component_registry: ComponentRegistry,
+        count: Arc<dyn TableCountSnapshot>,
+        runtime: RT,
+        usage_tracker: FunctionUsageTracker,
+        retention_validator: Arc<dyn RetentionValidator>,
+        virtual_system_mapping: VirtualSystemMapping,
+        table_number_allocator: Arc<dyn TableNumberAllocator>,
+    ) -> Self {
         Self {
             identity,
             reads: TransactionReadSet::new(),
@@ -241,6 +278,7 @@ impl<RT: Runtime> Transaction<RT> {
             retention_validator,
             usage_tracker,
             virtual_system_mapping,
+            table_number_allocator,
             #[cfg(any(test, feature = "testing"))]
             index_size_override: None,
         }

--- a/crates/local_backend/src/lib.rs
+++ b/crates/local_backend/src/lib.rs
@@ -320,6 +320,17 @@ pub async fn make_app(
         None
     };
 
+    let table_number_allocator: Arc<dyn database::TableNumberAllocator> =
+        if config.partition_id.is_some() {
+            if let Some(nats_url) = &config.nats_url {
+                Arc::new(database::NatsTableNumberAllocator::connect(nats_url).await?)
+            } else {
+                Arc::new(database::LocalTableNumberAllocator)
+            }
+        } else {
+            Arc::new(database::LocalTableNumberAllocator)
+        };
+
     let two_phase_decision_log: Arc<dyn database::two_phase::TwoPhaseDecisionLog> =
         if config.partition_id.is_some() {
             if let Some(nats_url) = &config.nats_url {
@@ -381,6 +392,7 @@ pub async fn make_app(
             .map(database::two_phase::NodeAddresses::from_config),
         two_phase_decision_log,
         timestamp_oracle,
+        table_number_allocator,
         None, // raft_state: set after Raft node starts, not during Database::load
     )
     .await?;


### PR DESCRIPTION
## Summary

Closes #141.

This PR chooses the globally stable table-number design instead of trying to deeply rewrite public document IDs during replica apply.

- Adds a `TableNumberAllocator` abstraction with a local allocator for single-node/test paths and a NATS KV CAS allocator for partitioned clustered startup.
- Threads the allocator into write transactions so user table creation reserves from one global counter.
- Updates replica `_tables` apply to preserve source `TableMetadata.number` exactly and fail loudly if a same-name local table has a mismatched number.
- Keeps tablet-id remapping by table name, but removes the unsafe local table-number reassignment that made embedded public IDs non-portable.
- Adds regression coverage for a cross-partition embedded public ID plus a client-style round-trip lookup on the replica.

## Why

Convex public document IDs encode table numbers. The previous replica-apply path reassigned table numbers locally, but document values could still contain ID strings from the source node's namespace. That could break `db.get(id)`, nested references, validators, and any system metadata carrying document IDs.

Using globally stable table numbers makes public IDs portable across nodes and avoids a fragile deep-rewrite pass over arbitrary document values and metadata.

## Scope note

This is a forward correctness fix for clustered allocation and replica apply. It does not migrate already-diverged local data produced by older builds with per-node table-number assignment.

## Validation

- `cargo check -p local_backend`
- `cargo check -p application --features testing`
- `cargo test -p database test_replica_preserves_global_table_numbers_for_embedded_ids -- --nocapture`
- `cargo test -p database write_scaling_tests -- --nocapture`

