### PR TITLE
fix: bound remote read frontier waits

### DIFF
--- a/crates/common/src/knobs.rs
+++ b/crates/common/src/knobs.rs
@@ -390,6 +390,14 @@ pub static REPLICATION_FRONTIER_HEARTBEAT_INTERVAL: LazyLock<Duration> = LazyLoc
     ))
 });
 
+/// Maximum time to wait for a remote partition's read frontier before
+/// failing the request. This should be comfortably above the heartbeat interval
+/// so normal idle frontier progress succeeds, but bounded so missing transport
+/// progress does not hang user operations forever.
+pub static REMOTE_READ_FRONTIER_WAIT_TIMEOUT: LazyLock<Duration> = LazyLock::new(|| {
+    Duration::from_millis(env_config("REMOTE_READ_FRONTIER_WAIT_TIMEOUT_MS", 5000))
+});
+
 /// This is the max duration between a Commit and bumping max_repeatable_ts.
 /// When reading from a follower persistence, we can only read commits at
 /// timestamps <= max_repeatable_ts (because commits > max_repeatable_ts are

--- a/crates/database/src/committer.rs
+++ b/crates/database/src/committer.rs
@@ -50,6 +50,7 @@ use common::{
         COMMIT_TRACE_THRESHOLD,
         MAX_REPEATABLE_TIMESTAMP_COMMIT_DELAY,
         MAX_REPEATABLE_TIMESTAMP_IDLE_FREQUENCY,
+        REMOTE_READ_FRONTIER_WAIT_TIMEOUT,
         REPLICATION_FRONTIER_HEARTBEAT_INTERVAL,
         TRANSACTION_WARN_READ_SET_INTERVALS,
     },
@@ -3473,8 +3474,33 @@ impl CommitterClient {
             begin_ts,
             required,
         );
-        join_all(waits).await;
-        Ok(())
+        let started = tokio::time::Instant::now();
+        let wait_all = join_all(waits);
+        let timeout = tokio::time::sleep(*REMOTE_READ_FRONTIER_WAIT_TIMEOUT);
+        futures::pin_mut!(wait_all, timeout);
+        select_biased! {
+            _ = wait_all.fuse() => {
+                metrics::log_remote_read_frontier_wait_seconds(
+                    "success",
+                    started.elapsed().as_secs_f64(),
+                );
+                Ok(())
+            },
+            _ = timeout.fuse() => {
+                metrics::log_remote_read_frontier_wait_seconds(
+                    "timeout",
+                    started.elapsed().as_secs_f64(),
+                );
+                metrics::log_remote_read_frontier_wait_timeout();
+                anyhow::bail!(
+                    "Timed out after {:?} waiting for remote read frontiers to reach begin_ts={} \
+                     on partitions {:?}",
+                    *REMOTE_READ_FRONTIER_WAIT_TIMEOUT,
+                    begin_ts,
+                    required,
+                )
+            },
+        }
     }
 
     pub fn commit<RT: Runtime>(

--- a/crates/database/src/metrics.rs
+++ b/crates/database/src/metrics.rs
@@ -256,6 +256,27 @@ pub fn log_replication_write_frontier_ts(source_partition: PartitionId, ts: Time
     );
 }
 
+register_convex_histogram!(
+    DATABASE_REMOTE_READ_FRONTIER_WAIT_SECONDS,
+    "Time spent waiting for remote read frontiers before a read/commit can proceed",
+    &OUTCOME_LABELS
+);
+pub fn log_remote_read_frontier_wait_seconds(outcome: &'static str, seconds: f64) {
+    log_distribution_with_labels(
+        &DATABASE_REMOTE_READ_FRONTIER_WAIT_SECONDS,
+        seconds,
+        vec![outcome_label(outcome)],
+    );
+}
+
+register_convex_counter!(
+    DATABASE_REMOTE_READ_FRONTIER_WAIT_TIMEOUTS_TOTAL,
+    "Number of remote replication frontier waits that timed out"
+);
+pub fn log_remote_read_frontier_wait_timeout() {
+    log_counter(&DATABASE_REMOTE_READ_FRONTIER_WAIT_TIMEOUTS_TOTAL, 1);
+}
+
 register_convex_gauge!(
     DATABASE_SELECTIVE_DELIVERY_INTERESTED_TABLES_INFO,
     "Number of unique tables currently tracked as selectively interesting on this node"

--- a/crates/database/src/nats_distributed_log.rs
+++ b/crates/database/src/nats_distributed_log.rs
@@ -51,6 +51,7 @@ const STREAM_NAME: &str = "CONVEX_COMMITS";
 /// to capture all partitions.
 const SUBJECT_BASE: &str = "convex.commits";
 const SYSTEM_TABLE_SUBJECT: &str = "convex.commits.system";
+const FRONTIER_HEARTBEAT_SUBJECT: &str = "convex.commits.frontier_heartbeat";
 
 /// Configuration for connecting to NATS.
 #[derive(Clone, Debug)]
@@ -78,6 +79,21 @@ pub struct NatsDistributedLog {
 impl NatsDistributedLog {
     fn partition_subject(partition: PartitionId) -> String {
         format!("{SUBJECT_BASE}.{}", partition.0)
+    }
+
+    fn selective_node_subjects(node_name: &str) -> Vec<String> {
+        vec![
+            SelectiveDeliveryRegistry::node_subject(node_name),
+            SYSTEM_TABLE_SUBJECT.to_string(),
+            FRONTIER_HEARTBEAT_SUBJECT.to_string(),
+        ]
+    }
+
+    fn is_frontier_heartbeat_delta(delta: &CommitDelta) -> bool {
+        delta.source_partition.is_some()
+            && delta.document_writes.is_empty()
+            && delta.document_updates.is_empty()
+            && delta.index_writes.is_empty()
     }
 
     async fn subscribe_subjects(
@@ -263,14 +279,8 @@ impl NatsDistributedLog {
         from_ts: Timestamp,
         node_name: &str,
     ) -> anyhow::Result<BoxStream<'static, anyhow::Result<ReplicationMessage>>> {
-        self.subscribe_subjects(
-            from_ts,
-            Some(vec![
-                SelectiveDeliveryRegistry::node_subject(node_name),
-                SYSTEM_TABLE_SUBJECT.to_string(),
-            ]),
-        )
-        .await
+        self.subscribe_subjects(from_ts, Some(Self::selective_node_subjects(node_name)))
+            .await
     }
 
     /// Connect to NATS and create/get the JetStream stream.
@@ -519,6 +529,23 @@ impl DistributedLog for NatsDistributedLog {
                 ts,
                 ack.sequence,
             );
+        } else if Self::is_frontier_heartbeat_delta(&delta) {
+            let ack = self
+                .jetstream
+                .publish(
+                    FRONTIER_HEARTBEAT_SUBJECT.to_string(),
+                    payload.clone().into(),
+                )
+                .await
+                .context("Failed to send selective-delivery frontier heartbeat publish")?
+                .await
+                .context("Failed to get selective-delivery frontier heartbeat acknowledgment")?;
+            metrics::log_selective_delivery_targeted_deliveries(1);
+            tracing::debug!(
+                "Published selective-delivery frontier heartbeat: ts={}, stream_seq={}",
+                ts,
+                ack.sequence,
+            );
         } else if let Some(registry) = &self.selective_registry {
             let interested_nodes = registry
                 .interested_nodes_for_tables(&touched_tables)
@@ -566,5 +593,56 @@ impl DistributedLog for NatsDistributedLog {
         source_partitions: Option<Vec<PartitionId>>,
     ) -> anyhow::Result<BoxStream<'static, anyhow::Result<ReplicationMessage>>> {
         self.subscribe_inner(from_ts, source_partitions).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use common::types::Timestamp;
+
+    use super::{
+        NatsDistributedLog,
+        FRONTIER_HEARTBEAT_SUBJECT,
+        SYSTEM_TABLE_SUBJECT,
+    };
+    use crate::{
+        commit_delta::CommitDelta,
+        partition::PartitionId,
+        selective_delivery::SelectiveDeliveryRegistry,
+        write_log::WriteSource,
+    };
+
+    #[test]
+    fn selective_node_subscriptions_include_frontier_heartbeats() {
+        assert_eq!(
+            NatsDistributedLog::selective_node_subjects("node-b"),
+            vec![
+                SelectiveDeliveryRegistry::node_subject("node-b"),
+                SYSTEM_TABLE_SUBJECT.to_string(),
+                FRONTIER_HEARTBEAT_SUBJECT.to_string(),
+            ],
+        );
+    }
+
+    #[test]
+    fn empty_source_partition_delta_is_frontier_heartbeat() -> anyhow::Result<()> {
+        let heartbeat = CommitDelta {
+            ts: Timestamp::try_from(42u64)?,
+            document_writes: Arc::new(Vec::new()),
+            document_updates: Vec::new(),
+            index_writes: Arc::new(Vec::new()),
+            write_source: WriteSource::new("replication_frontier_heartbeat_test"),
+            write_bytes: 0,
+            tablet_id_to_table_name: Default::default(),
+            source_partition: Some(PartitionId(1)),
+        };
+        assert!(NatsDistributedLog::is_frontier_heartbeat_delta(&heartbeat));
+
+        let mut no_source = heartbeat.clone();
+        no_source.source_partition = None;
+        assert!(!NatsDistributedLog::is_frontier_heartbeat_delta(&no_source));
+        Ok(())
     }
 }

--- a/crates/database/src/tests/write_scaling_tests.rs
+++ b/crates/database/src/tests/write_scaling_tests.rs
@@ -16,6 +16,7 @@ use common::{
     assert_obj,
     bootstrap_model::index::database_index::IndexedFields,
     interval::Interval,
+    knobs::REMOTE_READ_FRONTIER_WAIT_TIMEOUT,
     pause::PauseController,
     persistence::{
         NoopRetentionValidator,
@@ -1102,6 +1103,63 @@ async fn test_local_commit_waits_for_remote_frontier(rt: TestRuntime) -> anyhow:
 
     let commit_result = tokio::time::timeout(Duration::from_secs(1), commit).await??;
     commit_result?;
+    Ok(())
+}
+
+#[convex_macro::test_runtime]
+async fn test_local_commit_times_out_waiting_for_remote_read_frontier(
+    rt: TestRuntime,
+) -> anyhow::Result<()> {
+    let log = Arc::new(InMemoryDistributedLog::new());
+    let node_a = create_node(&rt, log.clone(), Some(partitioned_map(PartitionId(0)))).await?;
+    let node_b = create_node(&rt, log.clone(), Some(partitioned_map(PartitionId(1)))).await?;
+
+    insert_doc(&node_b, "projects", assert_obj!("name" => "seed")).await?;
+    let initial_delta = log
+        .deltas()
+        .into_iter()
+        .last()
+        .expect("seed project should publish a delta");
+    node_a
+        .committer_for_test()
+        .apply_replica_delta(initial_delta)
+        .await?;
+
+    // Advance node A's local snapshot without advancing partition 1's frontier.
+    insert_doc(&node_a, "messages", assert_obj!("text" => "lag-maker")).await?;
+
+    let mut tx = node_a.begin(Identity::system()).await?;
+    TestFacingModel::new(&mut tx)
+        .insert(&"messages".parse()?, assert_obj!("text" => "timeout"))
+        .await?;
+    let remote_tablet = tx
+        .table_mapping()
+        .namespace(TableNamespace::Global)
+        .name_to_tablet()("projects".parse()?)?;
+    tx.reads.record_indexed_derived(
+        TabletIndexName::by_id(remote_tablet),
+        IndexedFields::by_id(),
+        Interval::all(),
+    );
+
+    let node_a_for_commit = node_a.clone();
+    let commit = tokio::spawn(async move { node_a_for_commit.commit(tx).await });
+
+    tokio::time::sleep(Duration::from_millis(50)).await;
+    assert!(
+        !commit.is_finished(),
+        "commit should wait before the bounded remote read frontier timeout fires",
+    );
+
+    rt.advance_time(*REMOTE_READ_FRONTIER_WAIT_TIMEOUT + Duration::from_millis(1))
+        .await;
+
+    let commit_result = tokio::time::timeout(Duration::from_millis(100), commit).await??;
+    let err = commit_result.expect_err("stale remote frontier should time out");
+    assert!(
+        err.to_string().contains("Timed out after"),
+        "unexpected error: {err:#}",
+    );
     Ok(())
 }
 

--- a/crates/local_backend/src/router.rs
+++ b/crates/local_backend/src/router.rs
@@ -18,6 +18,7 @@ use axum::{
         post,
         put,
     },
+    Json,
     Router,
 };
 use common::{
@@ -41,6 +42,7 @@ use http::{
     StatusCode,
 };
 use metrics::SERVER_VERSION_STR;
+use serde::Serialize;
 use tower::ServiceBuilder;
 use tower_http::{
     cors::{
@@ -169,6 +171,17 @@ use crate::{
     ImportExportRouterState,
     RouterState,
 };
+
+const BUILD_GIT_SHA: &str = env!("VERGEN_GIT_SHA");
+const BUILD_GIT_COMMIT_TIMESTAMP: &str = env!("VERGEN_GIT_COMMIT_TIMESTAMP");
+
+#[derive(Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct BuildInfo {
+    server_version: String,
+    git_sha: &'static str,
+    git_commit_timestamp: &'static str,
+}
 
 async fn deploy_api_authority_middleware(
     State(st): State<DeployRouterState>,
@@ -698,12 +711,31 @@ where
     BackendAppState: FromMtState<S>,
     S: Clone + Send + Sync + 'static,
 {
+    let instance_version = version.clone();
+    let build_info = BuildInfo {
+        server_version: version,
+        git_sha: BUILD_GIT_SHA,
+        git_commit_timestamp: BUILD_GIT_COMMIT_TIMESTAMP,
+    };
     Router::new()
         .route(
             "/instance_name",
             get(|MtState(st): MtState<BackendAppState>| async move { st.instance_name.clone() }),
         )
-        .route("/instance_version", get(|| async move { version }))
+        .route(
+            "/instance_version",
+            get(move || {
+                let instance_version = instance_version.clone();
+                async move { instance_version }
+            }),
+        )
+        .route(
+            "/build_info",
+            get(move || {
+                let build_info = build_info.clone();
+                async move { Json(build_info) }
+            }),
+        )
         .route(
             "/",
             get(|| async { "This Convex deployment is running. See https://docs.convex.dev/." }),

--- a/self-hosted/docker-build/Dockerfile.backend
+++ b/self-hosted/docker-build/Dockerfile.backend
@@ -92,8 +92,10 @@ RUN if [[ -z "$debug" ]]; then strip ./convex-local-backend; strip ./generate_ke
 # Uses Ubuntu Noble (24.04) as the base image
 FROM ubuntu:noble
 ARG VERGEN_GIT_SHA
+ARG VERGEN_GIT_COMMIT_TIMESTAMP
 LABEL org.opencontainers.repository=https://github.com/get-convex/convex-backend
 LABEL org.opencontainers.image.revision=${VERGEN_GIT_SHA}
+LABEL org.opencontainers.image.created=${VERGEN_GIT_COMMIT_TIMESTAMP}
 
 WORKDIR /convex
 

--- a/self-hosted/docker-build/Dockerfile.backend
+++ b/self-hosted/docker-build/Dockerfile.backend
@@ -93,7 +93,8 @@ RUN if [[ -z "$debug" ]]; then strip ./convex-local-backend; strip ./generate_ke
 FROM ubuntu:noble
 ARG VERGEN_GIT_SHA
 ARG VERGEN_GIT_COMMIT_TIMESTAMP
-LABEL org.opencontainers.repository=https://github.com/get-convex/convex-backend
+LABEL org.opencontainers.repository=https://github.com/MartinKalema/horizontal-scaling-convex
+LABEL org.opencontainers.image.source=https://github.com/MartinKalema/horizontal-scaling-convex
 LABEL org.opencontainers.image.revision=${VERGEN_GIT_SHA}
 LABEL org.opencontainers.image.created=${VERGEN_GIT_COMMIT_TIMESTAMP}
 

--- a/self-hosted/docker-build/build_backend_image.sh
+++ b/self-hosted/docker-build/build_backend_image.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+#
+# Build the backend image with git provenance baked into both the binary and
+# the OCI image labels.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+IMAGE="${1:-ghcr.io/martinkalema/convex-horizontal-scaling:backend-latest}"
+
+GIT_SHA="$(git -C "$REPO_ROOT" rev-parse HEAD)"
+GIT_COMMIT_TIMESTAMP="$(git -C "$REPO_ROOT" show -s --format=%cI HEAD)"
+
+docker build \
+  --progress=plain \
+  --build-arg "VERGEN_GIT_SHA=$GIT_SHA" \
+  --build-arg "VERGEN_GIT_COMMIT_TIMESTAMP=$GIT_COMMIT_TIMESTAMP" \
+  -t "$IMAGE" \
+  -f "$REPO_ROOT/self-hosted/docker-build/Dockerfile.backend" \
+  "$REPO_ROOT"


### PR DESCRIPTION
## Summary
- add a bounded timeout and metrics for remote read frontier waits
- publish empty source-partition frontier heartbeats to a dedicated selective-delivery subject
- subscribe selective node consumers to frontier heartbeats so idle remote partitions can still advance read fences
- expose backend build provenance via `/build_info` and OCI image labels

Closes #161

## Tests
- `cargo test -p database remote_frontier -- --nocapture`
- `cargo test -p database remote_read_frontier -- --nocapture`
- `cargo test -p database nats_distributed_log::tests -- --nocapture`
- `cargo check -p database`
- `cargo check -p local_backend`
- rebuilt `ghcr.io/martinkalema/convex-horizontal-scaling:backend-latest` with `self-hosted/docker-build/build_backend_image.sh`
- verified local image labels:
  - `org.opencontainers.repository=https://github.com/MartinKalema/horizontal-scaling-convex`
  - `org.opencontainers.image.source=https://github.com/MartinKalema/horizontal-scaling-convex`
  - `org.opencontainers.image.revision=4c3324691cd25f2c452f7b46788937d2098438b3`
- restarted cluster with no-pull override and verified all six backend containers run image `sha256:8ba2b9c899350bb9357146c3d0220bdbcc215c37f8a22cb7e9ccd89d7300a3e6`
- verified `/build_info` on ports 3210, 3220, 3230, 3310, 3320, 3330 returns `gitSha=4c3324691cd25f2c452f7b46788937d2098438b3`
- before the build-provenance-only commits, verified the branch image with `bash self-hosted/docker/test.sh scaling` -> `ALL 77 TESTS PASSED`