### PR TITLE
fix: supervise replica delta consumers

### DIFF
--- a/crates/database/src/replica.rs
+++ b/crates/database/src/replica.rs
@@ -5,14 +5,20 @@
 //! serialized state machine update path (following the etcd/TiKV/Kafka
 //! pattern of one apply thread per node).
 
-use std::sync::Arc;
+use std::{
+    sync::Arc,
+    time::Duration,
+};
 
 use anyhow::Context;
 use common::runtime::{
     Runtime,
     SpawnHandle,
 };
-use futures::StreamExt;
+use futures::{
+    stream::BoxStream,
+    StreamExt,
+};
 
 use crate::{
     commit_delta::{
@@ -32,6 +38,50 @@ pub async fn apply_replication_message(
         committer.apply_replica_delta(delta).await
     })
     .await
+}
+
+pub async fn consume_replication_stream<F>(
+    stream: BoxStream<'static, anyhow::Result<ReplicationMessage>>,
+    committer: CommitterClient,
+    after_success: F,
+) -> anyhow::Result<()>
+where
+    F: FnMut(common::types::Timestamp, usize),
+{
+    consume_replication_stream_with(
+        stream,
+        move |message| {
+            let committer = committer.clone();
+            async move { apply_replication_message(&committer, message).await }
+        },
+        after_success,
+    )
+    .await
+}
+
+async fn consume_replication_stream_with<F, Fut, S>(
+    mut stream: BoxStream<'static, anyhow::Result<ReplicationMessage>>,
+    mut apply_message: F,
+    mut after_success: S,
+) -> anyhow::Result<()>
+where
+    F: FnMut(ReplicationMessage) -> Fut,
+    Fut: std::future::Future<Output = anyhow::Result<(common::types::Timestamp, usize)>>,
+    S: FnMut(common::types::Timestamp, usize),
+{
+    while let Some(result) = stream.next().await {
+        let message = result.context("Error reading from distributed log")?;
+        match apply_message(message).await {
+            Ok((applied_ts, num_updates)) => {
+                after_success(applied_ts, num_updates);
+            },
+            Err(e) => {
+                tracing::error!("Failed to apply replica delta; continuing consumer: {e:#}");
+            },
+        }
+    }
+
+    anyhow::bail!("ReplicaDeltaConsumer stream ended")
 }
 
 async fn apply_replication_message_with<F, Fut>(
@@ -93,15 +143,38 @@ impl ReplicaDeltaConsumer {
         committer: CommitterClient,
         from_ts: common::types::Timestamp,
     ) -> Self {
+        let runtime_for_task = runtime.clone();
         let handle = runtime.spawn("replica_delta_consumer", async move {
-            if let Err(e) = Self::run(distributed_log, committer, from_ts).await {
-                tracing::error!("ReplicaDeltaConsumer failed: {e:#}");
-            }
+            Self::run_supervised(runtime_for_task, distributed_log, committer, from_ts).await;
         });
         Self { _handle: handle }
     }
 
-    async fn run(
+    async fn run_supervised<RT: Runtime>(
+        runtime: RT,
+        distributed_log: Arc<dyn DistributedLog>,
+        committer: CommitterClient,
+        from_ts: common::types::Timestamp,
+    ) {
+        let mut backoff = Duration::from_millis(250);
+        loop {
+            match Self::run_once(distributed_log.clone(), committer.clone(), from_ts).await {
+                Ok(()) => {
+                    tracing::warn!("ReplicaDeltaConsumer exited cleanly; restarting");
+                },
+                Err(e) => {
+                    tracing::error!(
+                        "ReplicaDeltaConsumer failed; restarting after {:?}: {e:#}",
+                        backoff,
+                    );
+                },
+            }
+            runtime.wait(backoff).await;
+            backoff = (backoff * 2).min(Duration::from_secs(30));
+        }
+    }
+
+    async fn run_once(
         distributed_log: Arc<dyn DistributedLog>,
         committer: CommitterClient,
         from_ts: common::types::Timestamp,
@@ -111,25 +184,21 @@ impl ReplicaDeltaConsumer {
             u64::from(from_ts)
         );
 
-        let mut stream = distributed_log
+        let stream = distributed_log
             .subscribe(from_ts)
             .await
             .context("Failed to subscribe to distributed log")?;
 
         tracing::info!("ReplicaDeltaConsumer subscribed, waiting for deltas...");
 
-        while let Some(result) = stream.next().await {
-            let message = result.context("Error reading from distributed log")?;
-            let (applied_ts, num_updates) = apply_replication_message(&committer, message).await?;
+        consume_replication_stream(stream, committer, |applied_ts, num_updates| {
             tracing::info!(
                 "Applied replica delta: ts={}, {} updates",
                 u64::from(applied_ts),
                 num_updates,
             );
-        }
-
-        tracing::warn!("ReplicaDeltaConsumer stream ended — no more deltas");
-        Ok(())
+        })
+        .await
     }
 }
 
@@ -149,7 +218,10 @@ mod tests {
     use async_trait::async_trait;
     use common::types::Timestamp;
 
-    use super::apply_replication_message_with;
+    use super::{
+        apply_replication_message_with,
+        consume_replication_stream_with,
+    };
     use crate::{
         commit_delta::{
             CommitDelta,
@@ -268,6 +340,50 @@ mod tests {
         assert_eq!(counts.ack.load(Ordering::SeqCst), 1);
         assert_eq!(counts.nak.load(Ordering::SeqCst), 1);
         assert_eq!(counts.term.load(Ordering::SeqCst), 0);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn consumer_continues_after_apply_failure() -> anyhow::Result<()> {
+        let counts = Arc::new(AckCounts::default());
+        let first_ts = Timestamp::try_from(42u64)?;
+        let second_ts = Timestamp::try_from(43u64)?;
+        let attempts = Arc::new(AtomicUsize::new(0));
+        let successes = Arc::new(AtomicUsize::new(0));
+        let successes_for_callback = successes.clone();
+        let stream = futures::stream::iter(vec![
+            Ok(test_message(first_ts, counts.clone())),
+            Ok(test_message(second_ts, counts.clone())),
+        ]);
+
+        let err = consume_replication_stream_with(
+            Box::pin(stream),
+            move |message| {
+                let attempts = attempts.clone();
+                async move {
+                    apply_replication_message_with(message, |delta| async move {
+                        if attempts.fetch_add(1, Ordering::SeqCst) == 0 {
+                            anyhow::bail!("transient apply failure");
+                        }
+                        Ok(delta.ts)
+                    })
+                    .await
+                }
+            },
+            move |_ts, _num_updates| {
+                successes_for_callback.fetch_add(1, Ordering::SeqCst);
+            },
+        )
+        .await
+        .expect_err("finite test stream should report stream end");
+
+        assert!(
+            format!("{err:#}").contains("ReplicaDeltaConsumer stream ended"),
+            "unexpected error: {err:#}",
+        );
+        assert_eq!(counts.ack.load(Ordering::SeqCst), 1);
+        assert_eq!(counts.nak.load(Ordering::SeqCst), 1);
+        assert_eq!(successes.load(Ordering::SeqCst), 1);
         Ok(())
     }
 }

--- a/crates/local_backend/src/lib.rs
+++ b/crates/local_backend/src/lib.rs
@@ -754,91 +754,93 @@ pub async fn make_app(
                 *database.now_ts_for_reads()
             };
             let consumer_name = config.name();
-            let broad_consumer_name = consumer_name.clone();
-            let broad_nats_url = nats_url.clone();
+            let consumer_runtime = runtime.clone();
             runtime.spawn_background("replica_delta_consumer_setup", async move {
-                let consumer_nats =
-                    match database::nats_distributed_log::NatsDistributedLog::connect(
-                        database::nats_distributed_log::NatsConfig {
-                            url: broad_nats_url,
-                            consumer_name: Some(broad_consumer_name),
-                            partition_id: None,
-                        },
-                    )
-                    .await
-                    {
-                        Ok(n) => Arc::new(n),
-                        Err(e) => {
-                            tracing::error!(
-                                "Failed to connect NATS for ReplicaDeltaConsumer: {e:#}"
-                            );
-                            return;
-                        },
-                    };
-                let consumer_nats_dyn: Arc<dyn database::commit_delta::DistributedLog> =
-                    consumer_nats;
-                tracing::info!(
-                    use_selective_node_targeting,
-                    ?remote_partitions,
-                    "ReplicaDeltaConsumer subscribing to NATS..."
-                );
-                let subscribe_result = if use_selective_node_targeting {
-                    let selective_consumer =
-                        database::nats_distributed_log::NatsDistributedLog::connect(
+                let mut backoff = Duration::from_millis(250);
+                loop {
+                    tracing::info!(
+                        use_selective_node_targeting,
+                        ?remote_partitions,
+                        "ReplicaDeltaConsumer subscribing to NATS..."
+                    );
+                    let subscribe_result = if use_selective_node_targeting {
+                        match database::nats_distributed_log::NatsDistributedLog::connect(
                             database::nats_distributed_log::NatsConfig {
                                 url: nats_url.clone(),
                                 consumer_name: Some(format!("{consumer_name}-selective")),
                                 partition_id: None,
                             },
                         )
-                        .await;
-                    match selective_consumer {
-                        Ok(consumer) => {
-                            consumer
-                                .subscribe_selective_node(from_ts.into(), &consumer_name)
-                                .await
-                        },
-                        Err(e) => Err(e),
-                    }
-                } else {
-                    consumer_nats_dyn
-                        .subscribe_filtered(from_ts.into(), remote_partitions.clone())
                         .await
-                };
-                match subscribe_result {
-                    Ok(mut stream) => {
-                        tracing::info!("ReplicaDeltaConsumer subscribed, processing deltas...");
-                        while let Some(result) = futures::StreamExt::next(&mut stream).await {
-                            match result {
-                                Ok(message) => {
+                        {
+                            Ok(consumer) => {
+                                consumer
+                                    .subscribe_selective_node(from_ts.into(), &consumer_name)
+                                    .await
+                            },
+                            Err(e) => Err(e),
+                        }
+                    } else {
+                        match database::nats_distributed_log::NatsDistributedLog::connect(
+                            database::nats_distributed_log::NatsConfig {
+                                url: nats_url.clone(),
+                                consumer_name: Some(consumer_name.clone()),
+                                partition_id: None,
+                            },
+                        )
+                        .await
+                        {
+                            Ok(consumer) => {
+                                let consumer_nats_dyn: Arc<
+                                    dyn database::commit_delta::DistributedLog,
+                                > = Arc::new(consumer);
+                                consumer_nats_dyn
+                                    .subscribe_filtered(from_ts.into(), remote_partitions.clone())
+                                    .await
+                            },
+                            Err(e) => Err(e),
+                        }
+                    };
+                    match subscribe_result {
+                        Ok(stream) => {
+                            tracing::info!("ReplicaDeltaConsumer subscribed, processing deltas...");
+                            let result = database::replica::consume_replication_stream(
+                                stream,
+                                committer.clone(),
+                                |ts, n| {
                                     if use_selective_node_targeting {
                                         database::log_selective_delivery_shadow_receive();
                                     }
-                                    match database::replica::apply_replication_message(
-                                        &committer, message,
-                                    )
-                                    .await
-                                    {
-                                        Ok((ts, n)) => tracing::info!(
-                                            "Applied replica delta: ts={}, {} updates",
-                                            u64::from(ts),
-                                            n
-                                        ),
-                                        Err(e) => {
-                                            tracing::error!("Failed to apply NATS delta: {e:#}");
-                                            break;
-                                        },
-                                    }
+                                    tracing::info!(
+                                        "Applied replica delta: ts={}, {} updates",
+                                        u64::from(ts),
+                                        n
+                                    );
                                 },
-                                Err(e) => {
-                                    tracing::error!("Error reading NATS delta: {e:#}");
-                                    break;
-                                },
+                            )
+                            .await;
+                            if let Err(e) = result {
+                                tracing::error!(
+                                    "ReplicaDeltaConsumer stream failed; restarting after {:?}: \
+                                     {e:#}",
+                                    backoff,
+                                );
+                            } else {
+                                tracing::warn!(
+                                    "ReplicaDeltaConsumer stream ended; restarting after {:?}",
+                                    backoff,
+                                );
                             }
-                        }
-                        tracing::warn!("ReplicaDeltaConsumer stream ended");
-                    },
-                    Err(e) => tracing::error!("Failed to subscribe to NATS: {e:#}"),
+                        },
+                        Err(e) => {
+                            tracing::error!(
+                                "Failed to subscribe to NATS; retrying after {:?}: {e:#}",
+                                backoff,
+                            );
+                        },
+                    }
+                    consumer_runtime.wait(backoff).await;
+                    backoff = (backoff * 2).min(Duration::from_secs(30));
                 }
             });
             tracing::info!("Started ReplicaDeltaConsumer for replication");


### PR DESCRIPTION
## Summary

Closes #160.

This keeps replica delta consumers alive after transient failures instead of letting one bad apply/read/subscribe event permanently stop replication.

- Add a shared replica stream consumer that NAKs failed deltas through the existing apply path, logs the failure, and continues processing later messages.
- Supervise `ReplicaDeltaConsumer` so stream end, read errors, and subscribe failures restart with bounded exponential backoff.
- Apply the same supervision loop to the local-backend broad/selective NATS consumer setup path.
- Add a regression test proving a failed apply can NAK and the next message can still ACK successfully.

## Scope note

This does not solve replica apply idempotency (#138), timestamp-domain skip issues (#159), or poison-message parking/dead-letter handling. It fixes the immediate availability bug where the consumer task could die permanently.

## Validation

- `cargo test -p database replica::tests -- --nocapture`
- `cargo check -p database`
- `cargo check -p local_backend`
