### PR TITLE
fix: fence 2PC prepares from pending writes

### DIFF
--- a/crates/database/src/committer.rs
+++ b/crates/database/src/committer.rs
@@ -1438,6 +1438,18 @@ impl<RT: Runtime> Committer<RT> {
                 prepare_ts: existing.commit_ts,
             });
         }
+        if let Some(min_pending_ts) = self.pending_writes.min_ts() {
+            let metadata = ErrorMetadata::system_occ(
+                Some(u64::from(begin_ts)),
+                write_source.as_str().map(|source| source.to_string()),
+            );
+            anyhow::bail!(anyhow::anyhow!(metadata).context(format!(
+                "2PC Prepare for txn={} blocked by an unresolved pending write at ts={}; retry \
+                 after the pending write publishes",
+                transaction_id,
+                u64::from(min_pending_ts),
+            )));
+        }
 
         let commit_ts = if let Some(commit_ts) = explicit_commit_ts {
             anyhow::ensure!(
@@ -1536,6 +1548,17 @@ impl<RT: Runtime> Committer<RT> {
         write_source: WriteSource,
     ) -> anyhow::Result<ValidatedCommit> {
         self.ensure_leader_for_writes()?;
+        if !self.prepared_transactions.is_empty() {
+            let metadata = ErrorMetadata::system_occ(
+                Some(u64::from(*transaction.begin_timestamp)),
+                write_source.as_str().map(|source| source.to_string()),
+            );
+            anyhow::bail!(anyhow::anyhow!(metadata).context(format!(
+                "Commit blocked by {} unresolved 2PC prepared transaction(s); retry after the \
+                 prepared transaction commits or rolls back",
+                self.prepared_transactions.len(),
+            )));
+        }
 
         // Partition ownership check: verify that all authoritative writes for
         // this operation target tables owned by this node. Deploy metadata
@@ -2856,9 +2879,18 @@ impl<RT: Runtime> Committer<RT> {
             u64::from(prepared.commit_ts),
         );
 
-        // Remove from PendingWrites so it no longer blocks conflicting
-        // transactions. We pop it and discard.
-        self.pending_writes.pop_first(prepared.pending_write);
+        // Remove this exact prepared intent from PendingWrites so it no longer
+        // blocks conflicting transactions. Do not pop the FIFO head here: an
+        // older local commit may be pending ahead of this prepared transaction.
+        self.pending_writes
+            .remove(prepared.pending_write)
+            .ok_or_else(|| {
+                anyhow::anyhow!(
+                    "2PC RollbackPrepared: pending write for txn={} at ts={} was missing",
+                    transaction_id,
+                    u64::from(prepared.commit_ts),
+                )
+            })?;
 
         Ok(())
     }

--- a/crates/database/src/tests/write_scaling_tests.rs
+++ b/crates/database/src/tests/write_scaling_tests.rs
@@ -850,6 +850,130 @@ async fn test_local_only_prepare_does_not_wait_for_remote_frontier(
 }
 
 #[convex_macro::test_runtime]
+async fn test_local_commit_retries_while_prepare_is_unresolved(
+    rt: TestRuntime,
+) -> anyhow::Result<()> {
+    let log = Arc::new(InMemoryDistributedLog::new());
+    let node = create_node(&rt, log, Some(partitioned_map(PartitionId(0)))).await?;
+
+    let mut tx = node.begin(Identity::system()).await?;
+    TestFacingModel::new(&mut tx)
+        .insert(&"messages".parse()?, assert_obj!("text" => "prepared"))
+        .await?;
+    let final_tx = tx.finalize()?;
+    let txn_id = TwoPhaseTransactionId::new();
+    node.committer_for_test()
+        .prepare(
+            txn_id.clone(),
+            final_tx,
+            WriteSource::new("prepared_blocks_local_commit_test"),
+        )
+        .await?;
+
+    let err = insert_doc(
+        &node,
+        "messages",
+        assert_obj!("text" => "retry-after-prepare"),
+    )
+    .await
+    .expect_err("local commit should retry while a prepared transaction is unresolved");
+    assert!(
+        format!("{err:#}").contains("unresolved 2PC prepared transaction"),
+        "unexpected error: {err:#}",
+    );
+
+    node.committer_for_test().rollback_prepared(txn_id).await?;
+
+    insert_doc(&node, "messages", assert_obj!("text" => "after-rollback")).await?;
+
+    let messages = run_query(
+        node,
+        TableNamespace::root_component(),
+        Query::full_table_scan("messages".parse()?, Order::Asc),
+    )
+    .await?;
+    assert_eq!(
+        messages.len(),
+        1,
+        "rolled-back prepared write should not become visible, and the committer should accept \
+         new writes after rollback",
+    );
+
+    Ok(())
+}
+
+#[convex_macro::test_runtime]
+async fn test_prepare_retries_while_local_commit_is_pending(
+    rt: TestRuntime,
+    pause: PauseController,
+) -> anyhow::Result<()> {
+    let log = Arc::new(InMemoryDistributedLog::new());
+    let node = create_node(&rt, log, Some(partitioned_map(PartitionId(0)))).await?;
+
+    let hold_guard = pause.hold(AFTER_PENDING_WRITE_SNAPSHOT);
+    let node_for_commit = node.clone();
+    let local_commit = async move {
+        insert_doc(
+            &node_for_commit,
+            "messages",
+            assert_obj!("text" => "pending-local"),
+        )
+        .await
+    };
+
+    let node_for_prepare = node.clone();
+    let prepare_while_pending = async move {
+        let pause_guard = hold_guard.wait_for_blocked().await;
+
+        let mut tx = node_for_prepare.begin(Identity::system()).await?;
+        TestFacingModel::new(&mut tx)
+            .insert(&"messages".parse()?, assert_obj!("text" => "prepared"))
+            .await?;
+        let final_tx = tx.finalize()?;
+        let err = node_for_prepare
+            .committer_for_test()
+            .prepare(
+                TwoPhaseTransactionId::new(),
+                final_tx,
+                WriteSource::new("prepare_waits_for_pending_commit_test"),
+            )
+            .await
+            .expect_err("prepare should retry while an older local commit is pending");
+        assert!(
+            format!("{err:#}").contains("blocked by an unresolved pending write"),
+            "unexpected error: {err:#}",
+        );
+
+        if let Some(guard) = pause_guard {
+            guard.unpause();
+        }
+        anyhow::Ok(())
+    };
+
+    futures::try_join!(local_commit, prepare_while_pending)?;
+
+    let mut tx = node.begin(Identity::system()).await?;
+    TestFacingModel::new(&mut tx)
+        .insert(
+            &"messages".parse()?,
+            assert_obj!("text" => "prepared-after-publish"),
+        )
+        .await?;
+    let final_tx = tx.finalize()?;
+    let txn_id = TwoPhaseTransactionId::new();
+    node.committer_for_test()
+        .prepare(
+            txn_id.clone(),
+            final_tx,
+            WriteSource::new("prepare_after_pending_commit_test"),
+        )
+        .await?;
+    node.committer_for_test().rollback_prepared(txn_id).await?;
+
+    Ok(())
+}
+
+#[convex_macro::test_runtime]
 async fn test_local_commit_waits_for_remote_frontier(rt: TestRuntime) -> anyhow::Result<()> {
     let log = Arc::new(InMemoryDistributedLog::new());
     let node_a = create_node(&rt, log.clone(), Some(partitioned_map(PartitionId(0)))).await?;

--- a/crates/database/src/write_log.rs
+++ b/crates/database/src/write_log.rs
@@ -741,6 +741,16 @@ impl PendingWrites {
         }
     }
 
+    pub fn remove(
+        &mut self,
+        mut handle: PendingWriteHandle,
+    ) -> Option<(Timestamp, OrderedDocumentWrites, WriteSource, Snapshot)> {
+        let expected_ts = handle.0.take()?;
+        self.by_ts
+            .remove(&expected_ts)
+            .map(|(writes, write_source, snapshot)| (expected_ts, writes, write_source, snapshot))
+    }
+
     pub fn min_ts(&self) -> Option<Timestamp> {
         self.by_ts.first_key_value().map(|(ts, _)| *ts)
     }


### PR DESCRIPTION
## Summary

Refs #154.

This PR fixes the immediate pending-write corruption/crash path around 2PC prepares by adding conservative queue fences:

- Reject normal local commits with an OCC-style retry while a 2PC prepared transaction is unresolved.
- Reject new 2PC prepares while an older pending write is staged but not yet published.
- Remove prepared pending writes by exact handle during rollback instead of blindly popping the FIFO head.
- Add regressions for both bad interleavings:
  - local commit while a prepare is unresolved
  - prepare while an older local commit is pending

## Why

`PendingWrites` is ordered by timestamp and the publish path expects the FIFO head to be the write being published. A prepared transaction sitting in that queue could cause a later local commit to pop the prepared write and panic. Conversely, rollback could pop an unrelated older pending local commit. This PR prevents those unsafe interleavings.

## Scope note

This is a conservative correctness fix, not the full Cockroach-style write-intent model. It preserves the current monotonic `SnapshotManager::push` invariant by retrying conflicting queue-order cases instead of allowing unrelated commits to pass unresolved lower-timestamp prepares. Full intent-aware concurrency can be designed as follow-up work.

## Validation

- `cargo test -p database retries_while -- --nocapture`
- `cargo test -p database write_scaling_tests -- --nocapture`
- `cargo check -p database`
