### PR TITLE
fix: make scheduled jobs and crons cluster-singleton

### DIFF
--- a/crates/application/src/lib.rs
+++ b/crates/application/src/lib.rs
@@ -13,7 +13,13 @@ use std::{
         HashSet,
     },
     ops::Bound,
-    sync::Arc,
+    sync::{
+        atomic::{
+            AtomicBool,
+            Ordering,
+        },
+        Arc,
+    },
     time::{
         Duration,
         SystemTime,
@@ -112,6 +118,7 @@ use common::{
     runtime::{
         JoinSet,
         Runtime,
+        SpawnHandle,
         UnixTimestamp,
     },
     schemas::{
@@ -610,6 +617,38 @@ pub struct Application<RT: Runtime> {
     app_auth: Arc<ApplicationAuth>,
     log_manager_client: LogManagerClient,
     oidc_http_client: CachedHttpClient,
+    scheduled_and_cron_worker_starts_allowed: Arc<AtomicBool>,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ScheduledAndCronWorkerStartup {
+    Start,
+    Disabled,
+}
+
+fn start_scheduled_and_cron_workers<RT: Runtime>(
+    runtime: RT,
+    instance_name: String,
+    database: Database<RT>,
+    runner: Arc<ApplicationFunctionRunner<RT>>,
+    function_log: FunctionExecutionLog<RT>,
+) -> (ScheduledJobRunner, Box<dyn SpawnHandle>) {
+    let scheduled_job_runner = ScheduledJobRunner::start(
+        runtime.clone(),
+        instance_name.clone(),
+        database.clone(),
+        runner.clone(),
+        function_log.clone(),
+    );
+    let cron_job_executor_fut = CronJobExecutor::run(
+        runtime.clone(),
+        instance_name,
+        database,
+        runner,
+        function_log,
+    );
+    let cron_job_executor = runtime.spawn("cron_job_executor", cron_job_executor_fut);
+    (scheduled_job_runner, cron_job_executor)
 }
 
 /// Create storage based on the storage type configuration
@@ -706,6 +745,7 @@ impl<RT: Runtime> Application<RT> {
         export_provider: Arc<dyn ExportProvider<RT>>,
         deleted_tablet_receiver: tokio::sync::mpsc::Receiver<TabletId>,
         oidc_http_client: CachedHttpClient,
+        scheduled_and_cron_worker_startup: ScheduledAndCronWorkerStartup,
     ) -> anyhow::Result<Self> {
         let module_cache =
             ModuleCache::new(runtime.clone(), application_storage.modules_storage.clone()).await;
@@ -812,24 +852,25 @@ impl<RT: Runtime> Application<RT> {
         ));
         function_runner.set_action_callbacks(runner.clone());
 
-        let scheduled_job_runner = ScheduledJobRunner::start(
-            runtime.clone(),
-            instance_name.clone(),
-            database.clone(),
-            runner.clone(),
-            function_log.clone(),
-        );
-
-        let cron_job_executor_fut = CronJobExecutor::run(
-            runtime.clone(),
-            instance_name.clone(),
-            database.clone(),
-            runner.clone(),
-            function_log.clone(),
-        );
-        let cron_job_executor = Arc::new(Mutex::new(
-            runtime.spawn("cron_job_executor", cron_job_executor_fut),
-        ));
+        let (scheduled_job_runner, cron_job_executor) = match scheduled_and_cron_worker_startup {
+            ScheduledAndCronWorkerStartup::Start => {
+                let (scheduled_job_runner, cron_job_executor) = start_scheduled_and_cron_workers(
+                    runtime.clone(),
+                    instance_name.clone(),
+                    database.clone(),
+                    runner.clone(),
+                    function_log.clone(),
+                );
+                (Some(scheduled_job_runner), Some(cron_job_executor))
+            },
+            ScheduledAndCronWorkerStartup::Disabled => {
+                tracing::info!(
+                    "Scheduled job and cron workers are disabled until this node has cluster \
+                     authority"
+                );
+                (None, None)
+            },
+        };
 
         let export_worker = ExportWorker::new(
             runtime.clone(),
@@ -875,8 +916,8 @@ impl<RT: Runtime> Application<RT> {
 
         let workers = WorkerHandles {
             usage_gauges_tracking_worker,
-            scheduled_job_runner,
-            cron_job_executor,
+            scheduled_job_runner: Arc::new(Mutex::new(scheduled_job_runner)),
+            cron_job_executor: Arc::new(Mutex::new(cron_job_executor)),
             index_worker,
             fast_forward_worker,
             search_worker,
@@ -907,11 +948,59 @@ impl<RT: Runtime> Application<RT> {
             app_auth,
             log_manager_client,
             oidc_http_client,
+            scheduled_and_cron_worker_starts_allowed: Arc::new(AtomicBool::new(true)),
         })
     }
 
     pub fn runtime(&self) -> RT {
         self.runtime.clone()
+    }
+
+    pub fn start_scheduled_and_cron_workers(&self) {
+        if !self
+            .scheduled_and_cron_worker_starts_allowed
+            .load(Ordering::SeqCst)
+        {
+            return;
+        }
+        let mut scheduled_job_runner = self.workers.scheduled_job_runner.lock();
+        let mut cron_job_executor = self.workers.cron_job_executor.lock();
+        if scheduled_job_runner.is_some() || cron_job_executor.is_some() {
+            return;
+        }
+
+        tracing::info!("Starting scheduled job and cron workers on cluster authority node");
+        let (new_scheduled_job_runner, new_cron_job_executor) = start_scheduled_and_cron_workers(
+            self.runtime.clone(),
+            self.instance_name.clone(),
+            self.database.clone(),
+            self.runner.clone(),
+            self.function_log.clone(),
+        );
+        *scheduled_job_runner = Some(new_scheduled_job_runner);
+        *cron_job_executor = Some(new_cron_job_executor);
+    }
+
+    pub fn stop_scheduled_and_cron_workers(&self) {
+        let scheduled_job_runner = self.workers.scheduled_job_runner.lock().take();
+        let cron_job_executor = self.workers.cron_job_executor.lock().take();
+        if scheduled_job_runner.is_none() && cron_job_executor.is_none() {
+            return;
+        }
+
+        tracing::info!("Stopping scheduled job and cron workers on non-authority node");
+        if let Some(scheduled_job_runner) = scheduled_job_runner {
+            scheduled_job_runner.shutdown();
+        }
+        if let Some(mut cron_job_executor) = cron_job_executor {
+            cron_job_executor.shutdown();
+        }
+    }
+
+    #[cfg(any(test, feature = "testing"))]
+    pub fn scheduled_and_cron_workers_running_for_test(&self) -> bool {
+        self.workers.scheduled_job_runner.lock().is_some()
+            && self.workers.cron_job_executor.lock().is_some()
     }
 
     pub fn modules_storage(&self) -> &Arc<dyn Storage> {
@@ -3609,6 +3698,8 @@ impl<RT: Runtime> Application<RT> {
     }
 
     pub async fn shutdown(&self) -> anyhow::Result<()> {
+        self.scheduled_and_cron_worker_starts_allowed
+            .store(false, Ordering::SeqCst);
         self.workers.shutdown().await?;
         self.log_manager_client.shutdown().await?;
         self.runner.shutdown().await?;

--- a/crates/application/src/test_helpers.rs
+++ b/crates/application/src/test_helpers.rs
@@ -121,6 +121,7 @@ use crate::{
     log_visibility::RedactLogsToClient,
     scheduled_jobs::ScheduledJobContext,
     Application,
+    ScheduledAndCronWorkerStartup,
 };
 
 pub static OBJECTS_TABLE: LazyLock<TableName> = LazyLock::new(|| "objects".parse().unwrap());
@@ -131,6 +132,7 @@ pub struct ApplicationFixtureArgs {
     pub tp: Option<TestPersistence>,
     pub event_logger: Option<Arc<dyn UsageEventLogger>>,
     pub node_executor: Option<Arc<dyn NodeExecutor>>,
+    pub scheduled_and_cron_worker_startup: Option<ScheduledAndCronWorkerStartup>,
 }
 
 impl ApplicationFixtureArgs {
@@ -304,6 +306,8 @@ impl<RT: Runtime> ApplicationTestExt<RT> for Application<RT> {
             Arc::new(InProcessExportProvider),
             deleted_tablet_receiver,
             oidc_http_client,
+            args.scheduled_and_cron_worker_startup
+                .unwrap_or(ScheduledAndCronWorkerStartup::Start),
         )
         .await?;
 

--- a/crates/application/src/tests/scheduled_jobs.rs
+++ b/crates/application/src/tests/scheduled_jobs.rs
@@ -85,6 +85,7 @@ use crate::{
         OBJECTS_TABLE_COMPONENT,
     },
     Application,
+    ScheduledAndCronWorkerStartup,
 };
 
 /// Create a scheduled job in the old format with arguments inline in the
@@ -136,6 +137,25 @@ async fn wait_for_scheduled_job_execution(hold_guard: HoldGuard) {
     if let Some(pause_guard) = hold_guard.wait_for_blocked().await {
         pause_guard.unpause();
     }
+}
+
+#[convex_macro::test_runtime]
+async fn test_scheduled_and_cron_workers_can_start_disabled(rt: TestRuntime) -> anyhow::Result<()> {
+    let application = Application::new_for_tests_with_args(
+        &rt,
+        ApplicationFixtureArgs {
+            scheduled_and_cron_worker_startup: Some(ScheduledAndCronWorkerStartup::Disabled),
+            ..Default::default()
+        },
+    )
+    .await?;
+
+    assert!(!application.scheduled_and_cron_workers_running_for_test());
+    application.start_scheduled_and_cron_workers();
+    assert!(application.scheduled_and_cron_workers_running_for_test());
+    application.stop_scheduled_and_cron_workers();
+    assert!(!application.scheduled_and_cron_workers_running_for_test());
+    Ok(())
 }
 
 #[convex_macro::test_runtime]

--- a/crates/application/src/worker_handles.rs
+++ b/crates/application/src/worker_handles.rs
@@ -16,8 +16,8 @@ use crate::{
 #[derive(Clone)]
 pub struct WorkerHandles {
     pub(crate) usage_gauges_tracking_worker: UsageGaugesTrackingWorker,
-    pub(crate) scheduled_job_runner: ScheduledJobRunner,
-    pub(crate) cron_job_executor: Arc<Mutex<Box<dyn SpawnHandle>>>,
+    pub(crate) scheduled_job_runner: Arc<Mutex<Option<ScheduledJobRunner>>>,
+    pub(crate) cron_job_executor: Arc<Mutex<Option<Box<dyn SpawnHandle>>>>,
     pub(crate) index_worker: Arc<Mutex<Option<Box<dyn SpawnHandle>>>>,
     pub(crate) fast_forward_worker: Arc<Mutex<Box<dyn SpawnHandle>>>,
     pub(crate) search_worker: Arc<Mutex<SearchIndexWorkers>>,
@@ -51,8 +51,14 @@ impl WorkerHandles {
         if let Some(snapshot_import_worker) = snapshot_import_worker {
             shutdown_and_join(snapshot_import_worker).await?;
         }
-        self.scheduled_job_runner.shutdown();
-        self.cron_job_executor.lock().shutdown();
+        let scheduled_job_runner = self.scheduled_job_runner.lock().take();
+        if let Some(scheduled_job_runner) = scheduled_job_runner {
+            scheduled_job_runner.shutdown();
+        }
+        let cron_job_executor = self.cron_job_executor.lock().take();
+        if let Some(mut cron_job_executor) = cron_job_executor {
+            cron_job_executor.shutdown();
+        }
         let migration_worker = self.migration_worker.lock().take();
         if let Some(migration_worker) = migration_worker {
             shutdown_and_join(migration_worker).await?;

--- a/crates/local_backend/src/lib.rs
+++ b/crates/local_backend/src/lib.rs
@@ -26,6 +26,7 @@ use application::{
     log_visibility::RedactLogsToClient,
     Application,
     QueryCache,
+    ScheduledAndCronWorkerStartup,
 };
 use common::{
     self,
@@ -287,6 +288,57 @@ fn replica_delta_consumer_start_ts(
     } else {
         local_snapshot_ts
     }
+}
+
+fn should_run_cluster_singleton_workers(
+    replica_mode: bool,
+    partition_id: Option<database::partition::PartitionId>,
+    raft_state: Option<&database::raft_partition::RaftPartitionState>,
+) -> bool {
+    if !replica_mode && partition_id.is_none() {
+        return true;
+    }
+    if replica_mode {
+        return false;
+    }
+    let Some(partition_id) = partition_id else {
+        return true;
+    };
+    if partition_id != route_authority::CLUSTER_COORDINATOR_PARTITION {
+        return false;
+    }
+    raft_state.is_none_or(|raft_state| raft_state.is_leader())
+}
+
+fn start_cluster_singleton_worker_supervisor(
+    runtime: ProdRuntime,
+    application: Application<ProdRuntime>,
+    replica_mode: bool,
+    partition_id: Option<database::partition::PartitionId>,
+    raft_state: Option<database::raft_partition::RaftPartitionState>,
+) {
+    if !replica_mode && partition_id.is_none() {
+        return;
+    }
+    let supervisor_runtime = runtime.clone();
+    runtime.spawn_background("cluster_singleton_worker_authority", async move {
+        let mut running = false;
+        loop {
+            let should_run = should_run_cluster_singleton_workers(
+                replica_mode,
+                partition_id,
+                raft_state.as_ref(),
+            );
+            if should_run && !running {
+                application.start_scheduled_and_cron_workers();
+                running = true;
+            } else if !should_run && running {
+                application.stop_scheduled_and_cron_workers();
+                running = false;
+            }
+            supervisor_runtime.wait(Duration::from_millis(250)).await;
+        }
+    });
 }
 
 pub async fn make_app(
@@ -570,6 +622,12 @@ pub async fn make_app(
             fetch_client.clone(),
         )?);
 
+    let scheduled_and_cron_worker_startup =
+        if config.replication_mode == "replica" || config.partition_id.is_some() {
+            ScheduledAndCronWorkerStartup::Disabled
+        } else {
+            ScheduledAndCronWorkerStartup::Start
+        };
     let application = Application::new(
         runtime.clone(),
         database.clone(),
@@ -598,6 +656,7 @@ pub async fn make_app(
         Arc::new(InProcessExportProvider),
         deleted_tablet_receiver,
         oidc_http_client,
+        scheduled_and_cron_worker_startup,
     )
     .await?;
 
@@ -1095,6 +1154,14 @@ pub async fn make_app(
         );
     }
 
+    start_cluster_singleton_worker_supervisor(
+        runtime.clone(),
+        application.clone(),
+        config.replication_mode == "replica",
+        partition_id,
+        raft_state_for_app.clone(),
+    );
+
     let app_state = BackendAppState {
         origin,
         site_origin: config.convex_site_url()?,
@@ -1185,6 +1252,26 @@ mod tests {
         );
 
         Ok(())
+    }
+
+    #[test]
+    fn cluster_singleton_workers_follow_coordinator_authority() {
+        assert!(super::should_run_cluster_singleton_workers(
+            false, None, None,
+        ));
+        assert!(!super::should_run_cluster_singleton_workers(
+            true, None, None,
+        ));
+        assert!(super::should_run_cluster_singleton_workers(
+            false,
+            Some(database::partition::PartitionId(0)),
+            None,
+        ));
+        assert!(!super::should_run_cluster_singleton_workers(
+            false,
+            Some(database::partition::PartitionId(1)),
+            None,
+        ));
     }
 
     #[test]

--- a/docs/issue-journal.md
+++ b/docs/issue-journal.md
@@ -758,6 +758,27 @@ own for distributed changes.
   - `cargo check -p database`
   - `cargo check -p local_backend`
 
+### 2026-06 — Gated scheduled jobs and crons behind cluster singleton authority
+
+- **Status:** complete
+- **Related issue:** `#149`
+- **What this fixes:** scheduled-job and cron executors were started by
+  `Application::new` on every backend process. In clustered mode those workers
+  bypass foreground route authority and could poll or execute deployment-global
+  work from replicas, non-coordinator partitions, or Raft followers.
+- **Behavior:** `Application` now supports starting scheduled-job and cron
+  workers disabled, then toggling them explicitly. Single-node deployments keep
+  the old eager startup behavior. Clustered local-backend nodes start with the
+  workers disabled and run a coordinator-authority supervisor: replicas and
+  non-zero partitions stay idle, partition 0 runs the workers only while it is
+  allowed to own coordinator-singleton work, and partition-0 Raft followers
+  stop them until leadership returns.
+- **Validation:**
+  - `cargo test -p application test_scheduled_and_cron_workers_can_start_disabled -- --nocapture`
+  - `cargo test -p local_backend cluster_singleton_workers_follow_coordinator_authority -- --nocapture`
+  - `cargo check -p application`
+  - `cargo check -p local_backend`
+
 ## Open Issues
 
 - `#74` is no longer blocked on follower self-sufficiency. The current


### PR DESCRIPTION
## Summary
- add an application startup policy so scheduled-job and cron workers can start disabled in clustered deployments
- add explicit start/stop hooks for scheduler and cron workers
- run a local-backend coordinator-authority supervisor so replicas, non-coordinator partitions, and Raft followers do not execute singleton scheduled work
- keep single-node startup behavior unchanged

## Tests
- `cargo test -p application test_scheduled_and_cron_workers_can_start_disabled -- --nocapture`
- `cargo test -p local_backend cluster_singleton_workers_follow_coordinator_authority -- --nocapture`
- `cargo check -p application`
- `cargo check -p local_backend`

Closes #149