### PR TITLE
fix: resolve abandoned 2pc prepares

### DIFF
--- a/crates/database/src/committer.rs
+++ b/crates/database/src/committer.rs
@@ -970,6 +970,7 @@ impl<RT: Runtime> Committer<RT> {
                             transaction,
                             write_source,
                             prepare_ts,
+                            participants,
                             result,
                         }) => {
                             let r = self.handle_prepare_remote(
@@ -977,6 +978,7 @@ impl<RT: Runtime> Committer<RT> {
                                 transaction,
                                 write_source,
                                 prepare_ts,
+                                participants,
                             )
                             .await;
                             let _ = result.send(r);
@@ -3221,6 +3223,7 @@ impl<RT: Runtime> Committer<RT> {
         transaction: crate::two_phase::ParticipantTransaction,
         write_source: WriteSource,
         prepare_ts: Timestamp,
+        participants: Vec<crate::partition::PartitionId>,
     ) -> anyhow::Result<crate::two_phase::PrepareResult> {
         tracing::info!(
             "2PC Remote Prepare: txn={}, {} writes, prepare_ts={}",
@@ -3229,10 +3232,11 @@ impl<RT: Runtime> Committer<RT> {
             u64::from(prepare_ts),
         );
 
-        let redo = crate::two_phase::TwoPhaseRedoEntry::new(
+        let redo = crate::two_phase::TwoPhaseRedoEntry::new_with_participants(
             &transaction_id,
             prepare_ts,
             self.local_partition_for_two_phase(),
+            &participants,
             transaction.clone(),
             &write_source,
         )?;
@@ -4039,6 +4043,19 @@ impl CommitterClient {
         self.two_phase_decision_log.clone()
     }
 
+    pub(crate) async fn two_phase_redo_records(
+        &self,
+    ) -> anyhow::Result<BTreeMap<String, crate::two_phase::TwoPhaseRedoEntry>> {
+        let Some(value) = self
+            .persistence_reader
+            .get_persistence_global(PersistenceGlobalKey::TwoPhaseRedoRecords)
+            .await?
+        else {
+            return Ok(BTreeMap::new());
+        };
+        serde_json::from_value(value).context("2PC: Failed to parse durable redo records")
+    }
+
     async fn wait_for_remote_read_frontiers(
         &self,
         begin_ts: Timestamp,
@@ -4270,6 +4287,7 @@ impl CommitterClient {
         transaction: crate::two_phase::ParticipantTransaction,
         write_source: WriteSource,
         prepare_ts: Timestamp,
+        participants: Vec<crate::partition::PartitionId>,
     ) -> anyhow::Result<crate::two_phase::PrepareResult> {
         self.wait_for_remote_read_frontiers(
             *transaction.begin_timestamp,
@@ -4283,6 +4301,7 @@ impl CommitterClient {
             transaction,
             write_source,
             prepare_ts,
+            participants,
             result: tx,
         };
         self.sender.try_send(message).map_err(|e| match e {
@@ -4490,6 +4509,7 @@ enum CommitterMessage {
         transaction: crate::two_phase::ParticipantTransaction,
         write_source: WriteSource,
         prepare_ts: Timestamp,
+        participants: Vec<crate::partition::PartitionId>,
         result: oneshot::Sender<anyhow::Result<crate::two_phase::PrepareResult>>,
     },
     AllocateCommitTs {

--- a/crates/database/src/tests/write_scaling_tests.rs
+++ b/crates/database/src/tests/write_scaling_tests.rs
@@ -6,7 +6,13 @@
 //! pattern).
 
 use std::{
-    sync::Arc,
+    sync::{
+        atomic::{
+            AtomicBool,
+            Ordering,
+        },
+        Arc,
+    },
     time::Duration,
 };
 
@@ -271,6 +277,10 @@ fn partitioned_map_with_users_and_tasks(local_partition: PartitionId) -> Partiti
     PartitionMap::from_config("users=0,tasks=1", local_partition, 2)
 }
 
+fn three_partitioned_map(local_partition: PartitionId) -> PartitionMap {
+    PartitionMap::from_config("messages=0,projects=1,tasks=2", local_partition, 3)
+}
+
 async fn insert_doc_get_id(
     db: &Database<TestRuntime>,
     table: &str,
@@ -344,7 +354,13 @@ impl TwoPhaseCommitService for TestTwoPhaseCommitGrpcService {
 
         let result = self
             .committer
-            .prepare_remote(txn_id, transaction, req.write_source.into(), prepare_ts)
+            .prepare_remote(
+                txn_id,
+                transaction,
+                req.write_source.into(),
+                prepare_ts,
+                req.participants.iter().copied().map(PartitionId).collect(),
+            )
             .await
             .map_err(|e| Status::internal(format!("Prepare failed: {e:#}")))?;
 
@@ -444,6 +460,109 @@ impl TwoPhaseCommitService for FailingCommitAfterPrepareGrpcService {
         &self,
         _request: Request<TwoPcRollbackRequest>,
     ) -> Result<Response<TwoPcRollbackResponse>, Status> {
+        Ok(Response::new(TwoPcRollbackResponse {}))
+    }
+}
+
+struct FailingRollbackAfterPrepareGrpcService {
+    db: Database<TestRuntime>,
+    committer: CommitterClient,
+    local_partition: PartitionId,
+    fail_next_rollback: AtomicBool,
+}
+
+impl FailingRollbackAfterPrepareGrpcService {
+    fn new(db: Database<TestRuntime>, local_partition: PartitionId) -> Self {
+        Self {
+            committer: db.committer_for_test(),
+            db,
+            local_partition,
+            fail_next_rollback: AtomicBool::new(true),
+        }
+    }
+}
+
+#[tonic::async_trait]
+impl TwoPhaseCommitService for FailingRollbackAfterPrepareGrpcService {
+    async fn prepare(
+        &self,
+        request: Request<TwoPcPrepareRequest>,
+    ) -> Result<Response<TwoPcPrepareResponse>, Status> {
+        let req = request.into_inner();
+        let txn_id = TwoPhaseTransactionId(req.transaction_id);
+        let prepare_ts: Timestamp = req
+            .prepare_ts
+            .try_into()
+            .map_err(|e| Status::invalid_argument(format!("Invalid prepare timestamp: {e:#}")))?;
+        let write_source = WriteSource::new(req.write_source);
+        let mut tx =
+            self.db.begin(Identity::system()).await.map_err(|e| {
+                Status::internal(format!("Failed to begin local prepare tx: {e:#}"))
+            })?;
+        TestFacingModel::new(&mut tx)
+            .insert(
+                &"projects"
+                    .parse()
+                    .map_err(|e| Status::internal(format!("Invalid test table name: {e:#}")))?,
+                assert_obj!("name" => "prepared-before-rollback-rpc-failure"),
+            )
+            .await
+            .map_err(|e| Status::internal(format!("Failed to build local prepare tx: {e:#}")))?;
+        let final_tx = tx
+            .finalize()
+            .map_err(|e| Status::internal(format!("Failed to finalize local prepare tx: {e:#}")))?;
+        let write_indexes: Vec<_> = final_tx
+            .writes
+            .coalesced_writes()
+            .enumerate()
+            .map(|(index, _)| index)
+            .collect();
+        let partition_map = three_partitioned_map(self.local_partition);
+        let transaction = ParticipantTransaction::from_final_transaction(
+            &final_tx,
+            self.local_partition,
+            &write_indexes,
+            &partition_map,
+            &write_source,
+        )
+        .map_err(|e| Status::internal(format!("Failed to build local participant tx: {e:#}")))?;
+        let result = self
+            .committer
+            .prepare_remote(
+                txn_id,
+                transaction,
+                write_source,
+                prepare_ts,
+                req.participants.iter().copied().map(PartitionId).collect(),
+            )
+            .await
+            .map_err(|e| Status::internal(format!("Prepare failed: {e:#}")))?;
+        Ok(Response::new(TwoPcPrepareResponse {
+            prepare_ts: u64::from(result.prepare_ts),
+        }))
+    }
+
+    async fn commit_prepared(
+        &self,
+        _request: Request<TwoPcCommitRequest>,
+    ) -> Result<Response<TwoPcCommitResponse>, Status> {
+        Err(Status::failed_precondition(
+            "commit_prepared should not be called during rollback test",
+        ))
+    }
+
+    async fn rollback_prepared(
+        &self,
+        request: Request<TwoPcRollbackRequest>,
+    ) -> Result<Response<TwoPcRollbackResponse>, Status> {
+        if self.fail_next_rollback.swap(false, Ordering::SeqCst) {
+            return Err(Status::unavailable("forced rollback RPC failure"));
+        }
+        let req = request.into_inner();
+        self.committer
+            .rollback_prepared(TwoPhaseTransactionId(req.transaction_id))
+            .await
+            .map_err(|e| Status::internal(format!("RollbackPrepared failed: {e:#}")))?;
         Ok(Response::new(TwoPcRollbackResponse {}))
     }
 }
@@ -1659,6 +1778,7 @@ async fn test_prepared_participant_recovers_from_redo_after_restart(
             participant_tx,
             write_source.clone(),
             prepare_ts,
+            vec![PartitionId(1)],
         )
         .await?;
     node.shutdown().await?;
@@ -1843,7 +1963,13 @@ async fn test_raft_commit_delta_cleans_prepared_redo_on_follower(
         .await?;
     source
         .committer_for_test()
-        .prepare_remote(txn_id.clone(), participant_tx, write_source, prepare_ts)
+        .prepare_remote(
+            txn_id.clone(),
+            participant_tx,
+            write_source,
+            prepare_ts,
+            vec![PartitionId(1)],
+        )
         .await?;
     source.committer_for_test().commit_prepared(txn_id).await?;
 
@@ -2245,6 +2371,7 @@ fn test_remote_prepare_over_grpc_is_idempotent() -> anyhow::Result<()> {
                 write_source.clone(),
                 prepare_ts,
                 partition_map.placement_version(),
+                &[PartitionId(1)],
             )
             .await?;
         let second = client
@@ -2254,6 +2381,7 @@ fn test_remote_prepare_over_grpc_is_idempotent() -> anyhow::Result<()> {
                 write_source,
                 prepare_ts,
                 partition_map.placement_version(),
+                &[PartitionId(1)],
             )
             .await?;
 
@@ -2330,6 +2458,7 @@ fn test_remote_prepare_rejects_stale_placement_version() -> anyhow::Result<()> {
                 write_source,
                 prepare_ts,
                 stale_map.placement_version(),
+                &[PartitionId(1)],
             )
             .await
             .unwrap_err();
@@ -2554,6 +2683,186 @@ fn test_failed_remote_prepare_rolls_back_local_participant() -> anyhow::Result<(
         node_a.commit(retry_tx).await?;
 
         failing_server.shutdown().await?;
+        Ok(())
+    })
+}
+
+#[convex_macro::test_runtime]
+async fn test_watcher_rolls_back_abandoned_prepare_without_decision(
+    rt: TestRuntime,
+) -> anyhow::Result<()> {
+    let log = Arc::new(InMemoryDistributedLog::new());
+    let decision_log = Arc::new(InMemoryTwoPhaseDecisionLog::new());
+    let node = create_node_with_options_and_decision_log(
+        &rt,
+        log,
+        Some(partitioned_map(PartitionId(1))),
+        None,
+        None,
+        decision_log.clone(),
+    )
+    .await?;
+
+    let mut tx = node.begin(Identity::system()).await?;
+    TestFacingModel::new(&mut tx)
+        .insert(
+            &"projects".parse()?,
+            assert_obj!("name" => "abandoned-prepare"),
+        )
+        .await?;
+    let final_tx = tx.finalize()?;
+    let write_indexes: Vec<_> = final_tx
+        .writes
+        .coalesced_writes()
+        .enumerate()
+        .map(|(index, _)| index)
+        .collect();
+    let write_source = WriteSource::new("abandoned_prepare_timeout_test");
+    let participant_tx = ParticipantTransaction::from_final_transaction(
+        &final_tx,
+        PartitionId(1),
+        &write_indexes,
+        &partitioned_map(PartitionId(1)),
+        &write_source,
+    )?;
+    let txn_id = TwoPhaseTransactionId::new();
+    let prepare_ts = node.committer_for_test().allocate_commit_ts().await?;
+    node.committer_for_test()
+        .prepare_remote(
+            txn_id.clone(),
+            participant_tx,
+            write_source,
+            prepare_ts,
+            vec![PartitionId(1)],
+        )
+        .await?;
+
+    let resolved = crate::two_phase_watcher::rollback_expired_local_prepares(
+        &node.committer_for_test(),
+        PartitionId(1),
+        Duration::ZERO,
+    )
+    .await?;
+    assert_eq!(resolved, 1);
+
+    let decisions = decision_log.decisions();
+    let decision = decisions
+        .get(&txn_id.0)
+        .expect("watcher should write a durable rollback decision");
+    match decision {
+        TwoPhaseDecision::RolledBack { participants, .. } => {
+            assert_eq!(participants, &vec![1]);
+        },
+        other => panic!("expected rollback decision, got {other:?}"),
+    }
+
+    insert_doc(
+        &node,
+        "projects",
+        assert_obj!("name" => "after-abandoned-rollback"),
+    )
+    .await
+    .context("timed-out prepare should no longer block conflicting writes")?;
+    Ok(())
+}
+
+#[test]
+fn test_rollback_decision_survives_failed_rollback_rpc_for_watcher() -> anyhow::Result<()> {
+    let td = TestDriver::new_with_io();
+    let rt = td.rt();
+    td.run_until(async move {
+        let log = Arc::new(InMemoryDistributedLog::new());
+        let decision_log = Arc::new(InMemoryTwoPhaseDecisionLog::new());
+        let tso: Arc<dyn TimestampOracle> = Arc::new(InMemoryTimestampOracle::new());
+        let node_b = create_node_with_options_and_decision_log(
+            &rt,
+            log.clone(),
+            Some(three_partitioned_map(PartitionId(1))),
+            None,
+            Some(tso.clone()),
+            decision_log.clone(),
+        )
+        .await?;
+        let rollback_failing_server = start_two_pc_server(
+            FailingRollbackAfterPrepareGrpcService::new(node_b.clone(), PartitionId(1)),
+        )
+        .await?;
+        let prepare_failing_server = start_two_pc_server(FailingPrepareGrpcService).await?;
+        let node_a = create_node_with_options_and_decision_log(
+            &rt,
+            log.clone(),
+            Some(three_partitioned_map(PartitionId(0))),
+            Some(NodeAddresses::from_config(&format!(
+                "1={},2={}",
+                rollback_failing_server.addr(),
+                prepare_failing_server.addr(),
+            ))),
+            Some(tso),
+            decision_log.clone(),
+        )
+        .await?;
+
+        let mut tx = node_a.begin(Identity::system()).await?;
+        let mut model = TestFacingModel::new(&mut tx);
+        model
+            .insert(
+                &"projects".parse()?,
+                assert_obj!("name" => "prepared-before-rollback-rpc-failure"),
+            )
+            .await?;
+        model
+            .insert(
+                &"tasks".parse()?,
+                assert_obj!("title" => "force-later-prepare-failure"),
+            )
+            .await?;
+
+        let err = node_a
+            .commit(tx)
+            .await
+            .expect_err("second participant prepare failure should abort the 2PC transaction");
+        assert!(
+            format!("{err:#}").contains("forced prepare failure"),
+            "expected forced prepare failure, got: {err:#}",
+        );
+
+        let decisions = decision_log.decisions();
+        assert_eq!(decisions.len(), 1);
+        let (txn_id, decision) = decisions
+            .iter()
+            .next()
+            .expect("rollback decision should survive failed rollback RPC");
+        match decision {
+            TwoPhaseDecision::RolledBack { participants, .. } => {
+                assert!(
+                    participants.contains(&1),
+                    "rollback decision must include the prepared remote participant",
+                );
+                assert!(
+                    !participants.contains(&2),
+                    "rollback decision must not include the participant whose prepare failed",
+                );
+            },
+            other => panic!("expected rollback decision, got {other:?}"),
+        }
+
+        crate::two_phase_watcher::resolve_decision_for_local_partition(
+            &node_b.committer_for_test(),
+            PartitionId(1),
+            TwoPhaseTransactionId(txn_id.clone()),
+            decision.clone(),
+        )
+        .await;
+        insert_doc(
+            &node_b,
+            "projects",
+            assert_obj!("name" => "after-watcher-rollback"),
+        )
+        .await
+        .context("watcher recovery should clear the prepared remote participant")?;
+
+        rollback_failing_server.shutdown().await?;
+        prepare_failing_server.shutdown().await?;
         Ok(())
     })
 }

--- a/crates/database/src/two_phase.rs
+++ b/crates/database/src/two_phase.rs
@@ -17,7 +17,11 @@
 
 use std::{
     collections::BTreeMap,
-    time::Duration,
+    time::{
+        Duration,
+        SystemTime,
+        UNIX_EPOCH,
+    },
 };
 
 use anyhow::Context;
@@ -113,7 +117,7 @@ impl std::fmt::Display for TwoPhaseTransactionId {
 /// State of a 2PC transaction stored in NATS KV.
 /// This is the commit decision record — the point of no return.
 /// Follows Vitess's Metadata Manager (MM) pattern.
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub enum TwoPhaseDecision {
     /// All participants prepared successfully. Commit.
     Committed {
@@ -143,6 +147,10 @@ pub struct TwoPhaseRedoEntry {
     pub transaction_id: String,
     pub prepare_ts: u64,
     pub partition_id: u32,
+    #[serde(default)]
+    pub participants: Vec<u32>,
+    #[serde(default)]
+    pub prepared_at_unix_millis: Option<u64>,
     pub write_source: Option<String>,
     pub participant_transaction_hex: String,
 }
@@ -155,6 +163,24 @@ impl TwoPhaseRedoEntry {
         transaction: ParticipantTransaction,
         write_source: &WriteSource,
     ) -> anyhow::Result<Self> {
+        Self::new_with_participants(
+            transaction_id,
+            prepare_ts,
+            partition_id,
+            &[partition_id],
+            transaction,
+            write_source,
+        )
+    }
+
+    pub fn new_with_participants(
+        transaction_id: &TwoPhaseTransactionId,
+        prepare_ts: Timestamp,
+        partition_id: PartitionId,
+        participants: &[PartitionId],
+        transaction: ParticipantTransaction,
+        write_source: &WriteSource,
+    ) -> anyhow::Result<Self> {
         let proto = TwoPcParticipantTransactionProto::try_from(transaction)?;
         let mut bytes = Vec::new();
         proto
@@ -164,6 +190,8 @@ impl TwoPhaseRedoEntry {
             transaction_id: transaction_id.0.clone(),
             prepare_ts: u64::from(prepare_ts),
             partition_id: partition_id.0,
+            participants: participants.iter().map(|partition| partition.0).collect(),
+            prepared_at_unix_millis: Some(now_unix_millis()),
             write_source: write_source.as_str().map(str::to_string),
             participant_transaction_hex: hex::encode(bytes),
         })
@@ -181,6 +209,24 @@ impl TwoPhaseRedoEntry {
         PartitionId(self.partition_id)
     }
 
+    pub fn participants(&self) -> Vec<PartitionId> {
+        if self.participants.is_empty() {
+            vec![self.partition_id()]
+        } else {
+            self.participants.iter().copied().map(PartitionId).collect()
+        }
+    }
+
+    pub fn prepare_age(&self) -> Option<Duration> {
+        let prepared_at = self.prepared_at_unix_millis?;
+        let now = now_unix_millis();
+        Some(Duration::from_millis(now.saturating_sub(prepared_at)))
+    }
+
+    pub fn prepare_timed_out(&self, timeout: Duration) -> bool {
+        self.prepare_age().is_some_and(|age| age >= timeout)
+    }
+
     pub fn write_source(&self) -> WriteSource {
         WriteSource::from(self.write_source.clone())
     }
@@ -192,6 +238,15 @@ impl TwoPhaseRedoEntry {
             .context("2PC: Failed to parse participant transaction redo")?;
         ParticipantTransaction::try_from(proto)
     }
+}
+
+fn now_unix_millis() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis()
+        .try_into()
+        .unwrap_or(u64::MAX)
 }
 
 #[cfg(any(test, feature = "testing"))]
@@ -230,6 +285,27 @@ pub mod testing {
             Ok(())
         }
 
+        async fn write_decision_if_absent(
+            &self,
+            transaction_id: &TwoPhaseTransactionId,
+            decision: &TwoPhaseDecision,
+        ) -> anyhow::Result<bool> {
+            let mut decisions = self.decisions.lock();
+            if decisions.contains_key(&transaction_id.0) {
+                Ok(false)
+            } else {
+                decisions.insert(transaction_id.0.clone(), decision.clone());
+                Ok(true)
+            }
+        }
+
+        async fn get_decision(
+            &self,
+            transaction_id: &TwoPhaseTransactionId,
+        ) -> anyhow::Result<Option<TwoPhaseDecision>> {
+            Ok(self.decisions.lock().get(&transaction_id.0).cloned())
+        }
+
         async fn delete_decision(
             &self,
             transaction_id: &TwoPhaseTransactionId,
@@ -264,6 +340,22 @@ pub trait TwoPhaseDecisionLog: Send + Sync + 'static {
         decision: &TwoPhaseDecision,
     ) -> anyhow::Result<()>;
 
+    async fn write_decision_if_absent(
+        &self,
+        transaction_id: &TwoPhaseTransactionId,
+        decision: &TwoPhaseDecision,
+    ) -> anyhow::Result<bool> {
+        self.write_decision(transaction_id, decision).await?;
+        Ok(true)
+    }
+
+    async fn get_decision(
+        &self,
+        _transaction_id: &TwoPhaseTransactionId,
+    ) -> anyhow::Result<Option<TwoPhaseDecision>> {
+        Ok(None)
+    }
+
     async fn delete_decision(&self, transaction_id: &TwoPhaseTransactionId) -> anyhow::Result<()>;
 }
 
@@ -277,6 +369,14 @@ impl TwoPhaseDecisionLog for NoopTwoPhaseDecisionLog {
         _decision: &TwoPhaseDecision,
     ) -> anyhow::Result<()> {
         Ok(())
+    }
+
+    async fn write_decision_if_absent(
+        &self,
+        _transaction_id: &TwoPhaseTransactionId,
+        _decision: &TwoPhaseDecision,
+    ) -> anyhow::Result<bool> {
+        Ok(true)
     }
 
     async fn delete_decision(&self, _transaction_id: &TwoPhaseTransactionId) -> anyhow::Result<()> {
@@ -323,6 +423,40 @@ impl TwoPhaseDecisionLog for NatsTwoPhaseDecisionLog {
             .await
             .with_context(|| format!("2PC: Failed to write decision for {transaction_id}"))?;
         Ok(())
+    }
+
+    async fn write_decision_if_absent(
+        &self,
+        transaction_id: &TwoPhaseTransactionId,
+        decision: &TwoPhaseDecision,
+    ) -> anyhow::Result<bool> {
+        let payload = serde_json::to_vec(decision)
+            .with_context(|| format!("2PC: Failed to serialize decision for {transaction_id}"))?;
+        match self
+            .kv
+            .create(two_phase_decision_key(transaction_id), payload.into())
+            .await
+        {
+            Ok(_) => Ok(true),
+            Err(_) => Ok(false),
+        }
+    }
+
+    async fn get_decision(
+        &self,
+        transaction_id: &TwoPhaseTransactionId,
+    ) -> anyhow::Result<Option<TwoPhaseDecision>> {
+        let Some(entry) = self
+            .kv
+            .entry(two_phase_decision_key(transaction_id))
+            .await
+            .with_context(|| format!("2PC: Failed to read decision for {transaction_id}"))?
+        else {
+            return Ok(None);
+        };
+        serde_json::from_slice(&entry.value)
+            .with_context(|| format!("2PC: Failed to parse decision for {transaction_id}"))
+            .map(Some)
     }
 
     async fn delete_decision(&self, transaction_id: &TwoPhaseTransactionId) -> anyhow::Result<()> {
@@ -835,6 +969,7 @@ impl TwoPhaseCommitGrpcClient {
         write_source: WriteSource,
         prepare_ts: Timestamp,
         placement_version: crate::partition::PlacementVersion,
+        participants: &[PartitionId],
     ) -> anyhow::Result<PrepareResult> {
         let request = TwoPcPrepareRequest {
             transaction_id: transaction_id.0.clone(),
@@ -842,6 +977,7 @@ impl TwoPhaseCommitGrpcClient {
             write_source: write_source.as_str().unwrap_or_default().to_string(),
             prepare_ts: u64::from(prepare_ts),
             placement_version: u64::from(placement_version),
+            participants: participants.iter().map(|partition| partition.0).collect(),
         };
         let response = self
             .client

--- a/crates/database/src/two_phase_coordinator.rs
+++ b/crates/database/src/two_phase_coordinator.rs
@@ -120,6 +120,7 @@ async fn prepare_participant(
     node_addresses: Option<&NodeAddresses>,
     partition_map: &PartitionMap,
     transaction_id: &TwoPhaseTransactionId,
+    all_participants: &[PartitionId],
     participant: PartitionId,
     participant_tx: ParticipantTransaction,
     write_source: &WriteSource,
@@ -133,6 +134,7 @@ async fn prepare_participant(
                 participant_tx,
                 write_source.clone(),
                 prepare_ts,
+                all_participants.to_vec(),
             )
             .await?
     } else {
@@ -156,6 +158,7 @@ async fn prepare_participant(
                 write_source.clone(),
                 prepare_ts,
                 partition_map.placement_version(),
+                all_participants,
             )
             .await?
     };
@@ -235,10 +238,30 @@ async fn write_decision_record(
     transaction_id: &TwoPhaseTransactionId,
     decision: &TwoPhaseDecision,
 ) -> anyhow::Result<()> {
-    local_committer
-        .two_phase_decision_log()
-        .write_decision(transaction_id, decision)
-        .await
+    let decision_log = local_committer.two_phase_decision_log();
+    if decision_log
+        .write_decision_if_absent(transaction_id, decision)
+        .await?
+    {
+        return Ok(());
+    }
+    let existing = decision_log
+        .get_decision(transaction_id)
+        .await?
+        .with_context(|| {
+            format!(
+                "2PC Coordinator: decision for txn={transaction_id} already existed but could not \
+                 be read"
+            )
+        })?;
+    anyhow::ensure!(
+        existing == *decision,
+        "2PC Coordinator: durable decision for txn={} is already {:?}, cannot overwrite with {:?}",
+        transaction_id,
+        existing,
+        decision,
+    );
+    Ok(())
 }
 
 async fn delete_decision_record(
@@ -279,7 +302,6 @@ pub async fn coordinate_two_phase_commit(
     }
 
     let participant_indexes = participant_write_indexes(&transaction, partition_map, &write_source);
-    let txn_id = TwoPhaseTransactionId::new();
     let node_addresses = local_committer.node_addresses();
     let cluster_auth = local_committer.cluster_grpc_auth();
     let participants: Vec<_> = participant_indexes
@@ -297,11 +319,16 @@ pub async fn coordinate_two_phase_commit(
             ))
         })
         .collect::<anyhow::Result<_>>()?;
+    let all_participants: Vec<_> = participants
+        .iter()
+        .map(|(participant, _)| *participant)
+        .collect();
     metrics::log_two_phase_participants(participants.len());
 
     let mut last_retryable_error = None;
     let mut prepare_attempts = 0usize;
     for attempt in 0..MAX_PREPARE_TS_RETRIES {
+        let txn_id = TwoPhaseTransactionId::new();
         prepare_attempts = attempt + 1;
         let prepare_ts = local_committer.allocate_commit_ts().await?;
         tracing::info!(
@@ -320,6 +347,7 @@ pub async fn coordinate_two_phase_commit(
                 node_addresses,
                 partition_map,
                 &txn_id,
+                &all_participants,
                 *participant,
                 participant_tx.clone(),
                 &write_source,
@@ -337,7 +365,7 @@ pub async fn coordinate_two_phase_commit(
                     );
                     let retryable_prepare_ts_error =
                         is_retryable_prepare_ts_error(&err) && attempt + 1 < MAX_PREPARE_TS_RETRIES;
-                    if !retryable_prepare_ts_error && !prepared_participants.is_empty() {
+                    if !prepared_participants.is_empty() {
                         let decision = TwoPhaseDecision::RolledBack {
                             reason: err.to_string(),
                             participants: prepared_participants.iter().map(|p| p.0).collect(),
@@ -459,8 +487,8 @@ pub async fn coordinate_two_phase_commit(
     metrics::log_two_phase_prepare_attempts(prepare_attempts.max(1));
     Err(last_retryable_error.unwrap_or_else(|| {
         anyhow::anyhow!(
-            "2PC coordinator exhausted prepare timestamp retries for txn={}",
-            txn_id
+            "2PC coordinator exhausted prepare timestamp retries after {} attempt(s)",
+            prepare_attempts.max(1),
         )
     }))
 }

--- a/crates/database/src/two_phase_watcher.rs
+++ b/crates/database/src/two_phase_watcher.rs
@@ -21,11 +21,126 @@ use crate::{
     two_phase::{
         TwoPhaseDecision,
         TwoPhaseTransactionId,
+        PREPARE_TIMEOUT_SECS,
         TWO_PHASE_DECISION_TTL_SECS,
         TWO_PHASE_KV_BUCKET,
         TWO_PHASE_KV_PREFIX,
     },
 };
+
+/// Apply an existing durable 2PC decision to this local participant.
+pub async fn resolve_decision_for_local_partition(
+    committer: &CommitterClient,
+    local_partition: PartitionId,
+    txn_id: TwoPhaseTransactionId,
+    decision: TwoPhaseDecision,
+) {
+    match decision {
+        TwoPhaseDecision::Committed { participants, .. } => {
+            if !participants.contains(&local_partition.0) {
+                return;
+            }
+            // Transaction was committed but the coordinator may have crashed
+            // before sending CommitPrepared to all participants. Try to commit
+            // locally — if already committed, this is a no-op.
+            match committer.commit_prepared(txn_id.clone()).await {
+                Ok(ts) => {
+                    tracing::info!(
+                        "2PC Watcher: resolved committed txn={} at ts={}",
+                        txn_id,
+                        u64::from(ts),
+                    );
+                },
+                Err(e) => {
+                    // "unknown transaction" means it was already committed or
+                    // this participant never prepared.
+                    if e.to_string().contains("unknown transaction") {
+                        tracing::debug!(
+                            "2PC Watcher: committed txn={} already resolved locally",
+                            txn_id,
+                        );
+                    } else {
+                        tracing::debug!(
+                            "2PC Watcher: CommitPrepared for {txn_id} not ready: {e:#}"
+                        );
+                    }
+                },
+            }
+        },
+        TwoPhaseDecision::RolledBack { participants, .. } => {
+            if !participants.contains(&local_partition.0) {
+                return;
+            }
+            // Transaction was rolled back but cleanup may be incomplete.
+            match committer.rollback_prepared(txn_id.clone()).await {
+                Ok(()) | Err(_) => {
+                    tracing::debug!(
+                        "2PC Watcher: rolled back txn={} locally or it was already gone",
+                        txn_id,
+                    );
+                },
+            }
+        },
+    }
+}
+
+/// Resolve local prepared transactions that no longer have a coordinator
+/// decision. The watcher writes an authoritative rollback decision first, then
+/// applies that decision locally. The create-if-absent write prevents a timeout
+/// rollback from overwriting a coordinator's committed decision.
+pub async fn rollback_expired_local_prepares(
+    committer: &CommitterClient,
+    local_partition: PartitionId,
+    timeout: Duration,
+) -> anyhow::Result<usize> {
+    let records = committer.two_phase_redo_records().await?;
+    let decision_log = committer.two_phase_decision_log();
+    let mut resolved = 0usize;
+    for entry in records.values() {
+        if entry.partition_id() != local_partition || !entry.prepare_timed_out(timeout) {
+            continue;
+        }
+        let txn_id = entry.transaction_id();
+        let decision = match decision_log.get_decision(&txn_id).await? {
+            Some(decision) => decision,
+            None => {
+                let participants = entry
+                    .participants()
+                    .into_iter()
+                    .map(|partition| partition.0)
+                    .collect();
+                let rollback = TwoPhaseDecision::RolledBack {
+                    reason: format!(
+                        "2PC prepare timed out after {:?} without a durable coordinator decision",
+                        timeout,
+                    ),
+                    participants,
+                };
+                if decision_log
+                    .write_decision_if_absent(&txn_id, &rollback)
+                    .await?
+                {
+                    tracing::warn!(
+                        "2PC Watcher: wrote timeout rollback decision for abandoned txn={}",
+                        txn_id,
+                    );
+                    rollback
+                } else {
+                    decision_log.get_decision(&txn_id).await?.ok_or_else(|| {
+                        anyhow::anyhow!(
+                            "2PC Watcher: decision for txn={} appeared during timeout rollback \
+                             race but could not be read",
+                            txn_id,
+                        )
+                    })?
+                }
+            },
+        };
+        resolve_decision_for_local_partition(committer, local_partition, txn_id, decision).await;
+        resolved += 1;
+    }
+    Ok(resolved)
+}
 
 /// Start the transaction watcher as a background task.
 /// Periodically scans NATS KV for unresolved 2PC transactions.
@@ -105,53 +220,18 @@ pub fn start<RT: Runtime>(
                     },
                 };
 
-                match decision {
-                    TwoPhaseDecision::Committed { participants, .. } => {
-                        if !participants.contains(&local_partition.0) {
-                            continue;
-                        }
-                        // Transaction was committed but the coordinator may have
-                        // crashed before sending CommitPrepared to all participants.
-                        // Try to commit locally — if already committed, this is a no-op.
-                        match committer.commit_prepared(txn_id.clone()).await {
-                            Ok(ts) => {
-                                tracing::info!(
-                                    "2PC Watcher: resolved committed txn={} at ts={}",
-                                    txn_id,
-                                    u64::from(ts),
-                                );
-                            },
-                            Err(e) => {
-                                // "unknown transaction" means it was already committed.
-                                if e.to_string().contains("unknown transaction") {
-                                    tracing::debug!(
-                                        "2PC Watcher: committed txn={} already resolved locally",
-                                        txn_id,
-                                    );
-                                } else {
-                                    tracing::debug!(
-                                        "2PC Watcher: CommitPrepared for {txn_id} not ready: {e:#}"
-                                    );
-                                }
-                            },
-                        }
-                    },
-                    TwoPhaseDecision::RolledBack { participants, .. } => {
-                        if !participants.contains(&local_partition.0) {
-                            continue;
-                        }
-                        // Transaction was rolled back but cleanup may be incomplete.
-                        match committer.rollback_prepared(txn_id.clone()).await {
-                            Ok(()) | Err(_) => {
-                                tracing::debug!(
-                                    "2PC Watcher: rolled back txn={} locally or it was already \
-                                     gone",
-                                    txn_id,
-                                );
-                            },
-                        }
-                    },
-                }
+                resolve_decision_for_local_partition(&committer, local_partition, txn_id, decision)
+                    .await;
+            }
+
+            if let Err(err) = rollback_expired_local_prepares(
+                &committer,
+                local_partition,
+                Duration::from_secs(PREPARE_TIMEOUT_SECS),
+            )
+            .await
+            {
+                tracing::debug!("2PC Watcher: failed to resolve expired prepares: {err:#}");
             }
         }
     });

--- a/crates/local_backend/src/two_phase_service.rs
+++ b/crates/local_backend/src/two_phase_service.rs
@@ -180,6 +180,12 @@ impl TwoPhaseCommitService for TwoPhaseCommitGrpcService {
             .try_into()
             .map_err(|e| Status::invalid_argument(format!("Invalid prepare timestamp: {e:#}")))?;
         let placement_version = PlacementVersion::from(req.placement_version);
+        let participants = req
+            .participants
+            .iter()
+            .copied()
+            .map(database::partition::PartitionId)
+            .collect::<Vec<_>>();
         self.ensure_placement_version(placement_version).await?;
 
         if let Some(client) = self.leader_client().await? {
@@ -190,6 +196,7 @@ impl TwoPhaseCommitService for TwoPhaseCommitGrpcService {
                     req.write_source.into(),
                     prepare_ts,
                     placement_version,
+                    &participants,
                 )
                 .await
                 .map_err(|e| Status::internal(format!("Leader Prepare failed: {e:#}")))?;
@@ -200,7 +207,13 @@ impl TwoPhaseCommitService for TwoPhaseCommitGrpcService {
 
         let result = self
             .committer
-            .prepare_remote(txn_id, transaction, req.write_source.into(), prepare_ts)
+            .prepare_remote(
+                txn_id,
+                transaction,
+                req.write_source.into(),
+                prepare_ts,
+                participants,
+            )
             .await
             .map_err(|e| Status::internal(format!("Prepare failed: {e:#}")))?;
 

--- a/crates/pb/protos/replication.proto
+++ b/crates/pb/protos/replication.proto
@@ -143,6 +143,11 @@ message TwoPcPrepareRequest {
   // Participants reject mismatched versions so stale ownership maps cannot
   // prepare writes on the wrong partition during rebalancing.
   uint64 placement_version = 5;
+
+  // Full participant set for this 2PC attempt. Participants persist this in
+  // their redo record so a watcher can write an authoritative rollback
+  // decision if the coordinator disappears after prepare ACK.
+  repeated uint32 participants = 6;
 }
 
 message TwoPcPrepareResponse {

--- a/docs/issue-journal.md
+++ b/docs/issue-journal.md
@@ -693,6 +693,27 @@ own for distributed changes.
   - `cargo test -p database prepare -- --nocapture`
   - `cargo check -p local_backend`
 
+### 2026-06 — Resolved abandoned 2PC prepares with durable rollback decisions
+
+- **Status:** complete
+- **Related issue:** `#158`
+- **What this fixes:** prepared 2PC participants could be abandoned if the
+  coordinator disappeared after `Prepare` or if rollback RPC delivery failed
+  during a prepare-abort path. `PREPARE_TIMEOUT_SECS` existed, but the watcher
+  only scanned existing decision records and never created a durable rollback
+  decision for orphaned redo records.
+- **Behavior:** prepare redo records now include the full participant set and
+  prepare wall-clock time. Prepare requests carry that participant set to
+  remote nodes. Failed prepare paths write a durable rollback decision before
+  sending rollback RPCs, and the watcher scans local redo records for timed-out
+  prepares, writes a rollback decision if none exists, and resolves the local
+  participant from that decision.
+- **Validation:**
+  - `cargo test -p database rollback_decision -- --nocapture`
+  - `cargo test -p database prepare -- --nocapture`
+  - `cargo check -p database`
+  - `cargo check -p local_backend`
+
 ## Open Issues
 
 - `#74` is no longer blocked on follower self-sufficiency. The current


### PR DESCRIPTION
## Summary
- persist the full participant set and prepare wall-clock time in 2PC redo records
- propagate participant lists through prepare RPCs so watchers can write authoritative rollback decisions
- write rollback decisions before rollback RPCs on prepare-abort paths and let watchers time out orphaned prepares
- add tests for abandoned prepares and failed rollback RPC recovery

## Validation
- `cargo test -p database rollback_decision -- --nocapture`
- `cargo test -p database prepare -- --nocapture`
- `cargo check -p database`
- `cargo check -p local_backend`
- `git diff --check`

Closes #158