### PR TITLE
fix: replicate 2PC prepare redo through Raft

### DIFF
--- a/crates/database/src/committer.rs
+++ b/crates/database/src/committer.rs
@@ -5,6 +5,7 @@ use std::{
         BTreeSet,
         VecDeque,
     },
+    future::Future,
     ops::Bound,
     sync::Arc,
     time::Duration,
@@ -153,6 +154,7 @@ use crate::{
         user_documents_size_subgauge,
     },
     raft_node::RaftProposalResult,
+    raft_state_machine::RaftStateMachineEntry,
     reads::ReadSet,
     search_index_bootstrap::{
         stream_revision_pairs_for_indexes,
@@ -762,13 +764,39 @@ impl<RT: Runtime> Committer<RT> {
                                     )
                                     .await?;
                             }
-                            let mut sm = self.snapshot_manager.write();
-                            sm.push(commit_ts, snapshot, write_bytes);
-                            if let Some(source_partition) = source_partition {
-                                sm.update_replication_frontier(source_partition, commit_ts)?;
-                                sm.update_replication_write_frontier(source_partition, commit_ts)?;
-                                self.applied_delta_watermarks
-                                    .insert(source_partition, remote_ts);
+                            {
+                                let mut sm = self.snapshot_manager.write();
+                                sm.push(commit_ts, snapshot, write_bytes);
+                                if let Some(source_partition) = source_partition {
+                                    sm.update_replication_frontier(source_partition, commit_ts)?;
+                                    sm.update_replication_write_frontier(
+                                        source_partition,
+                                        commit_ts,
+                                    )?;
+                                    self.applied_delta_watermarks
+                                        .insert(source_partition, remote_ts);
+                                }
+                            }
+                            let committed_prepared_txn = if source_partition
+                                == Some(self.local_partition_for_two_phase())
+                            {
+                                self.remove_prepared_transaction_at_ts(remote_ts)?
+                            } else {
+                                None
+                            };
+                            if let Some(transaction_id) = committed_prepared_txn {
+                                if let Err(err) = Self::delete_two_phase_redo(
+                                    self.persistence.clone(),
+                                    &transaction_id,
+                                )
+                                .await
+                                {
+                                    tracing::warn!(
+                                        "2PC Raft Commit Apply: committed txn={} but failed to \
+                                         delete redo: {err:#}",
+                                        transaction_id,
+                                    );
+                                }
                             }
                             let _ = result.send(Ok(commit_ts));
                         },
@@ -872,6 +900,10 @@ impl<RT: Runtime> Committer<RT> {
                             } else {
                                 commit_id += 1;
                             }
+                        },
+                        Some(CommitterMessage::ApplyRaftPreparedRedo { redo, result }) => {
+                            let r = self.handle_raft_prepared_redo(redo);
+                            let _ = result.send(r);
                         },
                         Some(CommitterMessage::SetRaftState { raft_state, result }) => {
                             tracing::info!(
@@ -1511,8 +1543,11 @@ impl<RT: Runtime> Committer<RT> {
         table_mapping: &TableMapping,
         write_source: WriteSource,
         explicit_commit_ts: Option<Timestamp>,
+        require_leader: bool,
     ) -> anyhow::Result<crate::two_phase::PrepareResult> {
-        self.ensure_leader_for_writes()?;
+        if require_leader {
+            self.ensure_leader_for_writes()?;
+        }
         self.ensure_prepare_ownership(&writes, table_mapping, &write_source)?;
         self.validate_remote_read_frontiers(begin_ts, reads, table_mapping, &write_source)?;
 
@@ -1859,6 +1894,41 @@ impl<RT: Runtime> Committer<RT> {
         }
     }
 
+    async fn wait_for_raft_prepare(
+        raft_commit_waiter: RaftCommitWaiter,
+        transaction_id: &crate::two_phase::TwoPhaseTransactionId,
+        prepare_ts: Timestamp,
+    ) -> anyhow::Result<Option<u64>> {
+        let Some(raft_commit_waiter) = raft_commit_waiter else {
+            return Ok(None);
+        };
+        match raft_commit_waiter.await {
+            Ok(RaftProposalResult::Committed { index }) => Ok(Some(index)),
+            Ok(RaftProposalResult::Rejected) => anyhow::bail!(
+                "Raft rejected 2PC prepare for txn={} at ts={} before quorum commit",
+                transaction_id,
+                u64::from(prepare_ts),
+            ),
+            Err(_) => anyhow::bail!(
+                "Raft proposal result channel closed before 2PC prepare txn={} at ts={} reached \
+                 quorum",
+                transaction_id,
+                u64::from(prepare_ts),
+            ),
+        }
+    }
+
+    fn block_on_current_runtime<F: Future>(future: F) -> F::Output {
+        block_in_place(|| {
+            let rt = tokio::runtime::Handle::current();
+            if rt.runtime_flavor() == tokio::runtime::RuntimeFlavor::CurrentThread {
+                futures::executor::block_on(future)
+            } else {
+                rt.block_on(future)
+            }
+        })
+    }
+
     fn fail_committed_write(
         result: oneshot::Sender<anyhow::Result<Timestamp>>,
         commit_ts: Timestamp,
@@ -1900,20 +1970,14 @@ impl<RT: Runtime> Committer<RT> {
                 raft.partition_id(),
             );
         }
-        let envelope =
-            crate::nats_distributed_log::DeltaEnvelope::from_delta(delta, "", Some(raft.node_id()))
-                .with_context(|| {
-                    format!(
-                        "Failed to wrap commit delta at ts={} for Raft proposal",
-                        u64::from(delta.ts),
-                    )
-                })?;
-        let data = serde_json::to_vec(&envelope).with_context(|| {
-            format!(
-                "Failed to serialize commit delta at ts={} for Raft proposal",
-                u64::from(delta.ts),
-            )
-        })?;
+        let data = RaftStateMachineEntry::commit_delta(delta, raft.node_id())?
+            .to_bytes()
+            .with_context(|| {
+                format!(
+                    "Failed to serialize commit delta at ts={} for Raft proposal",
+                    u64::from(delta.ts),
+                )
+            })?;
         let (tx, rx) = oneshot::channel();
         raft.send(crate::raft_node::RaftMessage::Propose(
             crate::raft_node::RaftProposal {
@@ -1933,6 +1997,45 @@ impl<RT: Runtime> Committer<RT> {
 
     fn propose_commit_to_raft(&self, delta: &CommitDelta) -> anyhow::Result<RaftCommitWaiter> {
         Self::propose_commit_to_raft_state(self.raft_state.as_ref(), delta)
+    }
+
+    fn propose_two_phase_prepare_to_raft(
+        &self,
+        redo: &crate::two_phase::TwoPhaseRedoEntry,
+    ) -> anyhow::Result<RaftCommitWaiter> {
+        let Some(raft) = self.raft_state.as_ref() else {
+            return Ok(None);
+        };
+        if !raft.is_leader() {
+            anyhow::bail!(
+                "Raft leadership lost before proposing 2PC prepare for txn={} on partition {}",
+                redo.transaction_id,
+                raft.partition_id(),
+            );
+        }
+        let data = RaftStateMachineEntry::two_phase_prepare(redo.clone())
+            .to_bytes()
+            .with_context(|| {
+                format!(
+                    "Failed to serialize 2PC prepare for txn={} for Raft proposal",
+                    redo.transaction_id,
+                )
+            })?;
+        let (tx, rx) = oneshot::channel();
+        raft.send(crate::raft_node::RaftMessage::Propose(
+            crate::raft_node::RaftProposal {
+                data,
+                result_tx: tx,
+            },
+        ))
+        .with_context(|| {
+            format!(
+                "Failed to propose 2PC prepare for txn={} to Raft partition {}",
+                redo.transaction_id,
+                raft.partition_id(),
+            )
+        })?;
+        Ok(Some(rx))
     }
 
     fn build_commit_delta(
@@ -2839,6 +2942,7 @@ impl<RT: Runtime> Committer<RT> {
         transaction: crate::two_phase::ParticipantTransaction,
         write_source: WriteSource,
         prepare_ts: Timestamp,
+        require_leader: bool,
     ) -> anyhow::Result<crate::two_phase::PrepareResult> {
         let mut table_mapping = self
             .snapshot_manager
@@ -2855,7 +2959,98 @@ impl<RT: Runtime> Committer<RT> {
             &table_mapping,
             write_source,
             Some(prepare_ts),
+            require_leader,
         )
+    }
+
+    fn stage_two_phase_redo_entry(
+        &mut self,
+        entry: &crate::two_phase::TwoPhaseRedoEntry,
+        require_leader: bool,
+    ) -> anyhow::Result<crate::two_phase::PrepareResult> {
+        let transaction_id = entry.transaction_id();
+        let prepare_ts = entry.prepare_ts()?;
+        let transaction = entry.participant_transaction().with_context(|| {
+            format!(
+                "2PC: failed to decode participant transaction for redo txn={}",
+                transaction_id
+            )
+        })?;
+        anyhow::ensure!(
+            entry.partition_id() == self.local_partition_for_two_phase(),
+            "2PC redo txn={} belongs to partition {}, local partition is {}",
+            transaction_id,
+            entry.partition_id().0,
+            self.local_partition_for_two_phase().0,
+        );
+        self.stage_participant_prepared_transaction(
+            transaction_id,
+            transaction,
+            entry.write_source(),
+            prepare_ts,
+            require_leader,
+        )
+    }
+
+    fn stage_durable_two_phase_redo(
+        &mut self,
+        transaction_id: &crate::two_phase::TwoPhaseTransactionId,
+        require_leader: bool,
+    ) -> anyhow::Result<bool> {
+        if self.prepared_transactions.contains_key(transaction_id) {
+            return Ok(false);
+        }
+        let mut records = Self::block_on_current_runtime(Self::load_two_phase_redo_records(
+            self.persistence.clone(),
+        ))?;
+        let Some(entry) = records.remove(&transaction_id.0) else {
+            return Ok(false);
+        };
+        self.stage_two_phase_redo_entry(&entry, require_leader)
+            .with_context(|| format!("2PC: failed to stage durable redo txn={transaction_id}"))?;
+        Ok(true)
+    }
+
+    fn remove_prepared_transaction_at_ts(
+        &mut self,
+        commit_ts: Timestamp,
+    ) -> anyhow::Result<Option<crate::two_phase::TwoPhaseTransactionId>> {
+        let matching = self
+            .prepared_transactions
+            .iter()
+            .filter_map(|(transaction_id, prepared)| {
+                (prepared.commit_ts == commit_ts).then(|| transaction_id.clone())
+            })
+            .collect_vec();
+        anyhow::ensure!(
+            matching.len() <= 1,
+            "Found {} prepared transactions at ts={}; expected at most one",
+            matching.len(),
+            u64::from(commit_ts),
+        );
+        let Some(transaction_id) = matching.into_iter().next() else {
+            return Ok(None);
+        };
+        let prepared = self
+            .prepared_transactions
+            .remove(&transaction_id)
+            .ok_or_else(|| {
+                anyhow::anyhow!(
+                    "2PC cleanup: prepared transaction {} disappeared while cleaning ts={}",
+                    transaction_id,
+                    u64::from(commit_ts),
+                )
+            })?;
+        self.prepared_writes
+            .remove(prepared.prepared_write)
+            .ok_or_else(|| {
+                anyhow::anyhow!(
+                    "2PC cleanup: prepared intent for txn={} at ts={} was missing",
+                    transaction_id,
+                    u64::from(commit_ts),
+                )
+            })?;
+        Ok(Some(transaction_id))
     }
 
     async fn recover_two_phase_redo_records(&mut self) -> anyhow::Result<()> {
@@ -2899,15 +3094,10 @@ impl<RT: Runtime> Committer<RT> {
                 continue;
             }
 
-            self.stage_participant_prepared_transaction(
-                transaction_id.clone(),
-                transaction,
-                entry.write_source(),
-                prepare_ts,
-            )
-            .with_context(|| {
-                format!("2PC Recovery: failed to stage prepared txn={transaction_id}")
-            })?;
+            self.stage_two_phase_redo_entry(entry, false)
+                .with_context(|| {
+                    format!("2PC Recovery: failed to stage prepared txn={transaction_id}")
+                })?;
             tracing::info!(
                 "2PC Recovery: restored prepared txn={} at ts={}",
                 transaction_id,
@@ -2942,6 +3132,7 @@ impl<RT: Runtime> Committer<RT> {
             &transaction.table_mapping,
             write_source.clone(),
             None,
+            true,
         )?;
         let redo = crate::two_phase::TwoPhaseRedoEntry::new(
             &transaction_id,
@@ -2950,7 +3141,8 @@ impl<RT: Runtime> Committer<RT> {
             participant_transaction,
             &write_source,
         )?;
-        if let Err(err) = Self::persist_two_phase_redo(self.persistence.clone(), redo).await {
+        if let Err(err) = Self::persist_two_phase_redo(self.persistence.clone(), redo.clone()).await
+        {
             if let Err(rollback_err) = self.handle_rollback_prepared(transaction_id.clone()) {
                 tracing::error!(
                     "2PC Prepare: failed to rollback in-memory txn={} after redo write failure: \
@@ -2959,6 +3151,66 @@ impl<RT: Runtime> Committer<RT> {
                 );
             }
             return Err(err);
+        }
+        let raft_prepare_waiter = match self.propose_two_phase_prepare_to_raft(&redo) {
+            Ok(waiter) => waiter,
+            Err(err) => {
+                if let Err(rollback_err) = self.handle_rollback_prepared(transaction_id.clone()) {
+                    tracing::error!(
+                        "2PC Prepare: failed to rollback in-memory txn={} after Raft proposal \
+                         failure: {rollback_err:#}",
+                        transaction_id,
+                    );
+                }
+                if let Err(delete_err) =
+                    Self::delete_two_phase_redo(self.persistence.clone(), &transaction_id).await
+                {
+                    tracing::warn!(
+                        "2PC Prepare: failed to delete redo for txn={} after Raft proposal \
+                         failure: {delete_err:#}",
+                        transaction_id,
+                    );
+                }
+                return Err(err);
+            },
+        };
+        let raft_applied_index = match Self::wait_for_raft_prepare(
+            raft_prepare_waiter,
+            &transaction_id,
+            result.prepare_ts,
+        )
+        .await
+        {
+            Ok(index) => index,
+            Err(err) => {
+                if let Err(rollback_err) = self.handle_rollback_prepared(transaction_id.clone()) {
+                    tracing::error!(
+                        "2PC Prepare: failed to rollback in-memory txn={} after Raft quorum \
+                         failure: {rollback_err:#}",
+                        transaction_id,
+                    );
+                }
+                if let Err(delete_err) =
+                    Self::delete_two_phase_redo(self.persistence.clone(), &transaction_id).await
+                {
+                    tracing::warn!(
+                        "2PC Prepare: failed to delete redo for txn={} after Raft quorum failure: \
+                         {delete_err:#}",
+                        transaction_id,
+                    );
+                }
+                return Err(err);
+            },
+        };
+        if let Some(raft_applied_index) = raft_applied_index {
+            let Some(raft_state) = self.raft_state.as_ref() else {
+                anyhow::bail!(
+                    "2PC Prepare txn={} returned Raft applied index {} without Raft state",
+                    transaction_id,
+                    raft_applied_index,
+                );
+            };
+            raft_state.mark_applied(raft_applied_index).await?;
         }
         Ok(result)
     }
@@ -2989,8 +3241,10 @@ impl<RT: Runtime> Committer<RT> {
             transaction,
             write_source,
             prepare_ts,
+            true,
         )?;
-        if let Err(err) = Self::persist_two_phase_redo(self.persistence.clone(), redo).await {
+        if let Err(err) = Self::persist_two_phase_redo(self.persistence.clone(), redo.clone()).await
+        {
             if let Err(rollback_err) = self.handle_rollback_prepared(transaction_id.clone()) {
                 tracing::error!(
                     "2PC Prepare: failed to rollback in-memory txn={} after redo write failure: \
@@ -2999,6 +3253,66 @@ impl<RT: Runtime> Committer<RT> {
                 );
             }
             return Err(err);
+        }
+        let raft_prepare_waiter = match self.propose_two_phase_prepare_to_raft(&redo) {
+            Ok(waiter) => waiter,
+            Err(err) => {
+                if let Err(rollback_err) = self.handle_rollback_prepared(transaction_id.clone()) {
+                    tracing::error!(
+                        "2PC Prepare: failed to rollback in-memory txn={} after Raft proposal \
+                         failure: {rollback_err:#}",
+                        transaction_id,
+                    );
+                }
+                if let Err(delete_err) =
+                    Self::delete_two_phase_redo(self.persistence.clone(), &transaction_id).await
+                {
+                    tracing::warn!(
+                        "2PC Prepare: failed to delete redo for txn={} after Raft proposal \
+                         failure: {delete_err:#}",
+                        transaction_id,
+                    );
+                }
+                return Err(err);
+            },
+        };
+        let raft_applied_index = match Self::wait_for_raft_prepare(
+            raft_prepare_waiter,
+            &transaction_id,
+            result.prepare_ts,
+        )
+        .await
+        {
+            Ok(index) => index,
+            Err(err) => {
+                if let Err(rollback_err) = self.handle_rollback_prepared(transaction_id.clone()) {
+                    tracing::error!(
+                        "2PC Prepare: failed to rollback in-memory txn={} after Raft quorum \
+                         failure: {rollback_err:#}",
+                        transaction_id,
+                    );
+                }
+                if let Err(delete_err) =
+                    Self::delete_two_phase_redo(self.persistence.clone(), &transaction_id).await
+                {
+                    tracing::warn!(
+                        "2PC Prepare: failed to delete redo for txn={} after Raft quorum failure: \
+                         {delete_err:#}",
+                        transaction_id,
+                    );
+                }
+                return Err(err);
+            },
+        };
+        if let Some(raft_applied_index) = raft_applied_index {
+            let Some(raft_state) = self.raft_state.as_ref() else {
+                anyhow::bail!(
+                    "2PC Prepare txn={} returned Raft applied index {} without Raft state",
+                    transaction_id,
+                    raft_applied_index,
+                );
+            };
+            raft_state.mark_applied(raft_applied_index).await?;
         }
         Ok(result)
     }
@@ -3009,6 +3323,7 @@ impl<RT: Runtime> Committer<RT> {
         &mut self,
         transaction_id: crate::two_phase::TwoPhaseTransactionId,
     ) -> anyhow::Result<PublishedCommit> {
+        self.stage_durable_two_phase_redo(&transaction_id, true)?;
         let prepared = self
             .prepared_transactions
             .get(&transaction_id)
@@ -3116,6 +3431,19 @@ impl<RT: Runtime> Committer<RT> {
         &mut self,
         transaction_id: crate::two_phase::TwoPhaseTransactionId,
     ) -> anyhow::Result<()> {
+        if !self.prepared_transactions.contains_key(&transaction_id)
+            && Self::block_on_current_runtime(Self::load_two_phase_redo_records(
+                self.persistence.clone(),
+            ))?
+            .contains_key(&transaction_id.0)
+        {
+            tracing::info!(
+                "2PC RollbackPrepared: txn={} only existed as durable redo; deleting redo",
+                transaction_id,
+            );
+            return Ok(());
+        }
+
         let prepared = self
             .prepared_transactions
             .remove(&transaction_id)
@@ -3146,6 +3474,39 @@ impl<RT: Runtime> Committer<RT> {
             })?;
 
         Ok(())
+    }
+
+    fn handle_raft_prepared_redo(
+        &mut self,
+        redo: crate::two_phase::TwoPhaseRedoEntry,
+    ) -> anyhow::Result<crate::two_phase::PrepareResult> {
+        let transaction_id = redo.transaction_id();
+        let prepare_ts = redo.prepare_ts()?;
+        tracing::info!(
+            "2PC Raft Prepare Apply: txn={}, ts={}",
+            transaction_id,
+            u64::from(prepare_ts),
+        );
+
+        let result = self
+            .stage_two_phase_redo_entry(&redo, false)
+            .with_context(|| {
+                format!("2PC Raft Prepare Apply: failed to stage txn={transaction_id}")
+            })?;
+        if let Err(err) = Self::block_on_current_runtime(Self::persist_two_phase_redo(
+            self.persistence.clone(),
+            redo,
+        )) {
+            if let Err(rollback_err) = self.handle_rollback_prepared(transaction_id.clone()) {
+                tracing::error!(
+                    "2PC Raft Prepare Apply: failed to rollback in-memory txn={} after redo \
+                     persistence failure: {rollback_err:#}",
+                    transaction_id,
+                );
+            }
+            return Err(err);
+        }
+        Ok(result)
     }
 
     #[fastrace::trace]
@@ -3553,6 +3914,23 @@ impl CommitterClient {
     pub async fn apply_replica_delta(&self, delta: CommitDelta) -> anyhow::Result<Timestamp> {
         let (tx, rx) = oneshot::channel();
         let message = CommitterMessage::ApplyReplicaDelta { delta, result: tx };
+        self.sender.try_send(message).map_err(|e| match e {
+            TrySendError::Full(..) => metrics::committer_full_error().into(),
+            TrySendError::Closed(..) => metrics::shutdown_error(),
+        })?;
+        rx.await.map_err(|_| metrics::shutdown_error())?
+    }
+
+    /// Apply a 2PC prepare redo record that has reached this node through
+    /// Raft. This installs the prepared intent through the same single-writer
+    /// committer loop used by local prepares, so a promoted follower can
+    /// safely finish or roll back the transaction.
+    pub async fn apply_raft_prepared_redo(
+        &self,
+        redo: crate::two_phase::TwoPhaseRedoEntry,
+    ) -> anyhow::Result<crate::two_phase::PrepareResult> {
+        let (tx, rx) = oneshot::channel();
+        let message = CommitterMessage::ApplyRaftPreparedRedo { redo, result: tx };
         self.sender.try_send(message).map_err(|e| match e {
             TrySendError::Full(..) => metrics::committer_full_error().into(),
             TrySendError::Closed(..) => metrics::shutdown_error(),
@@ -4069,6 +4447,10 @@ enum CommitterMessage {
     ApplyReplicaDelta {
         delta: CommitDelta,
         result: oneshot::Sender<anyhow::Result<Timestamp>>,
+    },
+    ApplyRaftPreparedRedo {
+        redo: crate::two_phase::TwoPhaseRedoEntry,
+        result: oneshot::Sender<anyhow::Result<crate::two_phase::PrepareResult>>,
     },
     SetRaftState {
         raft_state: crate::raft_partition::RaftPartitionState,

--- a/crates/database/src/raft_state_machine.rs
+++ b/crates/database/src/raft_state_machine.rs
@@ -1,85 +1,118 @@
-//! State machine bridge: connects Raft committed entries to the Committer.
+//! Serializable entries applied by the Raft state machine.
 //!
-//! When a Raft entry is committed (replicated to a majority), it needs to be
-//! applied to the Convex state machine — the Committer's SnapshotManager,
-//! WriteLog, and Persistence. This module defines the serialization format
-//! for proposals and the apply logic.
-//!
-//! This is TiKV's Apply Worker pattern: committed Raft entries are decoded
-//! and applied to the local state machine in order.
-//!
-//! References:
-//!   - [TiKV: Raft in TiKV](https://www.pingcap.com/blog/raft-in-tikv/)
+//! Raft carries more than one kind of durable state-machine operation. Normal
+//! commits install [`CommitDelta`]s, while 2PC prepare entries install durable
+//! prepared redo records before a participant can acknowledge `Prepared`.
 
+use anyhow::Context;
 use serde::{
     Deserialize,
     Serialize,
 };
 
-/// A client mutation proposal serialized into a Raft log entry.
-///
-/// When a client sends a mutation to the Raft leader, the leader serializes
-/// it into a `RaftProposalData` and proposes it to Raft. Once committed
-/// (replicated to majority), the entry is deserialized and applied to the
-/// Committer on every node in the Raft group.
-#[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct RaftProposalData {
-    /// The mutation function path (e.g., "messages:send").
-    pub path: String,
-    /// Serialized function arguments.
-    pub args: String,
-    /// Write source identifier for logging.
-    pub write_source: String,
-    /// Unique proposal ID for matching responses.
-    pub proposal_id: String,
+use crate::{
+    commit_delta::CommitDelta,
+    nats_distributed_log::DeltaEnvelope,
+    two_phase::TwoPhaseRedoEntry,
+};
+
+/// Versioned Raft state-machine entry.
+#[derive(Serialize, Deserialize)]
+#[serde(tag = "type", content = "payload", rename_all = "snake_case")]
+pub enum RaftStateMachineEntry {
+    CommitDelta { envelope: DeltaEnvelope },
+    TwoPhasePrepare { redo: TwoPhaseRedoEntry },
 }
 
-impl RaftProposalData {
-    /// Serialize to bytes for Raft log entry.
-    pub fn to_bytes(&self) -> Vec<u8> {
-        serde_json::to_vec(self).expect("RaftProposalData serialization failed")
+impl RaftStateMachineEntry {
+    pub fn commit_delta(delta: &CommitDelta, source_raft_node_id: u64) -> anyhow::Result<Self> {
+        Ok(Self::CommitDelta {
+            envelope: DeltaEnvelope::from_delta(delta, "", Some(source_raft_node_id))?,
+        })
     }
 
-    /// Deserialize from Raft log entry bytes.
+    pub fn two_phase_prepare(redo: TwoPhaseRedoEntry) -> Self {
+        Self::TwoPhasePrepare { redo }
+    }
+
+    pub fn to_bytes(&self) -> anyhow::Result<Vec<u8>> {
+        serde_json::to_vec(self).context("Failed to serialize Raft state-machine entry")
+    }
+
     pub fn from_bytes(data: &[u8]) -> anyhow::Result<Self> {
-        serde_json::from_slice(data)
-            .map_err(|e| anyhow::anyhow!("Failed to deserialize RaftProposalData: {e}"))
+        match serde_json::from_slice(data) {
+            Ok(entry) => Ok(entry),
+            Err(entry_err) => {
+                // Backward compatibility: older Raft log entries were raw
+                // DeltaEnvelope JSON values without the typed wrapper.
+                let envelope: DeltaEnvelope = serde_json::from_slice(data).with_context(|| {
+                    format!(
+                        "Failed to deserialize typed Raft entry ({entry_err}) or legacy delta \
+                         envelope"
+                    )
+                })?;
+                Ok(Self::CommitDelta { envelope })
+            },
+        }
     }
-}
-
-/// Result of applying a committed Raft entry.
-#[derive(Debug)]
-pub enum ApplyResult {
-    /// The entry was applied successfully.
-    Success { proposal_id: String },
-    /// The entry failed to apply (OCC conflict, validation error, etc.).
-    /// The client should retry.
-    Error { proposal_id: String, error: String },
 }
 
 #[cfg(test)]
 mod tests {
+    use common::types::Timestamp;
+
     use super::*;
+    use crate::write_log::WriteSource;
 
     #[test]
-    fn test_proposal_roundtrip() {
-        let proposal = RaftProposalData {
-            path: "messages:send".to_string(),
-            args: r#"{"text":"hello","author":"test"}"#.to_string(),
-            write_source: "test".to_string(),
-            proposal_id: "abc-123".to_string(),
+    fn commit_delta_entry_roundtrips() -> anyhow::Result<()> {
+        let delta = CommitDelta {
+            ts: Timestamp::must(7),
+            document_writes: Default::default(),
+            document_updates: Vec::new(),
+            index_writes: Default::default(),
+            write_source: WriteSource::new("raft-entry-test"),
+            write_bytes: 0,
+            tablet_id_to_table_name: Default::default(),
+            source_partition: None,
         };
 
-        let bytes = proposal.to_bytes();
-        let decoded = RaftProposalData::from_bytes(&bytes).unwrap();
-
-        assert_eq!(decoded.path, "messages:send");
-        assert_eq!(decoded.proposal_id, "abc-123");
+        let bytes = RaftStateMachineEntry::commit_delta(&delta, 3)?.to_bytes()?;
+        match RaftStateMachineEntry::from_bytes(&bytes)? {
+            RaftStateMachineEntry::CommitDelta { envelope } => {
+                assert_eq!(envelope.source_raft_node_id(), Some(3));
+                assert_eq!(envelope.to_delta()?.ts, delta.ts);
+            },
+            RaftStateMachineEntry::TwoPhasePrepare { .. } => {
+                panic!("expected commit delta entry")
+            },
+        }
+        Ok(())
     }
 
     #[test]
-    fn test_proposal_invalid_bytes() {
-        let result = RaftProposalData::from_bytes(b"not json");
-        assert!(result.is_err());
+    fn legacy_delta_envelope_still_decodes_as_commit_delta() -> anyhow::Result<()> {
+        let delta = CommitDelta {
+            ts: Timestamp::must(8),
+            document_writes: Default::default(),
+            document_updates: Vec::new(),
+            index_writes: Default::default(),
+            write_source: WriteSource::new("legacy-raft-entry-test"),
+            write_bytes: 0,
+            tablet_id_to_table_name: Default::default(),
+            source_partition: None,
+        };
+        let legacy = serde_json::to_vec(&DeltaEnvelope::from_delta(&delta, "", Some(4))?)?;
+
+        match RaftStateMachineEntry::from_bytes(&legacy)? {
+            RaftStateMachineEntry::CommitDelta { envelope } => {
+                assert_eq!(envelope.source_raft_node_id(), Some(4));
+                assert_eq!(envelope.to_delta()?.ts, delta.ts);
+            },
+            RaftStateMachineEntry::TwoPhasePrepare { .. } => {
+                panic!("expected commit delta entry")
+            },
+        }
+        Ok(())
     }
 }

--- a/crates/database/src/tests/write_scaling_tests.rs
+++ b/crates/database/src/tests/write_scaling_tests.rs
@@ -113,6 +113,7 @@ use crate::{
         TwoPhaseCommitGrpcClient,
         TwoPhaseDecision,
         TwoPhaseDecisionLog,
+        TwoPhaseRedoEntry,
         TwoPhaseTransactionId,
     },
     Database,
@@ -1691,6 +1692,185 @@ async fn test_prepared_participant_recovers_from_redo_after_restart(
         .get_persistence_global(PersistenceGlobalKey::TwoPhaseRedoRecords)
         .await?;
     assert_eq!(redo, Some(serde_json::json!({})));
+    Ok(())
+}
+
+#[convex_macro::test_runtime]
+async fn test_raft_prepared_redo_apply_can_commit_after_failover(
+    rt: TestRuntime,
+) -> anyhow::Result<()> {
+    let log = Arc::new(InMemoryDistributedLog::new());
+    let node = create_node(&rt, log, Some(partitioned_map(PartitionId(1)))).await?;
+
+    let mut tx = node.begin(Identity::system()).await?;
+    TestFacingModel::new(&mut tx)
+        .insert(
+            &"projects".parse()?,
+            assert_obj!("name" => "raft-prepared-redo"),
+        )
+        .await?;
+    let final_tx = tx.finalize()?;
+    let write_indexes: Vec<_> = final_tx
+        .writes
+        .coalesced_writes()
+        .enumerate()
+        .map(|(index, _)| index)
+        .collect();
+    let write_source = WriteSource::new("raft_prepared_redo_apply_test");
+    let participant_tx = ParticipantTransaction::from_final_transaction(
+        &final_tx,
+        PartitionId(1),
+        &write_indexes,
+        &partitioned_map(PartitionId(1)),
+        &write_source,
+    )?;
+    let txn_id = TwoPhaseTransactionId::new();
+    let prepare_ts = node.committer_for_test().allocate_commit_ts().await?;
+    let redo = TwoPhaseRedoEntry::new(
+        &txn_id,
+        prepare_ts,
+        PartitionId(1),
+        participant_tx,
+        &write_source,
+    )?;
+
+    node.committer_for_test()
+        .apply_raft_prepared_redo(redo)
+        .await?;
+    let committed_ts = node
+        .committer_for_test()
+        .commit_prepared(txn_id.clone())
+        .await?;
+    assert_eq!(committed_ts, prepare_ts);
+
+    let projects = run_query(
+        node.clone(),
+        TableNamespace::root_component(),
+        Query::full_table_scan("projects".parse()?, Order::Asc),
+    )
+    .await?;
+    assert_eq!(projects.len(), 1);
+
+    let redo = node
+        .committer_for_test()
+        .persistence_reader()
+        .get_persistence_global(PersistenceGlobalKey::TwoPhaseRedoRecords)
+        .await?;
+    assert_eq!(redo, Some(serde_json::json!({})));
+    Ok(())
+}
+
+#[convex_macro::test_runtime]
+async fn test_raft_commit_delta_cleans_prepared_redo_on_follower(
+    rt: TestRuntime,
+) -> anyhow::Result<()> {
+    let log = Arc::new(InMemoryDistributedLog::new());
+    let table_number_allocator = Arc::new(InMemoryTableNumberAllocator::default());
+    let source = create_node_with_persistence_and_table_number_allocator(
+        &rt,
+        Arc::new(TestPersistence::new()),
+        log.clone(),
+        Some(partitioned_map(PartitionId(1))),
+        None,
+        Arc::new(NoopTwoPhaseDecisionLog),
+        None,
+        table_number_allocator.clone(),
+    )
+    .await?;
+    let follower = create_node_with_persistence_and_table_number_allocator(
+        &rt,
+        Arc::new(TestPersistence::new()),
+        log.clone(),
+        Some(partitioned_map(PartitionId(1))),
+        None,
+        Arc::new(NoopTwoPhaseDecisionLog),
+        None,
+        table_number_allocator,
+    )
+    .await?;
+
+    insert_doc(
+        &source,
+        "projects",
+        assert_obj!("name" => "seed-before-prepare"),
+    )
+    .await?;
+    let seed_delta = log
+        .deltas()
+        .into_iter()
+        .last()
+        .context("seed insert should publish a delta")?;
+    follower
+        .committer_for_test()
+        .apply_replica_delta(seed_delta)
+        .await?;
+
+    let mut tx = source.begin(Identity::system()).await?;
+    TestFacingModel::new(&mut tx)
+        .insert(
+            &"projects".parse()?,
+            assert_obj!("name" => "raft-commit-cleans-redo"),
+        )
+        .await?;
+    let final_tx = tx.finalize()?;
+    let write_indexes: Vec<_> = final_tx
+        .writes
+        .coalesced_writes()
+        .enumerate()
+        .map(|(index, _)| index)
+        .collect();
+    let write_source = WriteSource::new("raft_commit_delta_cleans_prepare_test");
+    let participant_tx = ParticipantTransaction::from_final_transaction(
+        &final_tx,
+        PartitionId(1),
+        &write_indexes,
+        &partitioned_map(PartitionId(1)),
+        &write_source,
+    )?;
+    let txn_id = TwoPhaseTransactionId::new();
+    let prepare_ts = source.committer_for_test().allocate_commit_ts().await?;
+    let redo = TwoPhaseRedoEntry::new(
+        &txn_id,
+        prepare_ts,
+        PartitionId(1),
+        participant_tx.clone(),
+        &write_source,
+    )?;
+
+    follower
+        .committer_for_test()
+        .apply_raft_prepared_redo(redo)
+        .await?;
+    source
+        .committer_for_test()
+        .prepare_remote(txn_id.clone(), participant_tx, write_source, prepare_ts)
+        .await?;
+    source.committer_for_test().commit_prepared(txn_id).await?;
+
+    let delta = log
+        .deltas()
+        .into_iter()
+        .last()
+        .context("prepared commit should publish a delta")?;
+    follower
+        .committer_for_test()
+        .apply_replica_delta(delta)
+        .await?;
+
+    let redo = follower
+        .committer_for_test()
+        .persistence_reader()
+        .get_persistence_global(PersistenceGlobalKey::TwoPhaseRedoRecords)
+        .await?;
+    assert_eq!(redo, Some(serde_json::json!({})));
+
+    insert_doc(
+        &follower,
+        "projects",
+        assert_obj!("name" => "after-raft-commit-cleanup"),
+    )
+    .await
+    .context("follower should accept local writes after Raft commit delta cleaned the prepare")?;
     Ok(())
 }
 

--- a/crates/local_backend/src/lib.rs
+++ b/crates/local_backend/src/lib.rs
@@ -906,6 +906,7 @@ pub async fn make_app(
         use database::{
             raft_node::RaftNodeConfig,
             raft_partition::RaftPartitionManager,
+            raft_state_machine::RaftStateMachineEntry,
             raft_storage::ConvexRaftStorage,
             raft_transport,
         };
@@ -984,10 +985,11 @@ pub async fn make_app(
 
         // Start the Raft node in a background task.
         // TiKV Apply Worker pattern: committed Raft entries are applied
-        // to the state machine. On the leader, the commit future waits for
-        // this Raft decision before applying locally, so on_committed skips
-        // only entries this node proposed. Followers deserialize the
-        // CommitDelta and apply it via apply_replica_delta.
+        // to the state machine. On the proposer, the future waits for this
+        // Raft decision before applying locally, so on_committed skips live
+        // local proposals. Followers deserialize typed entries and install
+        // either commit deltas or 2PC prepare redo records through the
+        // Committer loop.
         if let Some(mut node) = manager.take_node() {
             let committer = database.committer_client();
             let raft_state_for_apply = raft_state.clone();
@@ -995,33 +997,57 @@ pub async fn make_app(
                 if let Err(e) = node
                     .run(
                         |data| {
-                            // Deserialize the CommitDelta from the Raft entry.
-                            let envelope: database::nats_distributed_log::DeltaEnvelope =
-                                serde_json::from_slice(data).map_err(|e| {
-                                    anyhow::anyhow!("Failed to deserialize Raft entry: {e}")
-                                })?;
-                            let proposed_locally =
-                                envelope.source_raft_node_id() == Some(raft_node_id);
-                            let delta = envelope.to_delta()?;
+                            match RaftStateMachineEntry::from_bytes(data)? {
+                                RaftStateMachineEntry::CommitDelta { envelope } => {
+                                    let proposed_locally =
+                                        envelope.source_raft_node_id() == Some(raft_node_id);
+                                    let delta = envelope.to_delta()?;
 
-                            tracing::info!(
-                                "Applying committed Raft delta locally: ts={}, \
-                                 proposed_locally={}, leader_now={}",
-                                u64::from(delta.ts),
-                                proposed_locally,
-                                raft_state_for_apply.is_leader(),
-                            );
-                            // apply_replica_delta is async — use block_in_place
-                            // since we're in the Raft loop's sync callback.
-                            let committer = committer.clone();
-                            common::runtime::block_in_place(|| {
-                                let rt = tokio::runtime::Handle::current();
-                                rt.block_on(async {
-                                    committer.apply_replica_delta(delta).await.map_err(|e| {
-                                        anyhow::anyhow!("Raft state-machine apply failed: {e:#}")
-                                    })
-                                })
-                            })?;
+                                    tracing::info!(
+                                        "Applying committed Raft delta locally: ts={}, \
+                                         proposed_locally={}, leader_now={}",
+                                        u64::from(delta.ts),
+                                        proposed_locally,
+                                        raft_state_for_apply.is_leader(),
+                                    );
+                                    // apply_replica_delta is async — use block_in_place
+                                    // since we're in the Raft loop's sync callback.
+                                    let committer = committer.clone();
+                                    common::runtime::block_in_place(|| {
+                                        let rt = tokio::runtime::Handle::current();
+                                        rt.block_on(async {
+                                            committer.apply_replica_delta(delta).await.map_err(
+                                                |e| {
+                                                    anyhow::anyhow!(
+                                                        "Raft state-machine apply failed: {e:#}"
+                                                    )
+                                                },
+                                            )
+                                        })
+                                    })?;
+                                },
+                                RaftStateMachineEntry::TwoPhasePrepare { redo } => {
+                                    tracing::info!(
+                                        "Applying committed Raft 2PC prepare locally: txn={}, \
+                                         leader_now={}",
+                                        redo.transaction_id,
+                                        raft_state_for_apply.is_leader(),
+                                    );
+                                    let committer = committer.clone();
+                                    common::runtime::block_in_place(|| {
+                                        let rt = tokio::runtime::Handle::current();
+                                        rt.block_on(async {
+                                            committer.apply_raft_prepared_redo(redo).await.map_err(
+                                                |e| {
+                                                    anyhow::anyhow!(
+                                                        "Raft 2PC prepare apply failed: {e:#}"
+                                                    )
+                                                },
+                                            )
+                                        })
+                                    })?;
+                                },
+                            }
 
                             Ok(())
                         },

--- a/docs/issue-journal.md
+++ b/docs/issue-journal.md
@@ -672,6 +672,27 @@ own for distributed changes.
   - `cargo check -p database`
   - `cargo check -p local_backend`
 
+### 2026-06 — Replicated 2PC prepare redo through Raft before prepare ACK
+
+- **Status:** complete
+- **Related issue:** `#155`
+- **What this fixes:** 2PC participants previously acknowledged prepare after
+  staging an in-memory intent and writing only their local redo record. If the
+  participant leader failed before the final decision, the new Raft leader
+  could lack the prepared transaction needed to commit or roll it back.
+- **Behavior:** prepare records are now serialized as typed Raft
+  state-machine entries. A participant ACKs prepare only after the redo record
+  is locally durable and the prepare entry has reached Raft quorum. Followers
+  apply the Raft prepare through the committer loop, persist the redo, and stage
+  the prepared intent so a promoted follower can resolve the transaction.
+  Same-partition Raft commit deltas clean up the prepared intent and redo on
+  followers after the final commit applies.
+- **Validation:**
+  - `cargo test -p database raft_state_machine -- --nocapture`
+  - `cargo test -p database test_raft_ -- --nocapture`
+  - `cargo test -p database prepare -- --nocapture`
+  - `cargo check -p local_backend`
+
 ## Open Issues
 
 - `#74` is no longer blocked on follower self-sufficiency. The current


### PR DESCRIPTION
## Summary
- add typed Raft state-machine entries for commit deltas and 2PC prepare redo records, with legacy delta decoding preserved
- make prepare ACK wait for local redo durability plus Raft quorum, then mark the Raft prepare index applied
- apply Raft prepare redo through the committer loop and clean follower prepared intents when the same-partition commit delta applies

## Validation
- `cargo test -p database raft_state_machine -- --nocapture`
- `cargo test -p database test_raft_ -- --nocapture`
- `cargo test -p database prepare -- --nocapture`
- `cargo check -p database`
- `cargo check -p local_backend`

Closes #155