### PR TITLE
fix: gate background workers in cluster mode

### DIFF
--- a/crates/application/src/lib.rs
+++ b/crates/application/src/lib.rs
@@ -626,6 +626,40 @@ pub enum ScheduledAndCronWorkerStartup {
     Disabled,
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum AuthorityGatedWorkerStartup {
+    Start,
+    Disabled,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct ApplicationWorkerStartupPolicy {
+    pub scheduled_and_cron: ScheduledAndCronWorkerStartup,
+    pub authority_gated: AuthorityGatedWorkerStartup,
+}
+
+impl ApplicationWorkerStartupPolicy {
+    pub fn single_node() -> Self {
+        Self {
+            scheduled_and_cron: ScheduledAndCronWorkerStartup::Start,
+            authority_gated: AuthorityGatedWorkerStartup::Start,
+        }
+    }
+
+    pub fn clustered_fail_closed() -> Self {
+        Self {
+            scheduled_and_cron: ScheduledAndCronWorkerStartup::Disabled,
+            authority_gated: AuthorityGatedWorkerStartup::Disabled,
+        }
+    }
+}
+
+impl Default for ApplicationWorkerStartupPolicy {
+    fn default() -> Self {
+        Self::single_node()
+    }
+}
+
 fn start_scheduled_and_cron_workers<RT: Runtime>(
     runtime: RT,
     instance_name: String,
@@ -745,7 +779,7 @@ impl<RT: Runtime> Application<RT> {
         export_provider: Arc<dyn ExportProvider<RT>>,
         deleted_tablet_receiver: tokio::sync::mpsc::Receiver<TabletId>,
         oidc_http_client: CachedHttpClient,
-        scheduled_and_cron_worker_startup: ScheduledAndCronWorkerStartup,
+        worker_startup_policy: ApplicationWorkerStartupPolicy,
     ) -> anyhow::Result<Self> {
         let module_cache =
             ModuleCache::new(runtime.clone(), application_storage.modules_storage.clone()).await;
@@ -756,8 +790,17 @@ impl<RT: Runtime> Application<RT> {
             CONVEX_SITE.clone() => convex_site.parse()?
         };
 
+        let authority_gated_workers_enabled =
+            worker_startup_policy.authority_gated == AuthorityGatedWorkerStartup::Start;
+        if !authority_gated_workers_enabled {
+            tracing::info!(
+                "Authority-gated application workers are disabled until this clustered node has a \
+                 dedicated worker authority model"
+            );
+        }
+
         let mut index_worker = Arc::new(Mutex::new(None));
-        if *ENABLE_INDEX_BACKFILL {
+        if authority_gated_workers_enabled && *ENABLE_INDEX_BACKFILL {
             let index_worker_fut = IndexWorker::new(
                 runtime.clone(),
                 persistence.clone(),
@@ -770,42 +813,67 @@ impl<RT: Runtime> Application<RT> {
                 runtime.spawn("index_worker", index_worker_fut),
             )));
         };
-        let fast_forward_worker =
-            FastForwardIndexWorker::create_and_start(runtime.clone(), database.clone());
-        let fast_forward_worker = Arc::new(Mutex::new(
-            runtime.spawn("fast_forward_worker", fast_forward_worker),
-        ));
-        let search_worker = SearchIndexWorkers::create_and_start(
-            runtime.clone(),
-            database.clone(),
-            persistence.reader(),
-            application_storage.search_storage.clone(),
-            searcher,
-            segment_term_metadata_fetcher,
-        );
+        let fast_forward_worker = if authority_gated_workers_enabled {
+            let fast_forward_worker =
+                FastForwardIndexWorker::create_and_start(runtime.clone(), database.clone());
+            Some(runtime.spawn("fast_forward_worker", fast_forward_worker))
+        } else {
+            None
+        };
+        let fast_forward_worker = Arc::new(Mutex::new(fast_forward_worker));
+        let search_worker = if authority_gated_workers_enabled {
+            Some(SearchIndexWorkers::create_and_start(
+                runtime.clone(),
+                database.clone(),
+                persistence.reader(),
+                application_storage.search_storage.clone(),
+                searcher,
+                segment_term_metadata_fetcher,
+            ))
+        } else {
+            None
+        };
         let search_worker = Arc::new(Mutex::new(search_worker));
+        let search_and_vector_bootstrap_worker = if authority_gated_workers_enabled {
+            Some(database.start_search_and_vector_bootstrap())
+        } else {
+            None
+        };
         let search_and_vector_bootstrap_worker =
-            Arc::new(Mutex::new(database.start_search_and_vector_bootstrap()));
-        let table_summary_worker = TableSummaryWorker::start(
-            runtime.clone(),
-            database.clone(),
-            persistence.clone(),
-            lease_lost_shutdown,
-        );
-        let schema_worker = Arc::new(Mutex::new(runtime.spawn(
-            "schema_worker",
-            SchemaWorker::start(runtime.clone(), database.clone()),
-        )));
+            Arc::new(Mutex::new(search_and_vector_bootstrap_worker));
+        let table_summary_worker = if authority_gated_workers_enabled {
+            Some(TableSummaryWorker::start(
+                runtime.clone(),
+                database.clone(),
+                persistence.clone(),
+                lease_lost_shutdown,
+            ))
+        } else {
+            None
+        };
+        let table_summary_worker = Arc::new(Mutex::new(table_summary_worker));
+        let schema_worker = if authority_gated_workers_enabled {
+            Some(runtime.spawn(
+                "schema_worker",
+                SchemaWorker::start(runtime.clone(), database.clone()),
+            ))
+        } else {
+            None
+        };
+        let schema_worker = Arc::new(Mutex::new(schema_worker));
 
-        let system_table_cleanup_worker = SystemTableCleanupWorker::new(
-            runtime.clone(),
-            database.clone(),
-            application_storage.exports_storage.clone(),
-            deleted_tablet_receiver,
-        );
-        let system_table_cleanup_worker = Arc::new(Mutex::new(
-            runtime.spawn("system_table_cleanup_worker", system_table_cleanup_worker),
-        ));
+        let system_table_cleanup_worker = if authority_gated_workers_enabled {
+            let system_table_cleanup_worker = SystemTableCleanupWorker::new(
+                runtime.clone(),
+                database.clone(),
+                application_storage.exports_storage.clone(),
+                deleted_tablet_receiver,
+            );
+            Some(runtime.spawn("system_table_cleanup_worker", system_table_cleanup_worker))
+        } else {
+            None
+        };
+        let system_table_cleanup_worker = Arc::new(Mutex::new(system_table_cleanup_worker));
 
         // If local_log_sink is passed in, this is a local instance, so we enable log
         // streaming by default. Otherwise, it's hard to grant the
@@ -852,7 +920,9 @@ impl<RT: Runtime> Application<RT> {
         ));
         function_runner.set_action_callbacks(runner.clone());
 
-        let (scheduled_job_runner, cron_job_executor) = match scheduled_and_cron_worker_startup {
+        let (scheduled_job_runner, cron_job_executor) = match worker_startup_policy
+            .scheduled_and_cron
+        {
             ScheduledAndCronWorkerStartup::Start => {
                 let (scheduled_job_runner, cron_job_executor) = start_scheduled_and_cron_workers(
                     runtime.clone(),
@@ -872,39 +942,48 @@ impl<RT: Runtime> Application<RT> {
             },
         };
 
-        let export_worker = ExportWorker::new(
-            runtime.clone(),
-            database.clone(),
-            application_storage.exports_storage.clone(),
-            application_storage.files_storage.clone(),
-            export_provider,
-            usage_counter.clone(),
-            instance_name.clone(),
-        );
-        let export_worker = Arc::new(Mutex::new(Some(
-            runtime.spawn("export_worker", export_worker),
-        )));
+        let export_worker = if authority_gated_workers_enabled {
+            let export_worker = ExportWorker::new(
+                runtime.clone(),
+                database.clone(),
+                application_storage.exports_storage.clone(),
+                application_storage.files_storage.clone(),
+                export_provider,
+                usage_counter.clone(),
+                instance_name.clone(),
+            );
+            Some(runtime.spawn("export_worker", export_worker))
+        } else {
+            None
+        };
+        let export_worker = Arc::new(Mutex::new(export_worker));
 
-        let snapshot_import_worker = SnapshotImportWorker::start(
-            runtime.clone(),
-            database.clone(),
-            application_storage.snapshot_imports_storage.clone(),
-            file_storage.clone(),
-            usage_counter.clone(),
-        );
-        let snapshot_import_worker = Arc::new(Mutex::new(Some(
-            runtime.spawn("snapshot_import_worker", snapshot_import_worker),
-        )));
+        let snapshot_import_worker = if authority_gated_workers_enabled {
+            let snapshot_import_worker = SnapshotImportWorker::start(
+                runtime.clone(),
+                database.clone(),
+                application_storage.snapshot_imports_storage.clone(),
+                file_storage.clone(),
+                usage_counter.clone(),
+            );
+            Some(runtime.spawn("snapshot_import_worker", snapshot_import_worker))
+        } else {
+            None
+        };
+        let snapshot_import_worker = Arc::new(Mutex::new(snapshot_import_worker));
 
-        let migration_worker = MigrationWorker::new(
-            runtime.clone(),
-            persistence.clone(),
-            database.clone(),
-            application_storage.modules_storage.clone(),
-        );
-        let migration_worker = Arc::new(Mutex::new(Some(
-            runtime.spawn("migration_worker", migration_worker.go()),
-        )));
+        let migration_worker = if authority_gated_workers_enabled {
+            let migration_worker = MigrationWorker::new(
+                runtime.clone(),
+                persistence.clone(),
+                database.clone(),
+                application_storage.modules_storage.clone(),
+            );
+            Some(runtime.spawn("migration_worker", migration_worker.go()))
+        } else {
+            None
+        };
+        let migration_worker = Arc::new(Mutex::new(migration_worker));
 
         let usage_gauges_tracking_worker = UsageGaugesTrackingWorker::start(
             runtime.clone(),
@@ -1001,6 +1080,23 @@ impl<RT: Runtime> Application<RT> {
     pub fn scheduled_and_cron_workers_running_for_test(&self) -> bool {
         self.workers.scheduled_job_runner.lock().is_some()
             && self.workers.cron_job_executor.lock().is_some()
+    }
+
+    #[cfg(any(test, feature = "testing"))]
+    pub fn authority_gated_workers_running_for_test(&self) -> bool {
+        self.workers.fast_forward_worker.lock().is_some()
+            && self.workers.search_worker.lock().is_some()
+            && self
+                .workers
+                .search_and_vector_bootstrap_worker
+                .lock()
+                .is_some()
+            && self.workers.table_summary_worker.lock().is_some()
+            && self.workers.schema_worker.lock().is_some()
+            && self.workers.snapshot_import_worker.lock().is_some()
+            && self.workers.export_worker.lock().is_some()
+            && self.workers.system_table_cleanup_worker.lock().is_some()
+            && self.workers.migration_worker.lock().is_some()
     }
 
     pub fn modules_storage(&self) -> &Arc<dyn Storage> {

--- a/crates/application/src/test_helpers.rs
+++ b/crates/application/src/test_helpers.rs
@@ -121,7 +121,7 @@ use crate::{
     log_visibility::RedactLogsToClient,
     scheduled_jobs::ScheduledJobContext,
     Application,
-    ScheduledAndCronWorkerStartup,
+    ApplicationWorkerStartupPolicy,
 };
 
 pub static OBJECTS_TABLE: LazyLock<TableName> = LazyLock::new(|| "objects".parse().unwrap());
@@ -132,7 +132,7 @@ pub struct ApplicationFixtureArgs {
     pub tp: Option<TestPersistence>,
     pub event_logger: Option<Arc<dyn UsageEventLogger>>,
     pub node_executor: Option<Arc<dyn NodeExecutor>>,
-    pub scheduled_and_cron_worker_startup: Option<ScheduledAndCronWorkerStartup>,
+    pub worker_startup_policy: Option<ApplicationWorkerStartupPolicy>,
 }
 
 impl ApplicationFixtureArgs {
@@ -306,8 +306,7 @@ impl<RT: Runtime> ApplicationTestExt<RT> for Application<RT> {
             Arc::new(InProcessExportProvider),
             deleted_tablet_receiver,
             oidc_http_client,
-            args.scheduled_and_cron_worker_startup
-                .unwrap_or(ScheduledAndCronWorkerStartup::Start),
+            args.worker_startup_policy.unwrap_or_default(),
         )
         .await?;
 

--- a/crates/application/src/tests/scheduled_jobs.rs
+++ b/crates/application/src/tests/scheduled_jobs.rs
@@ -85,6 +85,7 @@ use crate::{
         OBJECTS_TABLE_COMPONENT,
     },
     Application,
+    ApplicationWorkerStartupPolicy,
     ScheduledAndCronWorkerStartup,
 };
 
@@ -144,7 +145,10 @@ async fn test_scheduled_and_cron_workers_can_start_disabled(rt: TestRuntime) -> 
     let application = Application::new_for_tests_with_args(
         &rt,
         ApplicationFixtureArgs {
-            scheduled_and_cron_worker_startup: Some(ScheduledAndCronWorkerStartup::Disabled),
+            worker_startup_policy: Some(ApplicationWorkerStartupPolicy {
+                scheduled_and_cron: ScheduledAndCronWorkerStartup::Disabled,
+                ..ApplicationWorkerStartupPolicy::single_node()
+            }),
             ..Default::default()
         },
     )
@@ -155,6 +159,22 @@ async fn test_scheduled_and_cron_workers_can_start_disabled(rt: TestRuntime) -> 
     assert!(application.scheduled_and_cron_workers_running_for_test());
     application.stop_scheduled_and_cron_workers();
     assert!(!application.scheduled_and_cron_workers_running_for_test());
+    Ok(())
+}
+
+#[convex_macro::test_runtime]
+async fn test_cluster_fail_closed_workers_start_disabled(rt: TestRuntime) -> anyhow::Result<()> {
+    let application = Application::new_for_tests_with_args(
+        &rt,
+        ApplicationFixtureArgs {
+            worker_startup_policy: Some(ApplicationWorkerStartupPolicy::clustered_fail_closed()),
+            ..Default::default()
+        },
+    )
+    .await?;
+
+    assert!(!application.scheduled_and_cron_workers_running_for_test());
+    assert!(!application.authority_gated_workers_running_for_test());
     Ok(())
 }
 

--- a/crates/application/src/worker_handles.rs
+++ b/crates/application/src/worker_handles.rs
@@ -19,30 +19,49 @@ pub struct WorkerHandles {
     pub(crate) scheduled_job_runner: Arc<Mutex<Option<ScheduledJobRunner>>>,
     pub(crate) cron_job_executor: Arc<Mutex<Option<Box<dyn SpawnHandle>>>>,
     pub(crate) index_worker: Arc<Mutex<Option<Box<dyn SpawnHandle>>>>,
-    pub(crate) fast_forward_worker: Arc<Mutex<Box<dyn SpawnHandle>>>,
-    pub(crate) search_worker: Arc<Mutex<SearchIndexWorkers>>,
-    pub(crate) search_and_vector_bootstrap_worker: Arc<Mutex<Box<dyn SpawnHandle>>>,
-    pub(crate) table_summary_worker: TableSummaryClient,
-    pub(crate) schema_worker: Arc<Mutex<Box<dyn SpawnHandle>>>,
+    pub(crate) fast_forward_worker: Arc<Mutex<Option<Box<dyn SpawnHandle>>>>,
+    pub(crate) search_worker: Arc<Mutex<Option<SearchIndexWorkers>>>,
+    pub(crate) search_and_vector_bootstrap_worker: Arc<Mutex<Option<Box<dyn SpawnHandle>>>>,
+    pub(crate) table_summary_worker: Arc<Mutex<Option<TableSummaryClient>>>,
+    pub(crate) schema_worker: Arc<Mutex<Option<Box<dyn SpawnHandle>>>>,
     pub(crate) snapshot_import_worker: Arc<Mutex<Option<Box<dyn SpawnHandle>>>>,
     pub(crate) export_worker: Arc<Mutex<Option<Box<dyn SpawnHandle>>>>,
-    pub(crate) system_table_cleanup_worker: Arc<Mutex<Box<dyn SpawnHandle>>>,
+    pub(crate) system_table_cleanup_worker: Arc<Mutex<Option<Box<dyn SpawnHandle>>>>,
     pub(crate) migration_worker: Arc<Mutex<Option<Box<dyn SpawnHandle>>>>,
 }
 
 impl WorkerHandles {
     pub async fn shutdown(&self) -> anyhow::Result<()> {
         self.usage_gauges_tracking_worker.shutdown().await?;
-        self.table_summary_worker.shutdown().await?;
-        self.system_table_cleanup_worker.lock().shutdown();
-        self.schema_worker.lock().shutdown();
+        let table_summary_worker = self.table_summary_worker.lock().take();
+        if let Some(table_summary_worker) = table_summary_worker {
+            table_summary_worker.shutdown().await?;
+        }
+        let system_table_cleanup_worker = self.system_table_cleanup_worker.lock().take();
+        if let Some(mut system_table_cleanup_worker) = system_table_cleanup_worker {
+            system_table_cleanup_worker.shutdown();
+        }
+        let schema_worker = self.schema_worker.lock().take();
+        if let Some(mut schema_worker) = schema_worker {
+            schema_worker.shutdown();
+        }
         let index_worker = self.index_worker.lock().take();
         if let Some(index_worker) = index_worker {
             shutdown_and_join(index_worker).await?;
         }
-        self.search_worker.lock().shutdown();
-        self.search_and_vector_bootstrap_worker.lock().shutdown();
-        self.fast_forward_worker.lock().shutdown();
+        let search_worker = self.search_worker.lock().take();
+        if let Some(mut search_worker) = search_worker {
+            search_worker.shutdown();
+        }
+        let search_and_vector_bootstrap_worker =
+            self.search_and_vector_bootstrap_worker.lock().take();
+        if let Some(mut search_and_vector_bootstrap_worker) = search_and_vector_bootstrap_worker {
+            search_and_vector_bootstrap_worker.shutdown();
+        }
+        let fast_forward_worker = self.fast_forward_worker.lock().take();
+        if let Some(mut fast_forward_worker) = fast_forward_worker {
+            fast_forward_worker.shutdown();
+        }
         let export_worker = self.export_worker.lock().take();
         if let Some(export_worker) = export_worker {
             shutdown_and_join(export_worker).await?;

--- a/crates/local_backend/src/lib.rs
+++ b/crates/local_backend/src/lib.rs
@@ -25,8 +25,8 @@ use application::{
     api::ApplicationApi,
     log_visibility::RedactLogsToClient,
     Application,
+    ApplicationWorkerStartupPolicy,
     QueryCache,
-    ScheduledAndCronWorkerStartup,
 };
 use common::{
     self,
@@ -342,6 +342,17 @@ fn start_cluster_singleton_worker_supervisor(
     });
 }
 
+fn application_worker_startup_policy(
+    replication_mode: &str,
+    partition_id: Option<database::partition::PartitionId>,
+) -> ApplicationWorkerStartupPolicy {
+    if replication_mode == "replica" || partition_id.is_some() {
+        ApplicationWorkerStartupPolicy::clustered_fail_closed()
+    } else {
+        ApplicationWorkerStartupPolicy::single_node()
+    }
+}
+
 pub async fn make_app(
     runtime: ProdRuntime,
     config: LocalConfig,
@@ -623,12 +634,10 @@ pub async fn make_app(
             fetch_client.clone(),
         )?);
 
-    let scheduled_and_cron_worker_startup =
-        if config.replication_mode == "replica" || config.partition_id.is_some() {
-            ScheduledAndCronWorkerStartup::Disabled
-        } else {
-            ScheduledAndCronWorkerStartup::Start
-        };
+    let worker_startup_policy = application_worker_startup_policy(
+        &config.replication_mode,
+        config.partition_id.map(database::partition::PartitionId),
+    );
     let application = Application::new(
         runtime.clone(),
         database.clone(),
@@ -657,7 +666,7 @@ pub async fn make_app(
         Arc::new(InProcessExportProvider),
         deleted_tablet_receiver,
         oidc_http_client,
-        scheduled_and_cron_worker_startup,
+        worker_startup_policy,
     )
     .await?;
 
@@ -1290,6 +1299,32 @@ mod tests {
             Some(database::partition::PartitionId(0)),
             Some(&raft_state),
         ));
+    }
+
+    #[test]
+    fn application_workers_fail_closed_for_clustered_nodes() {
+        assert_eq!(
+            super::application_worker_startup_policy("primary", None),
+            application::ApplicationWorkerStartupPolicy::single_node(),
+        );
+        assert_eq!(
+            super::application_worker_startup_policy("replica", None),
+            application::ApplicationWorkerStartupPolicy::clustered_fail_closed(),
+        );
+        assert_eq!(
+            super::application_worker_startup_policy(
+                "primary",
+                Some(database::partition::PartitionId(0)),
+            ),
+            application::ApplicationWorkerStartupPolicy::clustered_fail_closed(),
+        );
+        assert_eq!(
+            super::application_worker_startup_policy(
+                "primary",
+                Some(database::partition::PartitionId(1)),
+            ),
+            application::ApplicationWorkerStartupPolicy::clustered_fail_closed(),
+        );
     }
 
     #[test]

--- a/docs/cluster-authority-routing.md
+++ b/docs/cluster-authority-routing.md
@@ -113,6 +113,20 @@ explicit smaller route state:
 | `ActionCallbackRouterState` | Internal node action callback surfaces.                                           |
 | `ImportExportRouterState`   | Snapshot and streaming import/export surfaces.                                    |
 
+## Background Worker Authority
+
+Foreground route authority is not enough on its own: background workers can
+mutate the same deployment-global metadata or derived indexes without passing
+through HTTP middleware. The local backend therefore chooses an
+`ApplicationWorkerStartupPolicy` during `make_app`.
+
+| Worker surface                                                                                         | Cluster-mode behavior                                                                                                                                      |
+| ------------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Scheduled jobs and crons                                                                               | Start disabled, then run only on the coordinator singleton while partition 0 is Raft leader and has a fresh serving lease.                                  |
+| Index backfill, fast-forward indexing, search/vector indexing, schema validation, table summaries       | Fail closed in clustered mode until each worker has a documented owner, failover, and idempotency model.                                                   |
+| System-table cleanup, snapshot import, export, and migration workers                                    | Fail closed in clustered mode because they mutate deployment-global job/system state or external side-effect state without a clustered ownership protocol. |
+| Usage gauges and log manager                                                                           | Continue to run as local observational/reporting plumbing. If they become authoritative state mutators, they must move into an explicit worker authority.   |
+
 ## Adding A Route
 
 Every new local-backend route must choose one authority class before it is

--- a/docs/issue-journal.md
+++ b/docs/issue-journal.md
@@ -804,6 +804,31 @@ own for distributed changes.
   - `cargo check -p database`
   - `cargo check -p local_backend`
 
+### 2026-06 — Failed closed authority-sensitive application workers in cluster mode
+
+- **Status:** complete
+- **Related issue:** `#150`
+- **What this fixes:** several background workers still started eagerly in
+  every clustered backend process even though their work mutates
+  deployment-global metadata or maintains derived state that does not yet have
+  a per-partition ownership protocol. Scheduled jobs and crons were already
+  moved behind the cluster-singleton supervisor in `#149`; the remaining worker
+  surfaces needed an explicit fail-closed startup policy instead of accidental
+  local execution.
+- **Behavior:** `Application::new` now takes an
+  `ApplicationWorkerStartupPolicy`. Single-node deployments keep eager worker
+  startup. Clustered local-backend nodes start with scheduled/crons disabled
+  for the existing coordinator-authority supervisor and keep the remaining
+  authority-gated workers disabled until each surface is migrated. This covers
+  index backfill/fast-forward, search/vector index workers and bootstrap,
+  table summary checkpoints, schema validation, system-table cleanup, snapshot
+  import, export, and migration workers. Usage gauges and log manager remain
+  local observational/reporting plumbing.
+- **Validation:**
+  - `cargo test -p application start_disabled -- --nocapture`
+  - `cargo test -p local_backend application_workers_fail_closed_for_clustered_nodes -- --nocapture`
+  - `cargo check -p application -p local_backend`
+
 ## Open Issues
 
 - `#74` is no longer blocked on follower self-sufficiency. The current


### PR DESCRIPTION
## Summary
- add an explicit application worker startup policy for single-node vs clustered deployments
- keep scheduled jobs/crons behind the existing coordinator singleton supervisor while failing closed authority-gated workers in cluster mode
- disable index/search/schema/table-summary/system-cleanup/import/export/migration workers in clustered startup until each has a documented ownership protocol
- document the worker authority model and issue-journal entry

## Validation
- `cargo test -p application start_disabled -- --nocapture`
- `cargo test -p local_backend application_workers_fail_closed_for_clustered_nodes -- --nocapture`
- `cargo check -p application -p local_backend`

Closes #150