### PR TITLE
fix: fence coordinator reads with raft serving lease

### DIFF
--- a/crates/database/src/raft_node.rs
+++ b/crates/database/src/raft_node.rs
@@ -67,6 +67,18 @@ impl Default for RaftNodeConfig {
     }
 }
 
+impl RaftNodeConfig {
+    /// The Raft run loop ticks every 100ms.
+    pub const TICK_INTERVAL: Duration = Duration::from_millis(100);
+
+    pub fn leader_serving_lease_duration(&self) -> Duration {
+        let heartbeat = Self::TICK_INTERVAL * self.heartbeat_tick as u32;
+        let election = Self::TICK_INTERVAL * self.election_tick as u32;
+        let max_lease = election.saturating_sub(Self::TICK_INTERVAL);
+        (heartbeat * 2).min(max_lease).max(Self::TICK_INTERVAL)
+    }
+}
+
 /// A proposal from a client waiting to be committed via Raft.
 pub struct RaftProposal {
     /// Serialized mutation data.
@@ -111,6 +123,9 @@ pub struct LeadershipCallbacks {
     /// Called whenever the known leader changes (including on other nodes).
     /// Receives the new leader's node ID (0 if unknown).
     pub on_leader_changed: Box<dyn FnMut(u64) + Send>,
+    /// Called when the current leader observes enough recent peer responses
+    /// to keep serving coordinator-owned reads and subscriptions.
+    pub on_leader_serving_lease_refreshed: Box<dyn FnMut() + Send>,
 }
 
 impl Default for LeadershipCallbacks {
@@ -119,6 +134,7 @@ impl Default for LeadershipCallbacks {
             on_became_leader: Box::new(|| {}),
             on_lost_leadership: Box::new(|| {}),
             on_leader_changed: Box::new(|_| {}),
+            on_leader_serving_lease_refreshed: Box::new(|| {}),
         }
     }
 }
@@ -147,6 +163,37 @@ pub struct RaftNode {
     durable_applied_index: u64,
     /// Applied entries above `durable_applied_index` waiting for earlier gaps.
     applied_indexes_pending_persistence: BTreeSet<u64>,
+}
+
+fn is_leader_quorum_response(msg: &Message) -> bool {
+    matches!(
+        msg.get_msg_type(),
+        MessageType::MsgAppendResponse
+            | MessageType::MsgHeartbeatResponse
+            | MessageType::MsgSnapStatus
+    )
+}
+
+fn has_recent_peer_quorum(
+    node_id: u64,
+    peers: &[u64],
+    recent_peer_responses: &HashMap<u64, Instant>,
+    now: Instant,
+    lease_duration: Duration,
+) -> bool {
+    let mut recent_voters = 1usize; // self
+    for peer in peers {
+        if *peer == node_id {
+            continue;
+        }
+        if recent_peer_responses
+            .get(peer)
+            .is_some_and(|response_at| now.duration_since(*response_at) <= lease_duration)
+        {
+            recent_voters += 1;
+        }
+    }
+    recent_voters * 2 > peers.len()
 }
 
 impl RaftNode {
@@ -282,7 +329,9 @@ impl RaftNode {
         mut on_committed: impl FnMut(&[u8]) -> anyhow::Result<()>,
         mut on_snapshot: impl FnMut(&[u8]) -> anyhow::Result<()>,
     ) -> anyhow::Result<()> {
-        let tick_interval = Duration::from_millis(100);
+        let tick_interval = RaftNodeConfig::TICK_INTERVAL;
+        let leader_serving_lease_duration = self.config.leader_serving_lease_duration();
+        let mut recent_peer_responses = HashMap::new();
         let mut last_tick = Instant::now();
 
         loop {
@@ -290,6 +339,22 @@ impl RaftNode {
             loop {
                 match self.mailbox.try_recv() {
                     Ok(RaftMessage::Raft(msg)) => {
+                        if self.raw_node.raft.state == StateRole::Leader
+                            && is_leader_quorum_response(&msg)
+                            && msg.from != self.config.node_id
+                        {
+                            let now = Instant::now();
+                            recent_peer_responses.insert(msg.from, now);
+                            if has_recent_peer_quorum(
+                                self.config.node_id,
+                                &self.config.peers,
+                                &recent_peer_responses,
+                                now,
+                                leader_serving_lease_duration,
+                            ) {
+                                (self.leadership_callbacks.on_leader_serving_lease_refreshed)();
+                            }
+                        }
                         if let Err(e) = self.raw_node.step(msg) {
                             tracing::warn!("Raft step error: {e}");
                         }
@@ -327,6 +392,9 @@ impl RaftNode {
             // Tick the election/heartbeat timer.
             if last_tick.elapsed() >= tick_interval {
                 self.raw_node.tick();
+                if self.raw_node.raft.state == StateRole::Leader && self.config.peers.len() == 1 {
+                    (self.leadership_callbacks.on_leader_serving_lease_refreshed)();
+                }
                 last_tick = Instant::now();
             }
 
@@ -391,6 +459,7 @@ impl RaftNode {
                         );
                         self.is_leader_flag = true;
                         (self.leadership_callbacks.on_became_leader)();
+                        (self.leadership_callbacks.on_leader_serving_lease_refreshed)();
                     } else if !now_leader && self.is_leader_flag {
                         tracing::info!(
                             "Raft node {}: lost leadership for partition {}",
@@ -598,6 +667,7 @@ impl RaftNode {
             if now_leader && !self.is_leader_flag {
                 self.is_leader_flag = true;
                 (self.leadership_callbacks.on_became_leader)();
+                (self.leadership_callbacks.on_leader_serving_lease_refreshed)();
             } else if !now_leader && self.is_leader_flag {
                 self.is_leader_flag = false;
                 (self.leadership_callbacks.on_lost_leadership)();
@@ -868,6 +938,7 @@ mod tests {
                 observed_leader_id_clone.store(leader_id, std::sync::atomic::Ordering::SeqCst);
             }),
             on_lost_leadership: Box::new(|| {}),
+            on_leader_serving_lease_refreshed: Box::new(|| {}),
         });
 
         assert!(!became_leader.load(std::sync::atomic::Ordering::SeqCst));

--- a/crates/database/src/raft_partition.rs
+++ b/crates/database/src/raft_partition.rs
@@ -44,8 +44,10 @@ use std::{
         },
         Arc,
     },
+    time::Instant,
 };
 
+use parking_lot::Mutex;
 use raft::prelude::Message;
 use tokio::sync::mpsc;
 
@@ -74,12 +76,23 @@ pub struct RaftPartitionState {
     partition_id: PartitionId,
     /// This node's ID within the Raft group.
     node_id: u64,
+    /// Local serving lease for coordinator-owned reads/subscriptions.
+    leader_serving_lease_valid_until: Arc<Mutex<Option<Instant>>>,
 }
 
 impl RaftPartitionState {
     /// Check if this node is the leader for this partition.
     pub fn is_leader(&self) -> bool {
         self.is_leader.load(Ordering::SeqCst)
+    }
+
+    pub fn has_leader_serving_lease(&self) -> bool {
+        if !self.is_leader() {
+            return false;
+        }
+        self.leader_serving_lease_valid_until
+            .lock()
+            .is_some_and(|valid_until| valid_until > Instant::now())
     }
 
     /// Get the current leader's node ID.
@@ -132,7 +145,17 @@ impl RaftPartitionState {
             proposal_tx,
             partition_id,
             node_id,
+            leader_serving_lease_valid_until: Arc::new(Mutex::new(if is_leader {
+                Some(Instant::now() + std::time::Duration::from_secs(60))
+            } else {
+                None
+            })),
         }
+    }
+
+    #[cfg(any(test, feature = "testing"))]
+    pub fn expire_leader_serving_lease_for_test(&self) {
+        *self.leader_serving_lease_valid_until.lock() = Some(Instant::now());
     }
 }
 
@@ -169,9 +192,13 @@ impl RaftPartitionManager {
 
         let is_leader = Arc::new(AtomicBool::new(false));
         let leader_id = Arc::new(AtomicU64::new(0));
+        let leader_serving_lease_valid_until = Arc::new(Mutex::new(None));
+        let leader_serving_lease_duration = config.leader_serving_lease_duration();
 
         // Set up leadership callbacks that update shared atomic state.
         let is_leader_cb = is_leader.clone();
+        let serving_lease_refresh = leader_serving_lease_valid_until.clone();
+        let serving_lease_duration_refresh = leader_serving_lease_duration;
         let partition_id = config.partition_id;
 
         node.set_leadership_callbacks(LeadershipCallbacks {
@@ -185,9 +212,11 @@ impl RaftPartitionManager {
             }),
             on_lost_leadership: Box::new({
                 let is_leader_lost = is_leader.clone();
+                let serving_lease_lost = leader_serving_lease_valid_until.clone();
                 let partition_id_lost = partition_id;
                 move || {
                     is_leader_lost.store(false, Ordering::SeqCst);
+                    *serving_lease_lost.lock() = None;
                     metrics::log_raft_is_leader(partition_id_lost, false);
                     metrics::reset_raft_replication_health(partition_id_lost);
                     tracing::info!(
@@ -195,6 +224,10 @@ impl RaftPartitionManager {
                         partition_id_lost,
                     );
                 }
+            }),
+            on_leader_serving_lease_refreshed: Box::new(move || {
+                *serving_lease_refresh.lock() =
+                    Some(Instant::now() + serving_lease_duration_refresh);
             }),
             on_leader_changed: Box::new({
                 let leader_id_changed = leader_id.clone();
@@ -221,6 +254,7 @@ impl RaftPartitionManager {
             proposal_tx: mailbox_tx.clone(),
             partition_id: config.partition_id,
             node_id: config.node_id,
+            leader_serving_lease_valid_until,
         };
         metrics::log_raft_is_leader(config.partition_id, false);
         metrics::log_raft_leader_id(config.partition_id, 0);

--- a/crates/local_backend/src/lib.rs
+++ b/crates/local_backend/src/lib.rs
@@ -307,7 +307,8 @@ fn should_run_cluster_singleton_workers(
     if partition_id != route_authority::CLUSTER_COORDINATOR_PARTITION {
         return false;
     }
-    raft_state.is_none_or(|raft_state| raft_state.is_leader())
+    raft_state
+        .is_none_or(|raft_state| raft_state.is_leader() && raft_state.has_leader_serving_lease())
 }
 
 fn start_cluster_singleton_worker_supervisor(
@@ -1271,6 +1272,23 @@ mod tests {
             false,
             Some(database::partition::PartitionId(1)),
             None,
+        ));
+        let raft_state = database::raft_partition::RaftPartitionState::new_for_test(
+            true,
+            1,
+            database::partition::PartitionId(0),
+            1,
+        );
+        assert!(super::should_run_cluster_singleton_workers(
+            false,
+            Some(database::partition::PartitionId(0)),
+            Some(&raft_state),
+        ));
+        raft_state.expire_leader_serving_lease_for_test();
+        assert!(!super::should_run_cluster_singleton_workers(
+            false,
+            Some(database::partition::PartitionId(0)),
+            Some(&raft_state),
         ));
     }
 

--- a/crates/local_backend/src/query_forwarding_api.rs
+++ b/crates/local_backend/src/query_forwarding_api.rs
@@ -110,7 +110,12 @@ impl SelectiveQueryForwardingApi {
             return Ok(None);
         };
         if raft_state.is_leader() {
-            return Ok(None);
+            if raft_state.has_leader_serving_lease() {
+                return Ok(None);
+            }
+            anyhow::bail!(
+                "Coordinator partition is leader but does not have a fresh Raft serving lease"
+            );
         }
         let peer_grpc_urls = self.raft_peer_grpc_urls.as_ref().context(
             "Follower public query forwarding requires RAFT_PEERS gRPC URLs to find the current \
@@ -186,6 +191,14 @@ impl SelectiveQueryForwardingApi {
             return Err(self.unsupported_cluster_surface_error(
                 surface,
                 "the coordinator partition is running as a Raft follower".to_string(),
+            ));
+        }
+        if let Some(raft_state) = self.raft_state.as_ref()
+            && !raft_state.has_leader_serving_lease()
+        {
+            return Err(self.unsupported_cluster_surface_error(
+                surface,
+                "the coordinator partition does not have a fresh Raft serving lease".to_string(),
             ));
         }
         Ok(())

--- a/crates/local_backend/src/route_authority.rs
+++ b/crates/local_backend/src/route_authority.rs
@@ -460,6 +460,15 @@ fn ensure_cluster_coordinator_authority(
             "the coordinator partition is running as a Raft follower".to_string(),
         ));
     }
+    if let Some(raft_state) = st.raft_state()
+        && !raft_state.has_leader_serving_lease()
+    {
+        return Err(unsupported_local_backend_cluster_surface_error(
+            surface,
+            class,
+            "the coordinator partition does not have a fresh Raft serving lease".to_string(),
+        ));
+    }
     Ok(())
 }
 
@@ -491,12 +500,39 @@ pub(crate) fn ensure_local_backend_api_authority(
 
 #[cfg(test)]
 mod tests {
+    use database::{
+        partition::PartitionId,
+        raft_partition::RaftPartitionState,
+    };
+
     use super::{
         classify_local_backend_api_route,
+        ensure_local_backend_api_authority,
         normalize_local_backend_api_path,
+        ClusterAuthorityContext,
         RouteAuthorityClass,
         LOCAL_BACKEND_API_ROUTE_AUTHORITIES,
     };
+
+    struct TestAuthorityContext {
+        replica_mode: bool,
+        partition_id: Option<PartitionId>,
+        raft_state: Option<RaftPartitionState>,
+    }
+
+    impl ClusterAuthorityContext for TestAuthorityContext {
+        fn replica_mode(&self) -> bool {
+            self.replica_mode
+        }
+
+        fn partition_id(&self) -> Option<PartitionId> {
+            self.partition_id
+        }
+
+        fn raft_state(&self) -> Option<&RaftPartitionState> {
+            self.raft_state.as_ref()
+        }
+    }
 
     fn class_for(path: &str) -> Option<RouteAuthorityClass> {
         classify_local_backend_api_route(path).map(|rule| rule.class)
@@ -557,5 +593,25 @@ mod tests {
         assert!(LOCAL_BACKEND_API_ROUTE_AUTHORITIES
             .iter()
             .all(|rule| !rule.surface.is_empty() && !rule.rationale.is_empty()));
+    }
+
+    #[test]
+    fn test_coordinator_owner_requires_fresh_raft_serving_lease() {
+        let raft_state = RaftPartitionState::new_for_test(true, 1, PartitionId(0), 1);
+        let st = TestAuthorityContext {
+            replica_mode: false,
+            partition_id: Some(PartitionId(0)),
+            raft_state: Some(raft_state.clone()),
+        };
+        ensure_local_backend_api_authority(&st, "/api/sync")
+            .expect("fresh coordinator leader should serve sync");
+
+        raft_state.expire_leader_serving_lease_for_test();
+        let err = ensure_local_backend_api_authority(&st, "/api/sync")
+            .expect_err("stale coordinator leader should not serve sync");
+        assert!(
+            format!("{err:#}").contains("fresh Raft serving lease"),
+            "unexpected error: {err:#}",
+        );
     }
 }

--- a/crates/local_backend/src/subs/mod.rs
+++ b/crates/local_backend/src/subs/mod.rs
@@ -89,6 +89,7 @@ use crate::{
 const HEARTBEAT_INTERVAL: Duration = Duration::from_secs(5);
 /// How long before lack of client response causes a timeout.
 const CLIENT_TIMEOUT: Duration = Duration::from_secs(120);
+const SYNC_AUTHORITY_CHECK_INTERVAL: Duration = Duration::from_millis(250);
 
 struct SyncSocketDropToken {
     partition_id_label: String,
@@ -252,7 +253,44 @@ async fn run_sync_socket(
         r
     };
 
-    let result = try_join!(receive_messages, send_messages, sync_worker_go);
+    let authority_monitor = async {
+        loop {
+            if st.replica_mode {
+                anyhow::bail!("Sync socket authority lost: node is running in replica mode");
+            }
+            if let Some(partition_id) = st.partition_id {
+                if partition_id != crate::route_authority::CLUSTER_COORDINATOR_PARTITION {
+                    anyhow::bail!(
+                        "Sync socket authority lost: partition {} is not the coordinator",
+                        partition_id.0,
+                    );
+                }
+            }
+            if let Some(raft_state) = st.raft_state.as_ref() {
+                if !raft_state.is_leader() {
+                    anyhow::bail!(
+                        "Sync socket authority lost: coordinator partition is a Raft follower"
+                    );
+                }
+                if !raft_state.has_leader_serving_lease() {
+                    anyhow::bail!(
+                        "Sync socket authority lost: coordinator partition does not have a fresh \
+                         Raft serving lease"
+                    );
+                }
+            }
+            st.runtime.wait(SYNC_AUTHORITY_CHECK_INTERVAL).await;
+        }
+        #[allow(unreachable_code)]
+        Ok::<(), anyhow::Error>(())
+    };
+
+    let result = try_join!(
+        receive_messages,
+        send_messages,
+        sync_worker_go,
+        authority_monitor
+    );
 
     // This should only fail if we accidentally pass the wrong receiver to
     // `reunite`.

--- a/docs/issue-journal.md
+++ b/docs/issue-journal.md
@@ -779,6 +779,31 @@ own for distributed changes.
   - `cargo check -p application`
   - `cargo check -p local_backend`
 
+### 2026-06 — Fenced coordinator-owned reads and sync behind a Raft serving lease
+
+- **Status:** complete
+- **Related issue:** `#152`
+- **What this fixes:** coordinator-owned routes such as sync setup, latest
+  queries, actions, and deployment-global request surfaces previously trusted
+  only the local Raft leadership bit. A partition-0 leader isolated from quorum
+  could continue serving stale reads or accepting WebSocket sync setup until
+  its next Raft soft-state transition marked it non-leader.
+- **Behavior:** Raft now maintains a separate short coordinator serving lease.
+  Leadership election grants an initial lease, and leaders refresh it only
+  after observing recent peer quorum responses. Coordinator-owned route
+  authority, latest-query local execution, and cluster-singleton worker
+  ownership now require both Raft leadership and a fresh serving lease. If the
+  lease expires, the node fails closed instead of serving stale coordinator
+  work. Active sync WebSockets also monitor the same authority and close so
+  clients reconnect to the current coordinator.
+- **Validation:**
+  - `cargo test -p local_backend coordinator_owner_requires_fresh_raft_serving_lease -- --nocapture`
+  - `cargo test -p local_backend cluster_singleton_workers_follow_coordinator_authority -- --nocapture`
+  - `cargo test -p database leadership_callback -- --nocapture`
+  - `cargo test -p database single_node_election -- --nocapture`
+  - `cargo check -p database`
+  - `cargo check -p local_backend`
+
 ## Open Issues
 
 - `#74` is no longer blocked on follower self-sufficiency. The current


### PR DESCRIPTION
## Summary
- add a Raft coordinator serving lease separate from the raw leader bit
- refresh the lease on election and recent peer quorum responses, with single-voter refresh support
- require a fresh serving lease for coordinator-owned route authority, latest-query local execution, and cluster-singleton worker ownership
- close active sync WebSockets when coordinator authority or the serving lease is lost

## Tests
- `cargo test -p local_backend coordinator_owner_requires_fresh_raft_serving_lease -- --nocapture`
- `cargo test -p local_backend cluster_singleton_workers_follow_coordinator_authority -- --nocapture`
- `cargo test -p database leadership_callback -- --nocapture`
- `cargo test -p database single_node_election -- --nocapture`
- `cargo check -p database`
- `cargo check -p local_backend`

Closes #152