### PR TITLE
docs: update readme current status

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,249 +1,196 @@
 # Horizontal Scaling for Convex
 
-The first horizontal scaling implementation for the [Convex open-source backend](https://github.com/get-convex/convex-backend) — reads, writes, and automatic failover.
+Experimental fork of the [Convex open-source backend](https://github.com/get-convex/convex-backend) aiming to scale Convex horizontally while preserving the things that make Convex Convex:
 
-Convex is a reactive database: real-time subscriptions, in-memory snapshots, OCC with automatic retry, TypeScript function execution. No distributed database — CockroachDB, TiDB, Vitess, YugabyteDB, Spanner, or FoundationDB — has all of these together. This fork's goal is to scale those properties horizontally while keeping partitions, leaders, placement versions, and routing out of developer-facing APIs.
+- reactive subscriptions;
+- serializable transactions with optimistic conflict detection;
+- consistent snapshots;
+- TypeScript functions running against a database-like execution model;
+- developer APIs that do not expose partitions, leaders, placement versions, or routing details.
 
-## The Problem
+This project is currently an **alpha distributed-systems hardening effort**. It has working clustered read/write scaling milestones, Raft-backed partition durability, two-phase commit, NATS JetStream replication, and a growing correctness test suite. It should be treated as research-grade clustered infrastructure while the remaining correctness and operations roadmap is completed.
 
-Convex is a stateful system where the backend process holds the live database in memory. Two instances don't share state — they diverge. The [6 architectural bottlenecks](docs/why-convex-cannot-scale-horizontally.md) that prevent scaling: single Committer, in-memory SnapshotManager, in-memory WriteLog, single-process subscriptions, single-node OCC, and no distributed consensus. Convex's docs explicitly state self-hosted is single-node by design.
+Latest milestone: [v2.1.0-alpha.1: Distributed Correctness Hardening](https://github.com/MartinKalema/horizontal-scaling-convex/releases/tag/v2.1.0-alpha.1)
 
-## The Solution
+## Why This Exists
 
-We took the best engineering from five distributed databases and combined them:
+Convex is a reactive database. The backend keeps live state in memory, tracks query dependencies, retries conflicting mutations, and pushes subscription updates in real time. That model is powerful, but the self-hosted backend is single-node by design.
 
-| Problem | Pattern | Source |
-| --- | --- | --- |
-| Global timestamp ordering | Batch TSO via NATS KV — zero network calls in hot path | TiDB PD |
-| Table ownership | VSchema-style partition map — each node owns specific tables | Vitess |
-| Single writer per partition | Committer apply loop — one thread, one channel, serial processing | etcd, TiKV, Kafka |
-| Cross-partition writes | 2PC coordinator with prepare/commit/rollback | Vitess |
-| Table number conflicts | Descriptor ID reassignment on receiving node | CockroachDB |
-| Async commit ordering | All writes through single FuturesOrdered pipeline | CockroachDB Raft, TiKV apply worker |
-| Replica timestamp isolation | No TSO or system clock on apply — monotonic counters only | CockroachDB closed timestamp, TiDB resolved-ts |
-| Delta replication | NATS JetStream with durable consumers and self-delta skip | All five systems |
-| System table classification | Classify by what data describes, not which table stores it | CockroachDB system ranges |
-| Automatic leader failover | tikv/raft-rs consensus per partition — sub-second leader election | TiKV, etcd |
-| Raft transport | gRPC with batched messages and exponential backoff retry | TiKV RaftClient |
-| Leadership lifecycle | Committer starts on election, stops on demotion via SoftState | TiKV, CockroachDB |
-| Deployment state replication | GLOBAL table locality — `_modules`, `_udf_config`, `_source_packages` replicate to all nodes | CockroachDB GLOBAL tables, YugabyteDB system catalog |
-| Persistent Raft log | raft-engine — append-only WAL with ~1x write amplification, crash-safe atomic batches | TiKV raft-engine (replaced RocksDB in v6.1) |
+The hard part is not just "add sharding." A useful horizontally scaled Convex must preserve the same high-level semantics developers expect from Convex:
 
-The combination — real-time subscriptions + in-memory OCC + partitioned multi-writer + delta replication + 2PC — doesn't exist in any of those systems. CockroachDB doesn't have subscriptions. TiDB doesn't have in-memory snapshots. Vitess doesn't have OCC. We kept Convex's unique architecture and grafted distributed database patterns onto it.
+- subscriptions should remain correct and current;
+- transactions should remain serializable;
+- queries should observe consistent snapshots;
+- clients should not have to know which table lives on which node;
+- failover should not silently change the meaning of timestamps, document IDs, or subscriptions.
 
-Full details: [docs/what-we-built.md](docs/what-we-built.md)
+That is the north star of this fork.
 
-Project-wide design goals, including the rule that topology must not leak into
-developer APIs: [docs/project-goals.md](docs/project-goals.md)
+## Current Status
 
-Issue journal for regressions, fixes, and validation history:
-[docs/issue-journal.md](docs/issue-journal.md)
+This repository has moved beyond the initial primary/replica prototype into a clustered architecture with table-level partitioning and per-partition Raft groups.
 
-Operator observability, alert suggestions, and cluster runbooks:
-[docs/cluster-observability.md](docs/cluster-observability.md)
+What is implemented today:
 
-## Recently Landed
+- table-level write ownership across partitions;
+- a global timestamp oracle using NATS KV;
+- globally allocated table numbers for portable Convex document IDs;
+- cross-partition two-phase commit;
+- Raft-backed partition leadership and failover;
+- NATS JetStream commit-delta replication;
+- idempotent replica delta apply and retention-gap detection;
+- bounded remote-read frontier waits;
+- route authority checks that fail closed for unsafe clustered routes;
+- write-owner mutation routing so clients do not have to hand-route simple writes;
+- selective-delivery groundwork for reducing replication fanout;
+- cluster observability metrics and an issue journal for validation history and open correctness work.
 
-- **Raft snapshot catch-up for lagging followers:** followers that fall behind
-  compacted log history can now recover by installing a Raft snapshot instead
-  of requiring manual re-bootstrap.
-- **Fresh replica checkpoint bootstrap:** brand-new replicas can start from the
-  latest stored checkpoint object and then catch up from there, instead of
-  reconstructing from scratch.
-- **Active replica mutation forwarding:** in primary/replica mode, replica
-  `/api/mutation` requests now forward to the primary through gRPC instead of
-  executing the local write path.
+Important work still remains:
 
-## Results
+- authenticate internal cluster gRPC traffic;
+- make Raft the single visible apply point for partition commits;
+- replicate full intra-partition state needed for failover;
+- harden 2PC prepare durability, rollback, and decision retention;
+- gate background workers with cluster authority or leases;
+- unify timestamp domains for portable read-after-write fences;
+- define distributed index metadata and backfill correctness;
+- mature selective delivery into distributed reactive invalidation;
+- add formal Jepsen / Elle coverage and real cloud benchmarks.
 
-### Raft Failover Tests
+The open issues are the active roadmap: [GitHub Issues](https://github.com/MartinKalema/horizontal-scaling-convex/issues)
 
-```
-ALL 10 TESTS PASSED
+## Design Principles
 
-Test 1: All 3 Nodes Healthy
-  PASS  Node A (port 3210) healthy
-  PASS  Node B (port 3220) healthy
-  PASS  Node C (port 3230) healthy
+| Principle | Meaning |
+| --- | --- |
+| Preserve Convex semantics | Scaling is incomplete if it weakens reactive subscriptions, serializable transactions, or consistent snapshots. |
+| Hide topology from users | Partitions, leaders, Raft terms, NATS subjects, and placement versions are internal implementation details. |
+| Fail closed | Routes that are not safe in a cluster should reject rather than execute on the wrong node. |
+| Prefer explicit authority | Every route and worker should have a clear owner: partition owner, coordinator owner, Raft leader, or leased singleton. |
+| Test like a database | Shell tests are useful, but the target is Jepsen/Elle-style validation and deterministic simulation for the core distributed protocols. |
 
-Test 2: Write to Leader
-  PASS  Write to Node A succeeded
+Project-wide goals: [docs/project-goals.md](docs/project-goals.md)
 
-Test 3: Read from All Nodes
-  PASS  Node A sees data: 1 messages
-  PASS  All 3 nodes agree: 1 messages
+Issue journal: [docs/issue-journal.md](docs/issue-journal.md)
 
-Test 4: Kill Leader, Verify Failover
-  PASS  Failover: writes accepted on http://127.0.0.1:3220 after leader kill
-  PASS  Data written after failover: B=2 C=2 (pre-kill=1)
-
-Test 5: Restart Killed Node, Verify Rejoin
-  PASS  Node A recovered: sees 2 messages (>=1)
-  PASS  All nodes converged after rejoin: 2 messages
-```
-
-Based on CockroachDB roachtest failover/non-system/crash, TiKV fail-rs chaos testing, and YugabyteDB Jepsen nightly resilience benchmarks.
-
-### Write Scaling Tests
-
-```
-ALL 77 TESTS PASSED — 3,823 messages | 3,069 tasks | 1,390 sustained writes/node
-
- 1. Cross-partition data verification     (Vitess VDiff)         — PASS
- 2. Bank invariant — single table         (CockroachDB Jepsen)   — PASS
- 3. Bank invariant — multi-table          (TiDB bank-multitable) — PASS
- 4. Partition enforcement (5 subtests)    (Vitess Single mode)   — PASS
- 5. Concurrent write scaling              (CockroachDB KV)       — PASS 176 writes/sec
- 6. Monotonic reads                       (TiDB monotonic)       — PASS
- 7. Node restart recovery                 (TiDB kill -9)         — PASS
- 8. Idempotent re-run                     (CockroachDB workload) — PASS
- 9. Two-phase commit cross-partition      (Vitess 2PC)           — PASS
-10. Rapid-fire writes 50/node             (Jepsen stress)        — PASS
-11. Write-then-immediate-read             (stale read detection) — PASS
-12. Double node restart                   (CockroachDB nemesis)  — PASS
-13. Post-chaos invariant check            (workload check)       — PASS
-14. Sequential ordering                   (Jepsen sequential)    — PASS
-15. Set completeness (100 elements)       (Jepsen set)           — PASS
-16. Concurrent counter                    (Jepsen counter)       — PASS
-17. Write-then-cross-node-read            (cross-node stale)     — PASS
-18. Interleaved cross-partition reads     (read skew detection)  — PASS
-19. Large batch write (50 docs)           (atomicity)            — PASS
-20. Full cluster restart                  (CockroachDB nemesis)  — PASS
-21. Sustained writes 30 seconds           (endurance)            — PASS
-22. Duplicate insert idempotency          (correctness)          — PASS
-23. Mid-suite exhaustive invariant check  (workload check)       — PASS
-24. Single-key register                   (CockroachDB register) — PASS
-25. Disjoint record ordering              (CockroachDB comments) — PASS
-26. NATS partition simulation             (Chaos Mesh)           — PASS
-27. Write during deploy                   (deploy safety)        — PASS
-28. Empty table cross-node query          (boundary)             — PASS
-29. Max batch size 200 docs               (boundary)             — PASS
-30. Null and empty field values           (boundary)             — PASS
-31. Concurrent writes from both nodes     (race condition)       — PASS
-32. Rapid deploy cycle 3x                 (deploy stability)     — PASS
-33. Read during active replication        (consistency)          — PASS
-34. TSO monotonicity after restart        (TiDB TSO)             — PASS
-35. Single document read-modify-write     (register)             — PASS
-36. Write skew detection                  (G2 anomaly)           — PASS
-37. Ultimate final invariant check        (workload check)       — PASS
-```
-
-Every test pattern comes from a real bug found by Jepsen in a production database.
+Cluster authority routing: [docs/cluster-authority-routing.md](docs/cluster-authority-routing.md)
 
 ## Architecture
 
-### Raft Consensus (Automatic Failover)
+### Partitioned Write Ownership
 
-```
-Partition 0 — 3-node Raft group (tikv/raft-rs):
-
-  Node A (leader)  ────Raft────▶ Node B (follower)
-        │          ────Raft────▶ Node C (follower)
-        │
-        ▼
-   Committer active         Committers dormant
-   Accepts writes           Reject writes (redirect)
-        │
-        ├── NATS delta ──▶ Node B applies replica delta
-        └── NATS delta ──▶ Node C applies replica delta
-
-  Node A dies:
-    Node B elected leader (~1s) → Committer activates → accepts writes
-    Node C remains follower → applies deltas from Node B
-    Node A restarts → rejoins as follower → converges via NATS
-```
-
-Each partition is a 3-node Raft group. The leader runs the Committer. If the leader dies, followers elect a new leader within ~1 second and the Committer activates automatically. Zero manual intervention, zero data loss. Deployment state (`_modules`, `_udf_config`, `_source_packages`) replicates to all nodes via the CockroachDB GLOBAL table locality pattern so every node can serve queries.
-
-### Write Scaling (Partitioned Multi-Writer)
-
-```
-                    ┌──────────────────────────────┐
-                    │   Global Timestamp Oracle     │
-                    │   (NATS KV, TiDB PD pattern)  │
-                    └──────────┬───────────────────┘
-                               │
-              ┌────────────────┼────────────────┐
-              │                │                │
-        ┌─────┴──────┐        │        ┌───────┴─────┐
-        │  Node A    │        │        │   Node B    │
-        │  partition 0│        │        │  partition 1│
-        │  messages  │        │        │  projects   │
-        │  users     │        │        │  tasks      │
-        └─────┬──────┘        │        └───────┬─────┘
-              │        ┌──────┴──────┐         │
-              └───────▶│    NATS     │◀────────┘
-                       │  JetStream  │
-                       └──────┬──────┘
-                              │
-              ┌───────────────┼───────────────┐
-              ▼                               ▼
-         Node A sees                     Node B sees
-         all data                        all data
+```text
+                    Global Timestamp Oracle
+                    (NATS KV, CAS-backed)
+                              |
+              +---------------+---------------+
+              |                               |
+       Partition 0 owner               Partition 1 owner
+       users, messages                 projects, tasks
+              |                               |
+              +------------+------------------+
+                           |
+                    NATS JetStream
+                    commit deltas
+                           |
+              +------------+------------------+
+              |                               |
+       Other nodes apply                Other nodes apply
+       replicated state                 replicated state
 ```
 
-Each node owns specific tables and is the single Committer for those tables. Both nodes consume all NATS deltas for a complete read view. Writes to non-owned tables are rejected with partition routing info. Cross-partition writes go through 2PC.
+Each table is assigned to a partition. The owner partition is the authority for writes to that table. A single-partition mutation is routed to the owner. A mutation that touches tables from multiple partitions uses two-phase commit.
 
-### Read Scaling (Primary-Replica)
+### Per-Partition Raft Groups
 
+```text
+Partition 0 Raft group:
+
+  Node A leader  --Raft-->  Node B follower
+       |          --Raft-->  Node C follower
+       |
+       +-- accepts partition-0 writes
+
+If Node A fails:
+  Node B or Node C can be elected leader and resume ownership.
 ```
-Client ──mutation──▶ Primary ──persist──▶ PostgreSQL
-                        │
-                        ├──publish delta──▶ NATS JetStream
-                        │                        │
-Client ──query──▶ Replica ◀──consume delta───────┘
-Client ──mutation──▶ Replica ──gRPC forward──▶ Primary
+
+Raft is used for partition leadership and durability. The current roadmap includes additional work to make Raft the single visible apply point for partition commits and to replicate all intra-partition state required for failover.
+
+### Cross-Partition Commit
+
+```text
+Mutation touches users + tasks
+
+1. Coordinator allocates commit timestamp.
+2. Participant partitions prepare their writes.
+3. Coordinator records the decision.
+4. Participants commit or roll back the prepared transaction.
+5. Commit deltas replicate to other nodes.
 ```
 
-One Primary handles writes, multiple Replicas serve reads. Replicas remap
-TabletIds from the Primary's namespace to their own using the
-`tablet_id_to_table_name` mapping in each CommitDelta. If a client sends a
-mutation to a Replica, the Replica now forwards that request to the Primary
-over gRPC and returns the Primary's result.
+The implementation follows a Vitess/Percolator-style two-phase commit shape, adapted to Convex's in-memory snapshots and optimistic conflict detection.
+
+### Route Authority
+
+Clustered Convex has different authority classes:
+
+| Authority class | Examples |
+| --- | --- |
+| Partition owner | Mutations that write one partition's tables |
+| Coordinator owner | Sync setup, selected global metadata routes |
+| Explicit forwarding | Deploy and selected API paths that can safely forward |
+| Fail closed | Routes not yet migrated to a safe clustered execution model |
+
+This is how the project avoids accidentally running deployment-global or subscription-owning code on the wrong node.
+
+## Recently Landed
+
+- **Global table numbers:** clustered nodes allocate table numbers from a shared allocator so Convex document IDs remain portable across nodes.
+- **Replica replay hardening:** replica delta apply is idempotent, consumers are supervised, unmapped-table deltas retry instead of being silently dropped, and JetStream retention gaps fail closed with rebootstrap guidance.
+- **Remote-read frontier hardening:** remote-read waits are bounded, and heartbeat naming now reflects its actual role.
+- **Write-owner mutation routing:** single-partition mutations received by the wrong node can route to the owning partition instead of exposing topology to the client.
+- **Route authority cleanup:** clustered routes are classified by authority and unsafe routes reject instead of running locally by accident.
+- **Raft and 2PC hardening:** recent work added Raft persistence failure handling, prepared-intent separation, and durable 2PC recovery records.
+
+## Validation
+
+The repository currently includes:
+
+- 77 write-scaling integration tests;
+- 10 Raft failover tests;
+- database unit tests for replica replay, NATS delivery, remote-read frontier behavior, partition enforcement, 2PC, and table-number allocation;
+- Docker cluster scripts under [self-hosted/docker](self-hosted/docker).
+
+These tests are useful regression coverage and have caught real bugs. They complement, but do not replace, the longer-term validation roadmap: Jepsen/Elle workloads, network nemeses, cloud benchmarks, and deterministic simulation for the core replication/commit protocols.
+
+### Run The Local Test Harness
+
+```sh
+cd self-hosted/docker
+
+./test.sh              # All Docker harness tests
+./test.sh scaling      # Write-scaling tests
+./test.sh failover     # Raft failover tests
+```
 
 ## Quick Start
 
-One Docker Compose file, two profiles — same as CockroachDB, etcd, and YugabyteDB. Raft consensus is always on (single-node is a Raft group of 1).
-
-### Run
-
 ```sh
 cd self-hosted/docker
 
-# 1 node (dev/test)
+# 1 backend node for local development
 docker compose --profile single up
 
-# 6 nodes — 2 partitions × 3 Raft nodes (read + write scaling + HA)
+# 2 partitions x 3 Raft nodes
 docker compose --profile cluster up
 ```
 
-Images are published to `ghcr.io/martinkalema/convex-horizontal-scaling` — no local build needed.
+Images are published to:
 
-### Test
-
-```sh
-cd self-hosted/docker
-
-./test.sh              # All tests (87 tests — scaling + failover)
-./test.sh scaling      # Write scaling only (77 tests)
-./test.sh failover     # Raft failover only (10 tests)
+```text
+ghcr.io/martinkalema/convex-horizontal-scaling
 ```
-
-### Formal Jepsen Harness
-
-This repository contains the backend fork, Docker cluster topology, and the
-Jepsen-inspired shell and integration tests under `self-hosted/docker/`.
-
-The dedicated formal Jepsen harness is under development and lives in a
-separate repository:
-
-- GitHub: `https://github.com/MartinKalema/convex-jepsen-tests`
-- Local working copy: `/Users/martin/Desktop/convex-jepsen-tests`
-
-That separate repository is where the Clojure Jepsen suite, reusable
-workloads, and fault injectors will evolve. This repository remains the home
-for the Convex backend implementation itself and its integration/chaos test
-scripts.
 
 ### Deploy Functions
 
@@ -252,106 +199,69 @@ docker compose --profile cluster exec node-p0a ./generate_admin_key.sh
 npx convex deploy --url http://127.0.0.1:3210 --admin-key <KEY>
 ```
 
-### Resource Requirements
-
-Per-node requirements, following the format used by CockroachDB, YugabyteDB, and etcd.
-
-| | Dev/Test | Production |
-| --- | --- | --- |
-| **CPU** | 2 vCPUs | 4+ vCPUs |
-| **RAM** | 2 GB | 8+ GB |
-| **Storage** | 10 GB (HDD ok) | 50+ GB SSD |
-| **Network** | 100 Mbps | 1 Gbps |
-
-**Total cluster resources:**
-
-| Profile | Nodes | Min CPU | Min RAM | Min Storage |
-| --- | --- | --- | --- | --- |
-| `single` | 1 backend + postgres + NATS | 4 vCPUs | 4 GB | 20 GB |
-| `cluster` | 6 backends + postgres + NATS | 16 vCPUs | 16 GB | 80 GB |
-
-Observed idle memory usage per backend node: ~20 MB. Under load with in-memory snapshots: scales with dataset size (similar to CockroachDB's range cache).
-
-### Ports
-
-| Service | Single | Cluster |
-| --- | --- | --- |
-| Partition 0 node A API | 3210 | 3210 |
-| Partition 0 node B API | — | 3220 |
-| Partition 0 node C API | — | 3230 |
-| Partition 1 node A API | — | 3310 |
-| Partition 1 node B API | — | 3320 |
-| Partition 1 node C API | — | 3330 |
-| gRPC (Raft + 2PC) | 50051 | 50051–50063 |
-| Dashboard | 6791 | 6791 |
-| PostgreSQL | 5433 | 5433 |
-| NATS | 4222 | 4222 |
-
 ## Key Components
 
-| Component | File | What it does |
+| Component | File | Purpose |
 | --- | --- | --- |
-| RaftNode | `raft_node.rs` | Raft loop: tick, receive, propose, process Ready, advance. Leadership callbacks via SoftState |
-| RaftPartitionManager | `raft_partition.rs` | Wraps RaftNode, activates/deactivates Committer on leader election/demotion |
-| RaftTransport | `raft_transport.rs` | gRPC transport with batched messages, exponential backoff retry (TiKV RaftClient pattern) |
-| RaftStorage | `raft_storage.rs` | Persistent Raft log backed by TiKV raft-engine — entries + hard state survive restarts |
-| RaftStateMachine | `raft_state_machine.rs` | Serialization format for Raft log entries, bridges committed entries to Committer |
-| CommitDelta | `commit_delta.rs` | Captures everything changed in a transaction — documents, indexes, table mappings |
-| NatsDistributedLog | `nats_distributed_log.rs` | Publishes/subscribes deltas via NATS JetStream with per-partition subjects and self-delta skip |
-| apply_replica_delta | `committer.rs` | Classifies updates as GLOBAL or node-local, creates tables with reassigned numbers, applies through Raft-pattern pipeline |
-| BatchTimestampOracle | `timestamp_oracle.rs` | Reserves timestamp ranges from NATS KV via atomic CAS. Zero network calls in hot path |
-| PartitionMap | `partition.rs` | Table-to-partition assignment. System tables always on partition 0 |
-| TwoPhaseCoordinator | `two_phase_coordinator.rs` | Detects cross-partition writes, orchestrates prepare/commit/rollback |
-| TwoPhaseCommitService | `two_phase_service.rs` | gRPC Prepare/CommitPrepared/RollbackPrepared for remote partitions |
-| Transaction Watcher | `two_phase_watcher.rs` | Scans NATS KV for stuck 2PC transactions, resolves via commit or rollback |
-
-## Tests
-
-**346 unit tests** + **87 integration tests** across **42 categories**.
-
-### Raft Failover (10 tests, 5 categories)
-
-Leader election, write to leader, read from all nodes, kill leader + verify failover, restart killed node + verify rejoin. Based on CockroachDB roachtest failover/non-system/crash, TiKV fail-rs, and YugabyteDB Jepsen resilience benchmarks.
-
-### Write Scaling (77 tests, 37 categories)
-
-Every test pattern from CockroachDB's 7 nightly Jepsen workloads (bank, register, sequential, set, monotonic, G2, comments), TiDB's Jepsen suite (bank-multitable, monotonic, stale read), YugabyteDB's Jepsen tests (counter, linearizable set), Vitess (VDiff, partition enforcement, 2PC), CockroachDB roachtest (KV scaling, nemesis, workload check), Chaos Mesh (NATS partition), Elle anomaly classes (read skew, write skew), and boundary testing (empty tables, null fields, 200-doc batch).
-
-Full test details: [docs/write-scaling-tests.md](docs/write-scaling-tests.md)
-
-## Documentation
-
-| Document | Contents |
-| --- | --- |
-| [Project Goals](docs/project-goals.md) | Preserve Convex semantics while preventing topology leaks into developer APIs |
-| [Production Deployment](docs/production-deployment.md) | Kubernetes (GKE, EKS), bare VMs (EC2), load balancing, persistent storage, peer discovery |
-| [Raft Integration](docs/raft-integration.md) | tikv/raft-rs integration design — Raft loop, storage, transport, state machine, leader lifecycle |
-| [What We Built](docs/what-we-built.md) | What we took from each distributed database and what's new |
-| [Write Scaling Research](docs/write-scaling-research.md) | Vitess, TiDB, CockroachDB comparison |
-| [Two-Phase Commit Design](docs/two-phase-commit.md) | 2PC architecture with Vitess/TiDB/CockroachDB patterns |
-| [TSO Timestamp Fix](docs/tso-replica-timestamp-fix.md) | Three timestamp ordering fixes with distributed database research |
-| [Write Scaling Tests](docs/write-scaling-tests.md) | All 37 test categories with 77 assertions |
-| [Engineering Changes](docs/engineering-changes.md) | Every file changed, every architectural decision |
-| [Architecture Analysis](docs/why-convex-cannot-scale-horizontally.md) | The 6 bottlenecks in the original codebase |
-| [Convex Internals](docs/convex-internals-explained.md) | How the Committer, SnapshotManager, WriteLog, Subscriptions, and OCC work |
-| [Implementation Plan](docs/actual-implementation-plan.md) | Primary-Replica architecture design |
-| [Full Scaling Proposal](docs/horizontal-scaling-proposal.md) | Complete partitioned-write architecture proposal |
-| [Scalability Research](docs/convex-scalability-research.md) | Community research with 25+ source URLs |
+| `PartitionMap` / `PlacementState` | `crates/database/src/partition.rs` | Table ownership, placement versions, and route decisions. |
+| `BatchTimestampOracle` | `crates/database/src/timestamp_oracle.rs` | Cluster timestamp allocation through NATS KV. |
+| `TableNumberAllocator` | `crates/database/src/table_number_allocator.rs` | Shared table-number allocation for portable Convex IDs. |
+| `TwoPhaseCoordinator` | `crates/database/src/two_phase_coordinator.rs` | Cross-partition prepare/commit/rollback orchestration. |
+| `TwoPhaseCommitService` | `crates/local_backend/src/two_phase_service.rs` | Internal gRPC participant API for 2PC. |
+| `RaftNode` | `crates/database/src/raft_node.rs` | Raft loop, Ready processing, leadership callbacks. |
+| `RaftStorage` | `crates/database/src/raft_storage.rs` | Persistent Raft log backed by raft-engine. |
+| `NatsDistributedLog` | `crates/database/src/nats_distributed_log.rs` | NATS JetStream commit-delta publishing and subscription. |
+| `ReplicaDeltaConsumer` | `crates/database/src/replica.rs` | Supervised delta consumption and redelivery handling. |
+| `DeltaInterestTracker` | `crates/database/src/delta_interest.rs` | Live table-interest tracking for selective delivery. |
+| `RouteAuthority` | `crates/local_backend/src/route_authority.rs` | Cluster route classification and fail-closed decisions. |
+| `MutationForwarder` | `crates/local_backend/src/mutation_forwarder.rs` | Internal forwarding for routed mutations. |
+| `SelectiveQueryForwardingApi` | `crates/local_backend/src/query_forwarding_api.rs` | Query forwarding and read-interest warming. |
 
 ## Configuration
 
 | Variable | Description | Example |
 | --- | --- | --- |
-| `RAFT_NODE_ID` | This node's Raft ID (1-based) | `1` |
-| `RAFT_PEERS` | All Raft peers with gRPC addresses | `1=http://node-a:50051,2=http://node-b:50051,3=http://node-c:50051` |
+| `RAFT_NODE_ID` | This node's Raft ID inside its partition group | `1` |
+| `RAFT_PEERS` | Raft peer IDs and gRPC addresses | `1=http://node-a:50051,2=http://node-b:50051,3=http://node-c:50051` |
 | `PARTITION_ID` | This node's partition number | `0` |
 | `PARTITION_MAP` | Table-to-partition assignment | `messages=0,users=0,projects=1,tasks=1` |
-| `NUM_PARTITIONS` | Total partitions in cluster | `2` |
+| `NUM_PARTITIONS` | Number of table partitions | `2` |
 | `NATS_URL` | NATS JetStream connection | `nats://nats:4222` |
-| `NODE_ADDRESSES` | gRPC addresses for 2PC | `0=node-a:50051,1=node-b:50051` |
+| `NODE_ADDRESSES` | Partition owner gRPC addresses for forwarding and 2PC | `0=node-a:50051,1=node-b:50051` |
 | `INSTANCE_NAME` | Unique node identifier | `convex-node-a` |
-| `REPLICATION_MODE` | Node role | `primary` |
+| `REPLICATION_MODE` | Node role for primary/replica mode | `primary` |
+| `REMOTE_READ_FRONTIER_HEARTBEAT_INTERVAL_MS` | Idle heartbeat interval for remote-read frontier progress | `1000` |
+
+## Resource Requirements
+
+Approximate local development guidance:
+
+| Profile | Nodes | Minimum CPU | Minimum RAM | Minimum Storage |
+| --- | --- | --- | --- | --- |
+| `single` | 1 backend + Postgres + NATS | 4 vCPUs | 4 GB | 20 GB |
+| `cluster` | 6 backends + Postgres + NATS | 16 vCPUs | 16 GB | 80 GB |
+
+## Documentation
+
+| Document | Contents |
+| --- | --- |
+| [Project Goals](docs/project-goals.md) | The semantic guarantees this fork must preserve. |
+| [Issue Journal](docs/issue-journal.md) | Regressions, root causes, fixes, and validation notes. |
+| [Cluster Authority Routing](docs/cluster-authority-routing.md) | Route authority classes and fail-closed behavior. |
+| [Dynamic Placement](docs/dynamic-placement.md) | Placement metadata and future rebalancing control plane. |
+| [Cluster Observability](docs/cluster-observability.md) | Metrics, alerts, and operator guidance. |
+| [Raft Integration](docs/raft-integration.md) | Raft loop, storage, transport, and leadership lifecycle. |
+| [Two-Phase Commit Design](docs/two-phase-commit.md) | 2PC architecture and recovery model. |
+| [Write Scaling Tests](docs/write-scaling-tests.md) | Write-scaling test categories and coverage. |
+| [Production Deployment](docs/production-deployment.md) | Deployment notes for Kubernetes, VMs, and persistent storage. |
+| [Convex Internals](docs/convex-internals-explained.md) | Committer, SnapshotManager, WriteLog, subscriptions, and OCC. |
+
+## Related Release Notes
+
+- [v1.0.0: Early Read-Scaling Milestone](https://github.com/MartinKalema/horizontal-scaling-convex/releases/tag/v1.0.0)
+- [v2.0.0: Early Write-Scaling Milestone](https://github.com/MartinKalema/horizontal-scaling-convex/releases/tag/v2.0.0)
+- [v2.1.0-alpha.1: Distributed Correctness Hardening](https://github.com/MartinKalema/horizontal-scaling-convex/releases/tag/v2.1.0-alpha.1)
 
 ## License
 
-The original Convex backend is licensed under [FSL-1.1-Apache-2.0](LICENSE.md). Our modifications follow the same license.
+The original Convex backend is licensed under [FSL-1.1-Apache-2.0](LICENSE.md). This fork follows the same license.


### PR DESCRIPTION
## Summary

Updates the README to match the current public framing of the project:

- leads with the real end goal: horizontally scaling Convex while preserving reactive subscriptions, serializable transactions, consistent snapshots, and topology-free developer APIs;
- clearly marks the project as an alpha distributed-systems hardening effort;
- replaces stale/overconfident read/write scaling language with the current architecture and roadmap;
- updates Recently Landed, Validation, Key Components, Configuration, and release-note links.

## Validation

- `git diff --check`
- searched README for overclaiming / risky public phrases
