### PR TITLE
fix: stop Raft on persistence failure

### DIFF
--- a/crates/database/src/raft_node.rs
+++ b/crates/database/src/raft_node.rs
@@ -193,7 +193,7 @@ impl RaftNode {
         &mut self,
         mut on_committed: impl FnMut(&[u8]) -> anyhow::Result<()>,
         mut on_snapshot: impl FnMut(&[u8]) -> anyhow::Result<()>,
-    ) {
+    ) -> anyhow::Result<()> {
         let tick_interval = Duration::from_millis(100);
         let mut last_tick = Instant::now();
 
@@ -222,12 +222,12 @@ impl RaftNode {
                     },
                     Ok(RaftMessage::Shutdown) => {
                         tracing::info!("Raft node {} shutting down", self.config.node_id);
-                        return;
+                        return Ok(());
                     },
                     Err(mpsc::error::TryRecvError::Empty) => break,
                     Err(mpsc::error::TryRecvError::Disconnected) => {
                         tracing::info!("Raft mailbox closed, shutting down");
-                        return;
+                        return Ok(());
                     },
                 }
             }
@@ -367,6 +367,7 @@ impl RaftNode {
                     if let Err(e) = self.storage.apply_snapshot(ready.snapshot()) {
                         tracing::error!("Failed to persist snapshot: {e}");
                         drop(snapshot_timer);
+                        return Err(e);
                     } else if let Err(e) = on_snapshot(ready.snapshot().get_data()) {
                         tracing::error!("Failed to apply snapshot to state machine: {e}");
                         drop(snapshot_timer);
@@ -384,9 +385,11 @@ impl RaftNode {
                         .append_entries_and_hardstate(ready.entries(), hs)
                     {
                         tracing::error!("Failed to persist entries+hardstate: {e}");
+                        return Err(e);
                     }
                 } else if let Err(e) = self.storage.append_entries(ready.entries()) {
                     tracing::error!("Failed to persist entries: {e}");
+                    return Err(e);
                 }
 
                 // 5. Send persisted messages.
@@ -418,6 +421,7 @@ impl RaftNode {
                             if let Ok(cs) = self.raw_node.apply_conf_change(&cc) {
                                 if let Err(e) = self.storage.set_conf_state(cs) {
                                     tracing::error!("Failed to persist conf state: {e}");
+                                    return Err(e);
                                 }
                             }
                         },
@@ -446,6 +450,7 @@ impl RaftNode {
                     hs.set_commit(commit);
                     if let Err(e) = self.storage.set_hardstate(&hs) {
                         tracing::error!("Failed to persist commit index: {e}");
+                        return Err(e);
                     }
                 }
 
@@ -503,10 +508,10 @@ impl RaftNode {
     /// Process one Ready cycle manually (for testing without the full run
     /// loop). Returns committed entry data.
     #[cfg(test)]
-    pub(crate) fn process_ready_test(&mut self) -> Vec<Vec<u8>> {
+    pub(crate) fn try_process_ready_test(&mut self) -> anyhow::Result<Vec<Vec<u8>>> {
         let mut committed = Vec::new();
         if !self.raw_node.has_ready() {
-            return committed;
+            return Ok(committed);
         }
         let mut ready = self.raw_node.ready();
 
@@ -525,11 +530,13 @@ impl RaftNode {
         }
 
         if !ready.snapshot().is_empty() {
-            self.storage.apply_snapshot(ready.snapshot()).unwrap();
+            self.storage.apply_snapshot(ready.snapshot())?;
         }
-        self.storage.append_entries(ready.entries()).unwrap();
         if let Some(hs) = ready.hs() {
-            self.storage.set_hardstate(hs).unwrap();
+            self.storage
+                .append_entries_and_hardstate(ready.entries(), hs)?;
+        } else {
+            self.storage.append_entries(ready.entries())?;
         }
         for entry in ready.take_committed_entries() {
             if !entry.data.is_empty() {
@@ -543,7 +550,12 @@ impl RaftNode {
             }
         }
         self.raw_node.advance_apply();
-        committed
+        Ok(committed)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn process_ready_test(&mut self) -> Vec<Vec<u8>> {
+        self.try_process_ready_test().unwrap()
     }
 }
 
@@ -622,6 +634,46 @@ mod tests {
             committed_data.iter().any(|d| d == b"test mutation"),
             "Proposed data should be committed. Got: {:?}",
             committed_data
+        );
+    }
+
+    #[tokio::test]
+    async fn test_ready_persistence_failure_returns_before_advance() {
+        let config = RaftNodeConfig {
+            node_id: 1,
+            partition_id: PartitionId(0),
+            peers: vec![1],
+            election_tick: 10,
+            heartbeat_tick: 3,
+        };
+
+        let engine = test_engine();
+        let (_tx, rx) = mpsc::unbounded_channel();
+        let mut node = RaftNode::new(config, engine, rx, HashMap::new(), None).unwrap();
+
+        for _ in 0..20 {
+            node.raw_node.tick();
+        }
+        node.process_ready_test();
+        assert!(node.is_leader());
+
+        let persisted_last_index = node.storage.last_index().unwrap();
+        node.raw_node
+            .propose(vec![], b"must not persist".to_vec())
+            .unwrap();
+        node.storage.fail_next_write_for_test();
+
+        let err = node
+            .try_process_ready_test()
+            .expect_err("Ready processing should fail on raft-engine write failure");
+        assert!(
+            format!("{err:#}").contains("injected raft-engine write failure"),
+            "unexpected error: {err:#}",
+        );
+        assert_eq!(
+            node.storage.last_index().unwrap(),
+            persisted_last_index,
+            "failed Ready processing must not persist the proposed entry",
         );
     }
 

--- a/crates/database/src/raft_storage.rs
+++ b/crates/database/src/raft_storage.rs
@@ -84,6 +84,8 @@ pub struct ConvexRaftStorage {
     conf_state: ConfState,
     /// Hook for generating state-machine snapshots on demand.
     snapshot_provider: Option<Arc<dyn RaftSnapshotProvider>>,
+    #[cfg(test)]
+    fail_next_write: Arc<std::sync::atomic::AtomicBool>,
 }
 
 impl ConvexRaftStorage {
@@ -147,7 +149,31 @@ impl ConvexRaftStorage {
             engine,
             conf_state,
             snapshot_provider,
+            #[cfg(test)]
+            fail_next_write: Arc::new(std::sync::atomic::AtomicBool::new(false)),
         })
+    }
+
+    #[cfg(test)]
+    pub(crate) fn fail_next_write_for_test(&self) {
+        self.fail_next_write
+            .store(true, std::sync::atomic::Ordering::SeqCst);
+    }
+
+    #[cfg(test)]
+    fn check_fail_next_write_for_test(&self) -> anyhow::Result<()> {
+        if self
+            .fail_next_write
+            .swap(false, std::sync::atomic::Ordering::SeqCst)
+        {
+            anyhow::bail!("injected raft-engine write failure");
+        }
+        Ok(())
+    }
+
+    #[cfg(not(test))]
+    fn check_fail_next_write_for_test(&self) -> anyhow::Result<()> {
+        Ok(())
     }
 
     /// Region ID for raft-engine (partition_id as u64).
@@ -161,6 +187,7 @@ impl ConvexRaftStorage {
         if entries.is_empty() {
             return Ok(());
         }
+        self.check_fail_next_write_for_test()?;
         let mut batch = LogBatch::default();
         batch
             .add_entries::<RaftMessageExt>(self.region_id(), entries)
@@ -174,6 +201,7 @@ impl ConvexRaftStorage {
     /// Persist hard state (term, vote, commit index).
     /// Called during Ready processing alongside entry append.
     pub fn set_hardstate(&self, hs: &HardState) -> anyhow::Result<()> {
+        self.check_fail_next_write_for_test()?;
         let mut batch = LogBatch::default();
         batch
             .put_message(self.region_id(), HARD_STATE_KEY.to_vec(), hs)
@@ -192,6 +220,7 @@ impl ConvexRaftStorage {
         entries: &[Entry],
         hs: &HardState,
     ) -> anyhow::Result<()> {
+        self.check_fail_next_write_for_test()?;
         let mut batch = LogBatch::default();
         if !entries.is_empty() {
             batch
@@ -209,6 +238,7 @@ impl ConvexRaftStorage {
 
     /// Set the conf state (voter/learner membership).
     pub fn set_conf_state(&mut self, cs: ConfState) -> anyhow::Result<()> {
+        self.check_fail_next_write_for_test()?;
         let mut batch = LogBatch::default();
         batch
             .put_message(self.region_id(), CONF_STATE_KEY.to_vec(), &cs)
@@ -227,6 +257,7 @@ impl ConvexRaftStorage {
     }
 
     pub fn apply_snapshot(&mut self, snapshot: &Snapshot) -> anyhow::Result<()> {
+        self.check_fail_next_write_for_test()?;
         let metadata = snapshot.get_metadata();
         let mut batch = LogBatch::default();
         batch.add_command(self.region_id(), raft_engine::Command::Clean);

--- a/crates/local_backend/src/lib.rs
+++ b/crates/local_backend/src/lib.rs
@@ -953,55 +953,63 @@ pub async fn make_app(
             let committer = database.committer_client();
             let raft_state_for_apply = raft_state.clone();
             runtime.spawn_background("raft_node", async move {
-                node.run(
-                    |data| {
-                        // Deserialize the CommitDelta from the Raft entry.
-                        let envelope: database::nats_distributed_log::DeltaEnvelope =
-                            serde_json::from_slice(data).map_err(|e| {
-                                anyhow::anyhow!("Failed to deserialize Raft entry: {e}")
-                            })?;
-                        let proposed_locally = envelope.source_raft_node_id() == Some(raft_node_id);
-                        let delta = envelope.to_delta()?;
+                if let Err(e) = node
+                    .run(
+                        |data| {
+                            // Deserialize the CommitDelta from the Raft entry.
+                            let envelope: database::nats_distributed_log::DeltaEnvelope =
+                                serde_json::from_slice(data).map_err(|e| {
+                                    anyhow::anyhow!("Failed to deserialize Raft entry: {e}")
+                                })?;
+                            let proposed_locally =
+                                envelope.source_raft_node_id() == Some(raft_node_id);
+                            let delta = envelope.to_delta()?;
 
-                        // Skip only the entries this node already committed
-                        // locally before proposing them through Raft. Every
-                        // other committed entry must be applied here, even if
-                        // this node later became leader.
-                        if !proposed_locally {
-                            tracing::info!(
-                                "Applying committed Raft delta locally: ts={}, leader_now={}",
-                                u64::from(delta.ts),
-                                raft_state_for_apply.is_leader(),
-                            );
-                            // apply_replica_delta is async — use block_in_place
-                            // since we're in the Raft loop's sync callback.
+                            // Skip only the entries this node already committed
+                            // locally before proposing them through Raft. Every
+                            // other committed entry must be applied here, even if
+                            // this node later became leader.
+                            if !proposed_locally {
+                                tracing::info!(
+                                    "Applying committed Raft delta locally: ts={}, leader_now={}",
+                                    u64::from(delta.ts),
+                                    raft_state_for_apply.is_leader(),
+                                );
+                                // apply_replica_delta is async — use block_in_place
+                                // since we're in the Raft loop's sync callback.
+                                let committer = committer.clone();
+                                common::runtime::block_in_place(|| {
+                                    let rt = tokio::runtime::Handle::current();
+                                    rt.block_on(async {
+                                        if let Err(e) = committer.apply_replica_delta(delta).await {
+                                            tracing::error!("Raft follower apply failed: {e:#}");
+                                        }
+                                    })
+                                });
+                            }
+
+                            Ok(())
+                        },
+                        |snapshot_bytes| {
+                            let checkpoint =
+                                database::snapshot_checkpointer::checkpoint_from_bytes(
+                                    snapshot_bytes,
+                                )?;
                             let committer = committer.clone();
                             common::runtime::block_in_place(|| {
                                 let rt = tokio::runtime::Handle::current();
                                 rt.block_on(async {
-                                    if let Err(e) = committer.apply_replica_delta(delta).await {
-                                        tracing::error!("Raft follower apply failed: {e:#}");
-                                    }
+                                    committer.install_snapshot(checkpoint).await?;
+                                    Ok::<_, anyhow::Error>(())
                                 })
-                            });
-                        }
-
-                        Ok(())
-                    },
-                    |snapshot_bytes| {
-                        let checkpoint =
-                            database::snapshot_checkpointer::checkpoint_from_bytes(snapshot_bytes)?;
-                        let committer = committer.clone();
-                        common::runtime::block_in_place(|| {
-                            let rt = tokio::runtime::Handle::current();
-                            rt.block_on(async {
-                                committer.install_snapshot(checkpoint).await?;
-                                Ok::<_, anyhow::Error>(())
                             })
-                        })
-                    },
-                )
-                .await;
+                        },
+                    )
+                    .await
+                {
+                    tracing::error!("Raft node stopped after fatal error: {e:#}");
+                    panic!("Raft node stopped after fatal error: {e:#}");
+                }
             });
         }
 


### PR DESCRIPTION
## Summary

Closes #156.

This PR makes Raft Ready processing fail closed when raft-engine persistence fails instead of logging and continuing to `advance()`.

- `RaftNode::run` now returns `anyhow::Result<()>`.
- Snapshot persistence, entries+hardstate persistence, entry persistence, conf-state persistence, and commit-index hardstate persistence now stop the Raft loop on failure.
- The local-backend Raft background task treats that error as fatal instead of silently letting the node keep running with uncertain durable state.
- Adds a test-only raft-storage failure hook and a regression proving Ready processing returns before the proposed entry is persisted/advanced.

## Why

Raft safety depends on durable storage before the node advertises progress or advances local Raft state. Logging a raft-engine write failure and continuing can let a node count toward quorum for entries it cannot recover after crash.

## Validation

- `cargo test -p database raft_node::tests::test_ready_persistence_failure_returns_before_advance -- --nocapture`
- `cargo test -p database raft_node::tests -- --nocapture`
- `cargo test -p database raft_failover_tests -- --nocapture`
- `cargo check -p database`
- `cargo check -p local_backend`
