### PR TITLE
fix: apply full raft state on followers

### DIFF
--- a/crates/database/src/committer.rs
+++ b/crates/database/src/committer.rs
@@ -894,8 +894,14 @@ impl<RT: Runtime> Committer<RT> {
                                 span_commit_id = None;
                             }
                         },
-                        Some(CommitterMessage::ApplyReplicaDelta { delta, result }) => {
-                            if let Err(e) = self.apply_replica_delta(delta, result, commit_id) {
+                        Some(CommitterMessage::ApplyReplicaDelta {
+                            delta,
+                            mode,
+                            result,
+                        }) => {
+                            if let Err(e) =
+                                self.apply_replica_delta(delta, mode, result, commit_id)
+                            {
                                 tracing::error!("Failed to queue replica delta for apply: {e:#}");
                             } else {
                                 commit_id += 1;
@@ -2352,6 +2358,7 @@ impl<RT: Runtime> Committer<RT> {
     fn apply_replica_delta(
         &mut self,
         delta: CommitDelta,
+        mode: ReplicaDeltaApplyMode,
         result: oneshot::Sender<anyhow::Result<Timestamp>>,
         commit_id: usize,
     ) -> anyhow::Result<()> {
@@ -2420,31 +2427,16 @@ impl<RT: Runtime> Committer<RT> {
             remap
         };
 
-        // Classify each update as user-relevant or node-local.
+        // Classify each update for the selected replication scope.
         //
-        // CockroachDB GLOBAL table locality pattern: system tables are split
-        // into two categories (see pkg/sql/catalog/systemschema/system.go):
+        // Cross-partition NATS replication follows CockroachDB GLOBAL table
+        // locality: user data and globally needed deployment metadata are
+        // replicated, while node-local system state is filtered out.
         //
-        //   GLOBAL (replicated via Raft to all nodes):
-        //     system.descriptor, system.namespace, system.users, system.zones,
-        //     system.settings, system.role_members — schema and auth metadata
-        //     needed by every node to serve queries.
-        //
-        //   NODE-LOCAL (per-range operational state):
-        //     system.lease, system.sqlliveness, system.jobs,
-        //     system.statement_statistics — ephemeral per-node state.
-        //
-        // YugabyteDB uses a dedicated system catalog tablet (Raft-replicated)
-        // for pg_class, pg_attribute, pg_proc (stored procedures/functions).
-        // TiDB stores all metadata in TiKV (Raft-replicated) with schema
-        // version polling via tidb_schema_lease.
-        //
-        // Categories for Convex:
-        //   1. _tables entries for user tables → Phase 1 (table creation)
-        //   2. _index entries for user tables → Phase 2 (index creation)
-        //   3. User table document data → Phase 2 (data replication)
-        //   4. GLOBAL deployment tables → Phase 2 (function/schema replication)
-        //   5. Everything else (node-local system data) → SKIP
+        // Same-partition Raft replication is different: followers are HA
+        // copies that may become leader, so they must apply the full
+        // authoritative state, including system tables intentionally skipped
+        // by cross-partition read replicas.
         //
         // The key insight: we classify by what the data DESCRIBES, not by
         // which system table it's stored in. An _index entry creating
@@ -2483,54 +2475,67 @@ impl<RT: Runtime> Committer<RT> {
             let primary_tablet = update.id.tablet_id;
             let table_name = delta.tablet_id_to_table_name.get(&primary_tablet);
 
-            if table_name.map(|n| n == tables_table_name).unwrap_or(false) {
-                // _tables entry: kept for Phase 1 (user table creation).
-                // System table entries will be skipped in Phase 1 by the
-                // table_exists check.
-                tables_updates.push(update);
-            } else if table_name.map(|n| n == index_table_name).unwrap_or(false) {
-                // _index entry: check if it describes a user table index
-                // or a GLOBAL deployment table index.
-                let is_replicated_index = update.new_document.as_ref().map_or(false, |doc| {
-                    doc.value()
-                        .0
-                        .get(&"table_id".parse::<common::types::FieldName>().unwrap())
-                        .and_then(|v| {
-                            if let value::ConvexValue::String(s) = v {
-                                let tid: Result<value::TabletId, _> = s.parse();
-                                tid.ok()
-                            } else {
-                                None
-                            }
-                        })
-                        .map_or(false, |tid| {
-                            delta
-                                .tablet_id_to_table_name
-                                .get(&tid)
-                                .map_or(false, |name| {
-                                    !name.is_system() || is_global_deployment_table(name)
-                                })
-                        })
-                });
-                if is_replicated_index {
-                    other_updates.push(update);
-                } else {
-                    skipped_system += 1;
-                }
-            } else if table_name.map(|n| !n.is_system()).unwrap_or(false) {
-                // User table data: replicate.
-                other_updates.push(update);
-            } else if table_name
-                .map(|n| is_global_deployment_table(n))
-                .unwrap_or(false)
-            {
-                // GLOBAL deployment system table: replicate.
-                // These contain function code and config needed by every node
-                // to execute queries and mutations (CockroachDB GLOBAL pattern).
-                other_updates.push(update);
-            } else {
-                // Node-local system data: skip.
-                skipped_system += 1;
+            match mode {
+                ReplicaDeltaApplyMode::FullRaftState => {
+                    if table_name.map(|n| n == tables_table_name).unwrap_or(false) {
+                        tables_updates.push(update);
+                    } else {
+                        other_updates.push(update);
+                    }
+                },
+                ReplicaDeltaApplyMode::CrossPartitionReplica => {
+                    if table_name.map(|n| n == tables_table_name).unwrap_or(false) {
+                        // _tables entry: kept for Phase 1 (user table creation).
+                        // System table entries will be skipped in Phase 1 by the
+                        // table_exists check.
+                        tables_updates.push(update);
+                    } else if table_name.map(|n| n == index_table_name).unwrap_or(false) {
+                        // _index entry: check if it describes a user table index
+                        // or a GLOBAL deployment table index.
+                        let is_replicated_index =
+                            update.new_document.as_ref().map_or(false, |doc| {
+                                doc.value()
+                                    .0
+                                    .get(&"table_id".parse::<common::types::FieldName>().unwrap())
+                                    .and_then(|v| {
+                                        if let value::ConvexValue::String(s) = v {
+                                            let tid: Result<value::TabletId, _> = s.parse();
+                                            tid.ok()
+                                        } else {
+                                            None
+                                        }
+                                    })
+                                    .map_or(false, |tid| {
+                                        delta.tablet_id_to_table_name.get(&tid).map_or(
+                                            false,
+                                            |name| {
+                                                !name.is_system()
+                                                    || is_global_deployment_table(name)
+                                            },
+                                        )
+                                    })
+                            });
+                        if is_replicated_index {
+                            other_updates.push(update);
+                        } else {
+                            skipped_system += 1;
+                        }
+                    } else if table_name.map(|n| !n.is_system()).unwrap_or(false) {
+                        // User table data: replicate.
+                        other_updates.push(update);
+                    } else if table_name
+                        .map(|n| is_global_deployment_table(n))
+                        .unwrap_or(false)
+                    {
+                        // GLOBAL deployment system table: replicate.
+                        // These contain function code and config needed by every node
+                        // to execute queries and mutations (CockroachDB GLOBAL pattern).
+                        other_updates.push(update);
+                    } else {
+                        // Node-local system data: skip for cross-partition replicas.
+                        skipped_system += 1;
+                    }
+                },
             }
         }
         if skipped_system > 0 {
@@ -3913,11 +3918,35 @@ impl CommitterClient {
     }
 
     /// Send a replica delta through the Committer's apply loop.
-    /// Called by the ReplicaSnapshotUpdater to feed NATS deltas into the
-    /// single-writer state machine.
+    /// Called by the NATS replica consumer to feed cross-partition deltas into
+    /// the single-writer state machine. This path intentionally filters
+    /// node-local system tables that are not part of cross-partition read
+    /// replication.
     pub async fn apply_replica_delta(&self, delta: CommitDelta) -> anyhow::Result<Timestamp> {
+        self.apply_delta_with_mode(delta, ReplicaDeltaApplyMode::CrossPartitionReplica)
+            .await
+    }
+
+    /// Apply a same-partition Raft commit delta through the Committer's apply
+    /// loop. Unlike cross-partition NATS replication, Raft followers are HA
+    /// copies that can become leader, so this path applies full partition
+    /// state including system tables.
+    pub async fn apply_raft_commit_delta(&self, delta: CommitDelta) -> anyhow::Result<Timestamp> {
+        self.apply_delta_with_mode(delta, ReplicaDeltaApplyMode::FullRaftState)
+            .await
+    }
+
+    async fn apply_delta_with_mode(
+        &self,
+        delta: CommitDelta,
+        mode: ReplicaDeltaApplyMode,
+    ) -> anyhow::Result<Timestamp> {
         let (tx, rx) = oneshot::channel();
-        let message = CommitterMessage::ApplyReplicaDelta { delta, result: tx };
+        let message = CommitterMessage::ApplyReplicaDelta {
+            delta,
+            mode,
+            result: tx,
+        };
         self.sender.try_send(message).map_err(|e| match e {
             TrySendError::Full(..) => metrics::committer_full_error().into(),
             TrySendError::Closed(..) => metrics::shutdown_error(),
@@ -4452,6 +4481,12 @@ impl CommitterClient {
     }
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum ReplicaDeltaApplyMode {
+    CrossPartitionReplica,
+    FullRaftState,
+}
+
 enum CommitterMessage {
     Commit {
         queue_timer: Timer<VMHistogram>,
@@ -4465,6 +4500,7 @@ enum CommitterMessage {
     /// Goes through the same serial apply loop as local commits.
     ApplyReplicaDelta {
         delta: CommitDelta,
+        mode: ReplicaDeltaApplyMode,
         result: oneshot::Sender<anyhow::Result<Timestamp>>,
     },
     ApplyRaftPreparedRedo {

--- a/crates/database/src/tests/write_scaling_tests.rs
+++ b/crates/database/src/tests/write_scaling_tests.rs
@@ -123,6 +123,8 @@ use crate::{
         TwoPhaseTransactionId,
     },
     Database,
+    SystemMetadataModel,
+    TableModel,
     TestFacingModel,
     UserFacingModel,
     WriteSource,
@@ -308,6 +310,22 @@ async fn insert_doc(
     db.commit(tx).await
 }
 
+async fn insert_global_system_doc(
+    db: &Database<TestRuntime>,
+    table: &str,
+    fields: common::value::DocumentObject,
+) -> anyhow::Result<common::types::Timestamp> {
+    let table_name: TableName = table.parse()?;
+    let mut tx = db.begin(Identity::system()).await?;
+    TableModel::new(&mut tx)
+        .insert_table_metadata_for_test(TableNamespace::Global, &table_name)
+        .await?;
+    SystemMetadataModel::new_global(&mut tx)
+        .insert(&table_name, fields)
+        .await?;
+    db.commit(tx).await
+}
+
 async fn persisted_document_log_count(tp: &Arc<TestPersistence>) -> anyhow::Result<usize> {
     Ok(tp
         .load_documents(
@@ -319,6 +337,23 @@ async fn persisted_document_log_count(tp: &Arc<TestPersistence>) -> anyhow::Resu
         .try_collect::<Vec<_>>()
         .await?
         .len())
+}
+
+async fn global_table_scan_or_empty(
+    db: Database<TestRuntime>,
+    table: &str,
+) -> anyhow::Result<Vec<common::document::ResolvedDocument>> {
+    match run_query(
+        db,
+        TableNamespace::Global,
+        Query::full_table_scan(table.parse()?, Order::Asc),
+    )
+    .await
+    {
+        Ok(results) => Ok(results),
+        Err(err) if format!("{err:#}").contains("cannot find table") => Ok(Vec::new()),
+        Err(err) => Err(err),
+    }
 }
 
 struct TestTwoPhaseCommitGrpcService {
@@ -1726,6 +1761,55 @@ async fn test_replica_delta_fails_for_unmapped_user_table(rt: TestRuntime) -> an
             .replication_frontier_for_test(PartitionId(1))
             .is_some_and(|frontier| frontier > Timestamp::MIN),
         "retry after metadata should apply and advance the frontier",
+    );
+
+    Ok(())
+}
+
+#[convex_macro::test_runtime]
+async fn test_raft_delta_apply_preserves_full_system_state(rt: TestRuntime) -> anyhow::Result<()> {
+    let log = Arc::new(InMemoryDistributedLog::new());
+    let leader = create_node(&rt, log.clone(), Some(partitioned_map(PartitionId(0)))).await?;
+    let nats_replica = create_node(&rt, log.clone(), Some(partitioned_map(PartitionId(1)))).await?;
+    let raft_follower =
+        create_node(&rt, log.clone(), Some(partitioned_map(PartitionId(0)))).await?;
+
+    insert_global_system_doc(
+        &leader,
+        "_environment_variables",
+        assert_obj!("name" => "RAFT_FULL_STATE_TEST", "value" => "enabled"),
+    )
+    .await?;
+    let system_delta = log
+        .deltas()
+        .into_iter()
+        .last()
+        .expect("system metadata commit should publish a delta");
+
+    nats_replica
+        .committer_for_test()
+        .apply_replica_delta(system_delta.clone())
+        .await?;
+    let cross_partition_docs =
+        global_table_scan_or_empty(nats_replica, "_environment_variables").await?;
+    assert!(
+        cross_partition_docs.is_empty(),
+        "cross-partition NATS apply should continue filtering node-local system state",
+    );
+
+    raft_follower
+        .committer_for_test()
+        .apply_raft_commit_delta(system_delta)
+        .await?;
+    let raft_docs = global_table_scan_or_empty(raft_follower, "_environment_variables").await?;
+    assert_eq!(
+        raft_docs.len(),
+        1,
+        "same-partition Raft apply must preserve full system state for failover",
+    );
+    assert_eq!(
+        raft_docs[0].value().0.get("name"),
+        Some(&assert_val!("RAFT_FULL_STATE_TEST")),
     );
 
     Ok(())

--- a/crates/local_backend/src/lib.rs
+++ b/crates/local_backend/src/lib.rs
@@ -1016,7 +1016,7 @@ pub async fn make_app(
                                     common::runtime::block_in_place(|| {
                                         let rt = tokio::runtime::Handle::current();
                                         rt.block_on(async {
-                                            committer.apply_replica_delta(delta).await.map_err(
+                                            committer.apply_raft_commit_delta(delta).await.map_err(
                                                 |e| {
                                                     anyhow::anyhow!(
                                                         "Raft state-machine apply failed: {e:#}"

--- a/docs/issue-journal.md
+++ b/docs/issue-journal.md
@@ -714,6 +714,26 @@ own for distributed changes.
   - `cargo check -p database`
   - `cargo check -p local_backend`
 
+### 2026-06 — Split Raft full-state apply from cross-partition replica filtering
+
+- **Status:** complete
+- **Related issue:** `#157`
+- **What this fixes:** same-partition Raft followers were applying committed
+  leader deltas through the same filtered path used by cross-partition NATS
+  read replicas. That path intentionally drops node-local system tables, but a
+  Raft follower must have the full authoritative partition state before it can
+  safely become leader.
+- **Behavior:** the committer now distinguishes cross-partition replica apply
+  from same-partition Raft apply. NATS-delivered deltas keep the existing
+  user/global-deployment filtering. Raft committed deltas use full-state apply,
+  preserving system-table updates needed for failover while still flowing
+  through the same serialized committer/persistence pipeline.
+- **Validation:**
+  - `cargo test -p database test_raft_delta_apply_preserves_full_system_state -- --nocapture`
+  - `cargo test -p database test_raft_ -- --nocapture`
+  - `cargo check -p database`
+  - `cargo check -p local_backend`
+
 ## Open Issues
 
 - `#74` is no longer blocked on follower self-sufficiency. The current


### PR DESCRIPTION
## Summary
- split replicated delta apply into cross-partition NATS mode and same-partition Raft full-state mode
- keep NATS filtering for node-local system tables while preserving full system-table state on Raft followers
- switch Raft committed-delta callback to the full-state apply path
- add a regression test proving `_environment_variables` is filtered by NATS apply but preserved by Raft apply

## Validation
- `cargo test -p database test_raft_delta_apply_preserves_full_system_state -- --nocapture`
- `cargo test -p database test_raft_ -- --nocapture`
- `cargo check -p database`
- `cargo check -p local_backend`
- `git diff --check`

Closes #157