### PR TITLE
fix: retain 2pc decisions until resolved

### DIFF
--- a/crates/database/src/committer.rs
+++ b/crates/database/src/committer.rs
@@ -3450,6 +3450,10 @@ impl<RT: Runtime> Committer<RT> {
                 "2PC RollbackPrepared: txn={} only existed as durable redo; deleting redo",
                 transaction_id,
             );
+            Self::block_on_current_runtime(Self::delete_two_phase_redo(
+                self.persistence.clone(),
+                &transaction_id,
+            ))?;
             return Ok(());
         }
 

--- a/crates/database/src/tests/write_scaling_tests.rs
+++ b/crates/database/src/tests/write_scaling_tests.rs
@@ -463,42 +463,6 @@ impl TwoPhaseCommitService for FailingPrepareGrpcService {
     }
 }
 
-struct FailingCommitAfterPrepareGrpcService;
-
-#[tonic::async_trait]
-impl TwoPhaseCommitService for FailingCommitAfterPrepareGrpcService {
-    async fn prepare(
-        &self,
-        request: Request<TwoPcPrepareRequest>,
-    ) -> Result<Response<TwoPcPrepareResponse>, Status> {
-        let req = request.into_inner();
-        let prepare_ts: Timestamp = req
-            .prepare_ts
-            .try_into()
-            .map_err(|e| Status::invalid_argument(format!("Invalid prepare timestamp: {e:#}")))?;
-
-        Ok(Response::new(TwoPcPrepareResponse {
-            prepare_ts: u64::from(prepare_ts),
-        }))
-    }
-
-    async fn commit_prepared(
-        &self,
-        _request: Request<TwoPcCommitRequest>,
-    ) -> Result<Response<TwoPcCommitResponse>, Status> {
-        Err(Status::unavailable(
-            "forced commit failure after durable decision",
-        ))
-    }
-
-    async fn rollback_prepared(
-        &self,
-        _request: Request<TwoPcRollbackRequest>,
-    ) -> Result<Response<TwoPcRollbackResponse>, Status> {
-        Ok(Response::new(TwoPcRollbackResponse {}))
-    }
-}
-
 struct FailingRollbackAfterPrepareGrpcService {
     db: Database<TestRuntime>,
     committer: CommitterClient,
@@ -514,6 +478,117 @@ impl FailingRollbackAfterPrepareGrpcService {
             local_partition,
             fail_next_rollback: AtomicBool::new(true),
         }
+    }
+}
+
+struct FailingCommitAfterLocalPrepareGrpcService {
+    db: Database<TestRuntime>,
+    committer: CommitterClient,
+    local_partition: PartitionId,
+    fail_next_commit: AtomicBool,
+}
+
+impl FailingCommitAfterLocalPrepareGrpcService {
+    fn new(db: Database<TestRuntime>, local_partition: PartitionId) -> Self {
+        Self {
+            committer: db.committer_for_test(),
+            db,
+            local_partition,
+            fail_next_commit: AtomicBool::new(true),
+        }
+    }
+}
+
+#[tonic::async_trait]
+impl TwoPhaseCommitService for FailingCommitAfterLocalPrepareGrpcService {
+    async fn prepare(
+        &self,
+        request: Request<TwoPcPrepareRequest>,
+    ) -> Result<Response<TwoPcPrepareResponse>, Status> {
+        let req = request.into_inner();
+        let txn_id = TwoPhaseTransactionId(req.transaction_id);
+        let prepare_ts: Timestamp = req
+            .prepare_ts
+            .try_into()
+            .map_err(|e| Status::invalid_argument(format!("Invalid prepare timestamp: {e:#}")))?;
+        let write_source = WriteSource::new(req.write_source);
+        let mut tx =
+            self.db.begin(Identity::system()).await.map_err(|e| {
+                Status::internal(format!("Failed to begin local prepare tx: {e:#}"))
+            })?;
+        TestFacingModel::new(&mut tx)
+            .insert(
+                &"projects"
+                    .parse()
+                    .map_err(|e| Status::internal(format!("Invalid test table name: {e:#}")))?,
+                assert_obj!("name" => "prepared-before-commit-rpc-failure"),
+            )
+            .await
+            .map_err(|e| Status::internal(format!("Failed to build local prepare tx: {e:#}")))?;
+        let final_tx = tx
+            .finalize()
+            .map_err(|e| Status::internal(format!("Failed to finalize local prepare tx: {e:#}")))?;
+        let write_indexes: Vec<_> = final_tx
+            .writes
+            .coalesced_writes()
+            .enumerate()
+            .map(|(index, _)| index)
+            .collect();
+        let partition_map = partitioned_map(self.local_partition);
+        let transaction = ParticipantTransaction::from_final_transaction(
+            &final_tx,
+            self.local_partition,
+            &write_indexes,
+            &partition_map,
+            &write_source,
+        )
+        .map_err(|e| Status::internal(format!("Failed to build local participant tx: {e:#}")))?;
+        let result = self
+            .committer
+            .prepare_remote(
+                txn_id,
+                transaction,
+                write_source,
+                prepare_ts,
+                req.participants.iter().copied().map(PartitionId).collect(),
+            )
+            .await
+            .map_err(|e| Status::internal(format!("Prepare failed: {e:#}")))?;
+        Ok(Response::new(TwoPcPrepareResponse {
+            prepare_ts: u64::from(result.prepare_ts),
+        }))
+    }
+
+    async fn commit_prepared(
+        &self,
+        request: Request<TwoPcCommitRequest>,
+    ) -> Result<Response<TwoPcCommitResponse>, Status> {
+        let req = request.into_inner();
+        if self.fail_next_commit.swap(false, Ordering::SeqCst) {
+            return Err(Status::unavailable(
+                "forced commit failure after durable decision",
+            ));
+        }
+        let commit_ts = self
+            .committer
+            .commit_prepared(TwoPhaseTransactionId(req.transaction_id))
+            .await
+            .map_err(|e| Status::internal(format!("CommitPrepared failed: {e:#}")))?;
+        Ok(Response::new(TwoPcCommitResponse {
+            commit_ts: u64::from(commit_ts),
+        }))
+    }
+
+    async fn rollback_prepared(
+        &self,
+        request: Request<TwoPcRollbackRequest>,
+    ) -> Result<Response<TwoPcRollbackResponse>, Status> {
+        let req = request.into_inner();
+        self.committer
+            .rollback_prepared(TwoPhaseTransactionId(req.transaction_id))
+            .await
+            .map_err(|e| Status::internal(format!("RollbackPrepared failed: {e:#}")))?;
+        Ok(Response::new(TwoPcRollbackResponse {}))
     }
 }
 
@@ -2747,18 +2822,10 @@ fn test_failed_remote_prepare_rolls_back_local_participant() -> anyhow::Result<(
             format!("{err:#}").contains("forced prepare failure"),
             "expected remote prepare failure, got: {err:#}",
         );
-        let decisions = decision_log.decisions();
-        assert_eq!(decisions.len(), 1);
-        let decision = decisions
-            .values()
-            .next()
-            .expect("rollback decision should be durable");
-        match decision {
-            TwoPhaseDecision::RolledBack { participants, .. } => {
-                assert_eq!(participants, &vec![0]);
-            },
-            other => panic!("expected rollback decision, got {other:?}"),
-        }
+        assert!(
+            decision_log.decisions().is_empty(),
+            "rollback decision should be deleted once every prepared participant resolved",
+        );
 
         let mut retry_tx = node_a.begin(Identity::system()).await?;
         UserFacingModel::new(&mut retry_tx, TableNamespace::test_user())
@@ -2829,16 +2896,10 @@ async fn test_watcher_rolls_back_abandoned_prepare_without_decision(
     .await?;
     assert_eq!(resolved, 1);
 
-    let decisions = decision_log.decisions();
-    let decision = decisions
-        .get(&txn_id.0)
-        .expect("watcher should write a durable rollback decision");
-    match decision {
-        TwoPhaseDecision::RolledBack { participants, .. } => {
-            assert_eq!(participants, &vec![1]);
-        },
-        other => panic!("expected rollback decision, got {other:?}"),
-    }
+    assert!(
+        decision_log.decisions().is_empty(),
+        "single-participant timeout rollback should delete the decision after local resolution",
+    );
 
     insert_doc(
         &node,
@@ -2917,7 +2978,11 @@ fn test_rollback_decision_survives_failed_rollback_rpc_for_watcher() -> anyhow::
             .next()
             .expect("rollback decision should survive failed rollback RPC");
         match decision {
-            TwoPhaseDecision::RolledBack { participants, .. } => {
+            TwoPhaseDecision::RolledBack {
+                participants,
+                resolved_participants,
+                ..
+            } => {
                 assert!(
                     participants.contains(&1),
                     "rollback decision must include the prepared remote participant",
@@ -2925,6 +2990,12 @@ fn test_rollback_decision_survives_failed_rollback_rpc_for_watcher() -> anyhow::
                 assert!(
                     !participants.contains(&2),
                     "rollback decision must not include the participant whose prepare failed",
+                );
+                assert_eq!(
+                    resolved_participants,
+                    &vec![0],
+                    "local coordinator participant should be marked resolved while failed remote \
+                     rollback remains pending",
                 );
             },
             other => panic!("expected rollback decision, got {other:?}"),
@@ -2936,7 +3007,11 @@ fn test_rollback_decision_survives_failed_rollback_rpc_for_watcher() -> anyhow::
             TwoPhaseTransactionId(txn_id.clone()),
             decision.clone(),
         )
-        .await;
+        .await?;
+        assert!(
+            decision_log.decisions().is_empty(),
+            "decision should be deleted after the delayed participant resolves",
+        );
         insert_doc(
             &node_b,
             "projects",
@@ -2959,15 +3034,20 @@ fn test_commit_decision_survives_failed_participant_commit() -> anyhow::Result<(
         let log = Arc::new(InMemoryDistributedLog::new());
         let decision_log = Arc::new(InMemoryTwoPhaseDecisionLog::new());
         let tso: Arc<dyn TimestampOracle> = Arc::new(InMemoryTimestampOracle::new());
-        let node_b = create_node_with_options(
+        let node_b = create_node_with_options_and_decision_log(
             &rt,
             log.clone(),
             Some(partitioned_map(PartitionId(1))),
             None,
             Some(tso.clone()),
+            decision_log.clone(),
         )
         .await?;
-        let server = start_two_pc_server(FailingCommitAfterPrepareGrpcService).await?;
+        let server = start_two_pc_server(FailingCommitAfterLocalPrepareGrpcService::new(
+            node_b.clone(),
+            PartitionId(1),
+        ))
+        .await?;
 
         let node_a = create_node_with_options_and_decision_log(
             &rt,
@@ -3031,16 +3111,51 @@ fn test_commit_decision_survives_failed_participant_commit() -> anyhow::Result<(
 
         let decisions = decision_log.decisions();
         assert_eq!(decisions.len(), 1);
-        let decision = decisions
-            .values()
+        let (txn_id, decision) = decisions
+            .iter()
             .next()
             .expect("commit decision should remain for watcher recovery");
         match decision {
-            TwoPhaseDecision::Committed { participants, .. } => {
+            TwoPhaseDecision::Committed {
+                participants,
+                resolved_participants,
+                ..
+            } => {
                 assert_eq!(participants, &vec![0, 1]);
+                assert_eq!(
+                    resolved_participants,
+                    &vec![0],
+                    "local participant should be marked resolved while failed remote commit \
+                     remains pending",
+                );
             },
             other => panic!("expected commit decision, got {other:?}"),
         }
+
+        crate::two_phase_watcher::resolve_decision_for_local_partition(
+            &node_b.committer_for_test(),
+            PartitionId(1),
+            TwoPhaseTransactionId(txn_id.clone()),
+            decision.clone(),
+        )
+        .await?;
+        assert!(
+            decision_log.decisions().is_empty(),
+            "commit decision should be deleted after the delayed participant resolves",
+        );
+        let projects = run_query(
+            node_b,
+            TableNamespace::root_component(),
+            Query::full_table_scan("projects".parse()?, Order::Asc),
+        )
+        .await?;
+        assert!(
+            projects.iter().any(|project| {
+                project.value().0.get("name")
+                    == Some(&assert_val!("prepared-before-commit-rpc-failure"))
+            }),
+            "watcher recovery should commit the delayed remote participant",
+        );
 
         server.shutdown().await?;
         Ok(())

--- a/crates/database/src/two_phase.rs
+++ b/crates/database/src/two_phase.rs
@@ -123,12 +123,79 @@ pub enum TwoPhaseDecision {
     Committed {
         commit_ts: u64,
         participants: Vec<u32>,
+        #[serde(default)]
+        resolved_participants: Vec<u32>,
     },
     /// A participant failed to prepare, or coordinator timed out. Rollback.
     RolledBack {
         reason: String,
         participants: Vec<u32>,
+        #[serde(default)]
+        resolved_participants: Vec<u32>,
     },
+}
+
+impl TwoPhaseDecision {
+    pub fn committed(commit_ts: u64, participants: Vec<u32>) -> Self {
+        Self::Committed {
+            commit_ts,
+            participants,
+            resolved_participants: Vec::new(),
+        }
+    }
+
+    pub fn rolled_back(reason: String, participants: Vec<u32>) -> Self {
+        Self::RolledBack {
+            reason,
+            participants,
+            resolved_participants: Vec::new(),
+        }
+    }
+
+    pub fn participants(&self) -> &[u32] {
+        match self {
+            Self::Committed { participants, .. } | Self::RolledBack { participants, .. } => {
+                participants
+            },
+        }
+    }
+
+    pub fn resolved_participants(&self) -> &[u32] {
+        match self {
+            Self::Committed {
+                resolved_participants,
+                ..
+            }
+            | Self::RolledBack {
+                resolved_participants,
+                ..
+            } => resolved_participants,
+        }
+    }
+
+    pub fn mark_participant_resolved(&mut self, participant: PartitionId) {
+        let resolved = match self {
+            Self::Committed {
+                resolved_participants,
+                ..
+            }
+            | Self::RolledBack {
+                resolved_participants,
+                ..
+            } => resolved_participants,
+        };
+        if !resolved.contains(&participant.0) {
+            resolved.push(participant.0);
+            resolved.sort_unstable();
+            resolved.dedup();
+        }
+    }
+
+    pub fn all_participants_resolved(&self) -> bool {
+        self.participants()
+            .iter()
+            .all(|participant| self.resolved_participants().contains(participant))
+    }
 }
 
 /// Result from a successful Prepare on a participant.
@@ -306,6 +373,19 @@ pub mod testing {
             Ok(self.decisions.lock().get(&transaction_id.0).cloned())
         }
 
+        async fn mark_participant_resolved(
+            &self,
+            transaction_id: &TwoPhaseTransactionId,
+            participant: PartitionId,
+        ) -> anyhow::Result<Option<TwoPhaseDecision>> {
+            let mut decisions = self.decisions.lock();
+            let Some(decision) = decisions.get_mut(&transaction_id.0) else {
+                return Ok(None);
+            };
+            decision.mark_participant_resolved(participant);
+            Ok(Some(decision.clone()))
+        }
+
         async fn delete_decision(
             &self,
             transaction_id: &TwoPhaseTransactionId,
@@ -321,9 +401,6 @@ pub const TWO_PHASE_KV_PREFIX: &str = "2pc_";
 
 /// NATS KV bucket for 2PC state.
 pub const TWO_PHASE_KV_BUCKET: &str = "convex_2pc";
-
-/// Retain resolved 2PC decision records long enough for watcher recovery.
-pub const TWO_PHASE_DECISION_TTL_SECS: u64 = 3600;
 
 /// Timeout for prepared transactions before the watcher rolls them back.
 pub const PREPARE_TIMEOUT_SECS: u64 = 30;
@@ -356,6 +433,12 @@ pub trait TwoPhaseDecisionLog: Send + Sync + 'static {
         Ok(None)
     }
 
+    async fn mark_participant_resolved(
+        &self,
+        transaction_id: &TwoPhaseTransactionId,
+        participant: PartitionId,
+    ) -> anyhow::Result<Option<TwoPhaseDecision>>;
+
     async fn delete_decision(&self, transaction_id: &TwoPhaseTransactionId) -> anyhow::Result<()>;
 }
 
@@ -379,6 +462,14 @@ impl TwoPhaseDecisionLog for NoopTwoPhaseDecisionLog {
         Ok(true)
     }
 
+    async fn mark_participant_resolved(
+        &self,
+        _transaction_id: &TwoPhaseTransactionId,
+        _participant: PartitionId,
+    ) -> anyhow::Result<Option<TwoPhaseDecision>> {
+        Ok(None)
+    }
+
     async fn delete_decision(&self, _transaction_id: &TwoPhaseTransactionId) -> anyhow::Result<()> {
         Ok(())
     }
@@ -400,7 +491,6 @@ impl NatsTwoPhaseDecisionLog {
             .create_key_value(async_nats::jetstream::kv::Config {
                 bucket: TWO_PHASE_KV_BUCKET.to_string(),
                 history: 1,
-                max_age: Duration::from_secs(TWO_PHASE_DECISION_TTL_SECS),
                 ..Default::default()
             })
             .await
@@ -457,6 +547,50 @@ impl TwoPhaseDecisionLog for NatsTwoPhaseDecisionLog {
         serde_json::from_slice(&entry.value)
             .with_context(|| format!("2PC: Failed to parse decision for {transaction_id}"))
             .map(Some)
+    }
+
+    async fn mark_participant_resolved(
+        &self,
+        transaction_id: &TwoPhaseTransactionId,
+        participant: PartitionId,
+    ) -> anyhow::Result<Option<TwoPhaseDecision>> {
+        let key = two_phase_decision_key(transaction_id);
+        for _ in 0..10 {
+            let Some(entry) =
+                self.kv.entry(key.clone()).await.with_context(|| {
+                    format!("2PC: Failed to read decision for {transaction_id}")
+                })?
+            else {
+                return Ok(None);
+            };
+            let mut decision: TwoPhaseDecision = serde_json::from_slice(&entry.value)
+                .with_context(|| format!("2PC: Failed to parse decision for {transaction_id}"))?;
+            decision.mark_participant_resolved(participant);
+            let payload = serde_json::to_vec(&decision).with_context(|| {
+                format!("2PC: Failed to serialize decision for {transaction_id}")
+            })?;
+            match self
+                .kv
+                .update(key.clone(), payload.into(), entry.revision)
+                .await
+            {
+                Ok(_) => return Ok(Some(decision)),
+                Err(err)
+                    if err.kind()
+                        == async_nats::jetstream::kv::UpdateErrorKind::WrongLastRevision =>
+                {
+                    continue;
+                },
+                Err(err) => {
+                    anyhow::bail!(
+                        "2PC: Failed to mark {participant} resolved for {transaction_id}: {err:#}"
+                    );
+                },
+            }
+        }
+        anyhow::bail!(
+            "2PC: Failed to mark {participant} resolved for {transaction_id} after CAS retries"
+        )
     }
 
     async fn delete_decision(&self, transaction_id: &TwoPhaseTransactionId) -> anyhow::Result<()> {
@@ -1050,19 +1184,19 @@ mod tests {
 
     #[test]
     fn test_decision_serialization() {
-        let decision = TwoPhaseDecision::Committed {
-            commit_ts: 12345,
-            participants: vec![0, 1],
-        };
+        let mut decision = TwoPhaseDecision::committed(12345, vec![0, 1]);
+        decision.mark_participant_resolved(PartitionId(0));
         let json = serde_json::to_string(&decision).unwrap();
         let back: TwoPhaseDecision = serde_json::from_str(&json).unwrap();
         match back {
             TwoPhaseDecision::Committed {
                 commit_ts,
                 participants,
+                resolved_participants,
             } => {
                 assert_eq!(commit_ts, 12345);
                 assert_eq!(participants, vec![0, 1]);
+                assert_eq!(resolved_participants, vec![0]);
             },
             _ => panic!("Wrong variant"),
         }

--- a/crates/database/src/two_phase_coordinator.rs
+++ b/crates/database/src/two_phase_coordinator.rs
@@ -264,14 +264,26 @@ async fn write_decision_record(
     Ok(())
 }
 
-async fn delete_decision_record(
+async fn mark_participant_resolved(
     local_committer: &CommitterClient,
     transaction_id: &TwoPhaseTransactionId,
+    participant: PartitionId,
 ) -> anyhow::Result<()> {
-    local_committer
-        .two_phase_decision_log()
-        .delete_decision(transaction_id)
-        .await
+    let decision_log = local_committer.two_phase_decision_log();
+    let Some(decision) = decision_log
+        .mark_participant_resolved(transaction_id, participant)
+        .await?
+    else {
+        return Ok(());
+    };
+    if decision.all_participants_resolved() {
+        decision_log.delete_decision(transaction_id).await?;
+        tracing::info!(
+            "2PC Coordinator: deleted fully resolved decision for txn={}",
+            transaction_id,
+        );
+    }
+    Ok(())
 }
 
 fn is_retryable_prepare_ts_error(err: &anyhow::Error) -> bool {
@@ -366,10 +378,10 @@ pub async fn coordinate_two_phase_commit(
                     let retryable_prepare_ts_error =
                         is_retryable_prepare_ts_error(&err) && attempt + 1 < MAX_PREPARE_TS_RETRIES;
                     if !prepared_participants.is_empty() {
-                        let decision = TwoPhaseDecision::RolledBack {
-                            reason: err.to_string(),
-                            participants: prepared_participants.iter().map(|p| p.0).collect(),
-                        };
+                        let decision = TwoPhaseDecision::rolled_back(
+                            err.to_string(),
+                            prepared_participants.iter().map(|p| p.0).collect(),
+                        );
                         write_decision_record(local_committer, &txn_id, &decision)
                             .await
                             .with_context(|| {
@@ -380,7 +392,7 @@ pub async fn coordinate_two_phase_commit(
                             })?;
                     }
                     for prepared in prepared_participants.iter().rev().copied() {
-                        if let Err(rollback_err) = rollback_participant(
+                        match rollback_participant(
                             local_committer,
                             node_addresses,
                             partition_map,
@@ -390,12 +402,27 @@ pub async fn coordinate_two_phase_commit(
                         )
                         .await
                         {
-                            tracing::error!(
-                                "2PC Coordinator: rollback failed on {} for txn={}: \
-                                 {rollback_err:#}",
-                                prepared,
-                                txn_id,
-                            );
+                            Ok(()) => {
+                                if let Err(mark_err) =
+                                    mark_participant_resolved(local_committer, &txn_id, prepared)
+                                        .await
+                                {
+                                    tracing::warn!(
+                                        "2PC Coordinator: rollback resolved on {} for txn={} but \
+                                         failed to mark participant resolved: {mark_err:#}",
+                                        prepared,
+                                        txn_id,
+                                    );
+                                }
+                            },
+                            Err(rollback_err) => {
+                                tracing::error!(
+                                    "2PC Coordinator: rollback failed on {} for txn={}: \
+                                     {rollback_err:#}",
+                                    prepared,
+                                    txn_id,
+                                );
+                            },
                         }
                     }
 
@@ -424,10 +451,10 @@ pub async fn coordinate_two_phase_commit(
             continue;
         }
 
-        let decision = TwoPhaseDecision::Committed {
-            commit_ts: u64::from(prepare_ts),
-            participants: prepared_participants.iter().map(|p| p.0).collect(),
-        };
+        let decision = TwoPhaseDecision::committed(
+            u64::from(prepare_ts),
+            prepared_participants.iter().map(|p| p.0).collect(),
+        );
         write_decision_record(local_committer, &txn_id, &decision)
             .await
             .with_context(|| {
@@ -452,6 +479,14 @@ pub async fn coordinate_two_phase_commit(
                     return Err(err);
                 },
             };
+            mark_participant_resolved(local_committer, &txn_id, *participant)
+                .await
+                .with_context(|| {
+                    format!(
+                        "2PC Coordinator: participant {participant} committed txn={txn_id} but \
+                         resolution acknowledgement failed"
+                    )
+                })?;
             commit_results.push((*participant, commit_ts));
         }
 
@@ -472,12 +507,6 @@ pub async fn coordinate_two_phase_commit(
         );
         metrics::log_two_phase_prepare_attempts(prepare_attempts);
         metrics::log_two_phase_decision("commit");
-        if let Err(err) = delete_decision_record(local_committer, &txn_id).await {
-            tracing::warn!(
-                "2PC Coordinator: committed txn={} but failed to delete durable decision: {err:#}",
-                txn_id,
-            );
-        }
         timer.finish();
         return Ok(prepare_ts);
     }

--- a/crates/database/src/two_phase_watcher.rs
+++ b/crates/database/src/two_phase_watcher.rs
@@ -22,7 +22,6 @@ use crate::{
         TwoPhaseDecision,
         TwoPhaseTransactionId,
         PREPARE_TIMEOUT_SECS,
-        TWO_PHASE_DECISION_TTL_SECS,
         TWO_PHASE_KV_BUCKET,
         TWO_PHASE_KV_PREFIX,
     },
@@ -34,11 +33,11 @@ pub async fn resolve_decision_for_local_partition(
     local_partition: PartitionId,
     txn_id: TwoPhaseTransactionId,
     decision: TwoPhaseDecision,
-) {
-    match decision {
+) -> anyhow::Result<bool> {
+    let resolved = match decision {
         TwoPhaseDecision::Committed { participants, .. } => {
             if !participants.contains(&local_partition.0) {
-                return;
+                return Ok(false);
             }
             // Transaction was committed but the coordinator may have crashed
             // before sending CommitPrepared to all participants. Try to commit
@@ -50,6 +49,7 @@ pub async fn resolve_decision_for_local_partition(
                         txn_id,
                         u64::from(ts),
                     );
+                    true
                 },
                 Err(e) => {
                     // "unknown transaction" means it was already committed or
@@ -59,29 +59,59 @@ pub async fn resolve_decision_for_local_partition(
                             "2PC Watcher: committed txn={} already resolved locally",
                             txn_id,
                         );
+                        true
                     } else {
                         tracing::debug!(
                             "2PC Watcher: CommitPrepared for {txn_id} not ready: {e:#}"
                         );
+                        false
                     }
                 },
             }
         },
         TwoPhaseDecision::RolledBack { participants, .. } => {
             if !participants.contains(&local_partition.0) {
-                return;
+                return Ok(false);
             }
             // Transaction was rolled back but cleanup may be incomplete.
             match committer.rollback_prepared(txn_id.clone()).await {
-                Ok(()) | Err(_) => {
+                Ok(()) => {
                     tracing::debug!(
                         "2PC Watcher: rolled back txn={} locally or it was already gone",
                         txn_id,
                     );
+                    true
+                },
+                Err(e) if e.to_string().contains("unknown transaction") => {
+                    tracing::debug!(
+                        "2PC Watcher: rollback txn={} already resolved locally",
+                        txn_id,
+                    );
+                    true
+                },
+                Err(e) => {
+                    tracing::debug!("2PC Watcher: RollbackPrepared for {txn_id} not ready: {e:#}");
+                    false
                 },
             }
         },
+    };
+
+    if resolved {
+        let decision_log = committer.two_phase_decision_log();
+        if let Some(updated) = decision_log
+            .mark_participant_resolved(&txn_id, local_partition)
+            .await?
+            && updated.all_participants_resolved()
+        {
+            decision_log.delete_decision(&txn_id).await?;
+            tracing::info!(
+                "2PC Watcher: deleted fully resolved decision for txn={}",
+                txn_id,
+            );
+        }
     }
+    Ok(resolved)
 }
 
 /// Resolve local prepared transactions that no longer have a coordinator
@@ -109,13 +139,13 @@ pub async fn rollback_expired_local_prepares(
                     .into_iter()
                     .map(|partition| partition.0)
                     .collect();
-                let rollback = TwoPhaseDecision::RolledBack {
-                    reason: format!(
+                let rollback = TwoPhaseDecision::rolled_back(
+                    format!(
                         "2PC prepare timed out after {:?} without a durable coordinator decision",
                         timeout,
                     ),
                     participants,
-                };
+                );
                 if decision_log
                     .write_decision_if_absent(&txn_id, &rollback)
                     .await?
@@ -136,8 +166,11 @@ pub async fn rollback_expired_local_prepares(
                 }
             },
         };
-        resolve_decision_for_local_partition(committer, local_partition, txn_id, decision).await;
-        resolved += 1;
+        if resolve_decision_for_local_partition(committer, local_partition, txn_id, decision)
+            .await?
+        {
+            resolved += 1;
+        }
     }
     Ok(resolved)
 }
@@ -167,7 +200,6 @@ pub fn start<RT: Runtime>(
             .create_key_value(async_nats::jetstream::kv::Config {
                 bucket: TWO_PHASE_KV_BUCKET.to_string(),
                 history: 1,
-                max_age: Duration::from_secs(TWO_PHASE_DECISION_TTL_SECS),
                 ..Default::default()
             })
             .await
@@ -220,8 +252,16 @@ pub fn start<RT: Runtime>(
                     },
                 };
 
-                resolve_decision_for_local_partition(&committer, local_partition, txn_id, decision)
-                    .await;
+                if let Err(err) = resolve_decision_for_local_partition(
+                    &committer,
+                    local_partition,
+                    txn_id,
+                    decision,
+                )
+                .await
+                {
+                    tracing::debug!("2PC Watcher: failed to resolve local decision: {err:#}");
+                }
             }
 
             if let Err(err) = rollback_expired_local_prepares(

--- a/docs/issue-journal.md
+++ b/docs/issue-journal.md
@@ -714,6 +714,30 @@ own for distributed changes.
   - `cargo check -p database`
   - `cargo check -p local_backend`
 
+### 2026-06 — Retained 2PC decisions until every participant resolved
+
+- **Status:** complete
+- **Related issue:** `#151`
+- **What this fixes:** final 2PC decisions were still treated as TTL-scoped
+  recovery hints. The NATS KV bucket used a fixed max age, and the coordinator
+  deleted committed decisions after its immediate participant RPCs returned.
+  A participant that was down, slow, or unreachable after the final decision
+  could therefore lose the only durable source of truth for whether to commit
+  or roll back.
+- **Behavior:** committed and rolled-back decision records now carry a
+  `resolved_participants` set. The coordinator and watcher mark a participant
+  resolved only after that participant has durably committed or rolled back
+  locally. NATS decision updates use compare-and-swap so concurrent resolvers
+  do not clobber each other, the fixed one-hour bucket retention was removed,
+  and final decisions are deleted only after all participants are resolved.
+- **Validation:**
+  - `cargo test -p database decision_survives -- --nocapture`
+  - `cargo test -p database two_phase -- --nocapture`
+  - `cargo test -p database failed_remote_prepare_rolls_back_local_participant -- --nocapture`
+  - `cargo test -p database watcher_rolls_back_abandoned_prepare_without_decision -- --nocapture`
+  - `cargo check -p database`
+  - `cargo check -p local_backend`
+
 ### 2026-06 — Split Raft full-state apply from cross-partition replica filtering
 
 - **Status:** complete


### PR DESCRIPTION
## Summary
- retain committed and rolled-back 2PC decisions until all participants durably resolve
- track resolved participants in the decision record and update it with CAS in NATS KV
- remove fixed decision-record TTL and delete only after every participant is acknowledged
- keep failed commit/rollback decisions available for watcher recovery and clean redo-only rollback state

## Tests
- `cargo test -p database decision_survives -- --nocapture`
- `cargo test -p database two_phase -- --nocapture`
- `cargo test -p database failed_remote_prepare_rolls_back_local_participant -- --nocapture`
- `cargo test -p database watcher_rolls_back_abandoned_prepare_without_decision -- --nocapture`
- `cargo check -p database`
- `cargo check -p local_backend`

Closes #151