### PR TITLE
fix: persist raft applied index

### DIFF
--- a/crates/database/src/committer.rs
+++ b/crates/database/src/committer.rs
@@ -152,6 +152,7 @@ use crate::{
         table_summary_finish_bootstrap_timer,
         user_documents_size_subgauge,
     },
+    raft_node::RaftProposalResult,
     reads::ReadSet,
     search_index_bootstrap::{
         stream_revision_pairs_for_indexes,
@@ -205,6 +206,7 @@ enum PersistenceWrite {
         parent_trace: EncodedSpan,
         commit_id: usize,
         delta: CommitDelta,
+        raft_applied_index: Option<u64>,
     },
     RejectedBeforePersistence {
         pending_write: PendingWriteHandle,
@@ -360,11 +362,12 @@ fn checkpoint_index_entries(
     index_entries
 }
 
-type RaftCommitWaiter = Option<oneshot::Receiver<bool>>;
+type RaftCommitWaiter = Option<oneshot::Receiver<RaftProposalResult>>;
 
 struct PublishedCommit {
     commit_ts: Timestamp,
     delta: CommitDelta,
+    raft_applied_index: Option<u64>,
 }
 
 pub struct Committer<RT: Runtime> {
@@ -625,6 +628,7 @@ impl<RT: Runtime> Committer<RT> {
                             result,
                             parent_trace,
                             delta,
+                            raft_applied_index,
                             ..
                         } => {
                             let parent_span = initialize_root_from_parent("Committer::publish_commit", parent_trace);
@@ -646,6 +650,29 @@ impl<RT: Runtime> Committer<RT> {
                                 },
                             };
                             drop(_guard);
+                            if let Some(raft_applied_index) = raft_applied_index {
+                                let Some(raft_state) = self.raft_state.as_ref() else {
+                                    return Self::fail_committed_write(
+                                        result,
+                                        commit_ts,
+                                        "mark Raft applied index",
+                                        anyhow::anyhow!(
+                                            "commit returned Raft applied index {} without Raft state",
+                                            raft_applied_index,
+                                        ),
+                                    );
+                                };
+                                if let Err(err) =
+                                    raft_state.mark_applied(raft_applied_index).await
+                                {
+                                    return Self::fail_committed_write(
+                                        result,
+                                        commit_ts,
+                                        "mark Raft applied index",
+                                        err,
+                                    );
+                                }
+                            }
                             if let Err(err) = Self::publish_commit_delta(
                                 self.distributed_log.clone(),
                                 published_commit.delta,
@@ -942,6 +969,29 @@ impl<RT: Runtime> Committer<RT> {
                                 },
                             };
                             let commit_ts = published_commit.commit_ts;
+                            if let Some(raft_applied_index) = published_commit.raft_applied_index {
+                                let Some(raft_state) = self.raft_state.as_ref() else {
+                                    return Self::fail_committed_write(
+                                        result,
+                                        commit_ts,
+                                        "mark Raft applied index for prepared write",
+                                        anyhow::anyhow!(
+                                            "prepared commit returned Raft applied index {} without Raft state",
+                                            raft_applied_index,
+                                        ),
+                                    );
+                                };
+                                if let Err(err) =
+                                    raft_state.mark_applied(raft_applied_index).await
+                                {
+                                    return Self::fail_committed_write(
+                                        result,
+                                        commit_ts,
+                                        "mark Raft applied index for prepared write",
+                                        err,
+                                    );
+                                }
+                            }
                             if let Err(err) = Self::publish_commit_delta(
                                 self.distributed_log.clone(),
                                 published_commit.delta,
@@ -1792,13 +1842,13 @@ impl<RT: Runtime> Committer<RT> {
     async fn wait_for_raft_commit(
         raft_commit_waiter: RaftCommitWaiter,
         commit_ts: Timestamp,
-    ) -> anyhow::Result<()> {
+    ) -> anyhow::Result<Option<u64>> {
         let Some(raft_commit_waiter) = raft_commit_waiter else {
-            return Ok(());
+            return Ok(None);
         };
         match raft_commit_waiter.await {
-            Ok(true) => Ok(()),
-            Ok(false) => anyhow::bail!(
+            Ok(RaftProposalResult::Committed { index }) => Ok(Some(index)),
+            Ok(RaftProposalResult::Rejected) => anyhow::bail!(
                 "Raft rejected commit at ts={} before quorum commit",
                 u64::from(commit_ts),
             ),
@@ -2026,7 +2076,11 @@ impl<RT: Runtime> Committer<RT> {
         drop(snapshot_manager);
 
         apply_timer.finish();
-        Ok(PublishedCommit { commit_ts, delta })
+        Ok(PublishedCommit {
+            commit_ts,
+            delta,
+            raft_applied_index: None,
+        })
     }
 
     fn install_snapshot(
@@ -2995,7 +3049,7 @@ impl<RT: Runtime> Committer<RT> {
             source_partition,
         );
         let raft_commit_waiter = self.propose_commit_to_raft(&delta)?;
-        block_in_place(|| {
+        let raft_applied_index = block_in_place(|| {
             let wait_future = Self::wait_for_raft_commit(raft_commit_waiter, commit_ts);
             let rt = tokio::runtime::Handle::current();
             if rt.runtime_flavor() == tokio::runtime::RuntimeFlavor::CurrentThread {
@@ -3046,7 +3100,15 @@ impl<RT: Runtime> Committer<RT> {
         );
 
         // Publish commit — makes writes visible to reads.
-        self.publish_commit_from_updates(commit_ts, ordered_updates, write_source, snapshot, delta)
+        let mut published_commit = self.publish_commit_from_updates(
+            commit_ts,
+            ordered_updates,
+            write_source,
+            snapshot,
+            delta,
+        )?;
+        published_commit.raft_applied_index = raft_applied_index;
+        Ok(published_commit)
     }
 
     /// Rollback a previously prepared transaction: remove from PendingWrites.
@@ -3218,16 +3280,19 @@ impl<RT: Runtime> Committer<RT> {
         let rt = self.runtime.clone();
         Some(
             async move {
-                if let Err(err) = Self::wait_for_raft_commit(raft_commit_waiter, commit_ts).await {
-                    return Ok(PersistenceWrite::RejectedBeforePersistence {
-                        pending_write,
-                        commit_timer,
-                        result,
-                        commit_id,
-                        err,
-                    });
-                }
-
+                let raft_applied_index =
+                    match Self::wait_for_raft_commit(raft_commit_waiter, commit_ts).await {
+                        Ok(index) => index,
+                        Err(err) => {
+                            return Ok(PersistenceWrite::RejectedBeforePersistence {
+                                pending_write,
+                                commit_timer,
+                                result,
+                                commit_id,
+                                err,
+                            });
+                        },
+                    };
                 let mut backoff = Backoff::new(
                     INITIAL_PERSISTENCE_WRITES_BACKOFF,
                     MAX_PERSISTENCE_WRITES_BACKOFF,
@@ -3265,6 +3330,7 @@ impl<RT: Runtime> Committer<RT> {
                             parent_trace: parent_trace_copy,
                             commit_id,
                             delta,
+                            raft_applied_index,
                         });
                     }
                 }
@@ -4081,19 +4147,23 @@ mod tests {
         is_retryable_system_generated_id_conflict,
         Committer,
     };
+    use crate::raft_node::RaftProposalResult;
 
     #[tokio::test]
     async fn raft_commit_waiter_accepts_committed_proposal() -> anyhow::Result<()> {
         let (tx, rx) = oneshot::channel();
-        tx.send(true).unwrap();
+        tx.send(RaftProposalResult::Committed { index: 7 }).unwrap();
 
-        Committer::<TestRuntime>::wait_for_raft_commit(Some(rx), Timestamp::must(1)).await
+        let applied_index =
+            Committer::<TestRuntime>::wait_for_raft_commit(Some(rx), Timestamp::must(1)).await?;
+        assert_eq!(applied_index, Some(7));
+        Ok(())
     }
 
     #[tokio::test]
     async fn raft_commit_waiter_rejects_failed_proposal() {
         let (tx, rx) = oneshot::channel();
-        tx.send(false).unwrap();
+        tx.send(RaftProposalResult::Rejected).unwrap();
 
         let err = Committer::<TestRuntime>::wait_for_raft_commit(Some(rx), Timestamp::must(1))
             .await
@@ -4103,7 +4173,10 @@ mod tests {
 
     #[tokio::test]
     async fn raft_commit_waiter_allows_non_raft_commit() -> anyhow::Result<()> {
-        Committer::<TestRuntime>::wait_for_raft_commit(None, Timestamp::must(1)).await
+        let applied_index =
+            Committer::<TestRuntime>::wait_for_raft_commit(None, Timestamp::must(1)).await?;
+        assert_eq!(applied_index, None);
+        Ok(())
     }
 
     #[test]

--- a/crates/database/src/raft_node.rs
+++ b/crates/database/src/raft_node.rs
@@ -14,7 +14,10 @@
 //!   - [raft-rs five_mem_node example](https://github.com/tikv/raft-rs/blob/master/examples/five_mem_node/main.rs)
 
 use std::{
-    collections::HashMap,
+    collections::{
+        BTreeSet,
+        HashMap,
+    },
     sync::Arc,
     time::{
         Duration,
@@ -69,7 +72,13 @@ pub struct RaftProposal {
     /// Serialized mutation data.
     pub data: Vec<u8>,
     /// Channel to notify the client when the proposal is committed.
-    pub result_tx: tokio::sync::oneshot::Sender<bool>,
+    pub result_tx: tokio::sync::oneshot::Sender<RaftProposalResult>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RaftProposalResult {
+    Committed { index: u64 },
+    Rejected,
 }
 
 /// Messages that can be sent to the Raft node.
@@ -78,6 +87,12 @@ pub enum RaftMessage {
     Raft(Message),
     /// A client proposal to be committed.
     Propose(RaftProposal),
+    /// Mark a live local proposal as durably applied to the Convex state
+    /// machine after the committer has installed it locally.
+    MarkApplied {
+        index: u64,
+        result_tx: tokio::sync::oneshot::Sender<anyhow::Result<()>>,
+    },
     /// Shutdown the Raft node.
     Shutdown,
 }
@@ -115,7 +130,7 @@ pub struct RaftNode {
     /// Storage backend.
     pub(crate) storage: ConvexRaftStorage,
     /// Pending proposals waiting for commit (index → callback).
-    pending_proposals: HashMap<u64, tokio::sync::oneshot::Sender<bool>>,
+    pending_proposals: HashMap<u64, tokio::sync::oneshot::Sender<RaftProposalResult>>,
     /// Channel for receiving messages.
     mailbox: mpsc::UnboundedReceiver<RaftMessage>,
     /// Channels for sending Raft messages to other nodes.
@@ -127,6 +142,11 @@ pub struct RaftNode {
     is_leader_flag: bool,
     /// Leadership change callbacks.
     leadership_callbacks: LeadershipCallbacks,
+    /// Highest Raft log index durably applied to the local Convex state
+    /// machine.
+    durable_applied_index: u64,
+    /// Applied entries above `durable_applied_index` waiting for earlier gaps.
+    applied_indexes_pending_persistence: BTreeSet<u64>,
 }
 
 impl RaftNode {
@@ -152,13 +172,7 @@ impl RaftNode {
             snapshot_provider,
         )?;
 
-        // On restart, pick up where we left off (applied index from
-        // the persisted hard state's commit). This prevents raft-rs
-        // from re-applying already-committed entries.
-        let initial_state = storage
-            .initial_state()
-            .map_err(|e| anyhow::anyhow!("{e}"))?;
-        let applied = initial_state.hard_state.get_commit();
+        let applied = storage.applied_index()?;
 
         let raft_config = Config {
             id: config.node_id,
@@ -184,7 +198,81 @@ impl RaftNode {
             config,
             is_leader_flag: false,
             leadership_callbacks: LeadershipCallbacks::default(),
+            durable_applied_index: applied,
+            applied_indexes_pending_persistence: BTreeSet::new(),
         })
+    }
+
+    fn record_applied_index(&mut self, index: u64) -> anyhow::Result<()> {
+        if index <= self.durable_applied_index {
+            return Ok(());
+        }
+        self.applied_indexes_pending_persistence.insert(index);
+
+        let mut next_applied = self.durable_applied_index;
+        while self
+            .applied_indexes_pending_persistence
+            .remove(&(next_applied + 1))
+        {
+            next_applied += 1;
+        }
+        if next_applied > self.durable_applied_index {
+            self.storage.set_applied_index(next_applied)?;
+            self.durable_applied_index = next_applied;
+        }
+        Ok(())
+    }
+
+    fn record_snapshot_applied_index(&mut self, index: u64) -> anyhow::Result<()> {
+        if index > self.durable_applied_index {
+            self.storage.set_applied_index(index)?;
+            self.durable_applied_index = index;
+        }
+        self.applied_indexes_pending_persistence
+            .retain(|pending_index| *pending_index > index);
+        Ok(())
+    }
+
+    fn process_committed_entry(
+        &mut self,
+        entry: Entry,
+        on_committed: &mut impl FnMut(&[u8]) -> anyhow::Result<()>,
+    ) -> anyhow::Result<Option<Vec<u8>>> {
+        let index = entry.index;
+        if entry.data.is_empty() {
+            self.record_applied_index(index)?;
+            return Ok(None);
+        }
+
+        match entry.get_entry_type() {
+            EntryType::EntryConfChange | EntryType::EntryConfChangeV2 => {
+                // Configuration change — apply to Raft membership.
+                let cc = ConfChange::default();
+                if let Ok(cs) = self.raw_node.apply_conf_change(&cc) {
+                    if let Err(e) = self.storage.set_conf_state(cs) {
+                        tracing::error!("Failed to persist conf state: {e}");
+                        return Err(e);
+                    }
+                }
+                self.record_applied_index(index)?;
+                Ok(None)
+            },
+            EntryType::EntryNormal => {
+                if let Some(tx) = self.pending_proposals.remove(&index) {
+                    if tx.send(RaftProposalResult::Committed { index }).is_ok() {
+                        return Ok(None);
+                    }
+                    tracing::warn!(
+                        "Local Raft proposal at index {index} was committed but waiter dropped; \
+                         applying through the Raft state-machine callback"
+                    );
+                }
+
+                on_committed(&entry.data)?;
+                self.record_applied_index(index)?;
+                Ok(Some(entry.data.to_vec()))
+            },
+        }
     }
 
     /// Run the Raft loop. This is the main event loop following TiKV's pattern:
@@ -211,14 +299,18 @@ impl RaftNode {
                             let index = self.raw_node.raft.raft_log.last_index() + 1;
                             if let Err(e) = self.raw_node.propose(vec![], proposal.data) {
                                 tracing::warn!("Raft propose error: {e}");
-                                let _ = proposal.result_tx.send(false);
+                                let _ = proposal.result_tx.send(RaftProposalResult::Rejected);
                             } else {
                                 self.pending_proposals.insert(index, proposal.result_tx);
                             }
                         } else {
                             // Not leader — reject.
-                            let _ = proposal.result_tx.send(false);
+                            let _ = proposal.result_tx.send(RaftProposalResult::Rejected);
                         }
+                    },
+                    Ok(RaftMessage::MarkApplied { index, result_tx }) => {
+                        let result = self.record_applied_index(index);
+                        let _ = result_tx.send(result);
                     },
                     Ok(RaftMessage::Shutdown) => {
                         tracing::info!("Raft node {} shutting down", self.config.node_id);
@@ -308,7 +400,7 @@ impl RaftNode {
                         self.is_leader_flag = false;
                         // Reject all pending proposals — we're no longer leader.
                         for (_, tx) in self.pending_proposals.drain() {
-                            let _ = tx.send(false);
+                            let _ = tx.send(RaftProposalResult::Rejected);
                         }
                         (self.leadership_callbacks.on_lost_leadership)();
                     }
@@ -359,17 +451,23 @@ impl RaftNode {
                     }
                 }
 
-                // 2. Persist and apply any incoming snapshot before appending entries.
+                // 2. Apply and persist any incoming snapshot before appending entries.
                 if !ready.snapshot().is_empty() {
                     let snapshot_timer = metrics::raft_snapshot_apply_timer();
                     let snapshot_bytes = ready.snapshot().get_data().len();
                     metrics::log_raft_snapshot_apply_bytes(snapshot_bytes);
-                    if let Err(e) = self.storage.apply_snapshot(ready.snapshot()) {
+                    if let Err(e) = on_snapshot(ready.snapshot().get_data()) {
+                        tracing::error!("Failed to apply snapshot to state machine: {e}");
+                        drop(snapshot_timer);
+                        return Err(e);
+                    } else if let Err(e) = self.storage.apply_snapshot(ready.snapshot()) {
                         tracing::error!("Failed to persist snapshot: {e}");
                         drop(snapshot_timer);
                         return Err(e);
-                    } else if let Err(e) = on_snapshot(ready.snapshot().get_data()) {
-                        tracing::error!("Failed to apply snapshot to state machine: {e}");
+                    } else if let Err(e) =
+                        self.record_snapshot_applied_index(ready.snapshot().get_metadata().index)
+                    {
+                        tracing::error!("Failed to persist snapshot applied index: {e}");
                         drop(snapshot_timer);
                         return Err(e);
                     } else {
@@ -410,36 +508,9 @@ impl RaftNode {
 
                 // 6. Apply committed entries to state machine.
                 for entry in ready.take_committed_entries() {
-                    if entry.data.is_empty() {
-                        // Raft internal entry (leader election, etc.)
-                        continue;
-                    }
-
-                    match entry.get_entry_type() {
-                        EntryType::EntryConfChange | EntryType::EntryConfChangeV2 => {
-                            // Configuration change — apply to Raft membership.
-                            let cc = ConfChange::default();
-                            if let Ok(cs) = self.raw_node.apply_conf_change(&cc) {
-                                if let Err(e) = self.storage.set_conf_state(cs) {
-                                    tracing::error!("Failed to persist conf state: {e}");
-                                    return Err(e);
-                                }
-                            }
-                        },
-                        EntryType::EntryNormal => {
-                            // Normal entry — apply to state machine.
-                            if let Err(e) = on_committed(&entry.data) {
-                                tracing::error!("Failed to apply committed entry: {e}");
-                                return Err(e);
-                            }
-
-                            // Notify the proposer if this was our proposal.
-                            if self.raw_node.raft.state == StateRole::Leader {
-                                if let Some(tx) = self.pending_proposals.remove(&entry.index) {
-                                    let _ = tx.send(true);
-                                }
-                            }
-                        },
+                    if let Err(e) = self.process_committed_entry(entry, &mut on_committed) {
+                        tracing::error!("Failed to apply committed entry: {e}");
+                        return Err(e);
                     }
                 }
 
@@ -466,11 +537,9 @@ impl RaftNode {
 
                 // Apply remaining committed entries.
                 for entry in light_rd.take_committed_entries() {
-                    if !entry.data.is_empty() && entry.get_entry_type() == EntryType::EntryNormal {
-                        if let Err(e) = on_committed(&entry.data) {
-                            tracing::error!("Failed to apply light committed entry: {e}");
-                            return Err(e);
-                        }
+                    if let Err(e) = self.process_committed_entry(entry, &mut on_committed) {
+                        tracing::error!("Failed to apply light committed entry: {e}");
+                        return Err(e);
                     }
                 }
 
@@ -537,6 +606,7 @@ impl RaftNode {
 
         if !ready.snapshot().is_empty() {
             self.storage.apply_snapshot(ready.snapshot())?;
+            self.record_snapshot_applied_index(ready.snapshot().get_metadata().index)?;
         }
         if let Some(hs) = ready.hs() {
             self.storage
@@ -545,16 +615,14 @@ impl RaftNode {
             self.storage.append_entries(ready.entries())?;
         }
         for entry in ready.take_committed_entries() {
-            if !entry.data.is_empty() {
-                on_committed(&entry.data)?;
-                committed.push(entry.data.to_vec());
+            if let Some(data) = self.process_committed_entry(entry, &mut on_committed)? {
+                committed.push(data);
             }
         }
         let mut light_rd = self.raw_node.advance(ready);
         for entry in light_rd.take_committed_entries() {
-            if !entry.data.is_empty() {
-                on_committed(&entry.data)?;
-                committed.push(entry.data.to_vec());
+            if let Some(data) = self.process_committed_entry(entry, &mut on_committed)? {
+                committed.push(data);
             }
         }
         self.raw_node.advance_apply();
@@ -728,6 +796,49 @@ mod tests {
             node.raw_node.raft.raft_log.applied, applied_before,
             "failed state-machine apply must not advance the Raft applied index",
         );
+    }
+
+    #[tokio::test]
+    async fn test_restart_replays_committed_but_unapplied_entry() {
+        let config = RaftNodeConfig {
+            node_id: 1,
+            partition_id: PartitionId(0),
+            peers: vec![1],
+            election_tick: 10,
+            heartbeat_tick: 3,
+        };
+        let engine = test_engine();
+
+        {
+            let storage =
+                ConvexRaftStorage::new(PartitionId(0), engine.clone(), 1, vec![1], None).unwrap();
+            let mut entry = Entry::default();
+            entry.set_index(1);
+            entry.set_term(1);
+            entry.set_data(b"committed but unapplied".to_vec().into());
+
+            let mut hs = HardState::default();
+            hs.set_term(1);
+            hs.set_commit(1);
+            storage.append_entries_and_hardstate(&[entry], &hs).unwrap();
+            assert_eq!(storage.applied_index().unwrap(), 0);
+        }
+
+        let (_tx, rx) = mpsc::unbounded_channel();
+        let mut node = RaftNode::new(config, engine, rx, HashMap::new(), None).unwrap();
+        assert_eq!(
+            node.raw_node.raft.raft_log.applied, 0,
+            "restart must initialize applied from durable applied index, not HardState.commit",
+        );
+
+        let committed = node.process_ready_test();
+        assert!(
+            committed
+                .iter()
+                .any(|data| data == b"committed but unapplied"),
+            "committed-but-unapplied entry should replay after restart: {committed:?}",
+        );
+        assert_eq!(node.storage.applied_index().unwrap(), 1);
     }
 
     #[tokio::test]

--- a/crates/database/src/raft_partition.rs
+++ b/crates/database/src/raft_partition.rs
@@ -104,6 +104,20 @@ impl RaftPartitionState {
         })
     }
 
+    /// Mark a locally proposed Raft entry as durably applied after the
+    /// Committer has installed it into Convex state.
+    pub async fn mark_applied(&self, index: u64) -> anyhow::Result<()> {
+        let (result_tx, result_rx) = tokio::sync::oneshot::channel();
+        self.send(RaftMessage::MarkApplied { index, result_tx })?;
+        result_rx.await.map_err(|_| {
+            anyhow::anyhow!(
+                "Raft node for partition {} stopped before marking index {} applied",
+                self.partition_id,
+                index,
+            )
+        })?
+    }
+
     #[cfg(any(test, feature = "testing"))]
     pub fn new_for_test(
         is_leader: bool,

--- a/crates/database/src/raft_storage.rs
+++ b/crates/database/src/raft_storage.rs
@@ -11,6 +11,7 @@
 //!   - Log entries via `add_entries` (raft-engine tracks first/last index)
 //!   - HardState via `put_message` (term, vote, commit)
 //!   - ConfState via `put_message` (voter/learner membership)
+//!   - Applied index via a small raw KV value (state-machine apply progress)
 //!
 //! Reference: [TiKV raft-engine](https://github.com/tikv/raft-engine)
 //! Reference: [PingCAP Blog](https://www.pingcap.com/blog/raft-engine-a-log-structured-embedded-storage-engine-for-multi-raft-logs-in-tikv/)
@@ -39,6 +40,8 @@ use crate::partition::PartitionId;
 const HARD_STATE_KEY: &[u8] = b"hard_state";
 /// Key for storing ConfState in raft-engine's KV space.
 const CONF_STATE_KEY: &[u8] = b"conf_state";
+/// Key for storing the highest Raft log index durably applied to Convex state.
+const APPLIED_INDEX_KEY: &[u8] = b"applied_index";
 /// Key for storing the latest installed/generated snapshot in raft-engine's KV
 /// space.
 const SNAPSHOT_KEY: &[u8] = b"snapshot";
@@ -233,6 +236,44 @@ impl ConvexRaftStorage {
         self.engine
             .write(&mut batch, true)
             .context("Failed to write entries+HardState to raft-engine")?;
+        Ok(())
+    }
+
+    /// Highest Raft log index durably applied to the Convex state machine.
+    ///
+    /// This intentionally differs from `HardState.commit`: commit means a
+    /// quorum accepted the log entry; applied means this local replica
+    /// installed it.
+    pub fn applied_index(&self) -> anyhow::Result<u64> {
+        if let Some(raw) = self.engine.get(self.region_id(), APPLIED_INDEX_KEY) {
+            let bytes: [u8; 8] = raw
+                .as_slice()
+                .try_into()
+                .with_context(|| format!("Invalid Raft applied index value: {raw:?}"))?;
+            return Ok(u64::from_be_bytes(bytes));
+        }
+        // Backward compatibility for snapshots created before the applied-index
+        // key existed: an installed snapshot implies the state machine is applied
+        // through the snapshot metadata index.
+        Ok(self
+            .snapshot_metadata()?
+            .map(|metadata| metadata.index)
+            .unwrap_or(0))
+    }
+
+    pub fn set_applied_index(&self, index: u64) -> anyhow::Result<()> {
+        self.check_fail_next_write_for_test()?;
+        let mut batch = LogBatch::default();
+        batch
+            .put(
+                self.region_id(),
+                APPLIED_INDEX_KEY.to_vec(),
+                index.to_be_bytes().to_vec(),
+            )
+            .context("Failed to add applied index to LogBatch")?;
+        self.engine
+            .write(&mut batch, true)
+            .context("Failed to write applied index to raft-engine")?;
         Ok(())
     }
 
@@ -431,12 +472,11 @@ impl Storage for ConvexRaftStorage {
             ));
         };
 
-        let hard_state = self.hard_state().map_err(|e| {
+        let snapshot_index = self.applied_index().map_err(|e| {
             raft::Error::Store(StorageError::Other(Box::new(std::io::Error::other(
                 e.to_string(),
             ))))
         })?;
-        let snapshot_index = hard_state.commit;
         if snapshot_index == 0 {
             return Err(raft::Error::Store(
                 StorageError::SnapshotTemporarilyUnavailable,
@@ -513,6 +553,16 @@ mod tests {
         assert_eq!(retrieved.get_term(), 5);
         assert_eq!(retrieved.get_vote(), 2);
         assert_eq!(retrieved.get_commit(), 10);
+    }
+
+    #[test]
+    fn test_applied_index_persistence() {
+        let engine = test_engine();
+        let storage = ConvexRaftStorage::new(PartitionId(0), engine, 1, vec![1], None).unwrap();
+
+        assert_eq!(storage.applied_index().unwrap(), 0);
+        storage.set_applied_index(7).unwrap();
+        assert_eq!(storage.applied_index().unwrap(), 7);
     }
 
     #[test]
@@ -598,6 +648,11 @@ mod tests {
             hs.set_commit(5);
             storage.set_hardstate(&hs).unwrap();
 
+            assert!(
+                storage.snapshot(5, 2).is_err(),
+                "snapshot must not use commit index before applied index is persisted",
+            );
+            storage.set_applied_index(5).unwrap();
             let snapshot = storage.snapshot(5, 2).unwrap();
             assert_eq!(snapshot.get_metadata().index, 5);
             assert_eq!(snapshot.get_metadata().term, 2);

--- a/crates/database/src/tests/raft_failover_tests.rs
+++ b/crates/database/src/tests/raft_failover_tests.rs
@@ -94,6 +94,9 @@ fn tick_cycle(nodes: &mut [RaftNode], active: &[bool]) -> Vec<Vec<u8>> {
 
             if !ready.snapshot().is_empty() {
                 node.storage.apply_snapshot(ready.snapshot()).unwrap();
+                node.storage
+                    .set_applied_index(ready.snapshot().get_metadata().index)
+                    .unwrap();
             }
             node.storage.append_entries(ready.entries()).unwrap();
             if let Some(hs) = ready.hs() {
@@ -106,6 +109,7 @@ fn tick_cycle(nodes: &mut [RaftNode], active: &[bool]) -> Vec<Vec<u8>> {
                 {
                     committed.push(entry.data.to_vec());
                 }
+                node.storage.set_applied_index(entry.index).unwrap();
             }
 
             for msg in ready.take_persisted_messages() {
@@ -119,6 +123,7 @@ fn tick_cycle(nodes: &mut [RaftNode], active: &[bool]) -> Vec<Vec<u8>> {
                 {
                     committed.push(entry.data.to_vec());
                 }
+                node.storage.set_applied_index(entry.index).unwrap();
             }
             node.raw_node.advance_apply();
         }

--- a/crates/local_backend/src/lib.rs
+++ b/crates/local_backend/src/lib.rs
@@ -1004,29 +1004,24 @@ pub async fn make_app(
                                 envelope.source_raft_node_id() == Some(raft_node_id);
                             let delta = envelope.to_delta()?;
 
-                            // Skip only the entries this node proposed: the
-                            // local commit future is waiting for this Raft
-                            // decision and will publish after quorum. Every
-                            // other committed entry must be applied here, even
-                            // if this node later became leader.
-                            if !proposed_locally {
-                                tracing::info!(
-                                    "Applying committed Raft delta locally: ts={}, leader_now={}",
-                                    u64::from(delta.ts),
-                                    raft_state_for_apply.is_leader(),
-                                );
-                                // apply_replica_delta is async — use block_in_place
-                                // since we're in the Raft loop's sync callback.
-                                let committer = committer.clone();
-                                common::runtime::block_in_place(|| {
-                                    let rt = tokio::runtime::Handle::current();
-                                    rt.block_on(async {
-                                        committer.apply_replica_delta(delta).await.map_err(|e| {
-                                            anyhow::anyhow!("Raft follower apply failed: {e:#}")
-                                        })
+                            tracing::info!(
+                                "Applying committed Raft delta locally: ts={}, \
+                                 proposed_locally={}, leader_now={}",
+                                u64::from(delta.ts),
+                                proposed_locally,
+                                raft_state_for_apply.is_leader(),
+                            );
+                            // apply_replica_delta is async — use block_in_place
+                            // since we're in the Raft loop's sync callback.
+                            let committer = committer.clone();
+                            common::runtime::block_in_place(|| {
+                                let rt = tokio::runtime::Handle::current();
+                                rt.block_on(async {
+                                    committer.apply_replica_delta(delta).await.map_err(|e| {
+                                        anyhow::anyhow!("Raft state-machine apply failed: {e:#}")
                                     })
-                                })?;
-                            }
+                                })
+                            })?;
 
                             Ok(())
                         },

--- a/docs/issue-journal.md
+++ b/docs/issue-journal.md
@@ -647,6 +647,31 @@ own for distributed changes.
   - `cargo check -p database`
   - `cargo check -p local_backend`
 
+### 2026-06 — Persisted Raft state-machine applied index separately from commit index
+
+- **Status:** complete
+- **Related issue:** `#145`
+- **What this fixes:** Raft restart previously initialized `Config.applied`
+  from `HardState.commit`, treating quorum commit as if the local Convex state
+  machine had already installed every committed entry. A crash after commit
+  persistence but before state-machine apply could therefore skip a log entry
+  forever on restart.
+- **Behavior:** raft-engine now stores a separate durable applied index. Follower
+  and replayed entries persist that index only after successful state-machine
+  apply. Live local leader proposals report their committed log index back to
+  the commit future; after the committer publishes local visibility, it marks
+  that index applied through the Raft node. Raft snapshots are generated at the
+  durable applied index, not the commit index.
+- **Validation:**
+  - `cargo test -p database test_restart_replays_committed_but_unapplied_entry -- --nocapture`
+  - `cargo test -p database test_applied_index_persistence -- --nocapture`
+  - `cargo test -p database test_snapshot_persists_and_reloads -- --nocapture`
+  - `cargo test -p database raft_node::tests -- --nocapture`
+  - `cargo test -p database raft_commit_waiter -- --nocapture`
+  - `cargo test -p database raft_failover_tests -- --nocapture`
+  - `cargo check -p database`
+  - `cargo check -p local_backend`
+
 ## Open Issues
 
 - `#74` is no longer blocked on follower self-sufficiency. The current


### PR DESCRIPTION
## Summary
- persist a separate Raft state-machine applied index in raft-engine instead of deriving it from HardState.commit
- initialize Raft Config.applied from that durable applied index so committed-but-unapplied entries replay after restart
- generate Raft snapshots at the durable applied index, not the commit index
- add a local-proposal handshake so leaders mark Raft entries applied only after Convex local visibility is installed
- allow replayed local-origin Raft entries to apply through the state-machine callback after restart
- update the failover harness to record applied progress when it manually applies entries

## Validation
- cargo test -p database test_restart_replays_committed_but_unapplied_entry -- --nocapture
- cargo test -p database test_applied_index_persistence -- --nocapture
- cargo test -p database test_snapshot_persists_and_reloads -- --nocapture
- cargo test -p database raft_node::tests -- --nocapture
- cargo test -p database raft_commit_waiter -- --nocapture
- cargo test -p database raft_failover_tests -- --nocapture
- cargo test -p database test_failed_raft_proposal_does_not_publish_or_persist -- --nocapture
- cargo test -p database test_cross_partition_commit_uses_remote_prepare_over_grpc -- --nocapture
- cargo check -p database
- cargo check -p local_backend
- git diff --check

Fixes #145