### PR TITLE
fix: separate 2PC prepared intents

### DIFF
--- a/crates/database/src/committer.rs
+++ b/crates/database/src/committer.rs
@@ -175,6 +175,8 @@ use crate::{
         PackedDocumentUpdate,
         PendingWriteHandle,
         PendingWrites,
+        PreparedWriteHandle,
+        PreparedWrites,
         WriteSource,
     },
     ComponentRegistry,
@@ -188,7 +190,7 @@ const MAX_PERSISTENCE_WRITES_BACKOFF: Duration = Duration::from_secs(60);
 
 /// State held for a 2PC-prepared transaction awaiting commit/rollback.
 struct PreparedTransaction {
-    pending_write: PendingWriteHandle,
+    prepared_write: PreparedWriteHandle,
     commit_ts: Timestamp,
     write_bytes: u64,
     document_writes: Arc<Vec<DocumentLogEntry>>,
@@ -363,6 +365,9 @@ struct PublishedCommit {
 pub struct Committer<RT: Runtime> {
     // Internal staged commits for conflict checking.
     pending_writes: PendingWrites,
+    // 2PC prepared intents for conflict checking. These are intentionally
+    // separate from `pending_writes`, whose FIFO is only for publishable commits.
+    prepared_writes: PreparedWrites,
     // External log of writes for subscriptions.
     log: LogWriter,
 
@@ -395,8 +400,8 @@ pub struct Committer<RT: Runtime> {
     timestamp_oracle: Option<Arc<dyn crate::timestamp_oracle::TimestampOracle>>,
 
     // 2PC prepared transactions awaiting CommitPrepared or RollbackPrepared.
-    // Keyed by TwoPhaseTransactionId, storing the PendingWriteHandle and
-    // metadata needed to finalize the commit. (Vitess redo log pattern)
+    // Keyed by TwoPhaseTransactionId, storing the prepared intent and metadata
+    // needed to finalize the commit. (Vitess redo log pattern)
     prepared_transactions:
         std::collections::HashMap<crate::two_phase::TwoPhaseTransactionId, PreparedTransaction>,
 
@@ -492,14 +497,14 @@ impl<RT: Runtime> Committer<RT> {
         applied_delta_watermarks: BTreeMap<crate::partition::PartitionId, Timestamp>,
     ) -> CommitterClient {
         let persistence_reader = persistence.reader();
-        let conflict_checker = PendingWrites::new();
         let (tx, rx) = mpsc::channel(*COMMITTER_QUEUE_SIZE);
         let snapshot_reader = snapshot_manager.reader();
         let placement_state =
             partition_map.map(crate::partition::PlacementState::from_partition_map);
         let client_placement_state = placement_state.clone();
         let committer = Self {
-            pending_writes: conflict_checker,
+            pending_writes: PendingWrites::new(),
+            prepared_writes: PreparedWrites::new(),
             log,
             snapshot_manager,
             persistence,
@@ -757,6 +762,7 @@ impl<RT: Runtime> Committer<RT> {
                             ..
                         } => {
                             self.pending_writes = PendingWrites::new();
+                            self.prepared_writes = PreparedWrites::new();
                             self.prepared_transactions.clear();
                             self.queued_snapshots.clear();
                             self.log.reset(snapshot_ts);
@@ -1522,7 +1528,7 @@ impl<RT: Runtime> Committer<RT> {
         let (document_writes, index_writes, snapshot) =
             self.compute_writes(commit_ts, &ordered_update_refs)?;
 
-        let pending_write = self.pending_writes.push_back(
+        let prepared_write = self.prepared_writes.insert(
             commit_ts,
             writes
                 .into_iter()
@@ -1558,7 +1564,7 @@ impl<RT: Runtime> Committer<RT> {
         self.prepared_transactions.insert(
             transaction_id.clone(),
             PreparedTransaction {
-                pending_write,
+                prepared_write,
                 commit_ts,
                 write_bytes,
                 document_writes: Arc::new(doc_entries),
@@ -1595,7 +1601,7 @@ impl<RT: Runtime> Committer<RT> {
             anyhow::bail!(anyhow::anyhow!(metadata).context(format!(
                 "Commit blocked by {} unresolved 2PC prepared transaction(s); retry after the \
                  prepared transaction commits or rolls back",
-                self.prepared_transactions.len(),
+                self.prepared_writes.len(),
             )));
         }
 
@@ -1623,6 +1629,21 @@ impl<RT: Runtime> Committer<RT> {
                     }
                 }
             }
+        }
+
+        if let Some((intent_ts, intent_source)) = self
+            .prepared_writes
+            .conflicts_document_ids(transaction.writes.coalesced_writes().map(|write| write.id))
+        {
+            let metadata = ErrorMetadata::system_occ(
+                Some(u64::from(*transaction.begin_timestamp)),
+                write_source.as_str().map(|source| source.to_string()),
+            );
+            anyhow::bail!(anyhow::anyhow!(metadata).context(format!(
+                "Commit conflicts with unresolved 2PC prepared intent at ts={} from {:?}",
+                u64::from(intent_ts),
+                intent_source,
+            )));
         }
 
         self.validate_remote_read_frontiers(
@@ -1737,6 +1758,9 @@ impl<RT: Runtime> Committer<RT> {
             return Ok(Some(conflicting_read));
         }
         if let Some(conflicting_read) = self.pending_writes.is_stale(reads, reads_ts, commit_ts)? {
+            return Ok(Some(conflicting_read));
+        }
+        if let Some(conflicting_read) = self.prepared_writes.is_stale(reads, reads_ts, commit_ts)? {
             return Ok(Some(conflicting_read));
         }
         Ok(None)
@@ -1866,8 +1890,48 @@ impl<RT: Runtime> Committer<RT> {
         document_writes: Arc<Vec<DocumentLogEntry>>,
         index_writes: Arc<Vec<PersistenceIndexEntry>>,
     ) -> anyhow::Result<PublishedCommit> {
-        let apply_timer = metrics::commit_apply_timer();
         let commit_ts = pending_write.must_commit_ts();
+        let (ordered_updates, write_source, new_snapshot) =
+            match self.pending_writes.pop_first(pending_write) {
+                None => panic!("commit at {commit_ts} not pending"),
+                Some((ts, document_updates, write_source, snapshot)) => {
+                    if ts != commit_ts {
+                        panic!("commits out of order {ts} != {commit_ts}");
+                    }
+                    (document_updates, write_source, snapshot)
+                },
+            };
+
+        self.publish_commit_from_updates(
+            commit_ts,
+            ordered_updates,
+            write_source,
+            new_snapshot,
+            write_bytes,
+            document_writes,
+            index_writes,
+        )
+    }
+
+    #[fastrace::trace]
+    fn publish_commit_from_updates(
+        &mut self,
+        commit_ts: Timestamp,
+        ordered_updates: crate::write_log::OrderedDocumentWrites,
+        write_source: WriteSource,
+        new_snapshot: Snapshot,
+        write_bytes: u64,
+        document_writes: Arc<Vec<DocumentLogEntry>>,
+        index_writes: Arc<Vec<PersistenceIndexEntry>>,
+    ) -> anyhow::Result<PublishedCommit> {
+        let apply_timer = metrics::commit_apply_timer();
+        let latest_snapshot_ts = *self.snapshot_manager.read().latest_ts();
+        anyhow::ensure!(
+            latest_snapshot_ts < commit_ts,
+            "Commit at ts={} can no longer publish because latest snapshot is {}",
+            u64::from(commit_ts),
+            latest_snapshot_ts,
+        );
 
         if let Some(ref tso) = self.timestamp_oracle {
             let tso = tso.clone();
@@ -1886,17 +1950,6 @@ impl<RT: Runtime> Committer<RT> {
                 );
             }
         }
-
-        let (ordered_updates, write_source, new_snapshot) =
-            match self.pending_writes.pop_first(pending_write) {
-                None => panic!("commit at {commit_ts} not pending"),
-                Some((ts, document_updates, write_source, snapshot)) => {
-                    if ts != commit_ts {
-                        panic!("commits out of order {ts} != {commit_ts}");
-                    }
-                    (document_updates, write_source, snapshot)
-                },
-            };
 
         // Write transaction state at the commit ts to the document store.
         metrics::commit_rows(ordered_updates.len() as u64);
@@ -2924,9 +2977,31 @@ impl<RT: Runtime> Committer<RT> {
             }
         })?;
 
+        let (intent_ts, ordered_updates, write_source, snapshot) = self
+            .prepared_writes
+            .remove(prepared.prepared_write)
+            .ok_or_else(|| {
+                anyhow::anyhow!(
+                    "2PC CommitPrepared: prepared intent for txn={} at ts={} was missing",
+                    transaction_id,
+                    u64::from(prepared.commit_ts),
+                )
+            })?;
+        anyhow::ensure!(
+            intent_ts == prepared.commit_ts,
+            "2PC CommitPrepared: prepared intent for txn={} had ts={} but transaction expected \
+             ts={}",
+            transaction_id,
+            intent_ts,
+            prepared.commit_ts,
+        );
+
         // Publish commit — makes writes visible to reads.
-        self.publish_commit(
-            prepared.pending_write,
+        self.publish_commit_from_updates(
+            prepared.commit_ts,
+            ordered_updates,
+            write_source,
+            snapshot,
             prepared.write_bytes,
             prepared.document_writes,
             prepared.index_writes,
@@ -2954,14 +3029,14 @@ impl<RT: Runtime> Committer<RT> {
             u64::from(prepared.commit_ts),
         );
 
-        // Remove this exact prepared intent from PendingWrites so it no longer
-        // blocks conflicting transactions. Do not pop the FIFO head here: an
-        // older local commit may be pending ahead of this prepared transaction.
-        self.pending_writes
-            .remove(prepared.pending_write)
+        // Remove this exact prepared intent so it no longer blocks conflicting
+        // transactions. Prepared intents are not stored in PendingWrites, whose
+        // FIFO is reserved for normal commit publication.
+        self.prepared_writes
+            .remove(prepared.prepared_write)
             .ok_or_else(|| {
                 anyhow::anyhow!(
-                    "2PC RollbackPrepared: pending write for txn={} at ts={} was missing",
+                    "2PC RollbackPrepared: prepared intent for txn={} at ts={} was missing",
                     transaction_id,
                     u64::from(prepared.commit_ts),
                 )

--- a/crates/database/src/write_log.rs
+++ b/crates/database/src/write_log.rs
@@ -2,6 +2,7 @@ use std::{
     borrow::Cow,
     collections::{
         BTreeMap,
+        BTreeSet,
         VecDeque,
     },
     sync::Arc,
@@ -74,7 +75,8 @@ impl HeapSize for PackedDocumentUpdate {
     }
 }
 
-type OrderedDocumentWrites = WithHeapSize<Vec<(ResolvedDocumentId, PackedDocumentUpdate)>>;
+pub(crate) type OrderedDocumentWrites =
+    WithHeapSize<Vec<(ResolvedDocumentId, PackedDocumentUpdate)>>;
 
 impl PackedDocumentUpdate {
     pub fn pack(update: &impl DocumentUpdateRef) -> Self {
@@ -718,10 +720,14 @@ impl PendingWrites {
     pub fn is_stale(
         &self,
         reads: &ReadSet,
-        reads_ts: Timestamp,
+        _reads_ts: Timestamp,
         ts: Timestamp,
     ) -> anyhow::Result<Option<ConflictingReadWithWriteSource>> {
-        Ok(reads.writes_overlap_docs(self.iter(reads_ts.succ()?, ts)))
+        // Prepared writes are not visible in snapshots, so a reader can start
+        // after the prepare timestamp and still miss the intent. Treat every
+        // unresolved prepared write up to the candidate commit timestamp as a
+        // potential conflict.
+        Ok(reads.writes_overlap_docs(self.iter(Timestamp::MIN, ts)))
     }
 
     pub fn pop_first(
@@ -763,6 +769,90 @@ impl PendingWriteHandle {
         self.0.expect("pending write already committed")
     }
 }
+
+/// Prepared writes are 2PC intents: they participate in OCC conflict checks,
+/// but they are not part of the normal persistence/publish FIFO.
+pub struct PreparedWrites {
+    by_ts: BTreeMap<Timestamp, (OrderedDocumentWrites, WriteSource, Snapshot)>,
+}
+
+impl PreparedWrites {
+    pub fn new() -> Self {
+        Self {
+            by_ts: BTreeMap::new(),
+        }
+    }
+
+    pub fn insert(
+        &mut self,
+        ts: Timestamp,
+        writes: OrderedDocumentWrites,
+        write_source: WriteSource,
+        snapshot: Snapshot,
+    ) -> PreparedWriteHandle {
+        assert!(
+            self.by_ts
+                .insert(ts, (writes, write_source, snapshot))
+                .is_none(),
+            "prepared write already staged at {ts}",
+        );
+        PreparedWriteHandle(Some(ts))
+    }
+
+    pub fn iter(
+        &self,
+        from: Timestamp,
+        to: Timestamp,
+    ) -> impl Iterator<
+        Item = (
+            &Timestamp,
+            impl Iterator<Item = &(ResolvedDocumentId, PackedDocumentUpdate)>,
+            &WriteSource,
+        ),
+    > {
+        self.by_ts
+            .range(from..=to)
+            .map(|(ts, (w, source, _snapshot))| (ts, w.iter(), source))
+    }
+
+    pub fn is_stale(
+        &self,
+        reads: &ReadSet,
+        reads_ts: Timestamp,
+        ts: Timestamp,
+    ) -> anyhow::Result<Option<ConflictingReadWithWriteSource>> {
+        Ok(reads.writes_overlap_docs(self.iter(reads_ts.succ()?, ts)))
+    }
+
+    pub fn remove(
+        &mut self,
+        mut handle: PreparedWriteHandle,
+    ) -> Option<(Timestamp, OrderedDocumentWrites, WriteSource, Snapshot)> {
+        let expected_ts = handle.0.take()?;
+        self.by_ts
+            .remove(&expected_ts)
+            .map(|(writes, write_source, snapshot)| (expected_ts, writes, write_source, snapshot))
+    }
+
+    pub fn len(&self) -> usize {
+        self.by_ts.len()
+    }
+
+    pub fn conflicts_document_ids(
+        &self,
+        ids: impl IntoIterator<Item = ResolvedDocumentId>,
+    ) -> Option<(Timestamp, WriteSource)> {
+        let ids: BTreeSet<_> = ids.into_iter().collect();
+        for (ts, (writes, write_source, _snapshot)) in &self.by_ts {
+            if writes.iter().any(|(id, _)| ids.contains(id)) {
+                return Some((*ts, write_source.clone()));
+            }
+        }
+        None
+    }
+}
+
+pub struct PreparedWriteHandle(Option<Timestamp>);
 
 #[cfg(test)]
 mod tests {

--- a/docs/issue-journal.md
+++ b/docs/issue-journal.md
@@ -582,6 +582,30 @@ own for distributed changes.
   - `cargo test -p local_backend test_internal_grpc_services_reject_missing_cluster_auth -- --nocapture`
   - `cargo test -p local_backend test_http_mutation_forwards_when_replica_mode -- --nocapture`
 
+### 2026-06 — Separated 2PC prepared intents from the commit publish queue
+
+- **Status:** complete
+- **Related issue:** `#154`
+- **What this fixes:** 2PC prepare previously staged prepared writes in the
+  same `PendingWrites` FIFO used by the normal publish path. That made a
+  prepared transaction look like the next publishable commit and forced the
+  committer to block all local writes while a prepare was unresolved.
+- **Behavior:** prepared writes are now tracked as separate intents. They still
+  participate in OCC conflict checks and document-ID write locks, but they are
+  removed by `CommitPrepared`/`RollbackPrepared` directly instead of being
+  popped from the normal publish FIFO. Because the current 2PC protocol fixes
+  the prepare timestamp as the final visibility timestamp, normal commits still
+  retry while a prepare is unresolved; allowing unrelated commits to publish
+  ahead of a prepared transaction belongs with the later timestamp-domain /
+  rebasable snapshot work.
+- **Validation:**
+  - `cargo test -p database test_local_commit_retries_while_prepare_is_unresolved -- --nocapture`
+  - `cargo test -p database test_prepare_retries_while_local_commit_is_pending -- --nocapture`
+  - `cargo test -p database test_remote_prepare_over_grpc_is_idempotent -- --nocapture`
+  - `cargo test -p database test_prepared_participant_recovers_from_redo_after_restart -- --nocapture`
+  - `cargo test -p database test_cross_partition_commit_uses_remote_prepare_over_grpc -- --nocapture`
+  - `cargo check -p database`
+
 ## Open Issues
 
 - `#74` is no longer blocked on follower self-sufficiency. The current


### PR DESCRIPTION
## Summary
- move 2PC prepared writes out of the normal `PendingWrites` publish FIFO
- track prepared writes as separate intents used for OCC/read conflict checks and document-ID write locks
- commit/rollback prepared transactions now remove only their own prepared intent instead of popping the FIFO head
- keep the existing retry fence for normal commits while a fixed-timestamp prepare is unresolved

## Important correctness note
This PR fixes the FIFO poisoning/drop hazard without pretending the timestamp model changed. Because the current 2PC protocol uses the prepare timestamp as the final visibility timestamp, letting newer unrelated commits publish ahead of an unresolved prepare would make a later `CommitPrepared` unpublishable in the append-only snapshot/write-log model. That publish-ahead behavior belongs with the timestamp-domain/rebasable-snapshot work tracked separately.

## Validation
- cargo test -p database test_local_commit_retries_while_prepare_is_unresolved -- --nocapture
- cargo test -p database test_prepare_retries_while_local_commit_is_pending -- --nocapture
- cargo test -p database test_remote_prepare_over_grpc_is_idempotent -- --nocapture
- cargo test -p database test_prepared_participant_recovers_from_redo_after_restart -- --nocapture
- cargo test -p database test_cross_partition_commit_uses_remote_prepare_over_grpc -- --nocapture
- cargo check -p database
- git diff --check

Closes #154