### PR TITLE
fix: retry replica deltas with unmapped tables

### DIFF
--- a/crates/database/src/committer.rs
+++ b/crates/database/src/committer.rs
@@ -2486,12 +2486,15 @@ impl<RT: Runtime> Committer<RT> {
                 Some(t) => *t,
                 None => {
                     let table_name = delta.tablet_id_to_table_name.get(&primary_tablet);
-                    tracing::debug!(
-                        "Skipping update for unmapped table {:?} (TabletId {:?})",
+                    let err = anyhow::anyhow!(
+                        "Cannot apply replica delta at ts={} because table {:?} (TabletId {:?}) \
+                         is not mapped locally; retry after table metadata is available",
+                        u64::from(remote_ts),
                         table_name,
                         primary_tablet,
                     );
-                    continue;
+                    let _ = result.send(Err(err));
+                    return Ok(());
                 },
             };
             let remapped = DocumentUpdate {

--- a/crates/database/src/tests/write_scaling_tests.rs
+++ b/crates/database/src/tests/write_scaling_tests.rs
@@ -1346,6 +1346,59 @@ async fn test_replica_delta_redelivery_is_idempotent(rt: TestRuntime) -> anyhow:
 }
 
 #[convex_macro::test_runtime]
+async fn test_replica_delta_fails_for_unmapped_user_table(rt: TestRuntime) -> anyhow::Result<()> {
+    let log = Arc::new(InMemoryDistributedLog::new());
+    let node_a = create_node(&rt, log.clone(), Some(partitioned_map(PartitionId(0)))).await?;
+    let node_b = create_node(&rt, log.clone(), Some(partitioned_map(PartitionId(1)))).await?;
+
+    insert_doc(&node_b, "projects", assert_obj!("name" => "metadata")).await?;
+    let table_metadata_delta = log
+        .deltas()
+        .into_iter()
+        .last()
+        .expect("first project insert should publish table metadata");
+
+    insert_doc(&node_b, "projects", assert_obj!("name" => "data")).await?;
+    let data_delta = log
+        .deltas()
+        .into_iter()
+        .last()
+        .expect("second project insert should publish data");
+
+    let err = node_a
+        .committer_for_test()
+        .apply_replica_delta(data_delta.clone())
+        .await
+        .expect_err("data delta should fail until table metadata is available");
+    assert!(
+        format!("{err:#}").contains("is not mapped locally"),
+        "unexpected error: {err:#}",
+    );
+    assert_eq!(
+        node_a.replication_frontier_for_test(PartitionId(1)),
+        Some(Timestamp::MIN),
+        "failed delta must not advance remote read frontier",
+    );
+
+    node_a
+        .committer_for_test()
+        .apply_replica_delta(table_metadata_delta)
+        .await?;
+    node_a
+        .committer_for_test()
+        .apply_replica_delta(data_delta)
+        .await?;
+    assert!(
+        node_a
+            .replication_frontier_for_test(PartitionId(1))
+            .is_some_and(|frontier| frontier > Timestamp::MIN),
+        "retry after metadata should apply and advance the frontier",
+    );
+
+    Ok(())
+}
+
+#[convex_macro::test_runtime]
 async fn test_prepared_participant_recovers_from_redo_after_restart(
     rt: TestRuntime,
 ) -> anyhow::Result<()> {


### PR DESCRIPTION
## Summary

Closes #142.

Replica apply no longer treats user/global-table updates with missing local table mappings as successfully applied. If a delta references a replicated table that this node cannot map yet, the committer returns a retryable apply error before queueing persistence, publishing a snapshot, or advancing replication frontiers.

- Replace the silent `continue` for unmapped replicated updates with an explicit apply error.
- Keep the committer alive by returning the error through the replica apply result channel instead of treating this as a fatal committer failure.
- Add a regression that applies a data delta before its table metadata, verifies the frontier stays at `Timestamp::MIN`, then applies metadata and retries the same data delta successfully.

## Validation

- `cargo test -p database test_replica_delta_fails_for_unmapped_user_table -- --nocapture`
- `cargo test -p database test_replication_frontier_persists_across_restart -- --nocapture`
- `cargo test -p database replica::tests -- --nocapture`
- `cargo check -p database`
