### PR TITLE
fix: add portable read-after-write fences

### DIFF
--- a/crates/application/src/api.rs
+++ b/crates/application/src/api.rs
@@ -89,6 +89,15 @@ pub struct ReadAfterWriteFence {
     pub ts: Timestamp,
 }
 
+impl ReadAfterWriteFence {
+    pub fn from_source_partition(source_partition: Option<u32>, ts: Timestamp) -> Self {
+        Self {
+            source_partition: source_partition.map(PartitionId),
+            ts,
+        }
+    }
+}
+
 // A trait that abstracts the backend API. It all state and validation logic
 // so http routes can be kept thin and stateless. The implementor is also
 // responsible for routing the request to the appropriate backend in the hosted
@@ -267,6 +276,8 @@ pub trait ApplicationApi: Send + Sync {
 
     /// To be used for metrics only.
     async fn partition_id(&self, host: &ResolvedHostname) -> anyhow::Result<u64>;
+
+    fn read_after_write_source_partition(&self) -> Option<u32>;
 }
 
 // Implements ApplicationApi via Application.
@@ -561,6 +572,12 @@ impl<RT: Runtime> ApplicationApi for Application<RT> {
     async fn partition_id(&self, _host: &ResolvedHostname) -> anyhow::Result<u64> {
         // Not relevant; just return something
         Ok(0)
+    }
+
+    fn read_after_write_source_partition(&self) -> Option<u32> {
+        self.database
+            .local_partition()
+            .map(|partition| partition.0)
     }
 }
 

--- a/crates/application/src/api.rs
+++ b/crates/application/src/api.rs
@@ -24,6 +24,7 @@ use common::{
     RequestId,
 };
 use database::{
+    partition::PartitionId,
     Database,
     LogReader,
     ReadSet,
@@ -82,6 +83,12 @@ pub enum ExecuteQueryTimestamp {
     At(Timestamp),
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct ReadAfterWriteFence {
+    pub source_partition: Option<PartitionId>,
+    pub ts: Timestamp,
+}
+
 // A trait that abstracts the backend API. It all state and validation logic
 // so http routes can be kept thin and stateless. The implementor is also
 // responsible for routing the request to the appropriate backend in the hosted
@@ -107,6 +114,7 @@ pub trait ApplicationApi: Send + Sync {
         args: SerializedArgs,
         caller: FunctionCaller,
         ts: ExecuteQueryTimestamp,
+        read_after_write: Option<ReadAfterWriteFence>,
         journal: Option<SerializedQueryJournal>,
     ) -> anyhow::Result<RedactedQueryReturn>;
 
@@ -283,12 +291,18 @@ impl<RT: Runtime> ApplicationApi for Application<RT> {
         args: SerializedArgs,
         caller: FunctionCaller,
         ts: ExecuteQueryTimestamp,
+        read_after_write: Option<ReadAfterWriteFence>,
         journal: Option<SerializedQueryJournal>,
     ) -> anyhow::Result<RedactedQueryReturn> {
         anyhow::ensure!(
             caller.allowed_visibility() == AllowedVisibility::PublicOnly,
             "This method should not be used by internal callers."
         );
+        if let Some(fence) = read_after_write {
+            self.database
+                .wait_for_read_after_write_fence(fence.source_partition, fence.ts)
+                .await?;
+        }
         let ts = match ts {
             ExecuteQueryTimestamp::Latest => *self.now_ts_for_reads(),
             ExecuteQueryTimestamp::At(ts) => ts,

--- a/crates/convex/src/base_client/mod.rs
+++ b/crates/convex/src/base_client/mod.rs
@@ -152,6 +152,7 @@ impl LocalSyncState {
             udf_path,
             args: SerializedArgs::from_args(vec![Value::Object(args.clone()).into()])
                 .expect("Could not serialize query arguments"),
+            read_after_write: None,
             journal: None,
             component_path: None,
         });
@@ -277,6 +278,7 @@ impl LocalSyncState {
                     Value::Object(local_query.args.clone()).into()
                 ])
                 .expect("Could not serialize query arguments"),
+                read_after_write: None,
                 journal: None,
                 component_path: None,
             });
@@ -668,6 +670,7 @@ impl BaseConvexClient {
                 request_id,
                 result,
                 ts,
+                read_after_write: _,
                 log_lines,
             } => {
                 for log_line in log_lines.0 {

--- a/crates/convex/src/client/mod.rs
+++ b/crates/convex/src/client/mod.rs
@@ -564,6 +564,7 @@ pub mod tests {
             request_id: 0,
             result: result.into(),
             ts: Some(new_version.ts),
+            read_after_write: None,
             log_lines: LogLinesMessage(vec![]),
         };
         (mutation_response, transition_response)
@@ -844,6 +845,7 @@ pub mod tests {
                         query_id,
                         udf_path: "getValue1".parse()?,
                         args: SerializedArgs::from_args(vec![json!({})])?,
+                        read_after_write: None,
                         journal: None,
                         component_path: None,
                     })]
@@ -1012,6 +1014,7 @@ pub mod tests {
                         query_id: subscription1.query_id(),
                         udf_path: "getValue1".parse()?,
                         args: SerializedArgs::from_args(vec![json!({})])?,
+                        read_after_write: None,
                         journal: None,
                         component_path: None,
                     })]
@@ -1023,6 +1026,7 @@ pub mod tests {
                         query_id: subscription2.query_id(),
                         udf_path: "getValue2".parse()?,
                         args: SerializedArgs::from_args(vec![json!({})])?,
+                        read_after_write: None,
                         journal: None,
                         component_path: None,
                     })]
@@ -1034,6 +1038,7 @@ pub mod tests {
                         query_id: subscription3.query_id(),
                         udf_path: "getValue2".parse()?,
                         args: SerializedArgs::from_args(vec![json!({"hello": "world"})])?,
+                        read_after_write: None,
                         journal: None,
                         component_path: None,
                     })]
@@ -1073,6 +1078,7 @@ pub mod tests {
                         query_id,
                         udf_path: "getValue".parse()?,
                         args: SerializedArgs::from_args(vec![json!({})])?,
+                        read_after_write: None,
                         journal: None,
                         component_path: None,
                     })]

--- a/crates/convex/sync_types/src/lib.rs
+++ b/crates/convex/sync_types/src/lib.rs
@@ -27,6 +27,7 @@ pub use crate::{
         QueryId,
         QuerySetModification,
         QuerySetVersion,
+        ReadAfterWriteToken,
         SerializedQueryJournal,
         ServerMessage,
         SessionId,

--- a/crates/convex/sync_types/src/types/json.rs
+++ b/crates/convex/sync_types/src/types/json.rs
@@ -28,6 +28,7 @@ use crate::{
     Query,
     QueryId,
     QuerySetModification,
+    ReadAfterWriteToken,
     SerializedQueryJournal,
     ServerMessage,
     SessionRequestSeqNumber,
@@ -78,11 +79,42 @@ struct QueryJson {
     udf_path: String,
 
     #[serde(skip_serializing_if = "Option::is_none")]
+    read_after_write: Option<ReadAfterWriteTokenJson>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(deserialize_with = "double_option")]
     journal: Option<SerializedQueryJournal>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     component_path: Option<String>,
+}
+
+#[derive(Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct ReadAfterWriteTokenJson {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    source_partition: Option<u32>,
+    ts: String,
+}
+
+impl From<ReadAfterWriteToken> for ReadAfterWriteTokenJson {
+    fn from(token: ReadAfterWriteToken) -> Self {
+        Self {
+            source_partition: token.source_partition,
+            ts: u64_to_string(token.ts.into()),
+        }
+    }
+}
+
+impl TryFrom<ReadAfterWriteTokenJson> for ReadAfterWriteToken {
+    type Error = anyhow::Error;
+
+    fn try_from(token: ReadAfterWriteTokenJson) -> Result<Self, Self::Error> {
+        Ok(Self {
+            source_partition: token.source_partition,
+            ts: Timestamp::try_from(string_to_u64(&token.ts)?)?,
+        })
+    }
 }
 
 #[derive(Deserialize, Serialize)]
@@ -113,6 +145,7 @@ impl TryFrom<QuerySetModification> for JsonValue {
                 let query_json = QueryJson {
                     query_id: q.query_id,
                     udf_path: String::from(q.udf_path),
+                    read_after_write: q.read_after_write.map(Into::into),
                     journal: q.journal,
                     component_path: q.component_path,
                 };
@@ -144,6 +177,7 @@ impl TryFrom<JsonValue> for QuerySetModification {
                     query_id: q.query_id,
                     udf_path: q.udf_path.parse()?,
                     args: SerializedArgs(args.unwrap_or_default()),
+                    read_after_write: q.read_after_write.map(TryInto::try_into).transpose()?,
                     journal: q.journal,
                     component_path: q.component_path,
                 };
@@ -602,6 +636,7 @@ impl<V: Into<JsonValue>> From<ServerMessage<V>> for JsonValue {
                 request_id,
                 result: Ok(value),
                 ts,
+                read_after_write,
                 log_lines,
             } => {
                 let jv: JsonValue = value.into();
@@ -611,6 +646,7 @@ impl<V: Into<JsonValue>> From<ServerMessage<V>> for JsonValue {
                     "success": true,
                     "result": jv,
                     "ts": ts.map(|ts| u64_to_string(ts.into())),
+                    "readAfterWrite": read_after_write.map(ReadAfterWriteTokenJson::from),
                     "logLines": log_lines,
                 })
             },
@@ -618,6 +654,7 @@ impl<V: Into<JsonValue>> From<ServerMessage<V>> for JsonValue {
                 request_id,
                 result: Err(error_payload),
                 ts,
+                read_after_write,
                 log_lines,
             } => {
                 let mut response = json!({
@@ -626,6 +663,7 @@ impl<V: Into<JsonValue>> From<ServerMessage<V>> for JsonValue {
                     "success": false,
                     "result": error_payload.get_message(),
                     "ts": ts.map(|ts| u64_to_string(ts.into())),
+                    "readAfterWrite": read_after_write.map(ReadAfterWriteTokenJson::from),
                     "logLines": log_lines,
                 });
                 if let ErrorPayload::ErrorData { data, .. } = error_payload {
@@ -724,6 +762,7 @@ impl<V: TryFrom<JsonValue, Error = anyhow::Error>> TryFrom<JsonValue> for Server
                 success: bool,
                 result: JsonValue,
                 ts: Option<String>,
+                read_after_write: Option<ReadAfterWriteTokenJson>,
                 log_lines: LogLinesMessage,
                 #[serde(default, deserialize_with = "deserialize_some")]
                 error_data: Option<JsonValue>,
@@ -778,6 +817,7 @@ impl<V: TryFrom<JsonValue, Error = anyhow::Error>> TryFrom<JsonValue> for Server
                 success,
                 result,
                 ts,
+                read_after_write,
                 log_lines,
                 error_data,
             } => {
@@ -802,6 +842,7 @@ impl<V: TryFrom<JsonValue, Error = anyhow::Error>> TryFrom<JsonValue> for Server
                         .transpose()?
                         .map(Timestamp::try_from)
                         .transpose()?,
+                    read_after_write: read_after_write.map(TryInto::try_into).transpose()?,
                     log_lines,
                 }
             },
@@ -1026,8 +1067,12 @@ mod tests {
     };
     use crate::{
         testing::assert_roundtrips,
+        types::SerializedArgs,
         ClientMessage,
+        Query,
         QueryId,
+        QuerySetModification,
+        ReadAfterWriteToken,
         ServerMessage,
         StateModification,
         Timestamp,
@@ -1139,6 +1184,7 @@ mod tests {
                 data: TestValue(JsonValue::Null),
             }),
             ts: None,
+            read_after_write: None,
             log_lines: crate::LogLinesMessage(vec![]),
         });
     }
@@ -1166,6 +1212,57 @@ mod tests {
             client_clock_skew: Some(1),
             server_ts: Some(Timestamp::must(1)),
         });
+    }
+
+    #[test]
+    fn query_read_after_write_token_roundtrips() -> anyhow::Result<()> {
+        let modification = QuerySetModification::Add(Query {
+            query_id: QueryId::new(7),
+            udf_path: "messages:list".parse()?,
+            args: SerializedArgs::from_args(vec![json!({"channel": "general"})])?,
+            read_after_write: Some(ReadAfterWriteToken {
+                source_partition: Some(3),
+                ts: Timestamp::must(42),
+            }),
+            journal: None,
+            component_path: None,
+        });
+
+        let json = JsonValue::try_from(modification.clone())?;
+        assert_eq!(
+            json.get("readAfterWrite"),
+            Some(&json!({
+                "sourcePartition": 3,
+                "ts": u64_to_string(42),
+            }))
+        );
+        assert_eq!(QuerySetModification::try_from(json)?, modification);
+        Ok(())
+    }
+
+    #[test]
+    fn mutation_response_read_after_write_token_roundtrips() -> anyhow::Result<()> {
+        let message = ServerMessage::MutationResponse {
+            request_id: 8,
+            result: Ok(TestValue(JsonValue::String("ok".to_string()))),
+            ts: Some(Timestamp::must(42)),
+            read_after_write: Some(ReadAfterWriteToken {
+                source_partition: Some(3),
+                ts: Timestamp::must(42),
+            }),
+            log_lines: crate::LogLinesMessage(vec![]),
+        };
+
+        let json = JsonValue::from(message.clone());
+        assert_eq!(
+            json.get("readAfterWrite"),
+            Some(&json!({
+                "sourcePartition": 3,
+                "ts": u64_to_string(42),
+            }))
+        );
+        assert_eq!(ServerMessage::<TestValue>::try_from(json)?, message);
+        Ok(())
     }
 
     #[test]

--- a/crates/convex/sync_types/src/types/mod.rs
+++ b/crates/convex/sync_types/src/types/mod.rs
@@ -85,10 +85,21 @@ fn string_json_arg_strategy() -> impl proptest::strategy::Strategy<Value = JsonV
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 #[cfg_attr(any(test, feature = "testing"), derive(proptest_derive::Arbitrary))]
+pub struct ReadAfterWriteToken {
+    pub source_partition: Option<u32>,
+    pub ts: Timestamp,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(any(test, feature = "testing"), derive(proptest_derive::Arbitrary))]
 pub struct Query {
     pub query_id: QueryId,
     pub udf_path: UdfPath,
     pub args: SerializedArgs,
+
+    /// Optional causal fence for subscription startup. When present, the
+    /// backend waits until this write is visible before running the query.
+    pub read_after_write: Option<ReadAfterWriteToken>,
 
     /// Query journals are only specified on reconnect. Also old clients
     /// (<=0.2.1) don't send them.
@@ -379,6 +390,7 @@ pub enum ServerMessage<V: 'static> {
         request_id: SessionRequestSeqNumber,
         result: Result<V, ErrorPayload<V>>,
         ts: Option<Timestamp>,
+        read_after_write: Option<ReadAfterWriteToken>,
         log_lines: LogLinesMessage,
     },
     ActionResponse {

--- a/crates/database/src/committer.rs
+++ b/crates/database/src/committer.rs
@@ -1009,6 +1009,10 @@ impl<RT: Runtime> Committer<RT> {
                                         source_partition,
                                         commit_ts,
                                     )?;
+                                    sm.update_applied_delta_watermark(
+                                        source_partition,
+                                        remote_ts,
+                                    )?;
                                     self.applied_delta_watermarks
                                         .insert(source_partition, remote_ts);
                                 }
@@ -1049,9 +1053,15 @@ impl<RT: Runtime> Committer<RT> {
                                     partition_timestamp_map_to_json(&applied_delta_watermarks),
                                 )
                                 .await?;
+                            let origin_watermark = applied_delta_watermarks
+                                .get(&source_partition)
+                                .copied()
+                                .unwrap_or(commit_ts);
+                            self.applied_delta_watermarks = applied_delta_watermarks;
                             self.publish_replication_frontier_progress(
                                 commit_ts,
                                 source_partition,
+                                origin_watermark,
                             )?;
                             let _ = result.send(Ok(commit_ts));
                         },
@@ -1069,11 +1079,12 @@ impl<RT: Runtime> Committer<RT> {
                             self.queued_snapshots.clear();
                             self.log.reset(snapshot_ts);
                             self.last_assigned_ts = snapshot_ts;
-                            self.applied_delta_watermarks = applied_delta_watermarks;
+                            self.applied_delta_watermarks = applied_delta_watermarks.clone();
                             self.snapshot_manager.write().replace(
                                 snapshot_ts,
                                 snapshot,
                                 replication_frontiers,
+                                applied_delta_watermarks,
                             );
                             let _ = result.send(Ok(snapshot_ts));
                         },
@@ -1631,6 +1642,7 @@ impl<RT: Runtime> Committer<RT> {
         &mut self,
         frontier_ts: Timestamp,
         source_partition: crate::partition::PartitionId,
+        origin_watermark: Timestamp,
     ) -> anyhow::Result<()> {
         // Idle replica heartbeats advance the safe frontier for remote reads,
         // but they do not publish a newer readable snapshot. Keep that
@@ -1639,6 +1651,7 @@ impl<RT: Runtime> Committer<RT> {
         // exist.
         let mut snapshot_manager = self.snapshot_manager.write();
         snapshot_manager.update_replication_frontier(source_partition, frontier_ts)?;
+        snapshot_manager.update_applied_delta_watermark(source_partition, origin_watermark)?;
         Ok(())
     }
 
@@ -4283,6 +4296,12 @@ pub struct CommitterClient {
 }
 
 impl CommitterClient {
+    pub fn local_partition(&self) -> Option<crate::partition::PartitionId> {
+        self.placement_state
+            .as_ref()
+            .map(|placement_state| placement_state.local_partition())
+    }
+
     pub async fn finish_search_and_vector_bootstrap(
         &self,
         bootstrapped_indexes: BootstrappedSearchIndexes,

--- a/crates/database/src/database.rs
+++ b/crates/database/src/database.rs
@@ -56,6 +56,7 @@ use common::{
     knobs::{
         DEFAULT_DOCUMENTS_PAGE_SIZE,
         LIST_SNAPSHOT_MAX_AGE_SECS,
+        REMOTE_READ_FRONTIER_WAIT_TIMEOUT,
         SNAPSHOT_LIST_TIME_LIMIT,
     },
     pause::Fault,
@@ -1062,7 +1063,12 @@ impl<RT: Runtime> Database<RT> {
             None => BTreeMap::new(),
         };
 
-        let snapshot_manager = SnapshotManager::new(*ts, snapshot, replication_frontiers);
+        let snapshot_manager = SnapshotManager::new(
+            *ts,
+            snapshot,
+            replication_frontiers,
+            applied_delta_watermarks.clone(),
+        );
         let (snapshot_reader, snapshot_writer) = new_split_rw_lock(snapshot_manager);
 
         let retention_workers = retention_worker_seed
@@ -1725,6 +1731,40 @@ impl<RT: Runtime> Database<RT> {
             .lock()
             .wait_for_replication_write_frontier(partition, write_ts);
         fut.await;
+    }
+
+    /// Wait until a new read on this node can satisfy a portable
+    /// read-after-write token produced by a mutation response.
+    ///
+    /// Tokens from this node's own partition use the local snapshot timestamp.
+    /// Tokens from a remote partition use the origin-partition watermark, since
+    /// replica deltas can be applied at a translated local timestamp.
+    pub async fn wait_for_read_after_write_fence(
+        &self,
+        source_partition: Option<crate::partition::PartitionId>,
+        write_ts: Timestamp,
+    ) -> anyhow::Result<()> {
+        let local_partition = self.committer.local_partition();
+        if source_partition.is_none() || source_partition == local_partition {
+            self.wait_for_write_ts(write_ts).await;
+            return Ok(());
+        }
+
+        let source_partition = source_partition.expect("checked above");
+        let fut = self
+            .snapshot_manager
+            .lock()
+            .wait_for_applied_delta_watermark(source_partition, write_ts);
+        match tokio::time::timeout(*REMOTE_READ_FRONTIER_WAIT_TIMEOUT, fut).await {
+            Ok(()) => Ok(()),
+            Err(_) => Err(
+                anyhow::anyhow!(ErrorMetadata::service_unavailable()).context(format!(
+                    "Timed out after {:?} waiting for read-after-write fence from partition {} at \
+                     ts {}",
+                    *REMOTE_READ_FRONTIER_WAIT_TIMEOUT, source_partition.0, write_ts,
+                )),
+            ),
+        }
     }
 
     pub async fn begin_system(&self) -> anyhow::Result<Transaction<RT>> {

--- a/crates/database/src/database.rs
+++ b/crates/database/src/database.rs
@@ -1767,6 +1767,10 @@ impl<RT: Runtime> Database<RT> {
         }
     }
 
+    pub fn local_partition(&self) -> Option<crate::partition::PartitionId> {
+        self.committer.local_partition()
+    }
+
     pub async fn begin_system(&self) -> anyhow::Result<Transaction<RT>> {
         self.begin(Identity::system()).await
     }

--- a/crates/database/src/snapshot_manager.rs
+++ b/crates/database/src/snapshot_manager.rs
@@ -94,10 +94,13 @@ pub struct SnapshotManager {
     versions: VecDeque<(Timestamp, Snapshot)>,
     replication_frontiers: BTreeMap<PartitionId, Timestamp>,
     replication_write_frontiers: BTreeMap<PartitionId, Timestamp>,
+    applied_delta_watermarks: BTreeMap<PartitionId, Timestamp>,
     write_throughput_limiter: WriteThroughputLimiter,
     waiters: Mutex<VecDeque<(Timestamp, oneshot::Sender<()>)>>,
     replication_waiters: Mutex<BTreeMap<PartitionId, VecDeque<(Timestamp, oneshot::Sender<()>)>>>,
     replication_write_waiters:
+        Mutex<BTreeMap<PartitionId, VecDeque<(Timestamp, oneshot::Sender<()>)>>>,
+    applied_delta_watermark_waiters:
         Mutex<BTreeMap<PartitionId, VecDeque<(Timestamp, oneshot::Sender<()>)>>>,
 }
 
@@ -591,6 +594,7 @@ impl SnapshotManager {
         initial_ts: Timestamp,
         initial_snapshot: Snapshot,
         replication_frontiers: BTreeMap<PartitionId, Timestamp>,
+        applied_delta_watermarks: BTreeMap<PartitionId, Timestamp>,
     ) -> Self {
         let replication_write_frontiers = replication_frontiers
             .iter()
@@ -611,10 +615,12 @@ impl SnapshotManager {
             persisted_max_repeatable_ts: initial_ts,
             replication_frontiers,
             replication_write_frontiers,
+            applied_delta_watermarks,
             write_throughput_limiter: WriteThroughputLimiter::new(),
             waiters: Mutex::new(VecDeque::new()),
             replication_waiters: Mutex::new(BTreeMap::new()),
             replication_write_waiters: Mutex::new(BTreeMap::new()),
+            applied_delta_watermark_waiters: Mutex::new(BTreeMap::new()),
         }
     }
 
@@ -716,6 +722,30 @@ impl SnapshotManager {
         }
     }
 
+    fn notify_applied_delta_watermark_waiters(&self, partition: PartitionId) {
+        let Some(watermark) = self.applied_delta_watermarks.get(&partition).copied() else {
+            return;
+        };
+        let mut waiters = self.applied_delta_watermark_waiters.lock();
+        let Some(partition_waiters) = waiters.get_mut(&partition) else {
+            return;
+        };
+        let mut i = 0;
+        while i < partition_waiters.len() {
+            if watermark >= partition_waiters[i].0 || partition_waiters[i].1.is_closed() {
+                let waiter = partition_waiters
+                    .swap_remove_back(i)
+                    .expect("checked above");
+                let _ = waiter.1.send(());
+                continue;
+            }
+            i += 1;
+        }
+        if partition_waiters.is_empty() {
+            waiters.remove(&partition);
+        }
+    }
+
     /// Returns a future that blocks until the snapshot manager has advanced
     /// past the given timestamp.
     pub fn wait_for_higher_ts(&self, target_ts: Timestamp) -> impl Future<Output = ()> + use<> {
@@ -747,6 +777,10 @@ impl SnapshotManager {
 
     pub fn replication_write_frontier(&self, partition: PartitionId) -> Option<Timestamp> {
         self.replication_write_frontiers.get(&partition).copied()
+    }
+
+    pub fn applied_delta_watermark(&self, partition: PartitionId) -> Option<Timestamp> {
+        self.applied_delta_watermarks.get(&partition).copied()
     }
 
     pub fn update_replication_frontier(
@@ -787,6 +821,25 @@ impl SnapshotManager {
         self.replication_write_frontiers.insert(partition, ts);
         metrics::log_replication_write_frontier_ts(partition, ts);
         self.notify_replication_write_waiters(partition);
+        Ok(true)
+    }
+
+    pub fn update_applied_delta_watermark(
+        &mut self,
+        partition: PartitionId,
+        ts: Timestamp,
+    ) -> anyhow::Result<bool> {
+        if let Some(current) = self.applied_delta_watermarks.get(&partition) {
+            anyhow::ensure!(
+                ts >= *current,
+                "applied delta watermark for {partition} went backward from {current:?} to {ts:?}",
+            );
+            if ts == *current {
+                return Ok(false);
+            }
+        }
+        self.applied_delta_watermarks.insert(partition, ts);
+        self.notify_applied_delta_watermark_waiters(partition);
         Ok(true)
     }
 
@@ -836,6 +889,36 @@ impl SnapshotManager {
         } else {
             let (sender, receiver) = oneshot::channel();
             self.replication_write_waiters
+                .lock()
+                .entry(partition)
+                .or_default()
+                .push_back((target_ts, sender));
+            Some(receiver)
+        };
+
+        async move {
+            if let Some(receiver) = receiver {
+                _ = receiver.await;
+            }
+        }
+    }
+
+    pub fn wait_for_applied_delta_watermark(
+        &self,
+        partition: PartitionId,
+        target_ts: Timestamp,
+    ) -> impl Future<Output = ()> + use<> {
+        self.notify_applied_delta_watermark_waiters(partition);
+
+        let receiver = if self
+            .applied_delta_watermarks
+            .get(&partition)
+            .is_some_and(|watermark| *watermark >= target_ts)
+        {
+            None
+        } else {
+            let (sender, receiver) = oneshot::channel();
+            self.applied_delta_watermark_waiters
                 .lock()
                 .entry(partition)
                 .or_default()
@@ -984,6 +1067,7 @@ impl SnapshotManager {
         ts: Timestamp,
         snapshot: Snapshot,
         replication_frontiers: BTreeMap<PartitionId, Timestamp>,
+        applied_delta_watermarks: BTreeMap<PartitionId, Timestamp>,
     ) {
         let replication_write_frontiers = replication_frontiers
             .iter()
@@ -994,6 +1078,7 @@ impl SnapshotManager {
         self.persisted_max_repeatable_ts = ts;
         self.replication_frontiers = replication_frontiers;
         self.replication_write_frontiers = replication_write_frontiers;
+        self.applied_delta_watermarks = applied_delta_watermarks;
         metrics::log_latest_repeatable_ts(ts);
         metrics::log_persisted_max_repeatable_ts(ts);
         for (partition, frontier) in &self.replication_frontiers {
@@ -1007,6 +1092,10 @@ impl SnapshotManager {
         for partition in partitions {
             self.notify_replication_waiters(partition);
             self.notify_replication_write_waiters(partition);
+        }
+        let partitions: Vec<_> = self.applied_delta_watermarks.keys().copied().collect();
+        for partition in partitions {
+            self.notify_applied_delta_watermark_waiters(partition);
         }
     }
 

--- a/crates/database/src/tests/write_scaling_tests.rs
+++ b/crates/database/src/tests/write_scaling_tests.rs
@@ -2355,6 +2355,65 @@ async fn test_replica_delta_timestamp_translation_records_origin_watermark(
 }
 
 #[convex_macro::test_runtime]
+async fn test_read_after_write_fence_waits_for_remote_origin_watermark(
+    rt: TestRuntime,
+) -> anyhow::Result<()> {
+    let log = Arc::new(InMemoryDistributedLog::new());
+    let table_numbers: Arc<dyn TableNumberAllocator> =
+        Arc::new(InMemoryTableNumberAllocator::default());
+    let target = create_node_with_table_number_allocator(
+        &rt,
+        log.clone(),
+        Some(partitioned_map(PartitionId(0))),
+        table_numbers.clone(),
+    )
+    .await?;
+    let source = create_node_with_table_number_allocator(
+        &rt,
+        log.clone(),
+        Some(partitioned_map(PartitionId(1))),
+        table_numbers,
+    )
+    .await?;
+
+    insert_doc(&source, "projects", assert_obj!("name" => "remote fence")).await?;
+    let mut remote_delta = log
+        .deltas()
+        .into_iter()
+        .last()
+        .expect("remote project insert should publish a delta");
+    let local_ts = insert_doc(&target, "messages", assert_obj!("text" => "local fence")).await?;
+    let remote_ts = local_ts.pred()?;
+    remote_delta.ts = remote_ts;
+
+    let pending = tokio::time::timeout(
+        Duration::from_millis(50),
+        target.wait_for_read_after_write_fence(Some(PartitionId(1)), remote_ts),
+    )
+    .await;
+    assert!(
+        pending.is_err(),
+        "read-after-write fence should wait until the remote origin watermark is applied",
+    );
+
+    let applied_ts = target
+        .committer_for_test()
+        .apply_replica_delta(remote_delta)
+        .await?;
+    assert_ne!(
+        applied_ts, remote_ts,
+        "test should exercise translated local apply timestamps",
+    );
+    tokio::time::timeout(
+        Duration::from_secs(1),
+        target.wait_for_read_after_write_fence(Some(PartitionId(1)), remote_ts),
+    )
+    .await??;
+
+    Ok(())
+}
+
+#[convex_macro::test_runtime]
 async fn test_replica_table_number_allocation_waits_for_prior_publish(
     rt: TestRuntime,
 ) -> anyhow::Result<()> {

--- a/crates/local_backend/src/dashboard.rs
+++ b/crates/local_backend/src/dashboard.rs
@@ -333,6 +333,7 @@ pub async fn run_test_function(
     let response = match udf_return {
         Ok(result) => UdfResponse::Success {
             value: export_value(result.value.unpack()?, value_format, client_version)?,
+            read_after_write: None,
             log_lines: result.log_lines,
         },
         Err(error) => {

--- a/crates/local_backend/src/mutation_forwarder.rs
+++ b/crates/local_backend/src/mutation_forwarder.rs
@@ -14,6 +14,7 @@ use application::{
     api::{
         ApplicationApi,
         ExecuteQueryTimestamp,
+        ReadAfterWriteFence,
     },
     RedactedQueryReturn,
 };
@@ -24,7 +25,10 @@ use common::{
     version::ClientVersion,
     RequestId,
 };
-use database::Token;
+use database::{
+    partition::PartitionId,
+    Token,
+};
 use keybroker::Identity;
 use pb::replication::{
     forward_mutation_response,
@@ -207,6 +211,15 @@ impl MutationForwarder for MutationForwarderService {
             })?),
             None => ExecuteQueryTimestamp::Latest,
         };
+        let read_after_write = match req.read_after_write_ts {
+            Some(ts) => Some(ReadAfterWriteFence {
+                source_partition: req.read_after_write_source_partition.map(PartitionId),
+                ts: ts.try_into().map_err(|e: anyhow::Error| {
+                    Status::invalid_argument(format!("Invalid read-after-write ts: {e}"))
+                })?,
+            }),
+            None => None,
+        };
 
         let result = self
             .api
@@ -218,6 +231,7 @@ impl MutationForwarder for MutationForwarderService {
                 args,
                 caller,
                 ts,
+                read_after_write,
                 Some(req.journal),
             )
             .await;
@@ -338,6 +352,7 @@ impl MutationForwarderGrpcClient {
         identity: Identity,
         caller: FunctionCaller,
         ts: Option<u64>,
+        read_after_write: Option<ReadAfterWriteFence>,
         journal: Option<String>,
     ) -> anyhow::Result<RedactedQueryReturn> {
         let identity_proto: pb::convex_identity::UncheckedIdentity = identity.into();
@@ -348,6 +363,9 @@ impl MutationForwarderGrpcClient {
             caller: Some(caller.into()),
             ts,
             journal,
+            read_after_write_source_partition: read_after_write
+                .and_then(|fence| fence.source_partition.map(|partition| partition.0)),
+            read_after_write_ts: read_after_write.map(|fence| u64::from(fence.ts)),
         };
         let response = self
             .client

--- a/crates/local_backend/src/node_action_callbacks.rs
+++ b/crates/local_backend/src/node_action_callbacks.rs
@@ -138,6 +138,7 @@ pub async fn internal_query_post(
     let response = match udf_return.result {
         Ok(value) => UdfResponse::Success {
             value: export_value(value.unpack()?, value_format, client_version)?,
+            read_after_write: None,
             log_lines: udf_return.log_lines,
         },
         Err(error) => {
@@ -194,6 +195,7 @@ pub async fn internal_mutation_post(
     let response = match udf_result {
         Ok(write_return) => UdfResponse::Success {
             value: export_value(write_return.value.unpack()?, value_format, client_version)?,
+            read_after_write: None,
             log_lines: write_return.log_lines,
         },
         Err(write_error) => UdfResponse::nested_error(
@@ -251,6 +253,7 @@ pub async fn internal_action_post(
     let response = match udf_result {
         Ok(action_return) => UdfResponse::Success {
             value: export_value(action_return.value.unpack()?, value_format, client_version)?,
+            read_after_write: None,
             log_lines: action_return.log_lines,
         },
         Err(action_error) => UdfResponse::nested_error(

--- a/crates/local_backend/src/public_api.rs
+++ b/crates/local_backend/src/public_api.rs
@@ -2,7 +2,10 @@ use std::sync::Arc;
 
 use anyhow::Context;
 use application::{
-    api::ExecuteQueryTimestamp,
+    api::{
+        ExecuteQueryTimestamp,
+        ReadAfterWriteFence,
+    },
     redaction::{
         RedactedJsError,
         RedactedLogLines,
@@ -37,6 +40,7 @@ use common::{
     types::FunctionCaller,
     version::ClientVersion,
 };
+use database::partition::PartitionId;
 use errors::ErrorMetadata;
 use isolate::UdfArgsJson;
 use serde::{
@@ -70,6 +74,9 @@ pub struct UdfPostRequest {
     #[schema(value_type = Object)]
     pub args: UdfArgsJson,
 
+    #[serde(default)]
+    pub read_after_write: Option<ReadAfterWriteToken>,
+
     pub format: Option<String>,
 }
 
@@ -87,10 +94,13 @@ pub struct UdfPostWithTsRequest {
     pub args: UdfArgsJson,
     pub ts: SerializedTs,
 
+    #[serde(default)]
+    pub read_after_write: Option<ReadAfterWriteToken>,
+
     pub format: Option<String>,
 }
 
-#[derive(Serialize, Deserialize, ToSchema)]
+#[derive(Clone, Debug, Serialize, Deserialize, ToSchema)]
 pub struct SerializedTs(String);
 
 impl From<Timestamp> for SerializedTs {
@@ -118,7 +128,18 @@ pub struct UdfArgsQuery {
     pub path: String,
     pub args: UdfArgsJson,
 
+    #[serde(default)]
+    pub read_after_write: Option<ReadAfterWriteToken>,
+
     pub format: Option<String>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct ReadAfterWriteToken {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub source_partition: Option<u32>,
+    pub ts: SerializedTs,
 }
 
 #[derive(Serialize, Deserialize, ToSchema)]
@@ -128,6 +149,9 @@ pub enum UdfResponse {
     #[serde(rename_all = "camelCase")]
     Success {
         value: JsonValue,
+
+        #[serde(skip_serializing_if = "Option::is_none")]
+        read_after_write: Option<ReadAfterWriteToken>,
 
         #[serde(skip_serializing_if = "RedactedLogLines::is_empty")]
         #[schema(value_type = Vec<String>)]
@@ -194,6 +218,26 @@ impl UdfResponse {
             log_lines,
         })
     }
+}
+
+fn mutation_read_after_write_token(st: &RouterState, ts: Timestamp) -> ReadAfterWriteToken {
+    ReadAfterWriteToken {
+        source_partition: st.partition_id.map(|partition| partition.0),
+        ts: ts.into(),
+    }
+}
+
+fn read_after_write_fence(
+    token: Option<ReadAfterWriteToken>,
+) -> anyhow::Result<Option<ReadAfterWriteFence>> {
+    token
+        .map(|token| {
+            Ok(ReadAfterWriteFence {
+                source_partition: token.source_partition.map(PartitionId),
+                ts: Timestamp::try_from(token.ts)?,
+            })
+        })
+        .transpose()
 }
 
 async fn wait_for_local_mutation_visibility(
@@ -337,6 +381,10 @@ async fn maybe_forward_public_mutation(
             )?;
             UdfResponse::Success {
                 value: export_value(packed.unpack()?, value_format, client_version.clone())?,
+                read_after_write: Some(mutation_read_after_write_token(
+                    st,
+                    Timestamp::try_from(success.ts)?,
+                )),
                 log_lines: RedactedLogLines::from_vec(success.log_lines),
             }
         },
@@ -413,6 +461,7 @@ pub async fn public_function_post(
     let response = match udf_result {
         Ok(write_return) => UdfResponse::Success {
             value: export_value(write_return.value.unpack()?, value_format, client_version)?,
+            read_after_write: None,
             log_lines: write_return.log_lines,
         },
         Err(write_error) => UdfResponse::error(
@@ -504,6 +553,7 @@ pub async fn public_function_post_with_path(
     let response = match udf_result {
         Ok(write_return) => UdfResponse::Success {
             value: export_value(write_return.value.unpack()?, value_format, client_version)?,
+            read_after_write: None,
             log_lines: write_return.log_lines,
         },
         Err(write_error) => UdfResponse::error(
@@ -572,6 +622,7 @@ pub async fn public_query_get(
             req.args.into_serialized_args()?,
             FunctionCaller::HttpApi(client_version.clone()),
             ExecuteQueryTimestamp::Latest,
+            read_after_write_fence(req.read_after_write)?,
             journal,
         )
         .await?;
@@ -580,6 +631,7 @@ pub async fn public_query_get(
     let response = match query_result.result {
         Ok(value) => UdfResponse::Success {
             value: export_value(value.unpack()?, value_format, client_version)?,
+            read_after_write: None,
             log_lines,
         },
         Err(error) => UdfResponse::error(error, log_lines, value_format, client_version)?,
@@ -626,6 +678,7 @@ pub async fn public_query_post(
             req.args.into_serialized_args()?,
             FunctionCaller::HttpApi(client_version.clone()),
             ExecuteQueryTimestamp::Latest,
+            read_after_write_fence(req.read_after_write)?,
             journal,
         )
         .await?;
@@ -633,6 +686,7 @@ pub async fn public_query_post(
     let response = match query_return.result {
         Ok(value) => UdfResponse::Success {
             value: export_value(value.unpack()?, value_format, client_version)?,
+            read_after_write: None,
             log_lines: query_return.log_lines,
         },
         Err(error) => {
@@ -700,6 +754,7 @@ pub async fn public_query_at_ts_post(
             req.args.into_serialized_args()?,
             FunctionCaller::HttpApi(client_version.clone()),
             ExecuteQueryTimestamp::At(ts),
+            read_after_write_fence(req.read_after_write)?,
             journal,
         )
         .await?;
@@ -707,6 +762,7 @@ pub async fn public_query_at_ts_post(
     let response = match query_return.result {
         Ok(value) => UdfResponse::Success {
             value: export_value(value.unpack()?, value_format, client_version)?,
+            read_after_write: None,
             log_lines: query_return.log_lines,
         },
         Err(error) => {
@@ -745,13 +801,22 @@ pub async fn public_query_batch_post(
     Json(req_batch): Json<QueryBatchArgs>,
 ) -> Result<impl IntoResponse, HttpResponseError> {
     let mut results = vec![];
-    // All queries execute at the same timestamp.
-    let ts = st.api.latest_timestamp(&host, request_id.clone()).await?;
     let identity = st
         .api
         .authenticate(&host, request_id.clone(), auth_token)
         .await?;
-    for req in req_batch.queries {
+    let queries = req_batch.queries;
+    for req in &queries {
+        if let Some(fence) = read_after_write_fence(req.read_after_write.clone())? {
+            st.database
+                .wait_for_read_after_write_fence(fence.source_partition, fence.ts)
+                .await?;
+        }
+    }
+    // All queries execute at the same timestamp, after any portable freshness
+    // fences have been satisfied.
+    let ts = st.api.latest_timestamp(&host, request_id.clone()).await?;
+    for req in queries {
         let value_format = req.format.as_ref().map(|f| f.parse()).transpose()?;
         let export_path = parse_export_path(&req.path)?;
         let udf_return = st
@@ -765,11 +830,13 @@ pub async fn public_query_batch_post(
                 FunctionCaller::HttpApi(client_version.clone()),
                 ExecuteQueryTimestamp::At(*ts),
                 None,
+                None,
             )
             .await?;
         let response = match udf_return.result {
             Ok(value) => UdfResponse::Success {
                 value: export_value(value.unpack()?, value_format, client_version.clone())?,
+                read_after_write: None,
                 log_lines: udf_return.log_lines,
             },
             Err(error) => UdfResponse::error(
@@ -844,6 +911,7 @@ pub async fn public_mutation_post(
             wait_for_local_mutation_visibility(&st, write_return.ts, false).await;
             UdfResponse::Success {
                 value: export_value(write_return.value.unpack()?, value_format, client_version)?,
+                read_after_write: Some(mutation_read_after_write_token(&st, write_return.ts)),
                 log_lines: write_return.log_lines,
             }
         },
@@ -901,6 +969,7 @@ pub async fn public_action_post(
     let response = match action_result {
         Ok(action_return) => UdfResponse::Success {
             value: export_value(action_return.value.unpack()?, value_format, client_version)?,
+            read_after_write: None,
             log_lines: action_return.log_lines,
         },
         Err(action_error) => UdfResponse::error(
@@ -1048,13 +1117,22 @@ mod tests {
         match expected {
             Ok(expected) => {
                 let result: JsonValue = backend.expect_success(req).await?;
-                assert_eq!(
-                    result,
-                    json!({
-                        "status": "success",
-                        "value": expected,
-                    })
-                );
+                assert_eq!(result["status"], "success");
+                assert_eq!(result["value"], expected);
+                if uri == "/api/mutation" {
+                    assert!(
+                        result["readAfterWrite"]["ts"].as_str().is_some(),
+                        "mutation responses should include a portable read-after-write token"
+                    );
+                } else {
+                    assert_eq!(
+                        result,
+                        json!({
+                            "status": "success",
+                            "value": expected,
+                        })
+                    );
+                }
             },
             Err(expected) => {
                 backend
@@ -1158,6 +1236,44 @@ mod tests {
             Ok(json!("1")),
         )
         .await
+    }
+
+    #[convex_macro::prod_rt_test]
+    async fn test_http_query_accepts_read_after_write_token(rt: ProdRuntime) -> anyhow::Result<()> {
+        let backend = setup_backend_for_test(rt).await?;
+        backend.st.application.load_udf_tests_modules().await?;
+
+        let inserted: JsonValue = backend
+            .expect_success(post_request(
+                "/api/mutation",
+                json!({
+                    "path": "values:insertObject",
+                    "args": { "obj": { "hello": "fenced read" } },
+                }),
+            )?)
+            .await?;
+        let token = inserted["readAfterWrite"].clone();
+        assert!(
+            token["ts"].as_str().is_some(),
+            "mutation response should include a read-after-write token"
+        );
+        let inserted_id = inserted["value"]
+            .as_str()
+            .context("insertObject should return a document id string")?
+            .to_string();
+
+        let queried: JsonValue = backend
+            .expect_success(post_request(
+                "/api/query",
+                json!({
+                    "path": "values:getObject",
+                    "args": { "id": inserted_id },
+                    "readAfterWrite": token,
+                }),
+            )?)
+            .await?;
+        assert_eq!(queried["value"]["hello"], "fenced read");
+        Ok(())
     }
 
     #[convex_macro::prod_rt_test]
@@ -1413,6 +1529,7 @@ mod tests {
                 FunctionCaller::HttpApi(ClientVersion::unknown()),
                 None,
                 None,
+                None,
             )
             .await?;
 
@@ -1498,6 +1615,7 @@ mod tests {
                 FunctionCaller::HttpApi(ClientVersion::unknown()),
                 ExecuteQueryTimestamp::Latest,
                 None,
+                None,
             )
             .await?;
 
@@ -1577,6 +1695,7 @@ mod tests {
                 SerializedArgs::from_args(vec![json!({ "id": inserted_id })])?,
                 FunctionCaller::HttpApi(ClientVersion::unknown()),
                 ExecuteQueryTimestamp::Latest,
+                None,
                 None,
             )
             .await?;

--- a/crates/local_backend/src/query_forwarding_api.rs
+++ b/crates/local_backend/src/query_forwarding_api.rs
@@ -502,4 +502,8 @@ impl application::api::ApplicationApi for SelectiveQueryForwardingApi {
     async fn partition_id(&self, host: &ResolvedHostname) -> anyhow::Result<u64> {
         self.inner.partition_id(host).await
     }
+
+    fn read_after_write_source_partition(&self) -> Option<u32> {
+        self.inner.read_after_write_source_partition()
+    }
 }

--- a/crates/local_backend/src/query_forwarding_api.rs
+++ b/crates/local_backend/src/query_forwarding_api.rs
@@ -225,6 +225,7 @@ impl application::api::ApplicationApi for SelectiveQueryForwardingApi {
         args: SerializedArgs,
         caller: FunctionCaller,
         ts: application::api::ExecuteQueryTimestamp,
+        read_after_write: Option<application::api::ReadAfterWriteFence>,
         journal: Option<SerializedQueryJournal>,
     ) -> anyhow::Result<application::RedactedQueryReturn> {
         let result = if let Some(target_grpc_url) = self.public_query_target_grpc_url().await? {
@@ -248,13 +249,24 @@ impl application::api::ApplicationApi for SelectiveQueryForwardingApi {
                         application::api::ExecuteQueryTimestamp::Latest => None,
                         application::api::ExecuteQueryTimestamp::At(ts) => Some(u64::from(ts)),
                     },
+                    read_after_write,
                     journal.flatten(),
                 )
                 .await
                 .map_err(|e| anyhow::anyhow!(ErrorMetadata::service_unavailable()).context(e))?
         } else {
             self.inner
-                .execute_public_query(host, request_id, identity, path, args, caller, ts, journal)
+                .execute_public_query(
+                    host,
+                    request_id,
+                    identity,
+                    path,
+                    args,
+                    caller,
+                    ts,
+                    read_after_write,
+                    journal,
+                )
                 .await?
         };
         self.note_recent_interest(&result.token);

--- a/crates/pb/protos/replication.proto
+++ b/crates/pb/protos/replication.proto
@@ -83,6 +83,10 @@ message ForwardQueryRequest {
 
   // Optional serialized query journal for reconnect/retry flows.
   optional string journal = 6;
+
+  // Optional portable read-after-write fence from a mutation response.
+  optional uint32 read_after_write_source_partition = 7;
+  optional uint64 read_after_write_ts = 8;
 }
 
 message ForwardQueryResponse {

--- a/crates/sync/src/tests.rs
+++ b/crates/sync/src/tests.rs
@@ -65,6 +65,7 @@ use sync_types::{
     Query,
     QueryId,
     QuerySetModification,
+    ReadAfterWriteToken,
     StateModification,
     UserIdentityAttributes,
 };
@@ -239,12 +240,21 @@ impl<RT: Runtime> TestSyncWorker<RT> {
             request_id: outgoing_mutation_id,
             result,
             ts,
+            read_after_write,
             ..
         } = self.receive().await?);
         // Check that the mutation ID on the outgoing message matches to
         // confirm we intercepted the right message
         assert_eq!(request_id, outgoing_mutation_id);
-        Ok((result.unwrap().unpack()?, ts.unwrap()))
+        let ts = ts.unwrap();
+        assert_eq!(
+            read_after_write,
+            Some(ReadAfterWriteToken {
+                source_partition: None,
+                ts,
+            })
+        );
+        Ok((result.unwrap().unpack()?, ts))
     }
 
     async fn shutdown(self) -> anyhow::Result<()> {
@@ -288,11 +298,15 @@ async fn test_basic_account(rt: TestRuntime) -> anyhow::Result<()> {
     assert_eq!(result, ConvexValue::Null);
     must_let!(let ServerMessage::Transition { .. } = sync_worker.receive().await?);
 
-    // 2. Start a new subscription.
+    // 2. Start a new subscription fenced behind the mutation we just observed.
     let query = Query {
         query_id: QueryId::new(0),
         udf_path: "sync:accountBalance".parse()?,
         args: SerializedArgs::from_args(vec![assert_obj!("name" => name1.clone()).into()])?,
+        read_after_write: Some(ReadAfterWriteToken {
+            source_partition: None,
+            ts: initialization_ts,
+        }),
         journal: None,
         component_path: None,
     };
@@ -348,6 +362,7 @@ async fn test_basic_account(rt: TestRuntime) -> anyhow::Result<()> {
         query_id: QueryId::new(1),
         udf_path: "sync:accountBalance".parse()?,
         args: SerializedArgs::from_args(vec![assert_obj!("name" => name2.clone()).into()])?,
+        read_after_write: None,
         journal: None,
         component_path: None,
     };
@@ -442,6 +457,7 @@ async fn test_remove_in_progress_query(rt: TestRuntime) -> anyhow::Result<()> {
         query_id,
         udf_path: "sync:accountBalance".parse()?,
         args: SerializedArgs::from_args(vec![assert_obj!("name" => name1.clone()).into()])?,
+        read_after_write: None,
         journal: None,
         component_path: None,
     };
@@ -482,6 +498,7 @@ async fn test_query_failure(rt: TestRuntime) -> anyhow::Result<()> {
         query_id: QueryId::new(0),
         udf_path: "sync:fail".parse()?,
         args: SerializedArgs::from_args(vec![assert_obj!("i" => ConvexValue::from(0.0)).into()])?,
+        read_after_write: None,
         journal: None,
         component_path: None,
     };
@@ -489,6 +506,7 @@ async fn test_query_failure(rt: TestRuntime) -> anyhow::Result<()> {
         query_id: QueryId::new(1),
         udf_path: "sync:fail".parse()?,
         args: SerializedArgs::from_args(vec![assert_obj!("i" => ConvexValue::from(3.0)).into()])?,
+        read_after_write: None,
         journal: None,
         component_path: None,
     };
@@ -523,6 +541,7 @@ async fn test_query_failure(rt: TestRuntime) -> anyhow::Result<()> {
         query_id: QueryId::new(2),
         udf_path: "sync:succeed".parse()?,
         args: SerializedArgs::from_args(vec![json!({})])?,
+        read_after_write: None,
         journal: None,
         component_path: None,
     };
@@ -749,6 +768,7 @@ async fn test_value_deduplication_success(rt: TestRuntime) -> anyhow::Result<()>
         args: SerializedArgs::from_args(vec![
             assert_obj!("throwError" => ConvexValue::from(false)).into(),
         ])?,
+        read_after_write: None,
         journal: None,
         component_path: None,
     };
@@ -808,6 +828,7 @@ async fn test_value_deduplication_failure(rt: TestRuntime) -> anyhow::Result<()>
         args: SerializedArgs::from_args(vec![
             assert_obj!("throwError" => ConvexValue::from(true)).into(),
         ])?,
+        read_after_write: None,
         journal: None,
         component_path: None,
     };

--- a/crates/sync/src/worker.rs
+++ b/crates/sync/src/worker.rs
@@ -961,6 +961,7 @@ impl<RT: Runtime> SyncWorker<RT> {
                                             query.args.clone(),
                                             caller.clone(),
                                             ExecuteQueryTimestamp::At(new_ts),
+                                            None,
                                             query.journal.clone(),
                                         )
                                         .await

--- a/crates/sync/src/worker.rs
+++ b/crates/sync/src/worker.rs
@@ -15,6 +15,7 @@ use application::{
     api::{
         ApplicationApi,
         ExecuteQueryTimestamp,
+        ReadAfterWriteFence,
         SubscriptionClient,
         SubscriptionTrait,
         SubscriptionValidity,
@@ -87,6 +88,7 @@ use sync_types::{
     QueryId,
     QuerySetModification,
     QuerySetVersion,
+    ReadAfterWriteToken,
     SerializedQueryJournal,
     SessionId,
     StateModification,
@@ -597,6 +599,10 @@ impl<RT: Runtime> SyncWorker<RT> {
                                 request_id,
                                 result: Ok(udf_return.value),
                                 ts: Some(udf_return.ts),
+                                read_after_write: Some(ReadAfterWriteToken {
+                                    source_partition: api.read_after_write_source_partition(),
+                                    ts: udf_return.ts,
+                                }),
                                 log_lines: udf_return.log_lines.into(),
                             },
                             Err(RedactedMutationError { error, log_lines }) => {
@@ -604,6 +610,7 @@ impl<RT: Runtime> SyncWorker<RT> {
                                     request_id,
                                     result: Err(error.into_error_payload()),
                                     ts: None,
+                                    read_after_write: None,
                                     log_lines: log_lines.into(),
                                 }
                             },
@@ -961,7 +968,12 @@ impl<RT: Runtime> SyncWorker<RT> {
                                             query.args.clone(),
                                             caller.clone(),
                                             ExecuteQueryTimestamp::At(new_ts),
-                                            None,
+                                            query.read_after_write.as_ref().map(|token| {
+                                                ReadAfterWriteFence::from_source_partition(
+                                                    token.source_partition,
+                                                    token.ts,
+                                                )
+                                            }),
                                             query.journal.clone(),
                                         )
                                         .await

--- a/crates/value/src/heap_size.rs
+++ b/crates/value/src/heap_size.rs
@@ -42,6 +42,7 @@ use sync_types::{
     ErrorPayload,
     FunctionName,
     LogLinesMessage,
+    ReadAfterWriteToken,
     ServerMessage,
     SessionId,
     StateModification,
@@ -496,6 +497,13 @@ impl HeapSize for Timestamp {
     }
 }
 
+impl HeapSize for ReadAfterWriteToken {
+    #[inline]
+    fn heap_size(&self) -> usize {
+        0
+    }
+}
+
 impl HeapSize for CanonicalizedUdfPath {
     fn heap_size(&self) -> usize {
         // We use the string length as an approximation since we don't have
@@ -939,9 +947,14 @@ impl<V: HeapSize> HeapSize for ServerMessage<V> {
                 request_id,
                 result,
                 ts,
+                read_after_write,
                 log_lines,
             } => {
-                request_id.heap_size() + result.heap_size() + ts.heap_size() + log_lines.heap_size()
+                request_id.heap_size()
+                    + result.heap_size()
+                    + ts.heap_size()
+                    + read_after_write.heap_size()
+                    + log_lines.heap_size()
             },
             ServerMessage::ActionResponse {
                 request_id,


### PR DESCRIPTION
## Summary
- Add public mutation `readAfterWrite` tokens carrying source partition and commit timestamp.
- Accept and enforce those tokens on HTTP query/query_at_ts/query_batch before choosing a read timestamp.
- Add sync/WebSocket `readAfterWrite` tokens on mutation responses and query-set additions so subscription startup can wait for the client's last write.
- Propagate the fence through `ApplicationApi`, query forwarding, and sync worker execution without making sync depend on database internals.
- Track applied origin watermarks in `SnapshotManager` and wait on those watermarks for remote-partition tokens, instead of comparing against translated local apply timestamps.

## Tests
- `cargo test -p convex_sync_types read_after_write_token_roundtrips -- --nocapture`
- `cargo test -p sync test_basic_account -- --nocapture`
- `cargo test -p database test_read_after_write_fence_waits_for_remote_origin_watermark -- --nocapture`
- `env PROTOC=/Users/martin/Desktop/convex-horizontal-scaling/crates/pb_build/protoc/protoc-macos-universal cargo test -p local_backend test_http_query_accepts_read_after_write_token -- --nocapture`
- `env PROTOC=/Users/martin/Desktop/convex-horizontal-scaling/crates/pb_build/protoc/protoc-macos-universal cargo check -p convex_sync_types -p convex -p value -p database -p application -p sync -p local_backend`

Closes #140