### PR TITLE
fix: carry indexed table mappings in replica deltas

### DIFF
--- a/crates/database/src/committer.rs
+++ b/crates/database/src/committer.rs
@@ -370,6 +370,26 @@ fn checkpoint_index_entries(
     index_entries
 }
 
+fn insert_delta_table_mapping(
+    table_mapping: &TableMapping,
+    tablet_id_to_table_name: &mut BTreeMap<value::TabletId, TableName>,
+    tablet_id: value::TabletId,
+) {
+    if !tablet_id_to_table_name.contains_key(&tablet_id) {
+        if let Ok(name) = table_mapping.tablet_name(tablet_id) {
+            tablet_id_to_table_name.insert(tablet_id, name);
+        }
+    }
+}
+
+fn index_metadata_tablet_id(document: &ResolvedDocument) -> Option<value::TabletId> {
+    let table_id_field = "table_id".parse::<common::types::FieldName>().ok()?;
+    let value::ConvexValue::String(table_id) = document.value().0.get(&table_id_field)? else {
+        return None;
+    };
+    table_id.parse().ok()
+}
+
 fn remap_index_metadata_document(
     document: &ResolvedDocument,
     local_index_tablet: value::TabletId,
@@ -2424,11 +2444,23 @@ impl<RT: Runtime> Committer<RT> {
             .collect();
         let table_mapping = new_snapshot.table_registry.table_mapping().clone();
         let mut tablet_id_to_table_name = std::collections::BTreeMap::new();
+        let index_table_name: &TableName = &common::bootstrap_model::index::INDEX_TABLE;
         for update in &document_updates {
             let tablet_id = update.id.tablet_id;
-            if !tablet_id_to_table_name.contains_key(&tablet_id) {
-                if let Ok(name) = table_mapping.tablet_name(tablet_id) {
-                    tablet_id_to_table_name.insert(tablet_id, name);
+            insert_delta_table_mapping(&table_mapping, &mut tablet_id_to_table_name, tablet_id);
+
+            if tablet_id_to_table_name
+                .get(&tablet_id)
+                .is_some_and(|name| name == index_table_name)
+            {
+                for document in update.old_document.iter().chain(update.new_document.iter()) {
+                    if let Some(indexed_tablet_id) = index_metadata_tablet_id(document) {
+                        insert_delta_table_mapping(
+                            &table_mapping,
+                            &mut tablet_id_to_table_name,
+                            indexed_tablet_id,
+                        );
+                    }
                 }
             }
         }

--- a/crates/database/src/tests/write_scaling_tests.rs
+++ b/crates/database/src/tests/write_scaling_tests.rs
@@ -23,6 +23,7 @@ use common::{
     bootstrap_model::index::database_index::IndexedFields,
     interval::Interval,
     knobs::REMOTE_READ_FRONTIER_WAIT_TIMEOUT,
+    maybe_val,
     pause::PauseController,
     persistence::{
         NoopRetentionValidator,
@@ -32,8 +33,11 @@ use common::{
         TimestampRange,
     },
     query::{
+        IndexRange,
+        IndexRangeExpression,
         Order,
         Query,
+        QuerySource,
     },
     runtime::{
         new_unlimited_rate_limiter,
@@ -45,6 +49,8 @@ use common::{
     shutdown::ShutdownSignal,
     testing::TestPersistence,
     types::{
+        IndexDescriptor,
+        IndexName,
         TabletIndexName,
         Timestamp,
     },
@@ -86,6 +92,7 @@ use value::{
 };
 
 use crate::{
+    bootstrap_model::index::IndexModel,
     commit_delta::{
         testing::InMemoryDistributedLog,
         CommitDelta,
@@ -1837,6 +1844,104 @@ async fn test_replica_delta_fails_for_unmapped_user_table(rt: TestRuntime) -> an
             .replication_frontier_for_test(PartitionId(1))
             .is_some_and(|frontier| frontier > Timestamp::MIN),
         "retry after metadata should apply and advance the frontier",
+    );
+
+    Ok(())
+}
+
+#[convex_macro::test_runtime]
+async fn test_replicated_index_metadata_stays_pending_until_local_backfill(
+    rt: TestRuntime,
+) -> anyhow::Result<()> {
+    let log = Arc::new(InMemoryDistributedLog::new());
+    let table_number_allocator = Arc::new(InMemoryTableNumberAllocator::default());
+    let node_a = create_node_with_table_number_allocator(
+        &rt,
+        log.clone(),
+        Some(partitioned_map(PartitionId(0))),
+        table_number_allocator.clone(),
+    )
+    .await?;
+    let node_b_persistence = Arc::new(TestPersistence::new());
+    let node_b = create_node_with_persistence_and_table_number_allocator(
+        &rt,
+        node_b_persistence.clone(),
+        log.clone(),
+        Some(partitioned_map(PartitionId(1))),
+        None,
+        Arc::new(NoopTwoPhaseDecisionLog),
+        None,
+        table_number_allocator,
+    )
+    .await?;
+
+    insert_doc(&node_b, "projects", assert_obj!("name" => "seed")).await?;
+
+    let projects_table: TableName = "projects".parse()?;
+    let index_name = IndexName::new(projects_table, IndexDescriptor::new("by_name")?)?;
+    node_b
+        .create_backfilled_index_for_test(
+            node_b_persistence.clone(),
+            TableNamespace::test_user(),
+            index_name.clone(),
+            vec!["name".parse()?].try_into()?,
+        )
+        .await?;
+
+    for delta in log
+        .deltas()
+        .into_iter()
+        .filter(|delta| delta.source_partition == Some(PartitionId(1)))
+    {
+        node_a
+            .committer_for_test()
+            .apply_replica_delta(delta)
+            .await?;
+    }
+
+    let mut owner_tx = node_b.begin_system().await?;
+    let mut owner_indexes = IndexModel::new(&mut owner_tx);
+    assert!(
+        owner_indexes
+            .enabled_index_metadata(TableNamespace::test_user(), &index_name)?
+            .is_some(),
+        "owner partition should finish and enable the index"
+    );
+
+    let mut replica_tx = node_a.begin_system().await?;
+    let mut replica_indexes = IndexModel::new(&mut replica_tx);
+    let pending = replica_indexes
+        .pending_index_metadata(TableNamespace::test_user(), &index_name)?
+        .context("replica should store replicated index metadata as pending")?;
+    assert!(
+        pending.config.is_backfilling(),
+        "replica must rebuild the index locally before queries can use it"
+    );
+    assert!(
+        replica_indexes
+            .enabled_index_metadata(TableNamespace::test_user(), &index_name)?
+            .is_none(),
+        "replica must not expose remote-built index metadata as query-ready"
+    );
+    drop(replica_tx);
+
+    let indexed_query = Query {
+        source: QuerySource::IndexRange(IndexRange {
+            index_name,
+            range: vec![IndexRangeExpression::Eq(
+                "name".parse()?,
+                maybe_val!("seed"),
+            )],
+            order: Order::Asc,
+        }),
+        operators: vec![],
+    };
+    let err = run_query(node_a, TableNamespace::test_user(), indexed_query)
+        .await
+        .expect_err("replica should reject indexed reads while local index backfill is pending");
+    assert!(
+        format!("{err:?}").contains("Index projects.by_name is currently backfilling"),
+        "unexpected error: {err:#}",
     );
 
     Ok(())


### PR DESCRIPTION
## Summary
- include indexed user-table tablet mappings when building commit deltas for _index metadata rows
- keep replicated enabled index metadata pending/backfilling on cross-partition receivers until local backfill completes
- add a write-scaling regression that rejects indexed reads while the receiver's local index is still backfilling

Closes #143

## Tests
- cargo test -p database test_replicated_index_metadata_stays_pending_until_local_backfill -- --nocapture
- cargo test -p database replicated_index_metadata -- --nocapture
- cargo test -p database test_replica_delta_fails_for_unmapped_user_table -- --nocapture
- cargo check -p database