### PR TITLE
fix: make replica delta apply idempotent

### DIFF
--- a/crates/common/src/persistence.rs
+++ b/crates/common/src/persistence.rs
@@ -162,6 +162,11 @@ pub enum PersistenceGlobalKey {
     /// replica that had caught up through the transaction's snapshot.
     ReplicationFrontiers,
 
+    /// Latest origin commit timestamp durably applied per source partition.
+    /// This is separate from `ReplicationFrontiers`, which is expressed in
+    /// local apply timestamps and is used for read freshness fencing.
+    AppliedDeltaWatermarks,
+
     /// Latest snapshot of all tables' summaries, cached to speed up startup.
     TableSummary,
 
@@ -196,6 +201,7 @@ impl From<PersistenceGlobalKey> for String {
             },
             PersistenceGlobalKey::MaxRepeatableTimestamp => "max_repeatable_ts".to_string(),
             PersistenceGlobalKey::ReplicationFrontiers => "replication_frontiers".to_string(),
+            PersistenceGlobalKey::AppliedDeltaWatermarks => "applied_delta_watermarks".to_string(),
             PersistenceGlobalKey::TableSummary => "table_summary".to_string(),
             PersistenceGlobalKey::TwoPhaseRedoRecords => "two_phase_redo_records".to_string(),
             PersistenceGlobalKey::TablesByIdIndex => "tables_by_id".to_string(),
@@ -217,6 +223,7 @@ impl FromStr for PersistenceGlobalKey {
             "document_confirmed_deleted_ts" => Ok(Self::DocumentRetentionConfirmedDeletedTimestamp),
             "max_repeatable_ts" => Ok(Self::MaxRepeatableTimestamp),
             "replication_frontiers" => Ok(Self::ReplicationFrontiers),
+            "applied_delta_watermarks" => Ok(Self::AppliedDeltaWatermarks),
             "table_summary" => Ok(Self::TableSummary),
             "two_phase_redo_records" => Ok(Self::TwoPhaseRedoRecords),
             "tables_by_id" => Ok(Self::TablesByIdIndex),

--- a/crates/database/src/committer.rs
+++ b/crates/database/src/committer.rs
@@ -156,6 +156,8 @@ use crate::{
         BootstrappedSearchIndexes,
     },
     snapshot_manager::{
+        partition_timestamp_map_from_json,
+        partition_timestamp_map_to_json,
         replication_frontiers_to_json,
         SnapshotManager,
         TableSummaries,
@@ -214,17 +216,20 @@ enum PersistenceWrite {
     /// and replicated — flow through one sequential log.
     ReplicaDelta {
         commit_ts: Timestamp,
+        remote_ts: Timestamp,
         snapshot: Snapshot,
         remapped_updates: Vec<common::document::DocumentUpdate>,
         write_source: WriteSource,
         write_bytes: u64,
         source_partition: Option<crate::partition::PartitionId>,
+        applied_delta_watermarks: Option<BTreeMap<crate::partition::PartitionId, Timestamp>>,
         result: oneshot::Sender<anyhow::Result<Timestamp>>,
         commit_id: usize,
     },
     ReplicationFrontierHeartbeat {
         commit_ts: Timestamp,
         source_partition: crate::partition::PartitionId,
+        applied_delta_watermarks: BTreeMap<crate::partition::PartitionId, Timestamp>,
         result: oneshot::Sender<anyhow::Result<Timestamp>>,
         commit_id: usize,
     },
@@ -232,6 +237,7 @@ enum PersistenceWrite {
         snapshot_ts: Timestamp,
         snapshot: Snapshot,
         replication_frontiers: BTreeMap<crate::partition::PartitionId, Timestamp>,
+        applied_delta_watermarks: BTreeMap<crate::partition::PartitionId, Timestamp>,
         result: oneshot::Sender<anyhow::Result<Timestamp>>,
         commit_id: usize,
     },
@@ -402,6 +408,12 @@ pub struct Committer<RT: Runtime> {
     // When set, the Committer rejects writes if this node is not the Raft leader.
     // None means no Raft (existing behavior — always accept writes).
     raft_state: Option<crate::raft_partition::RaftPartitionState>,
+
+    // Durable idempotency frontier for replicated transport messages.
+    // Unlike `SnapshotManager::replication_frontiers`, this map is keyed by
+    // the origin partition's commit timestamp, not this node's local apply
+    // timestamp.
+    applied_delta_watermarks: BTreeMap<crate::partition::PartitionId, Timestamp>,
 }
 
 impl<RT: Runtime> Committer<RT> {
@@ -474,6 +486,7 @@ impl<RT: Runtime> Committer<RT> {
         two_phase_decision_log: Arc<dyn crate::two_phase::TwoPhaseDecisionLog>,
         timestamp_oracle: Option<Arc<dyn crate::timestamp_oracle::TimestampOracle>>,
         raft_state: Option<crate::raft_partition::RaftPartitionState>,
+        applied_delta_watermarks: BTreeMap<crate::partition::PartitionId, Timestamp>,
     ) -> CommitterClient {
         let persistence_reader = persistence.reader();
         let conflict_checker = PendingWrites::new();
@@ -499,6 +512,7 @@ impl<RT: Runtime> Committer<RT> {
             prepared_transactions: std::collections::HashMap::new(),
             queued_snapshots: VecDeque::new(),
             raft_state,
+            applied_delta_watermarks,
         };
         let handle = runtime.spawn("committer", async move {
             if let Err(err) = committer.go(rx).await {
@@ -673,11 +687,13 @@ impl<RT: Runtime> Committer<RT> {
                         },
                         PersistenceWrite::ReplicaDelta {
                             commit_ts,
+                            remote_ts,
                             snapshot,
                             remapped_updates,
                             write_source,
                             write_bytes,
                             source_partition,
+                            applied_delta_watermarks,
                             result,
                             ..
                         } => {
@@ -691,20 +707,37 @@ impl<RT: Runtime> Committer<RT> {
                             if !writes.is_empty() {
                                 self.log.append(commit_ts, writes, write_source);
                             }
+                            if let Some(frontiers) = applied_delta_watermarks {
+                                self.persistence
+                                    .write_persistence_global(
+                                        PersistenceGlobalKey::AppliedDeltaWatermarks,
+                                        partition_timestamp_map_to_json(&frontiers),
+                                    )
+                                    .await?;
+                            }
                             let mut sm = self.snapshot_manager.write();
                             sm.push(commit_ts, snapshot, write_bytes);
                             if let Some(source_partition) = source_partition {
                                 sm.update_replication_frontier(source_partition, commit_ts)?;
                                 sm.update_replication_write_frontier(source_partition, commit_ts)?;
+                                self.applied_delta_watermarks
+                                    .insert(source_partition, remote_ts);
                             }
                             let _ = result.send(Ok(commit_ts));
                         },
                         PersistenceWrite::ReplicationFrontierHeartbeat {
                             commit_ts,
                             source_partition,
+                            applied_delta_watermarks,
                             result,
                             ..
                         } => {
+                            self.persistence
+                                .write_persistence_global(
+                                    PersistenceGlobalKey::AppliedDeltaWatermarks,
+                                    partition_timestamp_map_to_json(&applied_delta_watermarks),
+                                )
+                                .await?;
                             self.publish_replication_frontier_progress(
                                 commit_ts,
                                 source_partition,
@@ -715,6 +748,7 @@ impl<RT: Runtime> Committer<RT> {
                             snapshot_ts,
                             snapshot,
                             replication_frontiers,
+                            applied_delta_watermarks,
                             result,
                             ..
                         } => {
@@ -723,6 +757,7 @@ impl<RT: Runtime> Committer<RT> {
                             self.queued_snapshots.clear();
                             self.log.reset(snapshot_ts);
                             self.last_assigned_ts = snapshot_ts;
+                            self.applied_delta_watermarks = applied_delta_watermarks;
                             self.snapshot_manager.write().replace(
                                 snapshot_ts,
                                 snapshot,
@@ -2029,11 +2064,20 @@ impl<RT: Runtime> Committer<RT> {
                             })
                             .unwrap_or_default()
                     });
+                let applied_delta_watermarks = checkpoint
+                    .globals
+                    .get(&String::from(PersistenceGlobalKey::AppliedDeltaWatermarks))
+                    .map(|value| {
+                        partition_timestamp_map_from_json(value.clone(), "applied delta watermarks")
+                    })
+                    .transpose()?
+                    .unwrap_or_default();
 
                 Ok(PersistenceWrite::InstallSnapshot {
                     snapshot_ts: checkpoint_ts,
                     snapshot: db_snapshot.snapshot,
                     replication_frontiers,
+                    applied_delta_watermarks,
                     result,
                     commit_id,
                 })
@@ -2080,6 +2124,20 @@ impl<RT: Runtime> Committer<RT> {
         // prepare. We therefore use the remote commit timestamp as a floor and
         // only bump above it when local monotonicity requires it.
         let remote_ts = delta.ts;
+        if let Some(source_partition) = delta.source_partition
+            && self
+                .applied_delta_watermarks
+                .get(&source_partition)
+                .is_some_and(|frontier| *frontier >= remote_ts)
+        {
+            tracing::info!(
+                "Skipping duplicate replica delta: source_partition={}, remote_ts={}",
+                source_partition.0,
+                u64::from(remote_ts),
+            );
+            let _ = result.send(Ok(remote_ts));
+            return Ok(());
+        }
         let latest_ts = self.snapshot_manager.read().latest_ts();
         let commit_ts = cmp::max(
             remote_ts,
@@ -2253,6 +2311,13 @@ impl<RT: Runtime> Committer<RT> {
                 }
                 frontiers
             };
+            let updated_applied_delta_watermarks = {
+                let mut frontiers = self.applied_delta_watermarks.clone();
+                frontiers.insert(source_partition, remote_ts);
+                frontiers
+            };
+            self.applied_delta_watermarks
+                .insert(source_partition, remote_ts);
             let persistence = self.persistence.clone();
             self.persistence_writes.push_back(
                 async move {
@@ -2265,6 +2330,7 @@ impl<RT: Runtime> Committer<RT> {
                     Ok(PersistenceWrite::ReplicationFrontierHeartbeat {
                         commit_ts,
                         source_partition,
+                        applied_delta_watermarks: updated_applied_delta_watermarks,
                         result,
                         commit_id,
                     })
@@ -2474,6 +2540,15 @@ impl<RT: Runtime> Committer<RT> {
             }
             frontiers
         });
+        let updated_applied_delta_watermarks = delta.source_partition.map(|source_partition| {
+            let mut frontiers = self.applied_delta_watermarks.clone();
+            frontiers.insert(source_partition, remote_ts);
+            frontiers
+        });
+        if let Some(source_partition) = delta.source_partition {
+            self.applied_delta_watermarks
+                .insert(source_partition, remote_ts);
+        }
 
         let persistence = self.persistence.clone();
         self.enqueue_snapshot(commit_id, commit_ts, snapshot.clone());
@@ -2482,6 +2557,7 @@ impl<RT: Runtime> Committer<RT> {
             let doc_writes = document_writes.clone();
             let idx_writes = index_writes.clone();
             let replication_frontiers = updated_replication_frontiers.clone();
+            let applied_delta_watermarks = updated_applied_delta_watermarks.clone();
             let source_partition = delta.source_partition;
             async move {
                 // Write to persistence (so function runner can load modules).
@@ -2508,11 +2584,13 @@ impl<RT: Runtime> Committer<RT> {
 
                 Ok(PersistenceWrite::ReplicaDelta {
                     commit_ts,
+                    remote_ts,
                     snapshot,
                     remapped_updates: all_remapped_updates,
                     write_source: delta.write_source,
                     write_bytes: delta.write_bytes,
                     source_partition,
+                    applied_delta_watermarks,
                     result,
                     commit_id,
                 })

--- a/crates/database/src/database.rs
+++ b/crates/database/src/database.rs
@@ -195,6 +195,7 @@ use crate::{
     search_index_bootstrap::SearchIndexBootstrapWorker,
     snapshot_checkpointer::checkpoint_to_bytes,
     snapshot_manager::{
+        partition_timestamp_map_from_json,
         replication_frontiers_from_json,
         replication_frontiers_to_json,
         Snapshot,
@@ -1049,6 +1050,13 @@ impl<RT: Runtime> Database<RT> {
                 })
                 .unwrap_or_default(),
         };
+        let applied_delta_watermarks = match reader
+            .get_persistence_global(PersistenceGlobalKey::AppliedDeltaWatermarks)
+            .await?
+        {
+            Some(value) => partition_timestamp_map_from_json(value, "applied delta watermarks")?,
+            None => BTreeMap::new(),
+        };
 
         let snapshot_manager = SnapshotManager::new(*ts, snapshot, replication_frontiers);
         let (snapshot_reader, snapshot_writer) = new_split_rw_lock(snapshot_manager);
@@ -1105,6 +1113,7 @@ impl<RT: Runtime> Database<RT> {
             two_phase_decision_log,
             timestamp_oracle,
             raft_state,
+            applied_delta_watermarks,
         );
         let table_mapping_snapshot_cache =
             AsyncLru::new(runtime.clone(), 20, 2, "table_mapping_snapshot");

--- a/crates/database/src/snapshot_manager.rs
+++ b/crates/database/src/snapshot_manager.rs
@@ -1045,6 +1045,10 @@ impl SnapshotManager {
 }
 
 pub fn replication_frontiers_to_json(frontiers: &BTreeMap<PartitionId, Timestamp>) -> JsonValue {
+    partition_timestamp_map_to_json(frontiers)
+}
+
+pub fn partition_timestamp_map_to_json(frontiers: &BTreeMap<PartitionId, Timestamp>) -> JsonValue {
     JsonValue::Object(
         frontiers
             .iter()
@@ -1056,8 +1060,15 @@ pub fn replication_frontiers_to_json(frontiers: &BTreeMap<PartitionId, Timestamp
 pub fn replication_frontiers_from_json(
     value: JsonValue,
 ) -> anyhow::Result<BTreeMap<PartitionId, Timestamp>> {
+    partition_timestamp_map_from_json(value, "replication frontiers")
+}
+
+pub fn partition_timestamp_map_from_json(
+    value: JsonValue,
+    name: &str,
+) -> anyhow::Result<BTreeMap<PartitionId, Timestamp>> {
     let JsonValue::Object(entries) = value else {
-        anyhow::bail!("replication frontiers must be a JSON object");
+        anyhow::bail!("{name} must be a JSON object");
     };
 
     entries

--- a/crates/database/src/tests/write_scaling_tests.rs
+++ b/crates/database/src/tests/write_scaling_tests.rs
@@ -18,8 +18,11 @@ use common::{
     interval::Interval,
     pause::PauseController,
     persistence::{
+        NoopRetentionValidator,
         Persistence,
         PersistenceGlobalKey,
+        PersistenceReader,
+        TimestampRange,
     },
     query::{
         Order,
@@ -39,6 +42,7 @@ use common::{
         Timestamp,
     },
 };
+use futures::TryStreamExt;
 use keybroker::Identity;
 use parking_lot::Mutex;
 use pb::replication::{
@@ -235,6 +239,19 @@ async fn insert_doc(
         .insert(&table_name, fields)
         .await?;
     db.commit(tx).await
+}
+
+async fn persisted_document_log_count(tp: &Arc<TestPersistence>) -> anyhow::Result<usize> {
+    Ok(tp
+        .load_documents(
+            TimestampRange::all(),
+            Order::Asc,
+            100_000,
+            Arc::new(NoopRetentionValidator),
+        )
+        .try_collect::<Vec<_>>()
+        .await?
+        .len())
 }
 
 struct TestTwoPhaseCommitGrpcService {
@@ -1054,6 +1071,99 @@ async fn test_replication_frontier_persists_across_restart(rt: TestRuntime) -> a
     assert_eq!(
         restarted.replication_frontier_for_test(PartitionId(1)),
         Some(persisted_frontier),
+    );
+
+    Ok(())
+}
+
+#[convex_macro::test_runtime]
+async fn test_replica_delta_redelivery_is_idempotent(rt: TestRuntime) -> anyhow::Result<()> {
+    let log = Arc::new(InMemoryDistributedLog::new());
+    let node_a_persistence = Arc::new(TestPersistence::new());
+    let node_a = create_node_with_persistence(
+        &rt,
+        node_a_persistence.clone(),
+        log.clone(),
+        Some(partitioned_map(PartitionId(0))),
+        None,
+        Arc::new(NoopTwoPhaseDecisionLog),
+        None,
+    )
+    .await?;
+    let node_b = create_node(&rt, log.clone(), Some(partitioned_map(PartitionId(1)))).await?;
+
+    insert_doc(&node_b, "projects", assert_obj!("name" => "redelivered")).await?;
+    let delta = log
+        .deltas()
+        .into_iter()
+        .last()
+        .expect("project insert should publish a delta");
+    let remote_ts = delta.ts;
+
+    let first_apply_ts = node_a
+        .committer_for_test()
+        .apply_replica_delta(delta.clone())
+        .await?;
+    let docs_after_first_apply = persisted_document_log_count(&node_a_persistence).await?;
+    let snapshot_ts_after_first_apply = *node_a.now_ts_for_reads();
+
+    let duplicate_apply_ts = node_a
+        .committer_for_test()
+        .apply_replica_delta(delta.clone())
+        .await?;
+
+    assert_eq!(
+        duplicate_apply_ts, remote_ts,
+        "duplicates should ACK as skipped without allocating a new local apply timestamp",
+    );
+    assert_eq!(
+        persisted_document_log_count(&node_a_persistence).await?,
+        docs_after_first_apply,
+        "redelivered delta must not append duplicate document log entries",
+    );
+    assert_eq!(
+        *node_a.now_ts_for_reads(),
+        snapshot_ts_after_first_apply,
+        "redelivered delta must not publish a new snapshot",
+    );
+    assert!(
+        first_apply_ts >= remote_ts,
+        "initial apply should use the remote timestamp as its floor",
+    );
+
+    let applied_frontiers = node_a_persistence
+        .reader()
+        .get_persistence_global(PersistenceGlobalKey::AppliedDeltaWatermarks)
+        .await?
+        .expect("replica applied frontier should be persisted");
+    let applied_frontiers = crate::snapshot_manager::partition_timestamp_map_from_json(
+        applied_frontiers,
+        "applied delta watermarks",
+    )?;
+    assert_eq!(applied_frontiers.get(&PartitionId(1)), Some(&remote_ts));
+
+    let restarted = create_node_with_persistence(
+        &rt,
+        node_a_persistence.clone(),
+        log,
+        Some(partitioned_map(PartitionId(0))),
+        None,
+        Arc::new(NoopTwoPhaseDecisionLog),
+        None,
+    )
+    .await?;
+    let duplicate_after_restart_ts = restarted
+        .committer_for_test()
+        .apply_replica_delta(delta)
+        .await?;
+    assert_eq!(
+        duplicate_after_restart_ts, remote_ts,
+        "restart should reload the applied frontier and skip redelivery",
+    );
+    assert_eq!(
+        persisted_document_log_count(&node_a_persistence).await?,
+        docs_after_first_apply,
+        "redelivered delta after restart must not append duplicate document log entries",
     );
 
     Ok(())


### PR DESCRIPTION
## Summary

Closes #138.

Replica delta apply is now idempotent across NATS redelivery by persisting a stable per-source origin watermark. If a delta from `(source_partition, origin_ts)` is redelivered after it has already been applied, the committer returns success without allocating a new local apply timestamp, appending document/index writes, publishing a new snapshot, or advancing the write log.

- Add `AppliedDeltaWatermarks` as a persistence global keyed by source partition and origin timestamp.
- Load that watermark on database startup and checkpoint install.
- Persist watermark updates for both data deltas and frontier-only heartbeat deltas.
- Skip duplicate replica deltas before computing a fresh local apply timestamp.
- Keep read freshness frontiers separate because those are local-apply-timestamp frontiers, not origin identity checkpoints.
- Add a regression that replays the same delta in-process and after restart, proving no duplicate document-log entries or snapshots are produced.

## Scope note

This makes redelivery safe for source-partition ordered deltas. It does not solve broader timestamp-domain unification (#139), NATS retention gap recovery (#162), or any remaining cross-stream ordering limitations.

## Validation

- `cargo test -p database test_replica_delta_redelivery_is_idempotent -- --nocapture`
- `cargo test -p database test_replication_frontier_persists_across_restart -- --nocapture`
- `cargo test -p common test_persistence_global_roundtrips -- --nocapture`
- `cargo check -p database`
