### PR TITLE
fix: document replica timestamp translation

### DIFF
--- a/crates/database/src/commit_delta.rs
+++ b/crates/database/src/commit_delta.rs
@@ -42,7 +42,11 @@ use crate::{
 /// 3. Maintain ordering (via the commit timestamp)
 #[derive(Clone, Debug)]
 pub struct CommitDelta {
-    /// The commit timestamp assigned by the Committer.
+    /// The commit timestamp assigned by the source partition's Committer.
+    ///
+    /// Receivers may translate this into a later local apply timestamp for
+    /// their own MVCC/write-log state, but this value remains the origin
+    /// timestamp used for source-partition watermarks and redelivery dedup.
     pub ts: Timestamp,
 
     /// Document writes for persistence replay. Contains document ID, new value,

--- a/crates/database/src/committer.rs
+++ b/crates/database/src/committer.rs
@@ -460,6 +460,10 @@ fn downgrade_replicated_index_metadata(
         IndexConfig,
     };
 
+    if metadata.name.is_by_id_or_creation_time() {
+        return;
+    }
+
     match &mut metadata.config {
         IndexConfig::Database { on_disk_state, .. } => {
             let staged = on_disk_state.is_staged();
@@ -485,6 +489,28 @@ fn downgrade_replicated_index_metadata(
             }
         },
     }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct ReplicaDeltaTimestamps {
+    /// Timestamp assigned by the source partition when it committed the write.
+    origin_ts: Timestamp,
+    /// Timestamp at which this node can safely publish the replicated state.
+    local_apply_ts: Timestamp,
+}
+
+fn replica_delta_timestamps(
+    origin_ts: Timestamp,
+    latest_local_ts: Timestamp,
+    last_assigned_ts: Timestamp,
+) -> anyhow::Result<ReplicaDeltaTimestamps> {
+    Ok(ReplicaDeltaTimestamps {
+        origin_ts,
+        local_apply_ts: cmp::max(
+            origin_ts,
+            cmp::max(latest_local_ts.succ()?, last_assigned_ts.succ()?),
+        ),
+    })
 }
 
 type RaftCommitWaiter = Option<oneshot::Receiver<RaftProposalResult>>;
@@ -2730,11 +2756,13 @@ impl<RT: Runtime> Committer<RT> {
             let _ = result.send(Ok(remote_ts));
             return Ok(());
         }
-        let latest_ts = self.snapshot_manager.read().latest_ts();
-        let commit_ts = cmp::max(
+        let timestamps = replica_delta_timestamps(
             remote_ts,
-            cmp::max(latest_ts.succ()?, self.last_assigned_ts.succ()?),
-        );
+            *self.snapshot_manager.read().latest_ts(),
+            self.last_assigned_ts,
+        )?;
+        let remote_ts = timestamps.origin_ts;
+        let commit_ts = timestamps.local_apply_ts;
         self.last_assigned_ts = commit_ts;
         tracing::info!(
             "Applying replica delta: remote_ts={}, local_ts={}, {} document updates, {} tablet \
@@ -4978,6 +5006,7 @@ mod tests {
     use super::{
         is_retryable_system_generated_id_conflict,
         remap_index_metadata_update,
+        replica_delta_timestamps,
         Committer,
     };
     use crate::{
@@ -5087,6 +5116,27 @@ mod tests {
         })
     }
 
+    fn test_by_id_index_metadata_update(
+        source_index_tablet: TabletId,
+        source_index_table_number: u32,
+        source_user_tablet: TabletId,
+    ) -> anyhow::Result<DocumentUpdate> {
+        let metadata = IndexMetadata::new_enabled(
+            GenericIndexName::by_id(source_user_tablet),
+            IndexedFields::by_id(),
+        );
+        let document = ResolvedDocument::new(
+            test_resolved_id(source_index_tablet, source_index_table_number, 98)?,
+            CreationTime::ONE,
+            metadata.try_into()?,
+        )?;
+        Ok(DocumentUpdate {
+            id: document.id(),
+            old_document: None,
+            new_document: Some(document),
+        })
+    }
+
     #[test]
     fn replicated_index_metadata_remaps_target_tablet_and_downgrades_query_ready_state(
     ) -> anyhow::Result<()> {
@@ -5110,6 +5160,25 @@ mod tests {
     }
 
     #[test]
+    fn replicated_builtin_index_metadata_remains_query_ready() -> anyhow::Result<()> {
+        let source_index_tablet = test_tablet(21);
+        let local_index_tablet = test_tablet(22);
+        let source_user_tablet = test_tablet(23);
+        let local_user_tablet = test_tablet(24);
+        let update = test_by_id_index_metadata_update(source_index_tablet, 2, source_user_tablet)?;
+        let tablet_remap = BTreeMap::from([(source_user_tablet, local_user_tablet)]);
+
+        let remapped =
+            remap_index_metadata_update(&update, local_index_tablet, &tablet_remap, true)?;
+
+        let metadata =
+            TabletIndexMetadata::from_document(remapped.new_document.unwrap())?.into_value();
+        assert_eq!(*metadata.name.table(), local_user_tablet);
+        assert!(metadata.config.is_enabled());
+        Ok(())
+    }
+
+    #[test]
     fn raft_index_metadata_remap_preserves_query_ready_state() -> anyhow::Result<()> {
         let source_index_tablet = test_tablet(11);
         let local_index_tablet = test_tablet(12);
@@ -5126,6 +5195,19 @@ mod tests {
             TabletIndexMetadata::from_document(remapped.new_document.unwrap())?.into_value();
         assert_eq!(*metadata.name.table(), local_user_tablet);
         assert!(metadata.config.is_enabled());
+        Ok(())
+    }
+
+    #[test]
+    fn replica_delta_timestamps_distinguish_origin_from_local_apply_ts() -> anyhow::Result<()> {
+        let timestamps = replica_delta_timestamps(
+            Timestamp::must(10),
+            Timestamp::must(30),
+            Timestamp::must(40),
+        )?;
+
+        assert_eq!(timestamps.origin_ts, Timestamp::must(10));
+        assert_eq!(timestamps.local_apply_ts, Timestamp::must(41));
         Ok(())
     }
 

--- a/crates/database/src/tests/write_scaling_tests.rs
+++ b/crates/database/src/tests/write_scaling_tests.rs
@@ -102,6 +102,7 @@ use crate::{
         StaticPlacementConfig,
     },
     raft_partition::RaftPartitionState,
+    snapshot_manager::partition_timestamp_map_from_json,
     table_number_allocator::{
         testing::InMemoryTableNumberAllocator,
         TableNumberAllocator,
@@ -2248,6 +2249,106 @@ async fn test_remote_read_frontier_heartbeat_does_not_advance_snapshot_ts(
         projects_after.len(),
         1,
         "heartbeat should not erase replica-queryable state",
+    );
+
+    Ok(())
+}
+
+#[convex_macro::test_runtime]
+async fn test_replica_delta_timestamp_translation_records_origin_watermark(
+    rt: TestRuntime,
+) -> anyhow::Result<()> {
+    let log = Arc::new(InMemoryDistributedLog::new());
+    let target_persistence = Arc::new(TestPersistence::new());
+    let table_numbers = Arc::new(InMemoryTableNumberAllocator::default());
+    let source = create_node_with_table_number_allocator(
+        &rt,
+        log.clone(),
+        Some(partitioned_map(PartitionId(1))),
+        table_numbers.clone(),
+    )
+    .await?;
+    let target = create_node_with_persistence_and_table_number_allocator(
+        &rt,
+        target_persistence.clone(),
+        log.clone(),
+        Some(partitioned_map(PartitionId(0))),
+        None,
+        Arc::new(NoopTwoPhaseDecisionLog),
+        None,
+        table_numbers,
+    )
+    .await?;
+
+    insert_doc(&source, "projects", assert_obj!("name" => "remote")).await?;
+    let mut remote_delta = log
+        .deltas()
+        .into_iter()
+        .last()
+        .expect("remote project insert should publish a delta");
+
+    let local_ts = insert_doc(&target, "messages", assert_obj!("text" => "local")).await?;
+    let remote_ts = local_ts.pred()?;
+    remote_delta.ts = remote_ts;
+    assert!(
+        remote_ts < local_ts,
+        "test setup should apply an older origin timestamp after newer local state",
+    );
+
+    let applied_ts = target
+        .committer_for_test()
+        .apply_replica_delta(remote_delta.clone())
+        .await?;
+    assert!(
+        applied_ts > local_ts,
+        "replica apply should translate to the next local visibility timestamp",
+    );
+    assert_ne!(
+        applied_ts, remote_ts,
+        "this regression must exercise the explicit timestamp translation path",
+    );
+    assert_eq!(
+        target.replication_frontier_for_test(PartitionId(1)),
+        Some(applied_ts),
+        "remote read frontier tracks this node's local visibility timestamp",
+    );
+    assert_eq!(
+        target.replication_write_frontier_for_test(PartitionId(1)),
+        Some(applied_ts),
+        "write frontier tracks local visibility for real replicated writes",
+    );
+
+    let persisted_watermarks = target_persistence
+        .reader()
+        .get_persistence_global(PersistenceGlobalKey::AppliedDeltaWatermarks)
+        .await?
+        .context("applied delta watermark should be persisted")?;
+    let persisted_watermarks =
+        partition_timestamp_map_from_json(persisted_watermarks, "applied delta watermarks")?;
+    assert_eq!(
+        persisted_watermarks.get(&PartitionId(1)).copied(),
+        Some(remote_ts),
+        "origin watermark remains in the source partition timestamp domain",
+    );
+
+    let duplicate_apply_ts = target
+        .committer_for_test()
+        .apply_replica_delta(remote_delta)
+        .await?;
+    assert_eq!(
+        duplicate_apply_ts, remote_ts,
+        "duplicate detection uses the persisted origin timestamp watermark",
+    );
+    let projects = run_query(
+        target,
+        TableNamespace::root_component(),
+        Query::full_table_scan("projects".parse()?, Order::Asc),
+    )
+    .await?;
+    assert_eq!(
+        projects.len(),
+        1,
+        "duplicate redelivery must not re-apply the translated write",
     );
 
     Ok(())

--- a/docs/tso-replica-timestamp-fix.md
+++ b/docs/tso-replica-timestamp-fix.md
@@ -59,7 +59,7 @@ All three systems follow the same rule: **the global timestamp allocator is cons
 | CockroachDB | Leaseholder (HLC on propose) | Advance local HLC to command's timestamp |
 | TiDB | Leader (TSO on commit) | Apply with the leader's commitTS |
 | Vitess | Source shard (MySQL auto-increment) | Target replays with source positioning |
-| Convex (fixed) | Local Committer (TSO on commit) | Local clock + monotonic counter |
+| Convex (current) | Source partition on commit | Explicit translation: source `origin_ts`, receiver `local_apply_ts` |
 
 ## Our Fix
 
@@ -73,14 +73,23 @@ let commit_ts = self.next_commit_ts()?;
 After:
 
 ```rust
-// Monotonic counters only: no TSO, no system clock.
-// Stays in the same timestamp domain as next_commit_ts().
+// Explicit timestamp translation: keep the source timestamp for dedup/freshness
+// watermarks, but publish the state at the receiver's next safe local timestamp.
+let origin_ts = delta.ts;
 let latest_ts = self.snapshot_manager.read().latest_ts();
-let commit_ts = cmp::max(latest_ts.succ()?, self.last_assigned_ts.succ()?);
-self.last_assigned_ts = commit_ts;
+let local_apply_ts = cmp::max(
+    origin_ts,
+    cmp::max(latest_ts.succ()?, self.last_assigned_ts.succ()?),
+);
+self.last_assigned_ts = local_apply_ts;
 ```
 
-No TSO (reserved for local commits), no system clock (would leap ahead of TSO range and poison `last_assigned_ts`). Only the two monotonic counters that stay in the same domain as `next_commit_ts()`: the snapshot manager's latest timestamp and the last assigned timestamp.
+No TSO (reserved for local commits), no system clock (would leap ahead of TSO range and poison `last_assigned_ts`). Replica apply now has two explicit timestamps:
+
+- `origin_ts`: the source partition's commit timestamp. This is persisted in `AppliedDeltaWatermarks` and used for duplicate/redelivery detection.
+- `local_apply_ts`: the receiver's visibility timestamp. This is used for the local snapshot, write log, and `ReplicationFrontiers` / `ReplicationWriteFrontiers`.
+
+This is a translation model, not timestamp identity. It is safe for the current single read-authority/fail-closed routing model, but portable client cursors and follower-safe reads must use the follow-up read-fencing work before relying on timestamps across nodes.
 
 ## Why System Clock Was Also Wrong (Second Fix)
 
@@ -110,15 +119,16 @@ All three systems follow the same rule on their apply paths:
 2. Timestamp domain mixing (system clock vs TSO range)
 3. Contention between apply and local commit paths
 
-### The Correct Fix
+### Current Translation Model
 
-Use only monotonic counters that stay in the same domain as `next_commit_ts()`:
+The current implementation intentionally keeps both timestamps:
 
 ```rust
-let commit_ts = cmp::max(latest_ts.succ()?, self.last_assigned_ts.succ()?);
+let origin_ts = delta.ts;
+let local_apply_ts = cmp::max(origin_ts, cmp::max(latest_ts.succ()?, last_assigned_ts.succ()?));
 ```
 
-No TSO. No system clock. These two values are always in the same numeric range as TSO-assigned timestamps because they're derived from the same `last_assigned_ts` counter that `next_commit_ts()` writes to.
+No TSO. No system clock. `origin_ts` remains durable in `AppliedDeltaWatermarks`; `local_apply_ts` is the local MVCC/write-log timestamp. A future timestamp-identity model would need a reorder buffer/watermark merge so every node can safely apply replicated deltas at exactly `origin_ts`.
 
 ## Third Fix: Async bump_max_repeatable_ts Racing with apply_replica_delta
 

--- a/docs/what-we-built.md
+++ b/docs/what-we-built.md
@@ -46,7 +46,7 @@ We added the last three rows while keeping the first four — the things that ma
 
 **CockroachDB's solution**: Global descriptor ID allocator — a single counter (`/system/desc-idgen`) incremented non-transactionally. Every table gets a cluster-unique ID.
 
-**What we built**: When `apply_replica_delta` receives a `_tables` entry for a table that doesn't exist locally, it reassigns the table number to a locally-unique value by scanning the table registry for the next available number. The TabletId (derived from `developer_id`) stays the same for correct remapping.
+**What we built**: User table numbers now come from a cluster-wide allocator, so public document IDs embedded in values stay portable across nodes. `apply_replica_delta` preserves the source table number and fails loudly if a local table name already exists with a conflicting number.
 
 **Problem 2**: Async max_repeatable_ts bumps race with synchronous replica delta applies, causing timestamp ordering violations in the write log.
 
@@ -62,7 +62,7 @@ We added the last three rows while keeping the first four — the things that ma
 
 **YugabyteDB's solution**: "Hybrid timestamps assigned to committed Raft log entries in the same tablet always keep increasing, even if there are leader changes. This is because the new leader always has all committed entries from previous leaders, and it makes sure to update its hybrid clock with the timestamp of the last committed entry before appending new entries."
 
-**What we built**: Replica delta apply uses only monotonic counters (`max(latest_ts + 1, last_assigned_ts + 1)`) — no TSO (reserved for local commits), no system clock (would leap ahead of TSO range). The same two counters that `next_commit_ts()` writes to, staying in the same numeric domain.
+**What we built**: Replica delta apply uses an explicit timestamp translation model. The source partition timestamp is persisted as the origin watermark for deduplication/freshness, while the receiver publishes the replicated state at `max(origin_ts, latest_ts + 1, last_assigned_ts + 1)`. No TSO is consumed during apply, and no system clock value is mixed into the local commit counter.
 
 **Source**: [YugabyteDB Raft consensus](https://docs.yugabyte.com/stable/architecture/docdb-replication/raft/), [YugabyteDB Jepsen testing](https://docs.yugabyte.com/stable/benchmark/resilience/jepsen-testing/)
 
@@ -72,7 +72,7 @@ We added the last three rows while keeping the first four — the things that ma
 
 **Spanner's solution**: TrueTime assigns timestamps with bounded uncertainty. "Writes with earlier timestamps are applied before those with later timestamps, with Paxos leaders using TrueTime to assign timestamps." A commit wait phase guarantees the commit timestamp is in the past for all replicas.
 
-**What we built**: Our TSO provides the same global ordering guarantee as TrueTime but without GPS clocks — batch allocation from a central counter is simpler and correctness is easier to verify. The Raft-pattern persistence pipeline ensures all writes are applied in timestamp order.
+**What we built**: Our TSO provides a global timestamp source for commit decisions without GPS clocks. Replica apply currently uses explicit origin-to-local timestamp translation, so portable read-after-write guarantees still require the follow-up read-fencing work rather than assuming every node has an identical MVCC timeline.
 
 **Source**: [Spanner TrueTime](https://docs.google.com/spanner/docs/true-time-external-consistency), [Spanner paper](https://research.google.com/pubs/archive/45855.pdf)
 


### PR DESCRIPTION
## Summary

- Make replica delta timestamp handling explicit with `origin_ts` and `local_apply_ts`.
- Keep reserved built-in index metadata (`by_id` / `by_creation_time`) query-ready during cross-partition metadata remap.
- Add regression coverage for applying an older origin delta after newer local state, persisting the origin watermark, and avoiding duplicate redelivery.
- Update docs to describe the current explicit timestamp translation model instead of overclaiming timestamp identity.

## Why

Replica apply can legitimately publish a remote delta at a later local timestamp when the receiver has already advanced beyond the source commit timestamp. That means we need to treat the source timestamp and local visibility timestamp as different domains until the future reorder-buffer/timestamp-identity model exists.

Closes #139.

## Validation

- `cargo test -p database replica_delta -- --nocapture`
- `cargo test -p database replicated_builtin_index_metadata_remains_query_ready -- --nocapture`
- `cargo check -p database -p local_backend`