### PR TITLE
perf: pool internal gRPC clients and expand failover coverage

### DIFF
--- a/crates/application/src/api.rs
+++ b/crates/application/src/api.rs
@@ -575,9 +575,7 @@ impl<RT: Runtime> ApplicationApi for Application<RT> {
     }
 
     fn read_after_write_source_partition(&self) -> Option<u32> {
-        self.database
-            .local_partition()
-            .map(|partition| partition.0)
+        self.database.local_partition().map(|partition| partition.0)
     }
 }
 

--- a/crates/application/src/application_function_runner/mod.rs
+++ b/crates/application/src/application_function_runner/mod.rs
@@ -916,13 +916,14 @@ impl<RT: Runtime> ApplicationFunctionRunner<RT> {
             // errors from the log.
             let result = match self
                 .database
-                .commit_with_write_source(tx, udf_path_string.clone())
+                .commit_with_write_source_outcome(tx, udf_path_string.clone())
                 .await
             {
-                Ok(ts) => Ok(MutationReturn {
+                Ok(outcome) => Ok(MutationReturn {
                     value,
                     log_lines,
-                    ts,
+                    ts: outcome.ts,
+                    source_partition: outcome.source_partition,
                 }),
                 Err(e) => {
                     if e.is_deterministic_user_error() {
@@ -1914,6 +1915,7 @@ impl<RT: Runtime> ApplicationFunctionRunner<RT> {
                     value: result,
                     log_lines,
                     ts,
+                    source_partition: None,
                 })
             },
             None => return Ok(None),

--- a/crates/application/src/lib.rs
+++ b/crates/application/src/lib.rs
@@ -472,6 +472,7 @@ pub struct MutationReturn {
     pub value: JsonPackedValue,
     pub log_lines: LogLines,
     pub ts: Timestamp,
+    pub source_partition: Option<database::partition::PartitionId>,
 }
 
 #[derive(Debug)]
@@ -479,6 +480,7 @@ pub struct RedactedMutationReturn {
     pub value: JsonPackedValue,
     pub log_lines: RedactedLogLines,
     pub ts: Timestamp,
+    pub source_partition: Option<database::partition::PartitionId>,
 }
 
 #[derive(thiserror::Error, Debug)]
@@ -1410,6 +1412,7 @@ impl<RT: Runtime> Application<RT> {
                     block_logging,
                 ),
                 ts: mutation_return.ts,
+                source_partition: mutation_return.source_partition,
             }),
             Ok(Err(mutation_error)) => Err(RedactedMutationError {
                 error: RedactedJsError::from_js_error(

--- a/crates/common/src/persistence.rs
+++ b/crates/common/src/persistence.rs
@@ -162,10 +162,16 @@ pub enum PersistenceGlobalKey {
     /// replica that had caught up through the transaction's snapshot.
     ReplicationFrontiers,
 
-    /// Latest origin commit timestamp durably applied per source partition.
-    /// This is separate from `ReplicationFrontiers`, which is expressed in
-    /// local apply timestamps and is used for read freshness fencing.
+    /// Latest origin commit timestamp observed per source partition.
+    /// This includes frontier-only heartbeats and is used for read-after-write
+    /// fencing in the origin partition's timestamp domain.
     AppliedDeltaWatermarks,
+
+    /// Latest origin commit timestamp for a non-empty data delta durably
+    /// applied per source partition. Unlike `AppliedDeltaWatermarks`, this
+    /// must not advance on frontier-only heartbeats because it is used for
+    /// transport redelivery idempotency.
+    AppliedDataDeltaWatermarks,
 
     /// Latest snapshot of all tables' summaries, cached to speed up startup.
     TableSummary,
@@ -207,6 +213,9 @@ impl From<PersistenceGlobalKey> for String {
             PersistenceGlobalKey::MaxRepeatableTimestamp => "max_repeatable_ts".to_string(),
             PersistenceGlobalKey::ReplicationFrontiers => "replication_frontiers".to_string(),
             PersistenceGlobalKey::AppliedDeltaWatermarks => "applied_delta_watermarks".to_string(),
+            PersistenceGlobalKey::AppliedDataDeltaWatermarks => {
+                "applied_data_delta_watermarks".to_string()
+            },
             PersistenceGlobalKey::TableSummary => "table_summary".to_string(),
             PersistenceGlobalKey::TwoPhaseRedoRecords => "two_phase_redo_records".to_string(),
             PersistenceGlobalKey::RaftNatsOutbox => "raft_nats_outbox".to_string(),
@@ -230,6 +239,7 @@ impl FromStr for PersistenceGlobalKey {
             "max_repeatable_ts" => Ok(Self::MaxRepeatableTimestamp),
             "replication_frontiers" => Ok(Self::ReplicationFrontiers),
             "applied_delta_watermarks" => Ok(Self::AppliedDeltaWatermarks),
+            "applied_data_delta_watermarks" => Ok(Self::AppliedDataDeltaWatermarks),
             "table_summary" => Ok(Self::TableSummary),
             "two_phase_redo_records" => Ok(Self::TwoPhaseRedoRecords),
             "raft_nats_outbox" => Ok(Self::RaftNatsOutbox),

--- a/crates/database/src/committer.rs
+++ b/crates/database/src/committer.rs
@@ -34,6 +34,7 @@ use common::{
         ParseDocument,
         ParsedDocument,
         ResolvedDocument,
+        ID_FIELD,
     },
     document_index_keys::DocumentIndexKeyValue,
     errors::{
@@ -199,17 +200,24 @@ type RaftNatsOutboxRecords = BTreeMap<String, serde_json::Value>;
 /// State held for a 2PC-prepared transaction awaiting commit/rollback.
 struct PreparedTransaction {
     prepared_write: PreparedWriteHandle,
+    origin_commit_ts: Timestamp,
     commit_ts: Timestamp,
     write_bytes: u64,
     document_writes: Arc<Vec<DocumentLogEntry>>,
     index_writes: Arc<Vec<PersistenceIndexEntry>>,
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct CommitOutcome {
+    pub ts: Timestamp,
+    pub source_partition: Option<crate::partition::PartitionId>,
+}
+
 enum PersistenceWrite {
     Commit {
         pending_write: PendingWriteHandle,
         commit_timer: StatusTimer,
-        result: oneshot::Sender<anyhow::Result<Timestamp>>,
+        result: oneshot::Sender<anyhow::Result<CommitOutcome>>,
         parent_trace: EncodedSpan,
         commit_id: usize,
         delta: CommitDelta,
@@ -218,7 +226,7 @@ enum PersistenceWrite {
     RejectedBeforePersistence {
         pending_write: PendingWriteHandle,
         commit_timer: StatusTimer,
-        result: oneshot::Sender<anyhow::Result<Timestamp>>,
+        result: oneshot::Sender<anyhow::Result<CommitOutcome>>,
         commit_id: usize,
         err: anyhow::Error,
     },
@@ -241,6 +249,7 @@ enum PersistenceWrite {
         write_bytes: u64,
         source_partition: Option<crate::partition::PartitionId>,
         applied_delta_watermarks: Option<BTreeMap<crate::partition::PartitionId, Timestamp>>,
+        applied_data_delta_watermarks: Option<BTreeMap<crate::partition::PartitionId, Timestamp>>,
         raft_nats_outbox_delta: Option<CommitDelta>,
         result: oneshot::Sender<anyhow::Result<Timestamp>>,
         commit_id: usize,
@@ -257,6 +266,7 @@ enum PersistenceWrite {
         snapshot: Snapshot,
         replication_frontiers: BTreeMap<crate::partition::PartitionId, Timestamp>,
         applied_delta_watermarks: BTreeMap<crate::partition::PartitionId, Timestamp>,
+        applied_data_delta_watermarks: BTreeMap<crate::partition::PartitionId, Timestamp>,
         result: oneshot::Sender<anyhow::Result<Timestamp>>,
         commit_id: usize,
     },
@@ -461,6 +471,42 @@ fn remap_index_metadata_update(
     })
 }
 
+fn replicated_index_update_is_already_present(
+    snapshot: &Snapshot,
+    update: &common::document::DocumentUpdate,
+) -> anyhow::Result<bool> {
+    let Some(document) = update
+        .new_document
+        .as_ref()
+        .or(update.old_document.as_ref())
+    else {
+        return Ok(false);
+    };
+    let metadata =
+        common::bootstrap_model::index::TabletIndexMetadata::from_document(document.clone())?
+            .into_value();
+    let existing = if metadata.config.is_enabled() {
+        snapshot.index_registry.get_enabled(&metadata.name)
+    } else {
+        snapshot.index_registry.get_pending(&metadata.name)
+    };
+    let Some(existing) = existing else {
+        return Ok(false);
+    };
+    if existing.id() == document.id().internal_id() {
+        return Ok(false);
+    }
+    anyhow::ensure!(
+        existing.metadata().config == metadata.config,
+        "Replicated _index metadata for {} has document id {} but local index id {} already \
+         exists with different config",
+        metadata.name,
+        document.id().internal_id(),
+        existing.id(),
+    );
+    Ok(true)
+}
+
 fn downgrade_replicated_index_metadata(
     metadata: &mut common::bootstrap_model::index::TabletIndexMetadata,
 ) {
@@ -595,11 +641,14 @@ pub struct Committer<RT: Runtime> {
     // None means no Raft (existing behavior — always accept writes).
     raft_state: Option<crate::raft_partition::RaftPartitionState>,
 
-    // Durable idempotency frontier for replicated transport messages.
-    // Unlike `SnapshotManager::replication_frontiers`, this map is keyed by
-    // the origin partition's commit timestamp, not this node's local apply
-    // timestamp.
+    // Durable origin-timestamp freshness frontier for replicated transport
+    // messages. This includes data deltas and frontier-only heartbeats, so it
+    // is safe for read-after-write waits but not for data redelivery dedupe.
     applied_delta_watermarks: BTreeMap<crate::partition::PartitionId, Timestamp>,
+
+    // Durable origin-timestamp idempotency frontier for non-empty replicated
+    // data deltas only. Heartbeats must never advance this map.
+    applied_data_delta_watermarks: BTreeMap<crate::partition::PartitionId, Timestamp>,
 }
 
 impl<RT: Runtime> Committer<RT> {
@@ -674,6 +723,7 @@ impl<RT: Runtime> Committer<RT> {
         timestamp_oracle: Option<Arc<dyn crate::timestamp_oracle::TimestampOracle>>,
         raft_state: Option<crate::raft_partition::RaftPartitionState>,
         applied_delta_watermarks: BTreeMap<crate::partition::PartitionId, Timestamp>,
+        applied_data_delta_watermarks: BTreeMap<crate::partition::PartitionId, Timestamp>,
     ) -> CommitterClient {
         let persistence_reader = persistence.reader();
         let (tx, rx) = mpsc::channel(*COMMITTER_QUEUE_SIZE);
@@ -700,6 +750,7 @@ impl<RT: Runtime> Committer<RT> {
             queued_snapshots: VecDeque::new(),
             raft_state,
             applied_delta_watermarks,
+            applied_data_delta_watermarks,
         };
         let handle = runtime.spawn("committer", async move {
             if let Err(err) = committer.go(rx).await {
@@ -938,7 +989,10 @@ impl<RT: Runtime> Committer<RT> {
                                     u64::from(commit_ts),
                                 );
                             }
-                            let _ = result.send(Ok(commit_ts));
+                            let _ = result.send(Ok(CommitOutcome {
+                                ts: commit_ts,
+                                source_partition: published_commit.delta.source_partition,
+                            }));
 
                             // When we next get free cycles and there is no ongoing bump,
                             // bump max_repeatable_ts so followers can read this commit.
@@ -993,6 +1047,7 @@ impl<RT: Runtime> Committer<RT> {
                             write_bytes,
                             source_partition,
                             applied_delta_watermarks,
+                            applied_data_delta_watermarks,
                             raft_nats_outbox_delta,
                             result,
                             ..
@@ -1014,6 +1069,16 @@ impl<RT: Runtime> Committer<RT> {
                                         partition_timestamp_map_to_json(&frontiers),
                                     )
                                     .await?;
+                                self.applied_delta_watermarks = frontiers;
+                            }
+                            if let Some(frontiers) = applied_data_delta_watermarks {
+                                self.persistence
+                                    .write_persistence_global(
+                                        PersistenceGlobalKey::AppliedDataDeltaWatermarks,
+                                        partition_timestamp_map_to_json(&frontiers),
+                                    )
+                                    .await?;
+                                self.applied_data_delta_watermarks = frontiers;
                             }
                             if let Some(delta) = raft_nats_outbox_delta.as_ref() {
                                 Self::add_raft_nats_outbox_delta(
@@ -1031,18 +1096,21 @@ impl<RT: Runtime> Committer<RT> {
                                         source_partition,
                                         commit_ts,
                                     )?;
+                                    let origin_watermark = self
+                                        .applied_delta_watermarks
+                                        .get(&source_partition)
+                                        .copied()
+                                        .unwrap_or(remote_ts);
                                     sm.update_applied_delta_watermark(
                                         source_partition,
-                                        remote_ts,
+                                        origin_watermark,
                                     )?;
-                                    self.applied_delta_watermarks
-                                        .insert(source_partition, remote_ts);
                                 }
                             }
                             let committed_prepared_txn = if source_partition
                                 == Some(self.local_partition_for_two_phase())
                             {
-                                self.remove_prepared_transaction_at_ts(remote_ts)?
+                                self.remove_prepared_transaction_at_origin_ts(remote_ts)?
                             } else {
                                 None
                             };
@@ -1092,6 +1160,7 @@ impl<RT: Runtime> Committer<RT> {
                             snapshot,
                             replication_frontiers,
                             applied_delta_watermarks,
+                            applied_data_delta_watermarks,
                             result,
                             ..
                         } => {
@@ -1102,6 +1171,7 @@ impl<RT: Runtime> Committer<RT> {
                             self.log.reset(snapshot_ts);
                             self.last_assigned_ts = snapshot_ts;
                             self.applied_delta_watermarks = applied_delta_watermarks.clone();
+                            self.applied_data_delta_watermarks = applied_data_delta_watermarks;
                             self.snapshot_manager.write().replace(
                                 snapshot_ts,
                                 snapshot,
@@ -1859,6 +1929,7 @@ impl<RT: Runtime> Committer<RT> {
         write_source: WriteSource,
         explicit_commit_ts: Option<Timestamp>,
         require_leader: bool,
+        allow_explicit_ts_rewrite: bool,
     ) -> anyhow::Result<crate::two_phase::PrepareResult> {
         if require_leader {
             self.ensure_leader_for_writes()?;
@@ -1872,13 +1943,13 @@ impl<RT: Runtime> Committer<RT> {
         if let Some(existing) = self.prepared_transactions.get(&transaction_id) {
             if let Some(commit_ts) = explicit_commit_ts {
                 anyhow::ensure!(
-                    existing.commit_ts == commit_ts,
+                    existing.origin_commit_ts == commit_ts,
                     "2PC Prepare retried with a different commit timestamp for {}",
                     transaction_id
                 );
             }
             return Ok(crate::two_phase::PrepareResult {
-                prepare_ts: existing.commit_ts,
+                prepare_ts: existing.origin_commit_ts,
             });
         }
         if let Some(min_pending_ts) = self.pending_writes.min_ts() {
@@ -1894,22 +1965,54 @@ impl<RT: Runtime> Committer<RT> {
             )));
         }
 
-        let commit_ts = if let Some(commit_ts) = explicit_commit_ts {
-            anyhow::ensure!(
-                commit_ts >= local_commit_floor,
-                "2PC Prepare assigned ts={} but this participant requires ts>={}",
-                commit_ts,
-                local_commit_floor,
-            );
-            commit_ts
+        let (origin_commit_ts, commit_ts) = if let Some(commit_ts) = explicit_commit_ts {
+            let local_commit_ts = if commit_ts >= local_commit_floor {
+                commit_ts
+            } else if allow_explicit_ts_rewrite {
+                tracing::info!(
+                    "2PC Raft Prepare Apply: staging origin ts={} at local ts={} because the \
+                     follower snapshot floor has advanced",
+                    u64::from(commit_ts),
+                    u64::from(local_commit_floor),
+                );
+                local_commit_floor
+            } else {
+                anyhow::bail!(
+                    "2PC Prepare assigned ts={} but this participant requires ts>={}",
+                    commit_ts,
+                    local_commit_floor,
+                );
+            };
+            (commit_ts, local_commit_ts)
         } else {
-            self.next_commit_ts()?
+            let commit_ts = self.next_commit_ts()?;
+            (commit_ts, commit_ts)
         };
         if commit_ts > self.last_assigned_ts {
             self.last_assigned_ts = commit_ts;
         }
+        // Replay/recovery paths are reconstructing a prepare that was already
+        // accepted by the leader and written durably or through Raft. Do not
+        // re-scan from the original transaction begin timestamp: followers may
+        // have already compacted that range even when the origin prepare
+        // timestamp itself still does not need rewriting.
+        let conflict_begin_ts = if allow_explicit_ts_rewrite {
+            let rewritten_begin_ts = commit_ts.pred()?;
+            tracing::info!(
+                "2PC Raft Prepare Apply: validating replayed prepare with local begin ts={} \
+                 instead of origin begin ts={} to stay within the follower write-log retention \
+                 window",
+                u64::from(rewritten_begin_ts),
+                u64::from(begin_ts),
+            );
+            rewritten_begin_ts
+        } else {
+            begin_ts
+        };
         let timer = metrics::commit_is_stale_timer();
-        if let Some(conflicting_read) = self.commit_has_conflict(reads, begin_ts, commit_ts)? {
+        if let Some(conflicting_read) =
+            self.commit_has_conflict(reads, conflict_begin_ts, commit_ts)?
+        {
             anyhow::bail!(conflicting_read.into_error(table_mapping, &write_source));
         }
         timer.finish();
@@ -1963,6 +2066,7 @@ impl<RT: Runtime> Committer<RT> {
             transaction_id.clone(),
             PreparedTransaction {
                 prepared_write,
+                origin_commit_ts,
                 commit_ts,
                 write_bytes,
                 document_writes: Arc::new(doc_entries),
@@ -1977,7 +2081,7 @@ impl<RT: Runtime> Committer<RT> {
         );
 
         Ok(crate::two_phase::PrepareResult {
-            prepare_ts: commit_ts,
+            prepare_ts: origin_commit_ts,
         })
     }
 
@@ -2244,8 +2348,8 @@ impl<RT: Runtime> Committer<RT> {
         })
     }
 
-    fn fail_committed_write(
-        result: oneshot::Sender<anyhow::Result<Timestamp>>,
+    fn fail_committed_write<T>(
+        result: oneshot::Sender<anyhow::Result<T>>,
         commit_ts: Timestamp,
         operation: &'static str,
         err: anyhow::Error,
@@ -2708,6 +2812,16 @@ impl<RT: Runtime> Committer<RT> {
                         serde_json::json!({}),
                     )
                     .await?;
+                if !checkpoint.globals.contains_key(&String::from(
+                    PersistenceGlobalKey::AppliedDataDeltaWatermarks,
+                )) {
+                    persistence
+                        .write_persistence_global(
+                            PersistenceGlobalKey::AppliedDataDeltaWatermarks,
+                            serde_json::json!({}),
+                        )
+                        .await?;
+                }
 
                 let replication_frontiers = checkpoint
                     .globals
@@ -2736,12 +2850,26 @@ impl<RT: Runtime> Committer<RT> {
                     })
                     .transpose()?
                     .unwrap_or_default();
+                let applied_data_delta_watermarks = checkpoint
+                    .globals
+                    .get(&String::from(
+                        PersistenceGlobalKey::AppliedDataDeltaWatermarks,
+                    ))
+                    .map(|value| {
+                        partition_timestamp_map_from_json(
+                            value.clone(),
+                            "applied data delta watermarks",
+                        )
+                    })
+                    .transpose()?
+                    .unwrap_or_default();
 
                 Ok(PersistenceWrite::InstallSnapshot {
                     snapshot_ts: checkpoint_ts,
                     snapshot: db_snapshot.snapshot,
                     replication_frontiers,
                     applied_delta_watermarks,
+                    applied_data_delta_watermarks,
                     result,
                     commit_id,
                 })
@@ -2789,28 +2917,56 @@ impl<RT: Runtime> Committer<RT> {
         // prepare. We therefore use the remote commit timestamp as a floor and
         // only bump above it when local monotonicity requires it.
         let remote_ts = delta.ts;
-        if let Some(source_partition) = delta.source_partition
-            && self
-                .applied_delta_watermarks
-                .get(&source_partition)
-                .is_some_and(|frontier| *frontier >= remote_ts)
+        let local_prepared_commit_ts = if mode == ReplicaDeltaApplyMode::FullRaftState
+            && delta.source_partition == Some(self.local_partition_for_two_phase())
         {
-            tracing::info!(
-                "Skipping duplicate replica delta: source_partition={}, remote_ts={}",
-                source_partition.0,
-                u64::from(remote_ts),
+            self.local_prepared_commit_ts_for_origin(remote_ts)?
+        } else {
+            None
+        };
+        let latest_local_ts = *self.snapshot_manager.read().latest_ts();
+        let timestamps =
+            replica_delta_timestamps(remote_ts, latest_local_ts, self.last_assigned_ts)?;
+        let remote_ts = timestamps.origin_ts;
+        let commit_ts = if let Some(local_prepared_commit_ts) = local_prepared_commit_ts {
+            if local_prepared_commit_ts > latest_local_ts
+                && local_prepared_commit_ts > self.last_assigned_ts
+            {
+                local_prepared_commit_ts
+            } else {
+                tracing::info!(
+                    "2PC Raft Commit Apply: origin ts={} prepared locally at ts={} but local \
+                     floor is latest_snapshot={}, last_assigned={}; applying committed delta at \
+                     ts={}",
+                    u64::from(remote_ts),
+                    u64::from(local_prepared_commit_ts),
+                    u64::from(latest_local_ts),
+                    u64::from(self.last_assigned_ts),
+                    u64::from(timestamps.local_apply_ts),
+                );
+                timestamps.local_apply_ts
+            }
+        } else {
+            timestamps.local_apply_ts
+        };
+        if mode == ReplicaDeltaApplyMode::CrossPartitionReplica
+            && delta.source_partition != Some(self.local_partition_for_two_phase())
+            && let Some(min_prepared_ts) = self
+                .prepared_transactions
+                .values()
+                .map(|prepared| prepared.commit_ts)
+                .min()
+            && commit_ts >= min_prepared_ts
+        {
+            let err = anyhow::anyhow!(
+                "Replica delta at ts={} would overtake unresolved 2PC prepared transaction at \
+                 ts={}; retry after the prepared transaction commits or rolls back",
+                u64::from(commit_ts),
+                u64::from(min_prepared_ts),
             );
-            let _ = result.send(Ok(remote_ts));
+            let _ = result.send(Err(err));
             return Ok(());
         }
-        let timestamps = replica_delta_timestamps(
-            remote_ts,
-            *self.snapshot_manager.read().latest_ts(),
-            self.last_assigned_ts,
-        )?;
-        let remote_ts = timestamps.origin_ts;
-        let commit_ts = timestamps.local_apply_ts;
-        self.last_assigned_ts = commit_ts;
         tracing::info!(
             "Applying replica delta: remote_ts={}, local_ts={}, {} document updates, {} tablet \
              mappings",
@@ -2958,6 +3114,9 @@ impl<RT: Runtime> Committer<RT> {
 
         let is_frontier_only = tables_updates.is_empty() && other_updates.is_empty();
         if is_frontier_only {
+            if commit_ts > self.last_assigned_ts {
+                self.last_assigned_ts = commit_ts;
+            }
             let Some(source_partition) = delta.source_partition else {
                 tracing::debug!(
                     "Skipping no-op replica delta at ts {} with no source partition",
@@ -2978,11 +3137,22 @@ impl<RT: Runtime> Committer<RT> {
             };
             let updated_applied_delta_watermarks = {
                 let mut frontiers = self.applied_delta_watermarks.clone();
-                frontiers.insert(source_partition, remote_ts);
+                if frontiers
+                    .get(&source_partition)
+                    .is_none_or(|current| *current < remote_ts)
+                {
+                    frontiers.insert(source_partition, remote_ts);
+                }
                 frontiers
             };
-            self.applied_delta_watermarks
-                .insert(source_partition, remote_ts);
+            if self
+                .applied_delta_watermarks
+                .get(&source_partition)
+                .is_none_or(|current| *current < remote_ts)
+            {
+                self.applied_delta_watermarks
+                    .insert(source_partition, remote_ts);
+            }
             let persistence = self.persistence.clone();
             self.persistence_writes.push_back(
                 async move {
@@ -3009,6 +3179,25 @@ impl<RT: Runtime> Committer<RT> {
                 source_partition.0,
             );
             return Ok(());
+        }
+
+        if let Some(source_partition) = delta.source_partition
+            && local_prepared_commit_ts.is_none()
+            && self
+                .applied_data_delta_watermarks
+                .get(&source_partition)
+                .is_some_and(|frontier| *frontier >= remote_ts)
+        {
+            tracing::info!(
+                "Skipping duplicate non-empty replica delta: source_partition={}, remote_ts={}",
+                source_partition.0,
+                u64::from(remote_ts),
+            );
+            let _ = result.send(Ok(remote_ts));
+            return Ok(());
+        }
+        if commit_ts > self.last_assigned_ts {
+            self.last_assigned_ts = commit_ts;
         }
 
         let mut snapshot = self.base_snapshot_for_new_writes();
@@ -3144,12 +3333,24 @@ impl<RT: Runtime> Committer<RT> {
                 .get(&primary_tablet)
                 .is_some_and(|name| name == index_table_name)
             {
-                remap_index_metadata_update(
+                let remapped = remap_index_metadata_update(
                     update,
                     local_tablet,
                     &remap,
                     mode == ReplicaDeltaApplyMode::CrossPartitionReplica,
-                )?
+                )?;
+                if replicated_index_update_is_already_present(&snapshot, &remapped)? {
+                    tracing::debug!(
+                        "Skipping replicated _index metadata for existing local index: {:?}",
+                        remapped
+                            .new_document
+                            .as_ref()
+                            .or(remapped.old_document.as_ref())
+                            .map(|document| document.id()),
+                    );
+                    continue;
+                }
+                remapped
             } else {
                 DocumentUpdate {
                     id: ResolvedDocumentId {
@@ -3213,12 +3414,42 @@ impl<RT: Runtime> Committer<RT> {
         });
         let updated_applied_delta_watermarks = delta.source_partition.map(|source_partition| {
             let mut frontiers = self.applied_delta_watermarks.clone();
-            frontiers.insert(source_partition, remote_ts);
+            if frontiers
+                .get(&source_partition)
+                .is_none_or(|current| *current < remote_ts)
+            {
+                frontiers.insert(source_partition, remote_ts);
+            }
             frontiers
         });
+        let updated_applied_data_delta_watermarks =
+            delta.source_partition.map(|source_partition| {
+                let mut frontiers = self.applied_data_delta_watermarks.clone();
+                if frontiers
+                    .get(&source_partition)
+                    .is_none_or(|current| *current < remote_ts)
+                {
+                    frontiers.insert(source_partition, remote_ts);
+                }
+                frontiers
+            });
         if let Some(source_partition) = delta.source_partition {
-            self.applied_delta_watermarks
-                .insert(source_partition, remote_ts);
+            if self
+                .applied_delta_watermarks
+                .get(&source_partition)
+                .is_none_or(|current| *current < remote_ts)
+            {
+                self.applied_delta_watermarks
+                    .insert(source_partition, remote_ts);
+            }
+            if self
+                .applied_data_delta_watermarks
+                .get(&source_partition)
+                .is_none_or(|current| *current < remote_ts)
+            {
+                self.applied_data_delta_watermarks
+                    .insert(source_partition, remote_ts);
+            }
         }
         let raft_nats_outbox_delta = (mode == ReplicaDeltaApplyMode::FullRaftState
             && delta.source_partition.is_some())
@@ -3232,6 +3463,7 @@ impl<RT: Runtime> Committer<RT> {
             let idx_writes = index_writes.clone();
             let replication_frontiers = updated_replication_frontiers.clone();
             let applied_delta_watermarks = updated_applied_delta_watermarks.clone();
+            let applied_data_delta_watermarks = updated_applied_data_delta_watermarks.clone();
             let source_partition = delta.source_partition;
             async move {
                 // Write to persistence (so function runner can load modules).
@@ -3265,6 +3497,7 @@ impl<RT: Runtime> Committer<RT> {
                     write_bytes: delta.write_bytes,
                     source_partition,
                     applied_delta_watermarks,
+                    applied_data_delta_watermarks,
                     raft_nats_outbox_delta,
                     result,
                     commit_id,
@@ -3378,30 +3611,90 @@ impl<RT: Runtime> Committer<RT> {
         write_source: WriteSource,
         prepare_ts: Timestamp,
         require_leader: bool,
+        allow_explicit_ts_rewrite: bool,
     ) -> anyhow::Result<crate::two_phase::PrepareResult> {
-        let mut table_mapping = self
+        let local_table_mapping = self
             .snapshot_manager
             .read()
             .latest_snapshot()
             .table_mapping()
             .clone();
+        let mut table_mapping = local_table_mapping.clone();
         transaction.augment_table_mapping(&mut table_mapping)?;
+        let writes = Self::remap_participant_system_table_writes(
+            transaction.writes,
+            &table_mapping,
+            &local_table_mapping,
+        )?;
         self.stage_prepared_transaction(
             transaction_id,
             *transaction.begin_timestamp,
             &transaction.reads,
-            transaction.writes,
+            writes,
             &table_mapping,
             write_source,
             Some(prepare_ts),
             require_leader,
+            allow_explicit_ts_rewrite,
         )
+    }
+
+    fn remap_participant_system_table_writes(
+        writes: Vec<DocumentUpdateWithPrevTs>,
+        source_mapping: &TableMapping,
+        local_mapping: &TableMapping,
+    ) -> anyhow::Result<Vec<DocumentUpdateWithPrevTs>> {
+        writes
+            .into_iter()
+            .map(|write| {
+                let Ok(table_name) = source_mapping.tablet_name(write.id.tablet_id) else {
+                    return Ok(write);
+                };
+                if &table_name != &*TABLES_TABLE
+                    && &table_name != &*common::bootstrap_model::index::INDEX_TABLE
+                {
+                    return Ok(write);
+                }
+                let local_table = local_mapping
+                    .namespace(value::TableNamespace::Global)
+                    .id(&table_name)?;
+                let remapped_id = ResolvedDocumentId::new(
+                    local_table.tablet_id,
+                    PublicDocumentId::new(local_table.table_number, write.id.internal_id()),
+                );
+                let old_document = match write.old_document {
+                    Some((document, ts)) => {
+                        Some((Self::remap_document_id(document, remapped_id)?, ts))
+                    },
+                    None => None,
+                };
+                let new_document = match write.new_document {
+                    Some(document) => Some(Self::remap_document_id(document, remapped_id)?),
+                    None => None,
+                };
+                Ok(DocumentUpdateWithPrevTs {
+                    id: remapped_id,
+                    old_document,
+                    new_document,
+                })
+            })
+            .collect()
+    }
+
+    fn remap_document_id(
+        document: ResolvedDocument,
+        remapped_id: ResolvedDocumentId,
+    ) -> anyhow::Result<ResolvedDocument> {
+        let mut value: BTreeMap<_, _> = document.value().0.clone().into();
+        value.remove(&common::types::FieldName::from(ID_FIELD.clone()));
+        ResolvedDocument::new(remapped_id, document.creation_time(), value.try_into()?)
     }
 
     fn stage_two_phase_redo_entry(
         &mut self,
         entry: &crate::two_phase::TwoPhaseRedoEntry,
         require_leader: bool,
+        allow_explicit_ts_rewrite: bool,
     ) -> anyhow::Result<crate::two_phase::PrepareResult> {
         let transaction_id = entry.transaction_id();
         let prepare_ts = entry.prepare_ts()?;
@@ -3424,6 +3717,7 @@ impl<RT: Runtime> Committer<RT> {
             entry.write_source(),
             prepare_ts,
             require_leader,
+            allow_explicit_ts_rewrite,
         )
     }
 
@@ -3441,27 +3735,58 @@ impl<RT: Runtime> Committer<RT> {
         let Some(entry) = records.remove(&transaction_id.0) else {
             return Ok(false);
         };
-        self.stage_two_phase_redo_entry(&entry, require_leader)
+        self.stage_two_phase_redo_entry(&entry, require_leader, false)
             .with_context(|| format!("2PC: failed to stage durable redo txn={transaction_id}"))?;
         Ok(true)
     }
 
-    fn remove_prepared_transaction_at_ts(
+    fn remove_prepared_transaction_at_origin_ts(
         &mut self,
-        commit_ts: Timestamp,
+        origin_commit_ts: Timestamp,
+    ) -> anyhow::Result<Option<crate::two_phase::TwoPhaseTransactionId>> {
+        self.remove_prepared_transaction_matching_ts(origin_commit_ts, |prepared| {
+            prepared.origin_commit_ts
+        })
+    }
+
+    fn local_prepared_commit_ts_for_origin(
+        &self,
+        origin_commit_ts: Timestamp,
+    ) -> anyhow::Result<Option<Timestamp>> {
+        let matching = self
+            .prepared_transactions
+            .iter()
+            .filter_map(|(transaction_id, prepared)| {
+                (prepared.origin_commit_ts == origin_commit_ts)
+                    .then(|| (transaction_id.clone(), prepared.commit_ts))
+            })
+            .collect_vec();
+        anyhow::ensure!(
+            matching.len() <= 1,
+            "Found {} prepared transactions at origin ts={}; expected at most one",
+            matching.len(),
+            u64::from(origin_commit_ts),
+        );
+        Ok(matching.into_iter().next().map(|(_, commit_ts)| commit_ts))
+    }
+
+    fn remove_prepared_transaction_matching_ts(
+        &mut self,
+        ts: Timestamp,
+        ts_selector: impl Fn(&PreparedTransaction) -> Timestamp,
     ) -> anyhow::Result<Option<crate::two_phase::TwoPhaseTransactionId>> {
         let matching = self
             .prepared_transactions
             .iter()
             .filter_map(|(transaction_id, prepared)| {
-                (prepared.commit_ts == commit_ts).then(|| transaction_id.clone())
+                (ts_selector(prepared) == ts).then(|| transaction_id.clone())
             })
             .collect_vec();
         anyhow::ensure!(
             matching.len() <= 1,
             "Found {} prepared transactions at ts={}; expected at most one",
             matching.len(),
-            u64::from(commit_ts),
+            u64::from(ts),
         );
         let Some(transaction_id) = matching.into_iter().next() else {
             return Ok(None);
@@ -3473,7 +3798,7 @@ impl<RT: Runtime> Committer<RT> {
                 anyhow::anyhow!(
                     "2PC cleanup: prepared transaction {} disappeared while cleaning ts={}",
                     transaction_id,
-                    u64::from(commit_ts),
+                    u64::from(ts),
                 )
             })?;
         self.prepared_writes
@@ -3482,7 +3807,7 @@ impl<RT: Runtime> Committer<RT> {
                 anyhow::anyhow!(
                     "2PC cleanup: prepared intent for txn={} at ts={} was missing",
                     transaction_id,
-                    u64::from(commit_ts),
+                    u64::from(prepared.commit_ts),
                 )
             })?;
         Ok(Some(transaction_id))
@@ -3529,7 +3854,7 @@ impl<RT: Runtime> Committer<RT> {
                 continue;
             }
 
-            self.stage_two_phase_redo_entry(entry, false)
+            self.stage_two_phase_redo_entry(entry, false, true)
                 .with_context(|| {
                     format!("2PC Recovery: failed to stage prepared txn={transaction_id}")
                 })?;
@@ -3568,6 +3893,7 @@ impl<RT: Runtime> Committer<RT> {
             write_source.clone(),
             None,
             true,
+            false,
         )?;
         let redo = crate::two_phase::TwoPhaseRedoEntry::new(
             &transaction_id,
@@ -3679,6 +4005,7 @@ impl<RT: Runtime> Committer<RT> {
             write_source,
             prepare_ts,
             true,
+            false,
         )?;
         if let Err(err) = Self::persist_two_phase_redo(self.persistence.clone(), redo.clone()).await
         {
@@ -3930,7 +4257,7 @@ impl<RT: Runtime> Committer<RT> {
         );
 
         let result = self
-            .stage_two_phase_redo_entry(&redo, false)
+            .stage_two_phase_redo_entry(&redo, false, true)
             .with_context(|| {
                 format!("2PC Raft Prepare Apply: failed to stage txn={transaction_id}")
             })?;
@@ -3956,7 +4283,7 @@ impl<RT: Runtime> Committer<RT> {
     fn start_commit(
         &mut self,
         transaction: FinalTransaction,
-        result: oneshot::Sender<anyhow::Result<Timestamp>>,
+        result: oneshot::Sender<anyhow::Result<CommitOutcome>>,
         write_source: WriteSource,
         parent_trace: EncodedSpan,
         commit_id: usize,
@@ -3964,7 +4291,13 @@ impl<RT: Runtime> Committer<RT> {
     ) -> Option<BoxFuture<'static, anyhow::Result<PersistenceWrite>>> {
         // Skip read-only transactions.
         if transaction.is_readonly() {
-            let _ = result.send(Ok(*transaction.begin_timestamp));
+            let _ = result.send(Ok(CommitOutcome {
+                ts: *transaction.begin_timestamp,
+                source_partition: self
+                    .placement_state
+                    .as_ref()
+                    .map(|placement_state| placement_state.local_partition()),
+            }));
             return None;
         }
         let commit_timer = metrics::commit_timer();
@@ -4293,7 +4626,16 @@ impl<RT: Runtime> Committer<RT> {
     }
 
     fn next_max_repeatable_ts(&mut self) -> anyhow::Result<Timestamp> {
-        if let Some(min_pending) = self.pending_writes.min_ts() {
+        if !self.prepared_transactions.is_empty() {
+            let current = *self.snapshot_manager.read().persisted_max_repeatable_ts();
+            tracing::debug!(
+                prepared_transactions = self.prepared_transactions.len(),
+                current = u64::from(current),
+                "Skipping max repeatable timestamp bump while 2PC prepared transactions are \
+                 unresolved",
+            );
+            Ok(current)
+        } else if let Some(min_pending) = self.pending_writes.min_ts() {
             // If there's a pending write, push max_repeatable_ts to be right
             // before the pending write, so followers can choose recent
             // timestamps but can't read at the timestamp of the pending write.
@@ -4608,15 +4950,23 @@ impl CommitterClient {
         transaction: Transaction<RT>,
         write_source: WriteSource,
     ) -> BoxFuture<'_, anyhow::Result<Timestamp>> {
-        self._commit(transaction, write_source).boxed()
+        async move { Ok(self.commit_outcome(transaction, write_source).await?.ts) }.boxed()
     }
 
-    #[fastrace::trace]
-    async fn _commit<RT: Runtime>(
+    pub fn commit_outcome<RT: Runtime>(
         &self,
         transaction: Transaction<RT>,
         write_source: WriteSource,
-    ) -> anyhow::Result<Timestamp> {
+    ) -> BoxFuture<'_, anyhow::Result<CommitOutcome>> {
+        self._commit_outcome(transaction, write_source).boxed()
+    }
+
+    #[fastrace::trace]
+    async fn _commit_outcome<RT: Runtime>(
+        &self,
+        transaction: Transaction<RT>,
+        write_source: WriteSource,
+    ) -> anyhow::Result<CommitOutcome> {
         let _timer = metrics::commit_client_timer(transaction.identity());
         self.check_generated_ids(&transaction).await?;
 
@@ -4932,7 +5282,7 @@ enum CommitterMessage {
     Commit {
         queue_timer: Timer<VMHistogram>,
         transaction: FinalTransaction,
-        result: oneshot::Sender<anyhow::Result<Timestamp>>,
+        result: oneshot::Sender<anyhow::Result<CommitOutcome>>,
         write_source: WriteSource,
         parent_trace: EncodedSpan,
     },

--- a/crates/database/src/committer.rs
+++ b/crates/database/src/committer.rs
@@ -719,7 +719,9 @@ impl<RT: Runtime> Committer<RT> {
             placement_state: client_placement_state,
             node_addresses,
             two_phase_decision_log,
-            cluster_grpc_auth,
+            two_phase_client_pool: Arc::new(crate::two_phase::TwoPhaseCommitGrpcClientPool::new(
+                cluster_grpc_auth,
+            )),
         }
     }
 
@@ -4324,7 +4326,7 @@ pub struct CommitterClient {
     placement_state: Option<crate::partition::PlacementState>,
     node_addresses: Option<crate::two_phase::NodeAddresses>,
     two_phase_decision_log: Arc<dyn crate::two_phase::TwoPhaseDecisionLog>,
-    cluster_grpc_auth: Option<ClusterGrpcAuth>,
+    two_phase_client_pool: Arc<crate::two_phase::TwoPhaseCommitGrpcClientPool>,
 }
 
 impl CommitterClient {
@@ -4470,8 +4472,11 @@ impl CommitterClient {
         self.node_addresses.as_ref()
     }
 
-    pub(crate) fn cluster_grpc_auth(&self) -> Option<ClusterGrpcAuth> {
-        self.cluster_grpc_auth.clone()
+    pub(crate) async fn two_phase_client(
+        &self,
+        addr: &str,
+    ) -> anyhow::Result<Arc<crate::two_phase::TwoPhaseCommitGrpcClient>> {
+        self.two_phase_client_pool.client(addr).await
     }
 
     pub fn placement_version(&self) -> crate::partition::PlacementVersion {

--- a/crates/database/src/database.rs
+++ b/crates/database/src/database.rs
@@ -1062,6 +1062,15 @@ impl<RT: Runtime> Database<RT> {
             Some(value) => partition_timestamp_map_from_json(value, "applied delta watermarks")?,
             None => BTreeMap::new(),
         };
+        let applied_data_delta_watermarks = match reader
+            .get_persistence_global(PersistenceGlobalKey::AppliedDataDeltaWatermarks)
+            .await?
+        {
+            Some(value) => {
+                partition_timestamp_map_from_json(value, "applied data delta watermarks")?
+            },
+            None => BTreeMap::new(),
+        };
 
         let snapshot_manager = SnapshotManager::new(
             *ts,
@@ -1125,6 +1134,7 @@ impl<RT: Runtime> Database<RT> {
             timestamp_oracle,
             raft_state,
             applied_delta_watermarks,
+            applied_data_delta_watermarks,
         );
         let table_mapping_snapshot_cache =
             AsyncLru::new(runtime.clone(), 20, 2, "table_mapping_snapshot");
@@ -2133,11 +2143,23 @@ impl<RT: Runtime> Database<RT> {
         transaction: Transaction<RT>,
         write_source: impl Into<WriteSource>,
     ) -> anyhow::Result<Timestamp> {
+        Ok(self
+            .commit_with_write_source_outcome(transaction, write_source)
+            .await?
+            .ts)
+    }
+
+    #[fastrace::trace]
+    pub async fn commit_with_write_source_outcome(
+        &self,
+        transaction: Transaction<RT>,
+        write_source: impl Into<WriteSource>,
+    ) -> anyhow::Result<crate::committer::CommitOutcome> {
         task::consume_budget().await;
         let readonly = transaction.is_readonly();
         let result = self
             .committer
-            .commit(transaction, write_source.into())
+            .commit_outcome(transaction, write_source.into())
             .await?;
         if !readonly {
             self.write_commits_since_load.fetch_add(1, Ordering::SeqCst);

--- a/crates/database/src/tests/raft_failover_tests.rs
+++ b/crates/database/src/tests/raft_failover_tests.rs
@@ -15,6 +15,7 @@ use std::{
 };
 
 use raft::{
+    GetEntriesContext,
     SnapshotStatus,
     StateRole,
     Storage,
@@ -181,6 +182,41 @@ fn node_idx(nodes: &[RaftNode], id: u64) -> usize {
     nodes.iter().position(|n| n.node_id() == id).unwrap()
 }
 
+fn persisted_entry_data(node: &RaftNode) -> Vec<Vec<u8>> {
+    let first = node.storage.first_index().unwrap();
+    let last = node.storage.last_index().unwrap();
+    if first > last {
+        return vec![];
+    }
+    node.storage
+        .entries(first, last + 1, None, GetEntriesContext::empty(false))
+        .unwrap()
+        .into_iter()
+        .map(|entry| entry.data.to_vec())
+        .collect()
+}
+
+fn persisted_log_contains(node: &RaftNode, payload: &[u8]) -> bool {
+    persisted_entry_data(node)
+        .iter()
+        .any(|data| data.as_slice() == payload)
+}
+
+fn wait_for_committed_payload(
+    nodes: &mut [RaftNode],
+    active: &[bool],
+    payload: &[u8],
+    ticks: usize,
+) -> bool {
+    for _ in 0..ticks {
+        let committed = tick_cycle(nodes, active);
+        if committed.iter().any(|data| data.as_slice() == payload) {
+            return true;
+        }
+    }
+    false
+}
+
 // ============================================================
 // Test 1: 3-node election (already existed, rewritten with helpers)
 // ============================================================
@@ -336,6 +372,308 @@ async fn test_write_during_leader_transition() {
         post_committed.iter().any(|d| d == b"after kill"),
         "Post-kill write should be committed on new leader"
     );
+}
+
+#[tokio::test]
+async fn test_unquorumed_leader_proposal_is_truncated_after_failover() {
+    let mut nodes = create_three_node_group();
+    let old_leader_id = elect_leader(&mut nodes);
+    let old_leader_idx = node_idx(&nodes, old_leader_id);
+    let all_active = vec![true; 3];
+    let unquorumed_payload = b"old-leader-local-only";
+
+    nodes[old_leader_idx]
+        .raw_node
+        .propose(vec![], unquorumed_payload.to_vec())
+        .unwrap();
+
+    let mut committed = Vec::new();
+    for _ in 0..3 {
+        committed.extend(tick_cycle_with_message_filter(
+            &mut nodes,
+            &all_active,
+            |from, _, msg| {
+                !(from == old_leader_id
+                    && matches!(
+                        msg.get_msg_type(),
+                        raft::prelude::MessageType::MsgAppend
+                            | raft::prelude::MessageType::MsgHeartbeat
+                    ))
+            },
+        ));
+    }
+
+    assert!(
+        persisted_log_contains(&nodes[old_leader_idx], unquorumed_payload),
+        "old leader should have persisted the local proposal before losing leadership",
+    );
+    assert!(
+        !committed
+            .iter()
+            .any(|data| data.as_slice() == unquorumed_payload),
+        "proposal without quorum must not commit before failover",
+    );
+
+    let mut active = vec![true; 3];
+    active[old_leader_idx] = false;
+    let mut new_leader_id = 0;
+    for _ in 0..80 {
+        tick_cycle(&mut nodes, &active);
+        if let Some(new_leader) = nodes
+            .iter()
+            .enumerate()
+            .find(|(i, node)| {
+                active[*i]
+                    && node.raw_node.raft.state == StateRole::Leader
+                    && node.node_id() != old_leader_id
+            })
+            .map(|(_, node)| node.node_id())
+        {
+            new_leader_id = new_leader;
+            break;
+        }
+    }
+    assert_ne!(
+        new_leader_id, 0,
+        "majority should elect a replacement leader"
+    );
+
+    let new_leader_idx = node_idx(&nodes, new_leader_id);
+    let committed_payload = b"new-leader-committed";
+    nodes[new_leader_idx]
+        .raw_node
+        .propose(vec![], committed_payload.to_vec())
+        .unwrap();
+    assert!(
+        wait_for_committed_payload(&mut nodes, &active, committed_payload, 40),
+        "new leader should commit a replacement entry with the surviving majority",
+    );
+
+    active[old_leader_idx] = true;
+    for _ in 0..120 {
+        tick_cycle(&mut nodes, &active);
+        if nodes
+            .iter()
+            .all(|node| persisted_log_contains(node, committed_payload))
+            && nodes
+                .iter()
+                .all(|node| !persisted_log_contains(node, unquorumed_payload))
+        {
+            break;
+        }
+    }
+
+    for node in &nodes {
+        assert!(
+            !persisted_log_contains(node, unquorumed_payload),
+            "uncommitted old-leader entry must be truncated on node {} after rejoin",
+            node.node_id(),
+        );
+        assert!(
+            persisted_log_contains(node, committed_payload),
+            "replacement committed entry should be present on node {}",
+            node.node_id(),
+        );
+    }
+}
+
+#[tokio::test]
+async fn test_quorumed_proposal_survives_leader_death_before_all_followers_catch_up() {
+    let mut nodes = create_three_node_group();
+    let leader_id = elect_leader(&mut nodes);
+    let leader_idx = node_idx(&nodes, leader_id);
+    let lagging_follower_id = nodes
+        .iter()
+        .find(|node| node.node_id() != leader_id)
+        .expect("expected a follower")
+        .node_id();
+    let lagging_follower_idx = node_idx(&nodes, lagging_follower_id);
+    let all_active = vec![true; 3];
+    let payload = b"quorumed-before-leader-death";
+
+    nodes[leader_idx]
+        .raw_node
+        .propose(vec![], payload.to_vec())
+        .unwrap();
+
+    let mut committed = false;
+    for _ in 0..40 {
+        let cycle_committed =
+            tick_cycle_with_message_filter(&mut nodes, &all_active, |from, to, msg| {
+                !(from == leader_id
+                    && to == lagging_follower_id
+                    && matches!(
+                        msg.get_msg_type(),
+                        raft::prelude::MessageType::MsgAppend
+                            | raft::prelude::MessageType::MsgHeartbeat
+                    ))
+            });
+        if cycle_committed
+            .iter()
+            .any(|data| data.as_slice() == payload)
+        {
+            committed = true;
+            break;
+        }
+    }
+    assert!(
+        committed,
+        "leader plus one follower should commit while the other follower is lagging",
+    );
+    assert!(
+        !persisted_log_contains(&nodes[lagging_follower_idx], payload),
+        "the isolated follower should genuinely lag before leader death",
+    );
+
+    let mut active = vec![true; 3];
+    active[leader_idx] = false;
+    let survivor_with_entry = nodes
+        .iter()
+        .enumerate()
+        .find(|(i, node)| *i != leader_idx && persisted_log_contains(node, payload))
+        .map(|(_, node)| node.node_id())
+        .expect("one surviving follower should have the quorumed entry");
+
+    let mut new_leader_id = 0;
+    for _ in 0..80 {
+        tick_cycle(&mut nodes, &active);
+        if let Some(new_leader) = nodes
+            .iter()
+            .enumerate()
+            .find(|(i, node)| active[*i] && node.raw_node.raft.state == StateRole::Leader)
+            .map(|(_, node)| node.node_id())
+        {
+            new_leader_id = new_leader;
+            break;
+        }
+    }
+    assert_eq!(
+        new_leader_id, survivor_with_entry,
+        "only the surviving voter with the committed entry should be able to lead safely",
+    );
+
+    active[leader_idx] = true;
+    for _ in 0..120 {
+        tick_cycle(&mut nodes, &active);
+        if nodes
+            .iter()
+            .all(|node| persisted_log_contains(node, payload))
+        {
+            break;
+        }
+    }
+
+    for node in &nodes {
+        assert!(
+            persisted_log_contains(node, payload),
+            "quorumed proposal should survive leader death and catch up node {}",
+            node.node_id(),
+        );
+    }
+}
+
+#[tokio::test]
+async fn test_isolated_old_leader_steps_down_without_quorum() {
+    let mut nodes = create_three_node_group();
+    let old_leader_id = elect_leader(&mut nodes);
+    let old_leader_idx = node_idx(&nodes, old_leader_id);
+    let all_active = vec![true; 3];
+
+    for _ in 0..80 {
+        tick_cycle_with_message_filter(&mut nodes, &all_active, |from, to, _| {
+            from != old_leader_id && to != old_leader_id
+        });
+        if nodes[old_leader_idx].raw_node.raft.state != StateRole::Leader {
+            break;
+        }
+    }
+
+    assert_ne!(
+        nodes[old_leader_idx].raw_node.raft.state,
+        StateRole::Leader,
+        "old leader should step down after losing quorum",
+    );
+    assert_eq!(
+        nodes[old_leader_idx].raw_node.raft.leader_id, 0,
+        "isolated old leader should not believe it still has a known leader",
+    );
+}
+
+#[tokio::test]
+async fn test_majority_commits_while_old_leader_is_isolated() {
+    let mut nodes = create_three_node_group();
+    let old_leader_id = elect_leader(&mut nodes);
+    let old_leader_idx = node_idx(&nodes, old_leader_id);
+    let all_active = vec![true; 3];
+
+    for _ in 0..80 {
+        tick_cycle_with_message_filter(&mut nodes, &all_active, |from, to, _| {
+            from != old_leader_id && to != old_leader_id
+        });
+        if nodes
+            .iter()
+            .enumerate()
+            .any(|(i, node)| i != old_leader_idx && node.raw_node.raft.state == StateRole::Leader)
+        {
+            break;
+        }
+    }
+
+    let new_leader_idx = nodes
+        .iter()
+        .enumerate()
+        .find(|(i, node)| i != &old_leader_idx && node.raw_node.raft.state == StateRole::Leader)
+        .map(|(i, _)| i)
+        .expect("surviving majority should elect a new leader");
+    let majority_payload = b"majority-after-old-leader-isolated";
+    nodes[new_leader_idx]
+        .raw_node
+        .propose(vec![], majority_payload.to_vec())
+        .unwrap();
+
+    let mut committed = Vec::new();
+    for _ in 0..40 {
+        committed.extend(tick_cycle_with_message_filter(
+            &mut nodes,
+            &all_active,
+            |from, to, _| from != old_leader_id && to != old_leader_id,
+        ));
+        if committed
+            .iter()
+            .any(|data| data.as_slice() == majority_payload)
+        {
+            break;
+        }
+    }
+
+    assert!(
+        committed
+            .iter()
+            .any(|data| data.as_slice() == majority_payload),
+        "surviving majority should continue committing while old leader is isolated",
+    );
+    assert!(
+        !persisted_log_contains(&nodes[old_leader_idx], majority_payload),
+        "isolated old leader should not see majority writes before the partition heals",
+    );
+
+    for _ in 0..120 {
+        tick_cycle(&mut nodes, &all_active);
+        if nodes
+            .iter()
+            .all(|node| persisted_log_contains(node, majority_payload))
+        {
+            break;
+        }
+    }
+
+    for node in &nodes {
+        assert!(
+            persisted_log_contains(node, majority_payload),
+            "majority commit should catch up node {} after isolation heals",
+            node.node_id(),
+        );
+    }
 }
 
 // ============================================================
@@ -592,5 +930,72 @@ async fn test_lagging_follower_catches_up_via_snapshot() {
     assert!(
         nodes[lagging_idx].storage.first_index().unwrap() > 1,
         "lagging follower should have installed a snapshot instead of replaying from index 1",
+    );
+}
+
+#[tokio::test]
+async fn test_failed_snapshot_delivery_retries_and_catches_up() {
+    let mut nodes = create_three_node_group();
+    let leader_id = elect_leader(&mut nodes);
+    let leader_idx = node_idx(&nodes, leader_id);
+    let lagging_idx = (0..3).find(|&i| i != leader_idx).unwrap();
+    let lagging_id = nodes[lagging_idx].node_id();
+
+    let mut active = vec![true; 3];
+    active[lagging_idx] = false;
+
+    for i in 0..12 {
+        nodes[leader_idx]
+            .raw_node
+            .propose(vec![], format!("snapshot-retry-entry-{i}").into_bytes())
+            .unwrap();
+        for _ in 0..5 {
+            tick_cycle(&mut nodes, &active);
+        }
+    }
+
+    let compact_index = nodes[leader_idx].raw_node.raft.raft_log.committed;
+    assert!(
+        compact_index > 1,
+        "expected committed work before compaction"
+    );
+    nodes[leader_idx].storage.compact(compact_index).unwrap();
+
+    active[lagging_idx] = true;
+    nodes[leader_idx]
+        .raw_node
+        .propose(vec![], b"post-failed-snapshot".to_vec())
+        .unwrap();
+
+    for _ in 0..40 {
+        tick_cycle_with_message_filter(&mut nodes, &active, |_, to, msg| {
+            !(to == lagging_id && msg.get_msg_type() == raft::prelude::MessageType::MsgSnapshot)
+        });
+    }
+
+    assert!(
+        nodes[lagging_idx].storage.last_index().unwrap()
+            < nodes[leader_idx].storage.last_index().unwrap(),
+        "lagging follower should remain behind while snapshot delivery fails",
+    );
+
+    for _ in 0..120 {
+        tick_cycle(&mut nodes, &active);
+        if nodes[lagging_idx].storage.last_index().unwrap()
+            == nodes[leader_idx].storage.last_index().unwrap()
+            && nodes[lagging_idx].storage.first_index().unwrap() > 1
+        {
+            break;
+        }
+    }
+
+    assert_eq!(
+        nodes[lagging_idx].storage.last_index().unwrap(),
+        nodes[leader_idx].storage.last_index().unwrap(),
+        "lagging follower should catch up after snapshot delivery recovers",
+    );
+    assert!(
+        nodes[lagging_idx].storage.first_index().unwrap() > 1,
+        "lagging follower should install the retried snapshot",
     );
 }

--- a/crates/database/src/tests/write_scaling_tests.rs
+++ b/crates/database/src/tests/write_scaling_tests.rs
@@ -20,7 +20,14 @@ use anyhow::Context;
 use async_trait::async_trait;
 use common::{
     assert_obj,
-    bootstrap_model::index::database_index::IndexedFields,
+    bootstrap_model::index::{
+        database_index::IndexedFields,
+        INDEX_TABLE,
+    },
+    document::{
+        ResolvedDocument,
+        ID_FIELD,
+    },
     interval::Interval,
     knobs::REMOTE_READ_FRONTIER_WAIT_TIMEOUT,
     maybe_val,
@@ -85,6 +92,7 @@ use tonic::{
 };
 use value::{
     assert_val,
+    InternalId,
     PublicDocumentId,
     ResolvedDocumentId,
     TableName,
@@ -478,6 +486,22 @@ struct FailingRollbackAfterPrepareGrpcService {
     fail_next_rollback: AtomicBool,
 }
 
+struct AmbiguousPrepareAfterLocalPrepareGrpcService {
+    db: Database<TestRuntime>,
+    committer: CommitterClient,
+    local_partition: PartitionId,
+}
+
+impl AmbiguousPrepareAfterLocalPrepareGrpcService {
+    fn new(db: Database<TestRuntime>, local_partition: PartitionId) -> Self {
+        Self {
+            committer: db.committer_for_test(),
+            db,
+            local_partition,
+        }
+    }
+}
+
 impl FailingRollbackAfterPrepareGrpcService {
     fn new(db: Database<TestRuntime>, local_partition: PartitionId) -> Self {
         Self {
@@ -504,6 +528,87 @@ impl FailingCommitAfterLocalPrepareGrpcService {
             local_partition,
             fail_next_commit: AtomicBool::new(true),
         }
+    }
+}
+
+#[tonic::async_trait]
+impl TwoPhaseCommitService for AmbiguousPrepareAfterLocalPrepareGrpcService {
+    async fn prepare(
+        &self,
+        request: Request<TwoPcPrepareRequest>,
+    ) -> Result<Response<TwoPcPrepareResponse>, Status> {
+        let req = request.into_inner();
+        let txn_id = TwoPhaseTransactionId(req.transaction_id);
+        let prepare_ts: Timestamp = req
+            .prepare_ts
+            .try_into()
+            .map_err(|e| Status::invalid_argument(format!("Invalid prepare timestamp: {e:#}")))?;
+        let write_source = WriteSource::new(req.write_source);
+        let mut tx =
+            self.db.begin(Identity::system()).await.map_err(|e| {
+                Status::internal(format!("Failed to begin local prepare tx: {e:#}"))
+            })?;
+        TestFacingModel::new(&mut tx)
+            .insert(
+                &"projects"
+                    .parse()
+                    .map_err(|e| Status::internal(format!("Invalid test table name: {e:#}")))?,
+                assert_obj!("name" => "prepared-before-ambiguous-prepare-failure"),
+            )
+            .await
+            .map_err(|e| Status::internal(format!("Failed to build local prepare tx: {e:#}")))?;
+        let final_tx = tx
+            .finalize()
+            .map_err(|e| Status::internal(format!("Failed to finalize local prepare tx: {e:#}")))?;
+        let write_indexes: Vec<_> = final_tx
+            .writes
+            .coalesced_writes()
+            .enumerate()
+            .map(|(index, _)| index)
+            .collect();
+        let partition_map = partitioned_map(self.local_partition);
+        let transaction = ParticipantTransaction::from_final_transaction(
+            &final_tx,
+            self.local_partition,
+            &write_indexes,
+            &partition_map,
+            &write_source,
+        )
+        .map_err(|e| Status::internal(format!("Failed to build local participant tx: {e:#}")))?;
+        self.committer
+            .prepare_remote(
+                txn_id,
+                transaction,
+                write_source,
+                prepare_ts,
+                req.participants.iter().copied().map(PartitionId).collect(),
+            )
+            .await
+            .map_err(|e| Status::internal(format!("Prepare failed: {e:#}")))?;
+        Err(Status::unknown(
+            "transport error: connection error: stream closed because of a broken pipe",
+        ))
+    }
+
+    async fn commit_prepared(
+        &self,
+        _request: Request<TwoPcCommitRequest>,
+    ) -> Result<Response<TwoPcCommitResponse>, Status> {
+        Err(Status::failed_precondition(
+            "commit_prepared should not be called after ambiguous prepare failure",
+        ))
+    }
+
+    async fn rollback_prepared(
+        &self,
+        request: Request<TwoPcRollbackRequest>,
+    ) -> Result<Response<TwoPcRollbackResponse>, Status> {
+        let req = request.into_inner();
+        self.committer
+            .rollback_prepared(TwoPhaseTransactionId(req.transaction_id))
+            .await
+            .map_err(|e| Status::internal(format!("RollbackPrepared failed: {e:#}")))?;
+        Ok(Response::new(TwoPcRollbackResponse {}))
     }
 }
 
@@ -1366,6 +1471,142 @@ async fn test_local_commit_retries_while_prepare_is_unresolved(
 }
 
 #[convex_macro::test_runtime]
+async fn test_max_repeatable_bump_does_not_overtake_prepared_commit(
+    rt: TestRuntime,
+) -> anyhow::Result<()> {
+    let log = Arc::new(InMemoryDistributedLog::new());
+    let node = create_node(&rt, log, Some(partitioned_map(PartitionId(0)))).await?;
+
+    let mut tx = node.begin(Identity::system()).await?;
+    TestFacingModel::new(&mut tx)
+        .insert(
+            &"messages".parse()?,
+            assert_obj!("text" => "prepared-after-repeatable-bump"),
+        )
+        .await?;
+    let final_tx = tx.finalize()?;
+    let txn_id = TwoPhaseTransactionId::new();
+    let prepare = node
+        .committer_for_test()
+        .prepare(
+            txn_id.clone(),
+            final_tx,
+            WriteSource::new("prepared_repeatable_bump_test"),
+        )
+        .await?;
+
+    let bumped = node.bump_max_repeatable_ts().await?;
+    assert!(
+        bumped < prepare.prepare_ts,
+        "max repeatable bump should not advance past unresolved prepare ts: bumped={} prepare={}",
+        u64::from(bumped),
+        u64::from(prepare.prepare_ts),
+    );
+
+    let committed = node.committer_for_test().commit_prepared(txn_id).await?;
+    assert_eq!(committed, prepare.prepare_ts);
+
+    let messages = run_query(
+        node,
+        TableNamespace::root_component(),
+        Query::full_table_scan("messages".parse()?, Order::Asc),
+    )
+    .await?;
+    assert_eq!(messages.len(), 1);
+
+    Ok(())
+}
+
+#[convex_macro::test_runtime]
+async fn test_cross_partition_replica_delta_waits_behind_unresolved_prepared_transaction(
+    rt: TestRuntime,
+) -> anyhow::Result<()> {
+    let log = Arc::new(InMemoryDistributedLog::new());
+    let node_a = create_node(
+        &rt,
+        log.clone(),
+        Some(partitioned_map_with_tasks(PartitionId(0))),
+    )
+    .await?;
+    let node_b = create_node(
+        &rt,
+        log.clone(),
+        Some(partitioned_map_with_tasks(PartitionId(1))),
+    )
+    .await?;
+
+    insert_doc(
+        &node_a,
+        "messages",
+        assert_obj!("text" => "remote-before-prepare"),
+    )
+    .await?;
+    let mut racing_delta = log
+        .deltas()
+        .into_iter()
+        .last()
+        .expect("seed message should publish a replica delta");
+    node_b
+        .committer_for_test()
+        .apply_replica_delta(racing_delta.clone())
+        .await?;
+
+    let mut tx = node_b.begin(Identity::system()).await?;
+    TestFacingModel::new(&mut tx)
+        .insert(
+            &"tasks".parse()?,
+            assert_obj!("title" => "prepared-local-task"),
+        )
+        .await?;
+    let final_tx = tx.finalize()?;
+    let txn_id = TwoPhaseTransactionId::new();
+    let prepare = node_b
+        .committer_for_test()
+        .prepare(
+            txn_id.clone(),
+            final_tx,
+            WriteSource::new("prepared_replica_delta_fence_test"),
+        )
+        .await?;
+
+    racing_delta.ts = prepare.prepare_ts;
+    let err = node_b
+        .committer_for_test()
+        .apply_replica_delta(racing_delta.clone())
+        .await
+        .expect_err("cross-partition replica delta should retry behind unresolved prepare");
+    assert!(
+        format!("{err:#}").contains("would overtake unresolved 2PC prepared transaction"),
+        "unexpected error: {err:#}",
+    );
+
+    let committed = node_b.committer_for_test().commit_prepared(txn_id).await?;
+    assert_eq!(committed, prepare.prepare_ts);
+
+    node_b
+        .committer_for_test()
+        .apply_replica_delta(racing_delta)
+        .await?;
+
+    let tasks = run_query(
+        node_b.clone(),
+        TableNamespace::root_component(),
+        Query::full_table_scan("tasks".parse()?, Order::Asc),
+    )
+    .await?;
+    let messages = run_query(
+        node_b,
+        TableNamespace::root_component(),
+        Query::full_table_scan("messages".parse()?, Order::Asc),
+    )
+    .await?;
+    assert_eq!(tasks.len(), 1);
+    assert_eq!(messages.len(), 1);
+
+    Ok(())
+}
+
+#[convex_macro::test_runtime]
 async fn test_prepare_retries_while_local_commit_is_pending(
     rt: TestRuntime,
     pause: PauseController,
@@ -1760,12 +2001,12 @@ async fn test_replica_delta_redelivery_is_idempotent(rt: TestRuntime) -> anyhow:
 
     let applied_frontiers = node_a_persistence
         .reader()
-        .get_persistence_global(PersistenceGlobalKey::AppliedDeltaWatermarks)
+        .get_persistence_global(PersistenceGlobalKey::AppliedDataDeltaWatermarks)
         .await?
-        .expect("replica applied frontier should be persisted");
+        .expect("replica applied data frontier should be persisted");
     let applied_frontiers = crate::snapshot_manager::partition_timestamp_map_from_json(
         applied_frontiers,
-        "applied delta watermarks",
+        "applied data delta watermarks",
     )?;
     assert_eq!(applied_frontiers.get(&PartitionId(1)), Some(&remote_ts));
 
@@ -1793,6 +2034,225 @@ async fn test_replica_delta_redelivery_is_idempotent(rt: TestRuntime) -> anyhow:
         "redelivered delta after restart must not append duplicate document log entries",
     );
 
+    Ok(())
+}
+
+#[convex_macro::test_runtime]
+async fn test_frontier_heartbeat_does_not_dedupe_later_data_delta(
+    rt: TestRuntime,
+) -> anyhow::Result<()> {
+    let log = Arc::new(InMemoryDistributedLog::new());
+    let target_persistence = Arc::new(TestPersistence::new());
+    let table_numbers = Arc::new(InMemoryTableNumberAllocator::default());
+    let source = create_node_with_table_number_allocator(
+        &rt,
+        log.clone(),
+        Some(partitioned_map(PartitionId(1))),
+        table_numbers.clone(),
+    )
+    .await?;
+    let target = create_node_with_persistence_and_table_number_allocator(
+        &rt,
+        target_persistence.clone(),
+        log.clone(),
+        Some(partitioned_map(PartitionId(0))),
+        None,
+        Arc::new(NoopTwoPhaseDecisionLog),
+        None,
+        table_numbers,
+    )
+    .await?;
+
+    insert_doc(&source, "projects", assert_obj!("name" => "late data")).await?;
+    let data_delta = log
+        .deltas()
+        .into_iter()
+        .last()
+        .expect("project insert should publish a delta");
+    let data_ts = data_delta.ts;
+    let heartbeat_ts = data_ts.succ()?;
+
+    target
+        .committer_for_test()
+        .apply_replica_delta(CommitDelta {
+            ts: heartbeat_ts,
+            document_writes: Arc::new(Vec::new()),
+            document_updates: Vec::new(),
+            index_writes: Arc::new(Vec::new()),
+            write_source: WriteSource::new("heartbeat_before_data_test"),
+            write_bytes: 0,
+            tablet_id_to_table_name: Default::default(),
+            source_partition: Some(PartitionId(1)),
+        })
+        .await?;
+
+    let freshness_watermarks = target_persistence
+        .reader()
+        .get_persistence_global(PersistenceGlobalKey::AppliedDeltaWatermarks)
+        .await?
+        .context("heartbeat should persist the freshness watermark")?;
+    let freshness_watermarks =
+        partition_timestamp_map_from_json(freshness_watermarks, "applied delta watermarks")?;
+    assert_eq!(
+        freshness_watermarks.get(&PartitionId(1)).copied(),
+        Some(heartbeat_ts),
+        "frontier-only heartbeat advances read-after-write freshness",
+    );
+    let data_watermarks = target_persistence
+        .reader()
+        .get_persistence_global(PersistenceGlobalKey::AppliedDataDeltaWatermarks)
+        .await?;
+    assert!(
+        data_watermarks.is_none(),
+        "frontier-only heartbeat must not advance data-delta idempotency",
+    );
+
+    let applied_ts = target
+        .committer_for_test()
+        .apply_replica_delta(data_delta)
+        .await?;
+    assert!(
+        applied_ts > heartbeat_ts,
+        "late data should apply at a fresh local timestamp after the heartbeat",
+    );
+
+    let projects = run_query(
+        target.clone(),
+        TableNamespace::root_component(),
+        Query::full_table_scan("projects".parse()?, Order::Asc),
+    )
+    .await?;
+    assert_eq!(
+        projects.len(),
+        1,
+        "non-empty data delta must not be skipped by a newer heartbeat watermark",
+    );
+
+    let persisted_data_watermarks = target_persistence
+        .reader()
+        .get_persistence_global(PersistenceGlobalKey::AppliedDataDeltaWatermarks)
+        .await?
+        .context("data delta should persist the data idempotency watermark")?;
+    let persisted_data_watermarks = partition_timestamp_map_from_json(
+        persisted_data_watermarks,
+        "applied data delta watermarks",
+    )?;
+    assert_eq!(
+        persisted_data_watermarks.get(&PartitionId(1)).copied(),
+        Some(data_ts),
+        "data idempotency tracks the non-empty delta, not the newer heartbeat",
+    );
+
+    let freshness_watermarks = target_persistence
+        .reader()
+        .get_persistence_global(PersistenceGlobalKey::AppliedDeltaWatermarks)
+        .await?
+        .context("freshness watermark should still be persisted")?;
+    let freshness_watermarks =
+        partition_timestamp_map_from_json(freshness_watermarks, "applied delta watermarks")?;
+    assert_eq!(
+        freshness_watermarks.get(&PartitionId(1)).copied(),
+        Some(heartbeat_ts),
+        "late data must not move the freshness watermark backward",
+    );
+
+    Ok(())
+}
+
+fn rewrite_index_document_ids(mut delta: CommitDelta) -> anyhow::Result<CommitDelta> {
+    let mut rewritten = 1u8;
+    for update in &mut delta.document_updates {
+        if !delta
+            .tablet_id_to_table_name
+            .get(&update.id.tablet_id)
+            .is_some_and(|name| name == &*INDEX_TABLE)
+        {
+            continue;
+        }
+        let internal_id = InternalId([rewritten; 16]);
+        rewritten += 1;
+        let remapped_id = ResolvedDocumentId::new(
+            update.id.tablet_id,
+            PublicDocumentId::new(update.id.document_id.table(), internal_id),
+        );
+        update.id = remapped_id;
+        update.old_document = update
+            .old_document
+            .take()
+            .map(|document| {
+                let mut fields: std::collections::BTreeMap<_, _> =
+                    document.value().0.clone().into();
+                fields.remove(&common::types::FieldName::from(ID_FIELD.clone()));
+                let value = fields.try_into()?;
+                ResolvedDocument::new(remapped_id, document.creation_time(), value)
+            })
+            .transpose()?;
+        update.new_document = update
+            .new_document
+            .take()
+            .map(|document| {
+                let mut fields: std::collections::BTreeMap<_, _> =
+                    document.value().0.clone().into();
+                fields.remove(&common::types::FieldName::from(ID_FIELD.clone()));
+                let value = fields.try_into()?;
+                ResolvedDocument::new(remapped_id, document.creation_time(), value)
+            })
+            .transpose()?;
+    }
+    Ok(delta)
+}
+
+#[convex_macro::test_runtime]
+async fn test_replica_delta_skips_equivalent_index_metadata_with_new_document_ids(
+    rt: TestRuntime,
+) -> anyhow::Result<()> {
+    let log = Arc::new(InMemoryDistributedLog::new());
+    let node_a_persistence = Arc::new(TestPersistence::new());
+    let node_a = create_node_with_persistence(
+        &rt,
+        node_a_persistence.clone(),
+        log.clone(),
+        Some(partitioned_map(PartitionId(0))),
+        None,
+        Arc::new(NoopTwoPhaseDecisionLog),
+        None,
+    )
+    .await?;
+    let node_b = create_node(&rt, log.clone(), Some(partitioned_map(PartitionId(1)))).await?;
+
+    insert_doc(&node_b, "projects", assert_obj!("name" => "catalog")).await?;
+    let delta = log
+        .deltas()
+        .into_iter()
+        .last()
+        .expect("project insert should publish table and index metadata");
+    node_a
+        .committer_for_test()
+        .apply_replica_delta(delta.clone())
+        .await?;
+    let document_log_count = persisted_document_log_count(&node_a_persistence).await?;
+
+    let mut duplicate_index_delta = rewrite_index_document_ids(delta)?;
+    duplicate_index_delta.ts = duplicate_index_delta.ts.succ()?;
+    duplicate_index_delta.document_updates.retain(|update| {
+        duplicate_index_delta
+            .tablet_id_to_table_name
+            .get(&update.id.tablet_id)
+            .is_some_and(|name| name == &*INDEX_TABLE)
+    });
+    duplicate_index_delta.document_writes = Arc::new(Vec::new());
+    duplicate_index_delta.index_writes = Arc::new(Vec::new());
+
+    node_a
+        .committer_for_test()
+        .apply_replica_delta(duplicate_index_delta)
+        .await?;
+
+    assert_eq!(
+        persisted_document_log_count(&node_a_persistence).await?,
+        document_log_count,
+        "equivalent duplicate _index metadata should be skipped without appending document writes",
+    );
     Ok(())
 }
 
@@ -2081,6 +2541,100 @@ async fn test_prepared_participant_recovers_from_redo_after_restart(
 }
 
 #[convex_macro::test_runtime]
+async fn test_prepared_participant_recovery_rewrites_when_restart_floor_advances(
+    rt: TestRuntime,
+) -> anyhow::Result<()> {
+    let log = Arc::new(InMemoryDistributedLog::new());
+    let tp = Arc::new(TestPersistence::new());
+    let node = create_node_with_persistence(
+        &rt,
+        tp.clone(),
+        log.clone(),
+        Some(partitioned_map(PartitionId(1))),
+        None,
+        Arc::new(NoopTwoPhaseDecisionLog),
+        None,
+    )
+    .await?;
+
+    let mut tx = node.begin(Identity::system()).await?;
+    TestFacingModel::new(&mut tx)
+        .insert(
+            &"projects".parse()?,
+            assert_obj!("name" => "recovered-from-redo-after-floor-advance"),
+        )
+        .await?;
+    let final_tx = tx.finalize()?;
+    let write_indexes: Vec<_> = final_tx
+        .writes
+        .coalesced_writes()
+        .enumerate()
+        .map(|(index, _)| index)
+        .collect();
+    let write_source = WriteSource::new("prepared_redo_recovery_floor_test");
+    let participant_tx = ParticipantTransaction::from_final_transaction(
+        &final_tx,
+        PartitionId(1),
+        &write_indexes,
+        &partitioned_map(PartitionId(1)),
+        &write_source,
+    )?;
+    let txn_id = TwoPhaseTransactionId::new();
+    let prepare_ts = node.committer_for_test().allocate_commit_ts().await?;
+    node.committer_for_test()
+        .prepare_remote(
+            txn_id.clone(),
+            participant_tx,
+            write_source.clone(),
+            prepare_ts,
+            vec![PartitionId(1)],
+        )
+        .await?;
+    node.shutdown().await?;
+
+    let restart_floor = prepare_ts.succ()?.succ()?;
+    tp.write_persistence_global(
+        PersistenceGlobalKey::MaxRepeatableTimestamp,
+        restart_floor.into(),
+    )
+    .await?;
+
+    let restarted = create_node_with_persistence(
+        &rt,
+        tp.clone(),
+        log,
+        Some(partitioned_map(PartitionId(1))),
+        None,
+        Arc::new(NoopTwoPhaseDecisionLog),
+        None,
+    )
+    .await?;
+    let committed_ts = restarted
+        .committer_for_test()
+        .commit_prepared(txn_id)
+        .await?;
+    assert!(
+        committed_ts > prepare_ts,
+        "recovered prepare should commit at a local timestamp above the advanced restart floor",
+    );
+
+    let projects = run_query(
+        restarted.clone(),
+        TableNamespace::root_component(),
+        Query::full_table_scan("projects".parse()?, Order::Asc),
+    )
+    .await?;
+    assert_eq!(projects.len(), 1);
+
+    let redo = tp
+        .reader()
+        .get_persistence_global(PersistenceGlobalKey::TwoPhaseRedoRecords)
+        .await?;
+    assert_eq!(redo, Some(serde_json::json!({})));
+    Ok(())
+}
+
+#[convex_macro::test_runtime]
 async fn test_raft_prepared_redo_apply_can_commit_after_failover(
     rt: TestRuntime,
 ) -> anyhow::Result<()> {
@@ -2142,6 +2696,72 @@ async fn test_raft_prepared_redo_apply_can_commit_after_failover(
         .get_persistence_global(PersistenceGlobalKey::TwoPhaseRedoRecords)
         .await?;
     assert_eq!(redo, Some(serde_json::json!({})));
+    Ok(())
+}
+
+#[convex_macro::test_runtime]
+async fn test_remote_table_catalog_writes_follow_owner_prepare_redo(
+    rt: TestRuntime,
+) -> anyhow::Result<()> {
+    let log = Arc::new(InMemoryDistributedLog::new());
+    let source = create_node(&rt, log.clone(), Some(partitioned_map(PartitionId(0)))).await?;
+
+    let mut tx = source.begin(Identity::system()).await?;
+    TestFacingModel::new(&mut tx)
+        .insert(
+            &"projects".parse()?,
+            assert_obj!("name" => "remote-catalog-redo"),
+        )
+        .await?;
+    let final_tx = tx.finalize()?;
+    let write_source = WriteSource::new("remote_catalog_owner_prepare_test");
+    let source_map = partitioned_map(PartitionId(0));
+    let participant_indexes = crate::two_phase_coordinator::participant_write_indexes(
+        &final_tx,
+        &source_map,
+        &write_source,
+    );
+    let owner_writes = participant_indexes
+        .get(&PartitionId(1))
+        .expect("projects writes and catalog metadata should route to partition 1");
+    assert_eq!(participant_indexes.len(), 1);
+    assert_eq!(
+        owner_writes.len(),
+        final_tx.writes.coalesced_writes().count()
+    );
+
+    let owner = create_node(&rt, log, Some(partitioned_map(PartitionId(1)))).await?;
+    let participant_tx = ParticipantTransaction::from_final_transaction(
+        &final_tx,
+        PartitionId(1),
+        owner_writes,
+        &source_map,
+        &write_source,
+    )?;
+    let txn_id = TwoPhaseTransactionId::new();
+    let prepare_ts = owner.committer_for_test().allocate_commit_ts().await?;
+    let redo = TwoPhaseRedoEntry::new(
+        &txn_id,
+        prepare_ts,
+        PartitionId(1),
+        participant_tx,
+        &write_source,
+    )?;
+
+    owner
+        .committer_for_test()
+        .apply_raft_prepared_redo(redo)
+        .await?;
+    let committed_ts = owner.committer_for_test().commit_prepared(txn_id).await?;
+    assert_eq!(committed_ts, prepare_ts);
+
+    let projects = run_query(
+        owner.clone(),
+        TableNamespace::root_component(),
+        Query::full_table_scan("projects".parse()?, Order::Asc),
+    )
+    .await?;
+    assert_eq!(projects.len(), 1);
     Ok(())
 }
 
@@ -2262,6 +2882,581 @@ async fn test_raft_commit_delta_cleans_prepared_redo_on_follower(
     )
     .await
     .context("follower should accept local writes after Raft commit delta cleaned the prepare")?;
+    Ok(())
+}
+
+#[convex_macro::test_runtime]
+async fn test_raft_prepared_redo_rewrites_when_follower_floor_advanced_by_replica_delta(
+    rt: TestRuntime,
+) -> anyhow::Result<()> {
+    let log = Arc::new(InMemoryDistributedLog::new());
+    let table_number_allocator = Arc::new(InMemoryTableNumberAllocator::default());
+    let source = create_node_with_persistence_and_table_number_allocator(
+        &rt,
+        Arc::new(TestPersistence::new()),
+        log.clone(),
+        Some(partitioned_map(PartitionId(1))),
+        None,
+        Arc::new(NoopTwoPhaseDecisionLog),
+        None,
+        table_number_allocator.clone(),
+    )
+    .await?;
+    let follower = create_node_with_persistence_and_table_number_allocator(
+        &rt,
+        Arc::new(TestPersistence::new()),
+        log.clone(),
+        Some(partitioned_map(PartitionId(1))),
+        None,
+        Arc::new(NoopTwoPhaseDecisionLog),
+        None,
+        table_number_allocator.clone(),
+    )
+    .await?;
+    let foreign = create_node_with_persistence_and_table_number_allocator(
+        &rt,
+        Arc::new(TestPersistence::new()),
+        log.clone(),
+        Some(partitioned_map(PartitionId(0))),
+        None,
+        Arc::new(NoopTwoPhaseDecisionLog),
+        None,
+        table_number_allocator,
+    )
+    .await?;
+
+    insert_doc(
+        &source,
+        "projects",
+        assert_obj!("name" => "seed-before-rewrite"),
+    )
+    .await?;
+    let seed_delta = log
+        .deltas()
+        .into_iter()
+        .last()
+        .context("seed insert should publish a delta")?;
+    follower
+        .committer_for_test()
+        .apply_replica_delta(seed_delta)
+        .await?;
+
+    let mut tx = source.begin(Identity::system()).await?;
+    TestFacingModel::new(&mut tx)
+        .insert(
+            &"projects".parse()?,
+            assert_obj!("name" => "raft-prepare-rewrite"),
+        )
+        .await?;
+    let final_tx = tx.finalize()?;
+    let write_indexes: Vec<_> = final_tx
+        .writes
+        .coalesced_writes()
+        .enumerate()
+        .map(|(index, _)| index)
+        .collect();
+    let write_source = WriteSource::new("raft_prepare_rewrite_test");
+    let participant_tx = ParticipantTransaction::from_final_transaction(
+        &final_tx,
+        PartitionId(1),
+        &write_indexes,
+        &partitioned_map(PartitionId(1)),
+        &write_source,
+    )?;
+    let txn_id = TwoPhaseTransactionId::new();
+    let prepare_ts = source.committer_for_test().allocate_commit_ts().await?;
+
+    insert_doc(
+        &foreign,
+        "messages",
+        assert_obj!("text" => "advance-follower-floor"),
+    )
+    .await?;
+    let mut foreign_delta = log
+        .deltas()
+        .into_iter()
+        .last()
+        .context("foreign insert should publish a delta")?;
+    if foreign_delta.ts <= prepare_ts {
+        foreign_delta.ts = prepare_ts.succ()?;
+    }
+    follower
+        .committer_for_test()
+        .apply_replica_delta(foreign_delta)
+        .await?;
+
+    let redo = TwoPhaseRedoEntry::new(
+        &txn_id,
+        prepare_ts,
+        PartitionId(1),
+        participant_tx.clone(),
+        &write_source,
+    )?;
+    let prepare_result = follower
+        .committer_for_test()
+        .apply_raft_prepared_redo(redo)
+        .await?;
+    assert_eq!(prepare_result.prepare_ts, prepare_ts);
+
+    insert_doc(
+        &foreign,
+        "messages",
+        assert_obj!("text" => "advance-follower-floor-after-prepare"),
+    )
+    .await?;
+    let mut post_prepare_foreign_delta = log
+        .deltas()
+        .into_iter()
+        .last()
+        .context("post-prepare foreign insert should publish a delta")?;
+    if post_prepare_foreign_delta.ts <= prepare_ts {
+        post_prepare_foreign_delta.ts = prepare_ts.succ()?.succ()?;
+    }
+    let err = follower
+        .committer_for_test()
+        .apply_replica_delta(post_prepare_foreign_delta.clone())
+        .await
+        .expect_err("foreign replica delta should wait behind unresolved prepared redo");
+    assert!(
+        format!("{err:#}").contains("would overtake unresolved 2PC prepared transaction"),
+        "unexpected error: {err:#}",
+    );
+
+    source
+        .committer_for_test()
+        .prepare_remote(
+            txn_id.clone(),
+            participant_tx,
+            write_source,
+            prepare_ts,
+            vec![PartitionId(1)],
+        )
+        .await?;
+    source.committer_for_test().commit_prepared(txn_id).await?;
+    let delta = log
+        .deltas()
+        .into_iter()
+        .last()
+        .context("prepared commit should publish a delta")?;
+    follower
+        .committer_for_test()
+        .apply_raft_commit_delta(delta)
+        .await?;
+    follower
+        .committer_for_test()
+        .apply_replica_delta(post_prepare_foreign_delta)
+        .await?;
+
+    let redo = follower
+        .committer_for_test()
+        .persistence_reader()
+        .get_persistence_global(PersistenceGlobalKey::TwoPhaseRedoRecords)
+        .await?;
+    assert_eq!(redo, Some(serde_json::json!({})));
+
+    let projects = run_query(
+        follower.clone(),
+        TableNamespace::root_component(),
+        Query::full_table_scan("projects".parse()?, Order::Asc),
+    )
+    .await?;
+    assert_eq!(projects.len(), 2);
+    Ok(())
+}
+
+#[convex_macro::test_runtime]
+async fn test_raft_prepared_redo_rewrites_when_pre_replay_heartbeat_advances_retention_floor(
+    rt: TestRuntime,
+) -> anyhow::Result<()> {
+    let log = Arc::new(InMemoryDistributedLog::new());
+    let table_number_allocator = Arc::new(InMemoryTableNumberAllocator::default());
+    let source = create_node_with_persistence_and_table_number_allocator(
+        &rt,
+        Arc::new(TestPersistence::new()),
+        log.clone(),
+        Some(partitioned_map(PartitionId(1))),
+        None,
+        Arc::new(NoopTwoPhaseDecisionLog),
+        None,
+        table_number_allocator.clone(),
+    )
+    .await?;
+    let follower = create_node_with_persistence_and_table_number_allocator(
+        &rt,
+        Arc::new(TestPersistence::new()),
+        log.clone(),
+        Some(partitioned_map(PartitionId(1))),
+        None,
+        Arc::new(NoopTwoPhaseDecisionLog),
+        None,
+        table_number_allocator,
+    )
+    .await?;
+
+    insert_doc(
+        &source,
+        "projects",
+        assert_obj!("name" => "seed-before-pre-replay-heartbeat"),
+    )
+    .await?;
+    let seed_delta = log
+        .deltas()
+        .into_iter()
+        .last()
+        .context("seed insert should publish a delta")?;
+    follower
+        .committer_for_test()
+        .apply_replica_delta(seed_delta)
+        .await?;
+
+    let mut tx = source.begin(Identity::system()).await?;
+    TestFacingModel::new(&mut tx)
+        .insert(
+            &"projects".parse()?,
+            assert_obj!("name" => "raft-prepare-pre-replay-heartbeat-rewrite"),
+        )
+        .await?;
+    let final_tx = tx.finalize()?;
+    let write_indexes: Vec<_> = final_tx
+        .writes
+        .coalesced_writes()
+        .enumerate()
+        .map(|(index, _)| index)
+        .collect();
+    let write_source = WriteSource::new("raft_prepare_pre_replay_heartbeat_rewrite_test");
+    let participant_tx = ParticipantTransaction::from_final_transaction(
+        &final_tx,
+        PartitionId(1),
+        &write_indexes,
+        &partitioned_map(PartitionId(1)),
+        &write_source,
+    )?;
+    let txn_id = TwoPhaseTransactionId::new();
+    let prepare_ts = source.committer_for_test().allocate_commit_ts().await?;
+
+    follower
+        .committer_for_test()
+        .apply_replica_delta(CommitDelta {
+            ts: prepare_ts.succ()?,
+            document_writes: Arc::new(Vec::new()),
+            document_updates: Vec::new(),
+            index_writes: Arc::new(Vec::new()),
+            write_source: WriteSource::new("pre_replay_heartbeat_test"),
+            write_bytes: 0,
+            tablet_id_to_table_name: Default::default(),
+            source_partition: Some(PartitionId(0)),
+        })
+        .await?;
+
+    let redo = TwoPhaseRedoEntry::new(
+        &txn_id,
+        prepare_ts,
+        PartitionId(1),
+        participant_tx.clone(),
+        &write_source,
+    )?;
+    let prepare_result = follower
+        .committer_for_test()
+        .apply_raft_prepared_redo(redo)
+        .await?;
+    assert_eq!(prepare_result.prepare_ts, prepare_ts);
+
+    source
+        .committer_for_test()
+        .prepare_remote(
+            txn_id.clone(),
+            participant_tx,
+            write_source,
+            prepare_ts,
+            vec![PartitionId(1)],
+        )
+        .await?;
+    source.committer_for_test().commit_prepared(txn_id).await?;
+    let delta = log
+        .deltas()
+        .into_iter()
+        .last()
+        .context("prepared commit should publish a delta")?;
+    follower
+        .committer_for_test()
+        .apply_raft_commit_delta(delta)
+        .await?;
+
+    let projects = run_query(
+        follower.clone(),
+        TableNamespace::root_component(),
+        Query::full_table_scan("projects".parse()?, Order::Asc),
+    )
+    .await?;
+    assert_eq!(projects.len(), 2);
+    Ok(())
+}
+
+#[convex_macro::test_runtime]
+async fn test_raft_prepared_redo_replay_uses_local_anchor_when_begin_ts_is_out_of_retention(
+    rt: TestRuntime,
+) -> anyhow::Result<()> {
+    let log = Arc::new(InMemoryDistributedLog::new());
+    let table_number_allocator = Arc::new(InMemoryTableNumberAllocator::default());
+    let source = create_node_with_persistence_and_table_number_allocator(
+        &rt,
+        Arc::new(TestPersistence::new()),
+        log.clone(),
+        Some(partitioned_map(PartitionId(1))),
+        None,
+        Arc::new(NoopTwoPhaseDecisionLog),
+        None,
+        table_number_allocator.clone(),
+    )
+    .await?;
+    let follower = create_node_with_persistence_and_table_number_allocator(
+        &rt,
+        Arc::new(TestPersistence::new()),
+        log.clone(),
+        Some(partitioned_map(PartitionId(1))),
+        None,
+        Arc::new(NoopTwoPhaseDecisionLog),
+        None,
+        table_number_allocator,
+    )
+    .await?;
+
+    insert_doc(
+        &source,
+        "projects",
+        assert_obj!("name" => "seed-before-out-of-retention-begin"),
+    )
+    .await?;
+    let seed_delta = log
+        .deltas()
+        .into_iter()
+        .last()
+        .context("seed insert should publish a delta")?;
+    follower
+        .committer_for_test()
+        .apply_replica_delta(seed_delta)
+        .await?;
+
+    let mut tx = source.begin(Identity::system()).await?;
+    TestFacingModel::new(&mut tx)
+        .insert(
+            &"projects".parse()?,
+            assert_obj!("name" => "raft-prepare-out-of-retention-begin"),
+        )
+        .await?;
+    let final_tx = tx.finalize()?;
+    let write_indexes: Vec<_> = final_tx
+        .writes
+        .coalesced_writes()
+        .enumerate()
+        .map(|(index, _)| index)
+        .collect();
+    let write_source = WriteSource::new("raft_prepare_out_of_retention_begin_test");
+    let participant_tx = ParticipantTransaction::from_final_transaction(
+        &final_tx,
+        PartitionId(1),
+        &write_indexes,
+        &partitioned_map(PartitionId(1)),
+        &write_source,
+    )?;
+    let txn_id = TwoPhaseTransactionId::new();
+    let prepare_ts = source.committer_for_test().allocate_commit_ts().await?;
+
+    follower
+        .committer_for_test()
+        .apply_replica_delta(CommitDelta {
+            ts: prepare_ts.pred()?,
+            document_writes: Arc::new(Vec::new()),
+            document_updates: Vec::new(),
+            index_writes: Arc::new(Vec::new()),
+            write_source: WriteSource::new("pre_replay_floor_to_prepare_test"),
+            write_bytes: 0,
+            tablet_id_to_table_name: Default::default(),
+            source_partition: Some(PartitionId(0)),
+        })
+        .await?;
+
+    let redo = TwoPhaseRedoEntry::new(
+        &txn_id,
+        prepare_ts,
+        PartitionId(1),
+        participant_tx.clone(),
+        &write_source,
+    )?;
+    let prepare_result = follower
+        .committer_for_test()
+        .apply_raft_prepared_redo(redo)
+        .await?;
+    assert_eq!(prepare_result.prepare_ts, prepare_ts);
+
+    source
+        .committer_for_test()
+        .prepare_remote(
+            txn_id.clone(),
+            participant_tx,
+            write_source,
+            prepare_ts,
+            vec![PartitionId(1)],
+        )
+        .await?;
+    source.committer_for_test().commit_prepared(txn_id).await?;
+    let delta = log
+        .deltas()
+        .into_iter()
+        .last()
+        .context("prepared commit should publish a delta")?;
+    follower
+        .committer_for_test()
+        .apply_raft_commit_delta(delta)
+        .await?;
+
+    let projects = run_query(
+        follower.clone(),
+        TableNamespace::root_component(),
+        Query::full_table_scan("projects".parse()?, Order::Asc),
+    )
+    .await?;
+    assert_eq!(projects.len(), 2);
+    Ok(())
+}
+
+#[convex_macro::test_runtime]
+async fn test_raft_prepared_redo_rewrites_when_heartbeat_advances_last_assigned(
+    rt: TestRuntime,
+) -> anyhow::Result<()> {
+    let log = Arc::new(InMemoryDistributedLog::new());
+    let table_number_allocator = Arc::new(InMemoryTableNumberAllocator::default());
+    let source = create_node_with_persistence_and_table_number_allocator(
+        &rt,
+        Arc::new(TestPersistence::new()),
+        log.clone(),
+        Some(partitioned_map(PartitionId(1))),
+        None,
+        Arc::new(NoopTwoPhaseDecisionLog),
+        None,
+        table_number_allocator.clone(),
+    )
+    .await?;
+    let follower = create_node_with_persistence_and_table_number_allocator(
+        &rt,
+        Arc::new(TestPersistence::new()),
+        log.clone(),
+        Some(partitioned_map(PartitionId(1))),
+        None,
+        Arc::new(NoopTwoPhaseDecisionLog),
+        None,
+        table_number_allocator,
+    )
+    .await?;
+
+    insert_doc(
+        &source,
+        "projects",
+        assert_obj!("name" => "seed-before-heartbeat"),
+    )
+    .await?;
+    let seed_delta = log
+        .deltas()
+        .into_iter()
+        .last()
+        .context("seed insert should publish a delta")?;
+    follower
+        .committer_for_test()
+        .apply_replica_delta(seed_delta)
+        .await?;
+
+    let mut tx = source.begin(Identity::system()).await?;
+    TestFacingModel::new(&mut tx)
+        .insert(
+            &"projects".parse()?,
+            assert_obj!("name" => "raft-prepare-heartbeat-rewrite"),
+        )
+        .await?;
+    let final_tx = tx.finalize()?;
+    let write_indexes: Vec<_> = final_tx
+        .writes
+        .coalesced_writes()
+        .enumerate()
+        .map(|(index, _)| index)
+        .collect();
+    let write_source = WriteSource::new("raft_prepare_heartbeat_rewrite_test");
+    let participant_tx = ParticipantTransaction::from_final_transaction(
+        &final_tx,
+        PartitionId(1),
+        &write_indexes,
+        &partitioned_map(PartitionId(1)),
+        &write_source,
+    )?;
+    let txn_id = TwoPhaseTransactionId::new();
+    let prepare_ts = source.committer_for_test().allocate_commit_ts().await?;
+
+    let redo = TwoPhaseRedoEntry::new(
+        &txn_id,
+        prepare_ts,
+        PartitionId(1),
+        participant_tx.clone(),
+        &write_source,
+    )?;
+    let prepare_result = follower
+        .committer_for_test()
+        .apply_raft_prepared_redo(redo)
+        .await?;
+    assert_eq!(prepare_result.prepare_ts, prepare_ts);
+
+    let heartbeat_ts = prepare_ts.succ()?;
+    follower
+        .committer_for_test()
+        .apply_replica_delta(CommitDelta {
+            ts: heartbeat_ts,
+            document_writes: Arc::new(Vec::new()),
+            document_updates: Vec::new(),
+            index_writes: Arc::new(Vec::new()),
+            write_source: WriteSource::new("heartbeat_after_prepare_test"),
+            write_bytes: 0,
+            tablet_id_to_table_name: Default::default(),
+            source_partition: Some(PartitionId(1)),
+        })
+        .await?;
+
+    source
+        .committer_for_test()
+        .prepare_remote(
+            txn_id.clone(),
+            participant_tx,
+            write_source,
+            prepare_ts,
+            vec![PartitionId(1)],
+        )
+        .await?;
+    source.committer_for_test().commit_prepared(txn_id).await?;
+    let delta = log
+        .deltas()
+        .into_iter()
+        .last()
+        .context("prepared commit should publish a delta")?;
+    let applied_ts = follower
+        .committer_for_test()
+        .apply_raft_commit_delta(delta)
+        .await?;
+    assert!(
+        applied_ts > heartbeat_ts,
+        "prepared commit should rewrite above heartbeat-advanced last_assigned",
+    );
+
+    let redo = follower
+        .committer_for_test()
+        .persistence_reader()
+        .get_persistence_global(PersistenceGlobalKey::TwoPhaseRedoRecords)
+        .await?;
+    assert_eq!(redo, Some(serde_json::json!({})));
+
+    let projects = run_query(
+        follower.clone(),
+        TableNamespace::root_component(),
+        Query::full_table_scan("projects".parse()?, Order::Asc),
+    )
+    .await?;
+    assert_eq!(projects.len(), 2);
     Ok(())
 }
 
@@ -2425,15 +3620,15 @@ async fn test_replica_delta_timestamp_translation_records_origin_watermark(
 
     let persisted_watermarks = target_persistence
         .reader()
-        .get_persistence_global(PersistenceGlobalKey::AppliedDeltaWatermarks)
+        .get_persistence_global(PersistenceGlobalKey::AppliedDataDeltaWatermarks)
         .await?
-        .context("applied delta watermark should be persisted")?;
+        .context("applied data delta watermark should be persisted")?;
     let persisted_watermarks =
-        partition_timestamp_map_from_json(persisted_watermarks, "applied delta watermarks")?;
+        partition_timestamp_map_from_json(persisted_watermarks, "applied data delta watermarks")?;
     assert_eq!(
         persisted_watermarks.get(&PartitionId(1)).copied(),
         Some(remote_ts),
-        "origin watermark remains in the source partition timestamp domain",
+        "data idempotency watermark remains in the source partition timestamp domain",
     );
 
     let duplicate_apply_ts = target
@@ -2442,7 +3637,7 @@ async fn test_replica_delta_timestamp_translation_records_origin_watermark(
         .await?;
     assert_eq!(
         duplicate_apply_ts, remote_ts,
-        "duplicate detection uses the persisted origin timestamp watermark",
+        "duplicate detection uses the persisted data idempotency watermark",
     );
     let projects = run_query(
         target,
@@ -3103,6 +4298,82 @@ fn test_failed_remote_prepare_rolls_back_local_participant() -> anyhow::Result<(
     })
 }
 
+#[test]
+fn test_ambiguous_remote_prepare_failure_rolls_back_attempted_participant() -> anyhow::Result<()> {
+    let td = TestDriver::new_with_io();
+    let rt = td.rt();
+    td.run_until(async move {
+        let log = Arc::new(InMemoryDistributedLog::new());
+        let decision_log = Arc::new(InMemoryTwoPhaseDecisionLog::new());
+        let tso: Arc<dyn TimestampOracle> = Arc::new(InMemoryTimestampOracle::new());
+        let node_b = create_node_with_options_and_decision_log(
+            &rt,
+            log.clone(),
+            Some(partitioned_map(PartitionId(1))),
+            None,
+            Some(tso.clone()),
+            decision_log.clone(),
+        )
+        .await?;
+        let ambiguous_server = start_two_pc_server(
+            AmbiguousPrepareAfterLocalPrepareGrpcService::new(node_b.clone(), PartitionId(1)),
+        )
+        .await?;
+        let node_a = create_node_with_options_and_decision_log(
+            &rt,
+            log,
+            Some(partitioned_map(PartitionId(0))),
+            Some(NodeAddresses::from_config(&format!(
+                "1={}",
+                ambiguous_server.addr()
+            ))),
+            Some(tso),
+            decision_log.clone(),
+        )
+        .await?;
+
+        let message_id =
+            insert_doc_get_id(&node_a, "messages", assert_obj!("text" => "seed")).await?;
+        let message_id = value::PublicDocumentId::from(message_id);
+
+        let mut tx = node_a.begin(Identity::system()).await?;
+        let mut model = TestFacingModel::new(&mut tx);
+        model
+            .insert(
+                &"projects".parse()?,
+                assert_obj!("name" => "ambiguous-prepare"),
+            )
+            .await?;
+        UserFacingModel::new(&mut tx, TableNamespace::test_user())
+            .replace(message_id, assert_obj!("text" => "prepared-local"))
+            .await?;
+
+        let err = node_a
+            .commit(tx)
+            .await
+            .expect_err("ambiguous remote prepare failure should abort the 2PC transaction");
+        assert!(
+            format!("{err:#}").contains("transport error"),
+            "expected transport-shaped prepare failure, got: {err:#}",
+        );
+        assert!(
+            decision_log.decisions().is_empty(),
+            "rollback decision should be deleted once attempted participants are resolved",
+        );
+        assert!(
+            node_b
+                .committer_for_test()
+                .two_phase_redo_records()
+                .await?
+                .is_empty(),
+            "ambiguous prepared participant should be rolled back immediately",
+        );
+
+        ambiguous_server.shutdown().await?;
+        Ok(())
+    })
+}
+
 #[convex_macro::test_runtime]
 async fn test_watcher_rolls_back_abandoned_prepare_without_decision(
     rt: TestRuntime,
@@ -3256,11 +4527,9 @@ fn test_rollback_decision_survives_failed_rollback_rpc_for_watcher() -> anyhow::
                     !participants.contains(&2),
                     "rollback decision must not include the participant whose prepare failed",
                 );
-                assert_eq!(
-                    resolved_participants,
-                    &vec![0],
-                    "local coordinator participant should be marked resolved while failed remote \
-                     rollback remains pending",
+                assert!(
+                    !resolved_participants.contains(&1),
+                    "prepared participant should remain unresolved after its rollback RPC fails",
                 );
             },
             other => panic!("expected rollback decision, got {other:?}"),

--- a/crates/database/src/two_phase.rs
+++ b/crates/database/src/two_phase.rs
@@ -26,7 +26,10 @@ use std::{
 };
 
 use anyhow::Context;
-use async_nats::jetstream::kv::Store;
+use async_nats::jetstream::kv::{
+    Operation as KvOperation,
+    Store,
+};
 use async_trait::async_trait;
 use common::{
     bootstrap_model::index::database_index::IndexedFields,
@@ -501,6 +504,19 @@ impl NatsTwoPhaseDecisionLog {
     }
 }
 
+fn parse_nats_decision_entry(
+    transaction_id: &TwoPhaseTransactionId,
+    operation: KvOperation,
+    value: &[u8],
+) -> anyhow::Result<Option<TwoPhaseDecision>> {
+    if operation != KvOperation::Put || value.is_empty() {
+        return Ok(None);
+    }
+    serde_json::from_slice(value)
+        .with_context(|| format!("2PC: Failed to parse decision for {transaction_id}"))
+        .map(Some)
+}
+
 #[async_trait]
 impl TwoPhaseDecisionLog for NatsTwoPhaseDecisionLog {
     async fn write_decision(
@@ -546,9 +562,7 @@ impl TwoPhaseDecisionLog for NatsTwoPhaseDecisionLog {
         else {
             return Ok(None);
         };
-        serde_json::from_slice(&entry.value)
-            .with_context(|| format!("2PC: Failed to parse decision for {transaction_id}"))
-            .map(Some)
+        parse_nats_decision_entry(transaction_id, entry.operation, &entry.value)
     }
 
     async fn mark_participant_resolved(
@@ -565,8 +579,11 @@ impl TwoPhaseDecisionLog for NatsTwoPhaseDecisionLog {
             else {
                 return Ok(None);
             };
-            let mut decision: TwoPhaseDecision = serde_json::from_slice(&entry.value)
-                .with_context(|| format!("2PC: Failed to parse decision for {transaction_id}"))?;
+            let Some(mut decision) =
+                parse_nats_decision_entry(transaction_id, entry.operation, &entry.value)?
+            else {
+                return Ok(None);
+            };
             decision.mark_participant_resolved(participant);
             let payload = serde_json::to_vec(&decision).with_context(|| {
                 format!("2PC: Failed to serialize decision for {transaction_id}")
@@ -605,14 +622,18 @@ impl TwoPhaseDecisionLog for NatsTwoPhaseDecisionLog {
 }
 
 /// Partition-to-address mapping for gRPC communication.
-/// Each entry maps a partition ID to the gRPC address of its owner node.
+/// Each entry maps a partition ID to one or more gRPC addresses for that
+/// partition's Raft peers.
 #[derive(Clone, Debug)]
 pub struct NodeAddresses {
-    addresses: BTreeMap<PartitionId, String>,
+    addresses: BTreeMap<PartitionId, Vec<String>>,
 }
 
 impl NodeAddresses {
-    /// Parse from config string: "0=host:port,1=host:port"
+    /// Parse from config string: "0=host:port|host:port,1=host:port|host:port".
+    ///
+    /// A partition can list multiple Raft peers with `|`, e.g.
+    /// "0=node-p0a:50051|node-p0b:50051,1=node-p1a:50051|node-p1b:50051".
     pub fn from_config(config: &str) -> Self {
         let mut addresses = BTreeMap::new();
         if !config.is_empty() {
@@ -620,7 +641,13 @@ impl NodeAddresses {
                 let pair = pair.trim();
                 if let Some((id, addr)) = pair.split_once('=') {
                     if let Ok(partition_id) = id.trim().parse::<u32>() {
-                        addresses.insert(PartitionId(partition_id), addr.trim().to_string());
+                        let peers = addr
+                            .split('|')
+                            .map(str::trim)
+                            .filter(|addr| !addr.is_empty())
+                            .map(str::to_string)
+                            .collect();
+                        addresses.insert(PartitionId(partition_id), peers);
                     }
                 }
             }
@@ -630,7 +657,15 @@ impl NodeAddresses {
 
     /// Get the gRPC address for a partition.
     pub fn address_for(&self, partition: PartitionId) -> Option<&str> {
-        self.addresses.get(&partition).map(|s| s.as_str())
+        self.addresses
+            .get(&partition)
+            .and_then(|addresses| addresses.first())
+            .map(|s| s.as_str())
+    }
+
+    /// Get all configured gRPC addresses for a partition.
+    pub fn addresses_for(&self, partition: PartitionId) -> Option<&[String]> {
+        self.addresses.get(&partition).map(Vec::as_slice)
     }
 
     /// Get all known partitions.
@@ -1204,7 +1239,31 @@ mod tests {
         let addrs = NodeAddresses::from_config("0=node-a:50051,1=node-b:50051");
         assert_eq!(addrs.address_for(PartitionId(0)), Some("node-a:50051"));
         assert_eq!(addrs.address_for(PartitionId(1)), Some("node-b:50051"));
+        assert_eq!(
+            addrs.addresses_for(PartitionId(0)).unwrap(),
+            &["node-a:50051".to_string()]
+        );
         assert_eq!(addrs.address_for(PartitionId(2)), None);
+    }
+
+    #[test]
+    fn test_node_addresses_parsing_multiple_peers() {
+        let addrs = NodeAddresses::from_config(
+            "0=node-p0a:50051|node-p0b:50051|node-p0c:50051,1=node-p1a:50051",
+        );
+        assert_eq!(addrs.address_for(PartitionId(0)), Some("node-p0a:50051"));
+        assert_eq!(
+            addrs.addresses_for(PartitionId(0)).unwrap(),
+            &[
+                "node-p0a:50051".to_string(),
+                "node-p0b:50051".to_string(),
+                "node-p0c:50051".to_string(),
+            ]
+        );
+        assert_eq!(
+            addrs.addresses_for(PartitionId(1)).unwrap(),
+            &["node-p1a:50051".to_string()]
+        );
     }
 
     #[test]
@@ -1238,5 +1297,30 @@ mod tests {
             },
             _ => panic!("Wrong variant"),
         }
+    }
+
+    #[test]
+    fn test_nats_decision_entry_delete_marker_is_absent() {
+        let txn_id = TwoPhaseTransactionId::new();
+        let parsed = parse_nats_decision_entry(&txn_id, KvOperation::Delete, &[]).unwrap();
+        assert_eq!(parsed, None);
+    }
+
+    #[test]
+    fn test_nats_decision_entry_empty_put_is_absent() {
+        let txn_id = TwoPhaseTransactionId::new();
+        let parsed = parse_nats_decision_entry(&txn_id, KvOperation::Put, &[]).unwrap();
+        assert_eq!(parsed, None);
+    }
+
+    #[test]
+    fn test_nats_decision_entry_put_parses_decision() {
+        let txn_id = TwoPhaseTransactionId::new();
+        let decision = TwoPhaseDecision::committed(12345, vec![0, 1]);
+        let payload = serde_json::to_vec(&decision).unwrap();
+        let parsed = parse_nats_decision_entry(&txn_id, KvOperation::Put, &payload)
+            .unwrap()
+            .unwrap();
+        assert_eq!(parsed, decision);
     }
 }

--- a/crates/database/src/two_phase.rs
+++ b/crates/database/src/two_phase.rs
@@ -17,6 +17,7 @@
 
 use std::{
     collections::BTreeMap,
+    sync::Arc,
     time::{
         Duration,
         SystemTime,
@@ -71,6 +72,7 @@ use serde::{
     Deserialize,
     Serialize,
 };
+use tokio::sync::Mutex;
 use tonic::{
     transport::Channel,
     Request,
@@ -1059,6 +1061,46 @@ pub struct TwoPhaseCommitGrpcClient {
     cluster_auth: Option<ClusterGrpcAuth>,
 }
 
+fn normalize_grpc_addr(addr: &str) -> String {
+    if addr.contains("://") {
+        addr.to_string()
+    } else {
+        format!("http://{addr}")
+    }
+}
+
+#[derive(Clone)]
+pub struct TwoPhaseCommitGrpcClientPool {
+    cluster_auth: Option<ClusterGrpcAuth>,
+    clients: Arc<Mutex<BTreeMap<String, Arc<TwoPhaseCommitGrpcClient>>>>,
+}
+
+impl TwoPhaseCommitGrpcClientPool {
+    pub fn new(cluster_auth: Option<ClusterGrpcAuth>) -> Self {
+        Self {
+            cluster_auth,
+            clients: Arc::new(Mutex::new(BTreeMap::new())),
+        }
+    }
+
+    pub async fn client(&self, addr: &str) -> anyhow::Result<Arc<TwoPhaseCommitGrpcClient>> {
+        let normalized_addr = normalize_grpc_addr(addr);
+        if let Some(client) = self.clients.lock().await.get(&normalized_addr).cloned() {
+            return Ok(client);
+        }
+
+        let client = Arc::new(
+            TwoPhaseCommitGrpcClient::connect_inner(&normalized_addr, self.cluster_auth.clone())
+                .await?,
+        );
+        let mut clients = self.clients.lock().await;
+        Ok(clients
+            .entry(normalized_addr)
+            .or_insert_with(|| client.clone())
+            .clone())
+    }
+}
+
 impl TwoPhaseCommitGrpcClient {
     pub async fn connect(addr: &str) -> anyhow::Result<Self> {
         Self::connect_inner(addr, None).await
@@ -1075,11 +1117,7 @@ impl TwoPhaseCommitGrpcClient {
         addr: &str,
         cluster_auth: Option<ClusterGrpcAuth>,
     ) -> anyhow::Result<Self> {
-        let normalized_addr = if addr.contains("://") {
-            addr.to_string()
-        } else {
-            format!("http://{addr}")
-        };
+        let normalized_addr = normalize_grpc_addr(addr);
         let client = TonicTwoPcClient::connect(normalized_addr.clone())
             .await
             .with_context(|| format!("Failed to connect to 2PC service at {normalized_addr}"))?;

--- a/crates/database/src/two_phase_coordinator.rs
+++ b/crates/database/src/two_phase_coordinator.rs
@@ -5,18 +5,41 @@
 //! 2. Allocates one global commit timestamp
 //! 3. Sends Prepare to each participant
 //! 4. If all succeed: sends CommitPrepared to all
-//! 5. If any fail: sends RollbackPrepared to prepared participants
+//! 5. If any fail: records rollback for participants that may have prepared
 //!
 //! The coordinator runs on the node where the mutation was received.
 //! Remote partitions are reached via gRPC.
 
 use std::collections::BTreeMap;
 
-use anyhow::Context;
-use common::types::Timestamp;
+use anyhow::{
+    anyhow,
+    Context,
+};
+use common::{
+    bootstrap_model::{
+        index::{
+            TabletIndexMetadata,
+            INDEX_TABLE,
+        },
+        tables::{
+            TableMetadata,
+            TABLES_TABLE,
+        },
+    },
+    document::{
+        DocumentUpdateWithPrevTs,
+        ParseDocument,
+        ResolvedDocument,
+    },
+    types::Timestamp,
+};
 
 use crate::{
-    committer::CommitterClient,
+    committer::{
+        CommitOutcome,
+        CommitterClient,
+    },
     metrics,
     partition::{
         routed_partition_for_table,
@@ -60,13 +83,10 @@ pub fn classify_transaction(
     let mut partitions: BTreeMap<PartitionId, Vec<usize>> = BTreeMap::new();
 
     for (i, write) in transaction.writes.coalesced_writes().enumerate() {
-        let tablet_id = write.id.tablet_id;
-        if let Ok(table_name) = transaction.table_mapping.tablet_name(tablet_id) {
-            if let Some(partition) =
-                routed_partition_for_table(&table_name, partition_map, write_source)
-            {
-                partitions.entry(partition).or_default().push(i);
-            }
+        if let Some(partition) =
+            routed_partition_for_write(transaction, write, partition_map, write_source)
+        {
+            partitions.entry(partition).or_default().push(i);
         }
     }
 
@@ -87,20 +107,19 @@ pub fn classify_transaction(
     }
 }
 
-fn participant_write_indexes(
+pub(crate) fn participant_write_indexes(
     transaction: &FinalTransaction,
     partition_map: &PartitionMap,
     write_source: &WriteSource,
 ) -> BTreeMap<PartitionId, Vec<usize>> {
     let mut participant_indexes: BTreeMap<PartitionId, Vec<usize>> = BTreeMap::new();
-    let local_partition = partition_map.local_partition();
 
     for (index, write) in transaction.writes.coalesced_writes().enumerate() {
-        let Ok(table_name) = transaction.table_mapping.tablet_name(write.id.tablet_id) else {
+        let Some(participant) =
+            routed_partition_for_write(transaction, write, partition_map, write_source)
+        else {
             continue;
         };
-        let participant = routed_partition_for_table(&table_name, partition_map, write_source)
-            .unwrap_or(local_partition);
         participant_indexes
             .entry(participant)
             .or_default()
@@ -109,6 +128,57 @@ fn participant_write_indexes(
 
     participant_indexes.retain(|_, indexes| !indexes.is_empty());
     participant_indexes
+}
+
+fn routed_partition_for_write(
+    transaction: &FinalTransaction,
+    write: &DocumentUpdateWithPrevTs,
+    partition_map: &PartitionMap,
+    write_source: &WriteSource,
+) -> Option<PartitionId> {
+    let table_name = transaction
+        .table_mapping
+        .tablet_name(write.id.tablet_id)
+        .ok()?;
+    if let Some(partition) = routed_partition_for_table(&table_name, partition_map, write_source) {
+        return Some(partition);
+    }
+    routed_partition_for_catalog_write(transaction, write, partition_map)
+}
+
+fn routed_partition_for_catalog_write(
+    transaction: &FinalTransaction,
+    write: &DocumentUpdateWithPrevTs,
+    partition_map: &PartitionMap,
+) -> Option<PartitionId> {
+    let catalog_table = transaction
+        .table_mapping
+        .tablet_name(write.id.tablet_id)
+        .ok()?;
+    if &catalog_table != &*TABLES_TABLE && &catalog_table != &*INDEX_TABLE {
+        return None;
+    }
+    let document = write
+        .new_document
+        .as_ref()
+        .or_else(|| write.old_document.as_ref().map(|(document, _)| document))?;
+    let user_table = if &catalog_table == &*TABLES_TABLE {
+        catalog_write_user_table(document)?
+    } else {
+        let index: common::document::ParsedDocument<TabletIndexMetadata> = document.parse().ok()?;
+        let index = index.into_value();
+        let indexed_tablet = *index.name.table();
+        transaction.table_mapping.tablet_name(indexed_tablet).ok()?
+    };
+    if user_table.is_system() {
+        return None;
+    }
+    Some(partition_map.partition_for_table(&user_table))
+}
+
+fn catalog_write_user_table(document: &ResolvedDocument) -> Option<value::TableName> {
+    let metadata: common::document::ParsedDocument<TableMetadata> = document.parse().ok()?;
+    Some(metadata.into_value().name)
 }
 
 async fn prepare_participant(
@@ -139,30 +209,58 @@ async fn prepare_participant(
                  {participant}"
             )
         })?;
-        let addr = node_addresses
-            .address_for(participant)
+        let addresses = node_addresses
+            .addresses_for(participant)
+            .filter(|addresses| !addresses.is_empty())
             .with_context(|| format!("Missing NODE_ADDRESSES entry for {participant}"))?;
-        let client = local_committer.two_phase_client(addr).await?;
-        client
-            .prepare(
-                transaction_id,
-                participant_tx,
-                write_source.clone(),
-                prepare_ts,
-                partition_map.placement_version(),
-                all_participants,
-            )
-            .await?
+        let mut last_err = None;
+        for addr in addresses {
+            match local_committer.two_phase_client(addr).await {
+                Ok(client) => {
+                    match client
+                        .prepare(
+                            transaction_id,
+                            participant_tx.clone(),
+                            write_source.clone(),
+                            prepare_ts,
+                            partition_map.placement_version(),
+                            all_participants,
+                        )
+                        .await
+                    {
+                        Ok(result) => {
+                            return verify_prepare_result(participant, prepare_ts, result)
+                        },
+                        Err(err) if should_try_next_participant_address(&err) => {
+                            tracing::warn!(
+                                "2PC Coordinator: prepare to participant {} via {} failed, trying \
+                                 next address: {err:#}",
+                                participant,
+                                addr,
+                            );
+                            last_err = Some(err);
+                        },
+                        Err(err) => return Err(err),
+                    }
+                },
+                Err(err) if should_try_next_participant_address(&err) => {
+                    tracing::warn!(
+                        "2PC Coordinator: failed to connect to participant {} via {}, trying next \
+                         address: {err:#}",
+                        participant,
+                        addr,
+                    );
+                    last_err = Some(err);
+                },
+                Err(err) => return Err(err),
+            }
+        }
+        return Err(last_err.unwrap_or_else(|| {
+            anyhow!("2PC: No usable NODE_ADDRESSES entry for participant {participant}")
+        }));
     };
 
-    anyhow::ensure!(
-        result.prepare_ts == prepare_ts,
-        "Participant {} prepared at ts={} but coordinator assigned ts={}",
-        participant,
-        result.prepare_ts,
-        prepare_ts,
-    );
-    Ok(())
+    verify_prepare_result(participant, prepare_ts, result)
 }
 
 async fn rollback_participant(
@@ -183,11 +281,15 @@ async fn rollback_participant(
                  {participant}"
             )
         })?;
-        let addr = node_addresses
-            .address_for(participant)
+        let addresses = node_addresses
+            .addresses_for(participant)
+            .filter(|addresses| !addresses.is_empty())
             .with_context(|| format!("Missing NODE_ADDRESSES entry for {participant}"))?;
-        let client = local_committer.two_phase_client(addr).await?;
-        client.rollback_prepared(transaction_id).await
+        try_participant_addresses("rollback", participant, addresses, |addr| async move {
+            let client = local_committer.two_phase_client(addr).await?;
+            client.rollback_prepared(transaction_id).await
+        })
+        .await
     }
 }
 
@@ -209,12 +311,62 @@ async fn commit_participant(
                  {participant}"
             )
         })?;
-        let addr = node_addresses
-            .address_for(participant)
+        let addresses = node_addresses
+            .addresses_for(participant)
+            .filter(|addresses| !addresses.is_empty())
             .with_context(|| format!("Missing NODE_ADDRESSES entry for {participant}"))?;
-        let client = local_committer.two_phase_client(addr).await?;
-        Ok(client.commit_prepared(transaction_id).await?.try_into()?)
+        try_participant_addresses("commit", participant, addresses, |addr| async move {
+            let client = local_committer.two_phase_client(addr).await?;
+            Ok(client.commit_prepared(transaction_id).await?.try_into()?)
+        })
+        .await
     }
+}
+
+fn verify_prepare_result(
+    participant: PartitionId,
+    prepare_ts: Timestamp,
+    result: crate::two_phase::PrepareResult,
+) -> anyhow::Result<()> {
+    anyhow::ensure!(
+        result.prepare_ts == prepare_ts,
+        "Participant {} prepared at ts={} but coordinator assigned ts={}",
+        participant,
+        result.prepare_ts,
+        prepare_ts,
+    );
+    Ok(())
+}
+
+async fn try_participant_addresses<'a, T, Fut>(
+    operation: &'static str,
+    participant: PartitionId,
+    addresses: &'a [String],
+    mut call: impl FnMut(&'a str) -> Fut,
+) -> anyhow::Result<T>
+where
+    Fut: std::future::Future<Output = anyhow::Result<T>>,
+{
+    let mut last_err = None;
+    for addr in addresses {
+        match call(addr).await {
+            Ok(result) => return Ok(result),
+            Err(err) if should_try_next_participant_address(&err) => {
+                tracing::warn!(
+                    "2PC Coordinator: {} to participant {} via {} failed, trying next address: \
+                     {err:#}",
+                    operation,
+                    participant,
+                    addr,
+                );
+                last_err = Some(err);
+            },
+            Err(err) => return Err(err),
+        }
+    }
+    Err(last_err.unwrap_or_else(|| {
+        anyhow!("2PC: No usable NODE_ADDRESSES entry for participant {participant}")
+    }))
 }
 
 async fn write_decision_record(
@@ -275,6 +427,31 @@ fn is_retryable_prepare_ts_error(err: &anyhow::Error) -> bool {
         .any(|cause| cause.to_string().contains("2PC Prepare assigned ts="))
 }
 
+fn is_ambiguous_prepare_error(err: &anyhow::Error) -> bool {
+    should_try_next_participant_address(err)
+}
+
+fn should_try_next_participant_address(err: &anyhow::Error) -> bool {
+    let message = format!("{err:#}").to_ascii_lowercase();
+    message.contains("transport error")
+        || message.contains("connection error")
+        || message.contains("connection refused")
+        || message.contains("broken pipe")
+        || message.contains("deadline has elapsed")
+        || message.contains("timed out")
+        || message.contains("unavailable")
+        || message.contains("no elected raft leader")
+        || message.contains("missing raft_peers entry for raft leader")
+        || message.contains("failed to connect to raft leader")
+        || message.contains("leader prepare failed")
+        || message.contains("leader commitprepared failed")
+        || message.contains("leader rollbackprepared failed")
+}
+
+fn is_unknown_rollback_error(err: &anyhow::Error) -> bool {
+    format!("{err:#}").contains("unknown transaction")
+}
+
 /// Execute the 2PC protocol for a transaction that cannot commit on the local
 /// fast path.
 pub async fn coordinate_two_phase_commit(
@@ -282,9 +459,9 @@ pub async fn coordinate_two_phase_commit(
     transaction: FinalTransaction,
     write_source: WriteSource,
     partition_map: &PartitionMap,
-) -> anyhow::Result<Timestamp> {
+) -> anyhow::Result<CommitOutcome> {
     let timer = metrics::two_phase_coordinator_timer();
-    match classify_transaction(&transaction, partition_map, &write_source) {
+    let source_partition = match classify_transaction(&transaction, partition_map, &write_source) {
         TransactionClassification::SinglePartition => {
             anyhow::bail!("2PC coordinator called for a local single-partition transaction");
         },
@@ -293,9 +470,10 @@ pub async fn coordinate_two_phase_commit(
                 "2PC Coordinator: routing single-partition transaction to remote owner {}",
                 owner,
             );
+            Some(owner)
         },
-        TransactionClassification::CrossPartition { partitions: _ } => {},
-    }
+        TransactionClassification::CrossPartition { partitions: _ } => None,
+    };
 
     let participant_indexes = participant_write_indexes(&transaction, partition_map, &write_source);
     let node_addresses = local_committer.node_addresses();
@@ -335,8 +513,10 @@ pub async fn coordinate_two_phase_commit(
         );
 
         let mut prepared_participants = Vec::new();
+        let mut attempted_participants = Vec::new();
         let mut retry_prepare = false;
         for (participant, participant_tx) in &participants {
+            attempted_participants.push(*participant);
             match prepare_participant(
                 local_committer,
                 node_addresses,
@@ -359,10 +539,15 @@ pub async fn coordinate_two_phase_commit(
                     );
                     let retryable_prepare_ts_error =
                         is_retryable_prepare_ts_error(&err) && attempt + 1 < MAX_PREPARE_TS_RETRIES;
-                    if !prepared_participants.is_empty() {
+                    let rollback_participants = if is_ambiguous_prepare_error(&err) {
+                        attempted_participants.clone()
+                    } else {
+                        prepared_participants.clone()
+                    };
+                    if !rollback_participants.is_empty() {
                         let decision = TwoPhaseDecision::rolled_back(
                             err.to_string(),
-                            prepared_participants.iter().map(|p| p.0).collect(),
+                            rollback_participants.iter().map(|p| p.0).collect(),
                         );
                         write_decision_record(local_committer, &txn_id, &decision)
                             .await
@@ -373,7 +558,7 @@ pub async fn coordinate_two_phase_commit(
                                 )
                             })?;
                     }
-                    for prepared in prepared_participants.iter().rev().copied() {
+                    for prepared in rollback_participants.iter().rev().copied() {
                         match rollback_participant(
                             local_committer,
                             node_addresses,
@@ -391,6 +576,20 @@ pub async fn coordinate_two_phase_commit(
                                     tracing::warn!(
                                         "2PC Coordinator: rollback resolved on {} for txn={} but \
                                          failed to mark participant resolved: {mark_err:#}",
+                                        prepared,
+                                        txn_id,
+                                    );
+                                }
+                            },
+                            Err(rollback_err) if is_unknown_rollback_error(&rollback_err) => {
+                                if let Err(mark_err) =
+                                    mark_participant_resolved(local_committer, &txn_id, prepared)
+                                        .await
+                                {
+                                    tracing::warn!(
+                                        "2PC Coordinator: rollback on {} for txn={} was already \
+                                         clean but failed to mark participant resolved: \
+                                         {mark_err:#}",
                                         prepared,
                                         txn_id,
                                     );
@@ -488,7 +687,10 @@ pub async fn coordinate_two_phase_commit(
         metrics::log_two_phase_prepare_attempts(prepare_attempts);
         metrics::log_two_phase_decision("commit");
         timer.finish();
-        return Ok(prepare_ts);
+        return Ok(CommitOutcome {
+            ts: prepare_ts,
+            source_partition,
+        });
     }
 
     metrics::log_two_phase_error("prepare");
@@ -504,7 +706,10 @@ pub async fn coordinate_two_phase_commit(
 
 #[cfg(test)]
 mod tests {
-    use super::is_retryable_prepare_ts_error;
+    use super::{
+        is_ambiguous_prepare_error,
+        is_retryable_prepare_ts_error,
+    };
 
     #[test]
     fn retryable_prepare_ts_error_detects_wrapped_grpc_status() {
@@ -519,5 +724,23 @@ mod tests {
     fn retryable_prepare_ts_error_rejects_unrelated_errors() {
         let err = anyhow::anyhow!("gRPC Prepare failed");
         assert!(!is_retryable_prepare_ts_error(&err));
+    }
+
+    #[test]
+    fn ambiguous_prepare_error_detects_transport_failure() {
+        let err = anyhow::anyhow!(
+            "gRPC Prepare failed: status: Unknown, message: \"transport error\", details: [], \
+             metadata: MetadataMap {{ headers: {{}} }}: transport error: connection error: stream \
+             closed because of a broken pipe"
+        );
+        assert!(is_ambiguous_prepare_error(&err));
+    }
+
+    #[test]
+    fn ambiguous_prepare_error_rejects_application_failure() {
+        let err = anyhow::anyhow!(
+            "gRPC Prepare failed: status: Internal, message: \"forced prepare failure\""
+        );
+        assert!(!is_ambiguous_prepare_error(&err));
     }
 }

--- a/crates/database/src/two_phase_coordinator.rs
+++ b/crates/database/src/two_phase_coordinator.rs
@@ -13,10 +13,7 @@
 use std::collections::BTreeMap;
 
 use anyhow::Context;
-use common::{
-    grpc::ClusterGrpcAuth,
-    types::Timestamp,
-};
+use common::types::Timestamp;
 
 use crate::{
     committer::CommitterClient,
@@ -30,7 +27,6 @@ use crate::{
     two_phase::{
         NodeAddresses,
         ParticipantTransaction,
-        TwoPhaseCommitGrpcClient,
         TwoPhaseDecision,
         TwoPhaseTransactionId,
     },
@@ -125,7 +121,6 @@ async fn prepare_participant(
     participant_tx: ParticipantTransaction,
     write_source: &WriteSource,
     prepare_ts: Timestamp,
-    cluster_auth: Option<ClusterGrpcAuth>,
 ) -> anyhow::Result<()> {
     let result = if participant == partition_map.local_partition() {
         local_committer
@@ -147,10 +142,7 @@ async fn prepare_participant(
         let addr = node_addresses
             .address_for(participant)
             .with_context(|| format!("Missing NODE_ADDRESSES entry for {participant}"))?;
-        let client = match cluster_auth {
-            Some(auth) => TwoPhaseCommitGrpcClient::connect_with_auth(addr, auth).await?,
-            None => TwoPhaseCommitGrpcClient::connect(addr).await?,
-        };
+        let client = local_committer.two_phase_client(addr).await?;
         client
             .prepare(
                 transaction_id,
@@ -179,7 +171,6 @@ async fn rollback_participant(
     partition_map: &PartitionMap,
     transaction_id: &TwoPhaseTransactionId,
     participant: PartitionId,
-    cluster_auth: Option<ClusterGrpcAuth>,
 ) -> anyhow::Result<()> {
     if participant == partition_map.local_partition() {
         local_committer
@@ -195,10 +186,7 @@ async fn rollback_participant(
         let addr = node_addresses
             .address_for(participant)
             .with_context(|| format!("Missing NODE_ADDRESSES entry for {participant}"))?;
-        let client = match cluster_auth {
-            Some(auth) => TwoPhaseCommitGrpcClient::connect_with_auth(addr, auth).await?,
-            None => TwoPhaseCommitGrpcClient::connect(addr).await?,
-        };
+        let client = local_committer.two_phase_client(addr).await?;
         client.rollback_prepared(transaction_id).await
     }
 }
@@ -209,7 +197,6 @@ async fn commit_participant(
     partition_map: &PartitionMap,
     transaction_id: &TwoPhaseTransactionId,
     participant: PartitionId,
-    cluster_auth: Option<ClusterGrpcAuth>,
 ) -> anyhow::Result<Timestamp> {
     if participant == partition_map.local_partition() {
         local_committer
@@ -225,10 +212,7 @@ async fn commit_participant(
         let addr = node_addresses
             .address_for(participant)
             .with_context(|| format!("Missing NODE_ADDRESSES entry for {participant}"))?;
-        let client = match cluster_auth {
-            Some(auth) => TwoPhaseCommitGrpcClient::connect_with_auth(addr, auth).await?,
-            None => TwoPhaseCommitGrpcClient::connect(addr).await?,
-        };
+        let client = local_committer.two_phase_client(addr).await?;
         Ok(client.commit_prepared(transaction_id).await?.try_into()?)
     }
 }
@@ -315,7 +299,6 @@ pub async fn coordinate_two_phase_commit(
 
     let participant_indexes = participant_write_indexes(&transaction, partition_map, &write_source);
     let node_addresses = local_committer.node_addresses();
-    let cluster_auth = local_committer.cluster_grpc_auth();
     let participants: Vec<_> = participant_indexes
         .iter()
         .map(|(participant, write_indexes)| -> anyhow::Result<_> {
@@ -364,7 +347,6 @@ pub async fn coordinate_two_phase_commit(
                 participant_tx.clone(),
                 &write_source,
                 prepare_ts,
-                cluster_auth.clone(),
             )
             .await
             {
@@ -398,7 +380,6 @@ pub async fn coordinate_two_phase_commit(
                             partition_map,
                             &txn_id,
                             prepared,
-                            cluster_auth.clone(),
                         )
                         .await
                         {
@@ -469,7 +450,6 @@ pub async fn coordinate_two_phase_commit(
                 partition_map,
                 &txn_id,
                 *participant,
-                cluster_auth.clone(),
             )
             .await
             {

--- a/crates/local_backend/src/lib.rs
+++ b/crates/local_backend/src/lib.rs
@@ -141,6 +141,7 @@ pub struct BackendAppState {
     pub raft_peer_http_origins: Option<BTreeMap<u64, String>>,
     pub raft_peer_grpc_urls: Option<BTreeMap<u64, String>>,
     pub cluster_grpc_auth: Option<common::grpc::ClusterGrpcAuth>,
+    pub mutation_forwarder_pool: mutation_forwarder::MutationForwarderGrpcClientPool,
     pub replica_mutation_forwarder: Option<Arc<mutation_forwarder::MutationForwarderGrpcClient>>,
     pub placement_metadata_store: Option<Arc<dyn database::partition::PlacementMetadataStore>>,
     /// Raft partition mailbox for receiving Raft messages from peers.
@@ -171,6 +172,7 @@ pub struct RouterState {
     pub raft_state: Option<database::raft_partition::RaftPartitionState>,
     pub raft_peer_grpc_urls: Option<BTreeMap<u64, String>>,
     pub cluster_grpc_auth: Option<common::grpc::ClusterGrpcAuth>,
+    pub mutation_forwarder_pool: mutation_forwarder::MutationForwarderGrpcClientPool,
     pub replica_mutation_forwarder: Option<Arc<mutation_forwarder::MutationForwarderGrpcClient>>,
 }
 
@@ -426,16 +428,12 @@ pub async fn make_app(
     let instance_secret = config.secret()?;
     let cluster_grpc_auth =
         common::grpc::ClusterGrpcAuth::from_shared_secret(instance_secret.as_bytes())?;
+    let mutation_forwarder_pool =
+        mutation_forwarder::MutationForwarderGrpcClientPool::new(Some(cluster_grpc_auth.clone()));
 
     let replica_mutation_forwarder = if config.replication_mode == "replica" {
         match config.primary_grpc_url.as_deref() {
-            Some(primary_grpc_url) => Some(Arc::new(
-                mutation_forwarder::MutationForwarderGrpcClient::connect_with_auth(
-                    primary_grpc_url,
-                    cluster_grpc_auth.clone(),
-                )
-                .await?,
-            )),
+            Some(primary_grpc_url) => Some(mutation_forwarder_pool.client(primary_grpc_url).await?),
             None => None,
         }
     } else {
@@ -1186,6 +1184,7 @@ pub async fn make_app(
         raft_peer_http_origins,
         raft_peer_grpc_urls,
         replica_mutation_forwarder,
+        mutation_forwarder_pool,
         placement_metadata_store,
         raft_mailbox_tx,
         cluster_grpc_auth: Some(cluster_grpc_auth),

--- a/crates/local_backend/src/mutation_forwarder.rs
+++ b/crates/local_backend/src/mutation_forwarder.rs
@@ -7,7 +7,10 @@
 //! supported public requests to the authoritative node when local execution is
 //! not appropriate.
 
-use std::sync::Arc;
+use std::{
+    collections::BTreeMap,
+    sync::Arc,
+};
 
 use anyhow::Context;
 use application::{
@@ -48,6 +51,7 @@ use pb::replication::{
 };
 use serde_json::Value as JsonValue;
 use sync_types::types::SerializedArgs;
+use tokio::sync::Mutex;
 use tonic::{
     transport::Channel,
     Request,
@@ -280,6 +284,46 @@ pub struct MutationForwarderGrpcClient {
     cluster_auth: Option<ClusterGrpcAuth>,
 }
 
+fn normalize_grpc_url(url: &str) -> String {
+    if url.contains("://") {
+        url.to_string()
+    } else {
+        format!("http://{url}")
+    }
+}
+
+#[derive(Clone)]
+pub struct MutationForwarderGrpcClientPool {
+    cluster_auth: Option<ClusterGrpcAuth>,
+    clients: Arc<Mutex<BTreeMap<String, Arc<MutationForwarderGrpcClient>>>>,
+}
+
+impl MutationForwarderGrpcClientPool {
+    pub fn new(cluster_auth: Option<ClusterGrpcAuth>) -> Self {
+        Self {
+            cluster_auth,
+            clients: Arc::new(Mutex::new(BTreeMap::new())),
+        }
+    }
+
+    pub async fn client(&self, url: &str) -> anyhow::Result<Arc<MutationForwarderGrpcClient>> {
+        let normalized_url = normalize_grpc_url(url);
+        if let Some(client) = self.clients.lock().await.get(&normalized_url).cloned() {
+            return Ok(client);
+        }
+
+        let client = Arc::new(
+            MutationForwarderGrpcClient::connect_inner(&normalized_url, self.cluster_auth.clone())
+                .await?,
+        );
+        let mut clients = self.clients.lock().await;
+        Ok(clients
+            .entry(normalized_url)
+            .or_insert_with(|| client.clone())
+            .clone())
+    }
+}
+
 impl MutationForwarderGrpcClient {
     /// Connect to the Primary's gRPC mutation forwarding service.
     pub async fn connect(primary_url: &str) -> anyhow::Result<Self> {
@@ -297,11 +341,7 @@ impl MutationForwarderGrpcClient {
         primary_url: &str,
         cluster_auth: Option<ClusterGrpcAuth>,
     ) -> anyhow::Result<Self> {
-        let normalized_url = if primary_url.contains("://") {
-            primary_url.to_string()
-        } else {
-            format!("http://{primary_url}")
-        };
+        let normalized_url = normalize_grpc_url(primary_url);
         let client = TonicMutationForwarderClient::connect(normalized_url.clone())
             .await
             .with_context(|| format!("Failed to connect to Primary at {normalized_url}"))?;

--- a/crates/local_backend/src/mutation_forwarder.rs
+++ b/crates/local_backend/src/mutation_forwarder.rs
@@ -149,6 +149,7 @@ impl MutationForwarder for MutationForwarderService {
                         value: ret.value.as_str().to_string(),
                         log_lines: ret.log_lines.iter().cloned().collect(),
                         ts: u64::from(ret.ts),
+                        source_partition: ret.source_partition.map(|partition| partition.0),
                     },
                 )),
             })),

--- a/crates/local_backend/src/public_api.rs
+++ b/crates/local_backend/src/public_api.rs
@@ -307,14 +307,9 @@ async fn maybe_forward_public_mutation(
                 );
                 return Ok(None);
             };
-            let client_result = match st.cluster_grpc_auth.clone() {
-                Some(auth) => {
-                    MutationForwarderGrpcClient::connect_with_auth(&leader_grpc_url, auth).await
-                },
-                None => MutationForwarderGrpcClient::connect(&leader_grpc_url).await,
-            };
+            let client_result = st.mutation_forwarder_pool.client(&leader_grpc_url).await;
             match client_result {
-                Ok(client) => Some(ForwardingMode::RaftFollower(Arc::new(client))),
+                Ok(client) => Some(ForwardingMode::RaftFollower(client)),
                 Err(e) => {
                     tracing::warn!(
                         "Skipping follower mutation forwarding because leader {} at {} is not \

--- a/crates/local_backend/src/public_api.rs
+++ b/crates/local_backend/src/public_api.rs
@@ -220,9 +220,12 @@ impl UdfResponse {
     }
 }
 
-fn mutation_read_after_write_token(st: &RouterState, ts: Timestamp) -> ReadAfterWriteToken {
+fn mutation_read_after_write_token(
+    source_partition: Option<PartitionId>,
+    ts: Timestamp,
+) -> ReadAfterWriteToken {
     ReadAfterWriteToken {
-        source_partition: st.partition_id.map(|partition| partition.0),
+        source_partition: source_partition.map(|partition| partition.0),
         ts: ts.into(),
     }
 }
@@ -243,16 +246,11 @@ fn read_after_write_fence(
 async fn wait_for_local_mutation_visibility(
     st: &RouterState,
     commit_ts: Timestamp,
-    require_replication_frontier: bool,
-) {
-    st.database.wait_for_write_ts(commit_ts).await;
-    if require_replication_frontier {
-        if let Some(partition_id) = st.partition_id {
-            st.database
-                .wait_for_replication_write_frontier(partition_id, commit_ts)
-                .await;
-        }
-    }
+    source_partition: Option<PartitionId>,
+) -> anyhow::Result<()> {
+    st.database
+        .wait_for_read_after_write_fence(source_partition, commit_ts)
+        .await
 }
 
 async fn maybe_forward_public_mutation(
@@ -364,9 +362,10 @@ async fn maybe_forward_public_mutation(
 
     let response = match forwarded.result {
         Some(pb::replication::forward_mutation_response::Result::Success(success)) => {
+            let commit_ts = Timestamp::try_from(success.ts)?;
+            let source_partition = success.source_partition.map(PartitionId);
             if matches!(forwarding_mode, ForwardingMode::RaftFollower(_)) {
-                wait_for_local_mutation_visibility(st, Timestamp::try_from(success.ts)?, true)
-                    .await;
+                wait_for_local_mutation_visibility(st, commit_ts, source_partition).await?;
             }
             let packed = JsonPackedValue::from_network(success.value).context(
                 ErrorMetadata::bad_request(
@@ -377,8 +376,8 @@ async fn maybe_forward_public_mutation(
             UdfResponse::Success {
                 value: export_value(packed.unpack()?, value_format, client_version.clone())?,
                 read_after_write: Some(mutation_read_after_write_token(
-                    st,
-                    Timestamp::try_from(success.ts)?,
+                    source_partition,
+                    commit_ts,
                 )),
                 log_lines: RedactedLogLines::from_vec(success.log_lines),
             }
@@ -903,10 +902,14 @@ pub async fn public_mutation_post(
     let value_format = req.format.as_ref().map(|f| f.parse()).transpose()?;
     let response = match udf_result {
         Ok(write_return) => {
-            wait_for_local_mutation_visibility(&st, write_return.ts, false).await;
+            wait_for_local_mutation_visibility(&st, write_return.ts, write_return.source_partition)
+                .await?;
             UdfResponse::Success {
                 value: export_value(write_return.value.unpack()?, value_format, client_version)?,
-                read_after_write: Some(mutation_read_after_write_token(&st, write_return.ts)),
+                read_after_write: Some(mutation_read_after_write_token(
+                    write_return.source_partition,
+                    write_return.ts,
+                )),
                 log_lines: write_return.log_lines,
             }
         },
@@ -1026,7 +1029,10 @@ mod tests {
             ResolvedHostname,
         },
         runtime::Runtime,
-        types::FunctionCaller,
+        types::{
+            FunctionCaller,
+            Timestamp,
+        },
         version::ClientVersion,
     };
     use database::{
@@ -1218,6 +1224,15 @@ mod tests {
             Ok(json!("1")),
         )
         .await
+    }
+
+    #[test]
+    fn test_mutation_read_after_write_token_uses_commit_source_partition() -> anyhow::Result<()> {
+        let token =
+            super::mutation_read_after_write_token(Some(PartitionId(7)), Timestamp::must(123));
+        assert_eq!(token.source_partition, Some(7));
+        assert_eq!(Timestamp::try_from(token.ts)?, Timestamp::must(123));
+        Ok(())
     }
 
     #[convex_macro::prod_rt_test]

--- a/crates/local_backend/src/query_forwarding_api.rs
+++ b/crates/local_backend/src/query_forwarding_api.rs
@@ -57,7 +57,7 @@ use value::{
     PublicDocumentId,
 };
 
-use crate::mutation_forwarder::MutationForwarderGrpcClient;
+use crate::mutation_forwarder::MutationForwarderGrpcClientPool;
 
 const SELECTIVE_QUERY_AUTHORITY_PARTITION: PartitionId = PartitionId(0);
 const RECENT_QUERY_INTEREST_TTL: Duration = Duration::from_secs(60);
@@ -71,7 +71,7 @@ pub struct SelectiveQueryForwardingApi {
     node_addresses: Option<NodeAddresses>,
     raft_state: Option<RaftPartitionState>,
     raft_peer_grpc_urls: Option<BTreeMap<u64, String>>,
-    cluster_grpc_auth: Option<ClusterGrpcAuth>,
+    mutation_forwarder_pool: MutationForwarderGrpcClientPool,
 }
 
 impl SelectiveQueryForwardingApi {
@@ -93,7 +93,7 @@ impl SelectiveQueryForwardingApi {
             node_addresses,
             raft_state,
             raft_peer_grpc_urls,
-            cluster_grpc_auth,
+            mutation_forwarder_pool: MutationForwarderGrpcClientPool::new(cluster_grpc_auth),
         }
     }
 
@@ -229,16 +229,14 @@ impl application::api::ApplicationApi for SelectiveQueryForwardingApi {
         journal: Option<SerializedQueryJournal>,
     ) -> anyhow::Result<application::RedactedQueryReturn> {
         let result = if let Some(target_grpc_url) = self.public_query_target_grpc_url().await? {
-            let client = match self.cluster_grpc_auth.clone() {
-                Some(auth) => {
-                    MutationForwarderGrpcClient::connect_with_auth(&target_grpc_url, auth).await
-                },
-                None => MutationForwarderGrpcClient::connect(&target_grpc_url).await,
-            }
-            .with_context(|| {
-                format!("Failed to connect to selective query authority at {target_grpc_url}")
-            })
-            .map_err(|e| anyhow::anyhow!(ErrorMetadata::service_unavailable()).context(e))?;
+            let client = self
+                .mutation_forwarder_pool
+                .client(&target_grpc_url)
+                .await
+                .with_context(|| {
+                    format!("Failed to connect to selective query authority at {target_grpc_url}")
+                })
+                .map_err(|e| anyhow::anyhow!(ErrorMetadata::service_unavailable()).context(e))?;
             client
                 .forward_query(
                     &String::from(path.clone()),

--- a/crates/local_backend/src/router.rs
+++ b/crates/local_backend/src/router.rs
@@ -568,6 +568,7 @@ pub fn router(st: BackendAppState) -> Router {
         raft_state: st.raft_state.clone(),
         raft_peer_grpc_urls: st.raft_peer_grpc_urls.clone(),
         cluster_grpc_auth: st.cluster_grpc_auth.clone(),
+        mutation_forwarder_pool: st.mutation_forwarder_pool.clone(),
         replica_mutation_forwarder: st.replica_mutation_forwarder.clone(),
     };
 

--- a/crates/local_backend/src/two_phase_service.rs
+++ b/crates/local_backend/src/two_phase_service.rs
@@ -22,6 +22,7 @@ use database::{
     two_phase::{
         ParticipantTransaction,
         TwoPhaseCommitGrpcClient,
+        TwoPhaseCommitGrpcClientPool,
         TwoPhaseTransactionId,
     },
     CommitterClient,
@@ -53,6 +54,7 @@ pub struct TwoPhaseCommitGrpcService {
     raft_peer_grpc_urls: Option<BTreeMap<u64, String>>,
     placement_metadata_store: Option<Arc<dyn PlacementMetadataStore>>,
     cluster_auth: Option<ClusterGrpcAuth>,
+    client_pool: TwoPhaseCommitGrpcClientPool,
 }
 
 impl TwoPhaseCommitGrpcService {
@@ -68,6 +70,7 @@ impl TwoPhaseCommitGrpcService {
             raft_state,
             raft_peer_grpc_urls,
             placement_metadata_store,
+            client_pool: TwoPhaseCommitGrpcClientPool::new(cluster_auth.clone()),
             cluster_auth,
         }
     }
@@ -76,7 +79,7 @@ impl TwoPhaseCommitGrpcService {
         TonicTwoPcServer::new(self)
     }
 
-    async fn leader_client(&self) -> Result<Option<TwoPhaseCommitGrpcClient>, Status> {
+    async fn leader_client(&self) -> Result<Option<Arc<TwoPhaseCommitGrpcClient>>, Status> {
         let Some(raft_state) = self.raft_state.as_ref() else {
             return Ok(None);
         };
@@ -99,11 +102,7 @@ impl TwoPhaseCommitGrpcService {
                     "Missing RAFT_PEERS entry for Raft leader node {leader_id}"
                 ))
             })?;
-        let client = match self.cluster_auth.clone() {
-            Some(auth) => TwoPhaseCommitGrpcClient::connect_with_auth(&leader_addr, auth).await,
-            None => TwoPhaseCommitGrpcClient::connect(&leader_addr).await,
-        }
-        .map_err(|e| {
+        let client = self.client_pool.client(&leader_addr).await.map_err(|e| {
             Status::unavailable(format!(
                 "Failed to connect to Raft leader {} at {}: {e:#}",
                 leader_id, leader_addr

--- a/crates/pb/protos/replication.proto
+++ b/crates/pb/protos/replication.proto
@@ -52,6 +52,10 @@ message MutationSuccess {
 
   // The commit timestamp.
   uint64 ts = 3;
+
+  // Partition that originated the committed write, if the commit can be
+  // represented by a single origin partition.
+  optional uint32 source_partition = 4;
 }
 
 message MutationError {

--- a/self-hosted/docker/docker-compose.yml
+++ b/self-hosted/docker/docker-compose.yml
@@ -15,7 +15,7 @@
 
 x-backend-common: &backend-common
   image: ghcr.io/martinkalema/convex-horizontal-scaling:backend-latest
-  pull_policy: always
+  pull_policy: ${BACKEND_PULL_POLICY:-missing}
   stop_grace_period: 10s
   stop_signal: SIGINT
   healthcheck:
@@ -123,7 +123,7 @@ services:
       PARTITION_ID: "0"
       PARTITION_MAP: messages=0,users=0,projects=1,tasks=1
       NUM_PARTITIONS: "2"
-      NODE_ADDRESSES: 0=node-p0a:50051,1=node-p1a:50051
+      NODE_ADDRESSES: 0=node-p0a:50051|node-p0b:50051|node-p0c:50051,1=node-p1a:50051|node-p1b:50051|node-p1c:50051
       RAFT_NODE_ID: "1"
       RAFT_PEERS: 1=http://node-p0a:50051,2=http://node-p0b:50051,3=http://node-p0c:50051
     depends_on:
@@ -150,7 +150,7 @@ services:
       PARTITION_ID: "0"
       PARTITION_MAP: messages=0,users=0,projects=1,tasks=1
       NUM_PARTITIONS: "2"
-      NODE_ADDRESSES: 0=node-p0a:50051,1=node-p1a:50051
+      NODE_ADDRESSES: 0=node-p0a:50051|node-p0b:50051|node-p0c:50051,1=node-p1a:50051|node-p1b:50051|node-p1c:50051
       RAFT_NODE_ID: "2"
       RAFT_PEERS: 1=http://node-p0a:50051,2=http://node-p0b:50051,3=http://node-p0c:50051
       REPLICA_STORAGE_PATH: /convex/data/storage
@@ -178,7 +178,7 @@ services:
       PARTITION_ID: "0"
       PARTITION_MAP: messages=0,users=0,projects=1,tasks=1
       NUM_PARTITIONS: "2"
-      NODE_ADDRESSES: 0=node-p0a:50051,1=node-p1a:50051
+      NODE_ADDRESSES: 0=node-p0a:50051|node-p0b:50051|node-p0c:50051,1=node-p1a:50051|node-p1b:50051|node-p1c:50051
       RAFT_NODE_ID: "3"
       RAFT_PEERS: 1=http://node-p0a:50051,2=http://node-p0b:50051,3=http://node-p0c:50051
       REPLICA_STORAGE_PATH: /convex/data/storage
@@ -208,7 +208,7 @@ services:
       PARTITION_ID: "1"
       PARTITION_MAP: messages=0,users=0,projects=1,tasks=1
       NUM_PARTITIONS: "2"
-      NODE_ADDRESSES: 0=node-p0a:50051,1=node-p1a:50051
+      NODE_ADDRESSES: 0=node-p0a:50051|node-p0b:50051|node-p0c:50051,1=node-p1a:50051|node-p1b:50051|node-p1c:50051
       RAFT_NODE_ID: "1"
       RAFT_PEERS: 1=http://node-p1a:50051,2=http://node-p1b:50051,3=http://node-p1c:50051
     depends_on:
@@ -235,7 +235,7 @@ services:
       PARTITION_ID: "1"
       PARTITION_MAP: messages=0,users=0,projects=1,tasks=1
       NUM_PARTITIONS: "2"
-      NODE_ADDRESSES: 0=node-p0a:50051,1=node-p1a:50051
+      NODE_ADDRESSES: 0=node-p0a:50051|node-p0b:50051|node-p0c:50051,1=node-p1a:50051|node-p1b:50051|node-p1c:50051
       RAFT_NODE_ID: "2"
       RAFT_PEERS: 1=http://node-p1a:50051,2=http://node-p1b:50051,3=http://node-p1c:50051
       REPLICA_STORAGE_PATH: /convex/data/storage
@@ -263,7 +263,7 @@ services:
       PARTITION_ID: "1"
       PARTITION_MAP: messages=0,users=0,projects=1,tasks=1
       NUM_PARTITIONS: "2"
-      NODE_ADDRESSES: 0=node-p0a:50051,1=node-p1a:50051
+      NODE_ADDRESSES: 0=node-p0a:50051|node-p0b:50051|node-p0c:50051,1=node-p1a:50051|node-p1b:50051|node-p1c:50051
       RAFT_NODE_ID: "3"
       RAFT_PEERS: 1=http://node-p1a:50051,2=http://node-p1b:50051,3=http://node-p1c:50051
       REPLICA_STORAGE_PATH: /convex/data/storage

--- a/self-hosted/docker/test-raft-failover.sh
+++ b/self-hosted/docker/test-raft-failover.sh
@@ -88,6 +88,14 @@ export const count = query({
     return msgs.length;
   },
 });
+
+export const countByPrefix = query({
+  args: { prefix: v.string() },
+  handler: async (ctx, args) => {
+    const msgs = await ctx.db.query("messages").collect();
+    return msgs.filter((msg) => msg.text.startsWith(args.prefix)).length;
+  },
+});
 TSEOF
 
 echo "  Deploying functions..."
@@ -98,18 +106,72 @@ echo "  Functions deployed."
 # --- Helpers ---
 
 mutate() {
-    curl -sf "$1/api/mutation" \
+    curl -sf -m 20 "$1/api/mutation" \
         -H "Authorization: Convex $2" \
         -H "Content-Type: application/json" \
         -d "{\"path\":\"messages:send\",\"args\":{\"text\":\"$3\"}}"
 }
 
 count_msgs() {
-    curl -sf "$1/api/query" \
+    curl -sf -m 20 "$1/api/query" \
         -H "Authorization: Convex $2" \
         -H "Content-Type: application/json" \
         -d '{"path":"messages:count","args":{}}' \
         | python3 -c "import sys,json; print(int(json.load(sys.stdin)['value']))"
+}
+
+count_prefix() {
+    curl -sf -m 20 "$1/api/query" \
+        -H "Authorization: Convex $2" \
+        -H "Content-Type: application/json" \
+        -d "{\"path\":\"messages:countByPrefix\",\"args\":{\"prefix\":\"$3\"}}" \
+        | python3 -c "import sys,json; print(int(json.load(sys.stdin)['value']))"
+}
+
+wait_for_node() {
+    local url="$1"
+    for _ in $(seq 1 45); do
+        curl -sf "$url/version" > /dev/null 2>&1 && return 0
+        sleep 1
+    done
+    return 1
+}
+
+refresh_keys() {
+    KEY_A=$(docker exec docker-node-p0a-1 ./generate_admin_key.sh 2>&1 | tail -1)
+    KEY_B=$(docker exec docker-node-p0b-1 ./generate_admin_key.sh 2>&1 | tail -1)
+    KEY_C=$(docker exec docker-node-p0c-1 ./generate_admin_key.sh 2>&1 | tail -1)
+}
+
+wait_for_prefix_count() {
+    local url="$1"
+    local key="$2"
+    local prefix="$3"
+    local expected="$4"
+    for _ in $(seq 1 30); do
+        local count
+        count=$(count_prefix "$url" "$key" "$prefix" 2>/dev/null || echo -1)
+        [ "$count" -eq "$expected" ] && return 0
+        sleep 1
+    done
+    return 1
+}
+
+write_to_either_survivor() {
+    local prefix="$1"
+    local text="$2"
+    shift 2
+    while [ "$#" -gt 0 ]; do
+        local url="$1"
+        local key="$2"
+        shift 2
+        local response
+        response=$(mutate "$url" "$key" "$prefix-$text" 2>&1 || echo "FAIL")
+        if echo "$response" | grep -q "success"; then
+            return 0
+        fi
+    done
+    return 1
 }
 
 # ============================================================
@@ -226,6 +288,228 @@ CB3=$(count_msgs "$NODE_B_URL" "$KEY_B" 2>/dev/null || echo 0)
 [ "$CA3" -eq "$CB3" ] \
     && pass "All nodes converged after rejoin: $CA3 messages" \
     || fail "Nodes diverged after rejoin" "A=$CA3 B=$CB3"
+
+# ============================================================
+echo ""
+echo -e "${BOLD}Test 6: Follower Entrypoint Write Routing${NC}"
+# ============================================================
+
+PREFIX="raft-follower-route-$(date +%s)"
+ACCEPTED=0
+for url_key_name in \
+    "$NODE_A_URL $KEY_A p0a" \
+    "$NODE_B_URL $KEY_B p0b" \
+    "$NODE_C_URL $KEY_C p0c"; do
+    URL=$(echo "$url_key_name" | cut -d' ' -f1)
+    KEY=$(echo "$url_key_name" | cut -d' ' -f2)
+    NAME=$(echo "$url_key_name" | cut -d' ' -f3)
+    R=$(mutate "$URL" "$KEY" "$PREFIX-$NAME" 2>&1 || echo "FAIL")
+    if echo "$R" | grep -q "success"; then
+        ACCEPTED=$((ACCEPTED + 1))
+    fi
+done
+
+[ "$ACCEPTED" -eq 3 ] \
+    && pass "All three Raft entrypoints accepted writes via leader/follower routing" \
+    || fail "Not all Raft entrypoints accepted routed writes" "accepted=$ACCEPTED expected=3"
+
+if wait_for_prefix_count "$NODE_A_URL" "$KEY_A" "$PREFIX" 3 \
+    && wait_for_prefix_count "$NODE_B_URL" "$KEY_B" "$PREFIX" 3 \
+    && wait_for_prefix_count "$NODE_C_URL" "$KEY_C" "$PREFIX" 3; then
+    pass "Follower-routed writes converged on all three nodes"
+else
+    CA_ROUTE=$(count_prefix "$NODE_A_URL" "$KEY_A" "$PREFIX" 2>/dev/null || echo -1)
+    CB_ROUTE=$(count_prefix "$NODE_B_URL" "$KEY_B" "$PREFIX" 2>/dev/null || echo -1)
+    CC_ROUTE=$(count_prefix "$NODE_C_URL" "$KEY_C" "$PREFIX" 2>/dev/null || echo -1)
+    fail "Follower-routed writes did not converge" "A=$CA_ROUTE B=$CB_ROUTE C=$CC_ROUTE"
+fi
+
+# ============================================================
+echo ""
+echo -e "${BOLD}Test 7: Majority Continues While One Follower Is Offline${NC}"
+# ============================================================
+
+PREFIX="raft-one-follower-offline-$(date +%s)"
+echo "  Stopping Node C..."
+docker stop docker-node-p0c-1 > /dev/null 2>&1
+sleep 5
+
+ACCEPTED=0
+for i in $(seq 1 6); do
+    if write_to_either_survivor "$PREFIX" "write-$i" \
+        "$NODE_A_URL" "$KEY_A" \
+        "$NODE_B_URL" "$KEY_B"; then
+        ACCEPTED=$((ACCEPTED + 1))
+    fi
+done
+
+[ "$ACCEPTED" -eq 6 ] \
+    && pass "Majority accepted writes while Node C was offline" \
+    || fail "Majority did not accept all writes while Node C was offline" "accepted=$ACCEPTED expected=6"
+
+if wait_for_prefix_count "$NODE_A_URL" "$KEY_A" "$PREFIX" "$ACCEPTED" \
+    && wait_for_prefix_count "$NODE_B_URL" "$KEY_B" "$PREFIX" "$ACCEPTED"; then
+    pass "Surviving majority agreed while follower was offline"
+else
+    CA_OFFLINE=$(count_prefix "$NODE_A_URL" "$KEY_A" "$PREFIX" 2>/dev/null || echo -1)
+    CB_OFFLINE=$(count_prefix "$NODE_B_URL" "$KEY_B" "$PREFIX" 2>/dev/null || echo -1)
+    fail "Surviving majority did not agree while follower was offline" "A=$CA_OFFLINE B=$CB_OFFLINE expected=$ACCEPTED"
+fi
+
+echo "  Restarting Node C..."
+docker start docker-node-p0c-1 > /dev/null 2>&1
+wait_for_node "$NODE_C_URL" || fail "Node C did not come back after follower-offline test"
+refresh_keys
+if wait_for_prefix_count "$NODE_C_URL" "$KEY_C" "$PREFIX" "$ACCEPTED"; then
+    pass "Restarted follower caught up with offline-window writes"
+else
+    CC_OFFLINE=$(count_prefix "$NODE_C_URL" "$KEY_C" "$PREFIX" 2>/dev/null || echo -1)
+    fail "Restarted follower did not catch up" "C=$CC_OFFLINE expected=$ACCEPTED"
+fi
+
+# ============================================================
+echo ""
+echo -e "${BOLD}Test 8: No-Quorum Writes Fail Closed${NC}"
+# ============================================================
+
+PREFIX="raft-no-quorum-$(date +%s)"
+echo "  Stopping Nodes B and C to remove quorum..."
+docker stop docker-node-p0b-1 docker-node-p0c-1 > /dev/null 2>&1
+sleep 7
+
+R=$(mutate "$NODE_A_URL" "$KEY_A" "$PREFIX-should-not-commit" 2>&1 || echo "FAIL")
+if echo "$R" | grep -q "success"; then
+    fail "Single surviving node accepted a write without quorum" "$R"
+else
+    pass "Single surviving node rejected writes without quorum"
+fi
+
+echo "  Restarting Nodes B and C..."
+docker start docker-node-p0b-1 docker-node-p0c-1 > /dev/null 2>&1
+wait_for_node "$NODE_B_URL" || fail "Node B did not come back after no-quorum test"
+wait_for_node "$NODE_C_URL" || fail "Node C did not come back after no-quorum test"
+refresh_keys
+sleep 5
+
+CA_NO_QUORUM=$(count_prefix "$NODE_A_URL" "$KEY_A" "$PREFIX" 2>/dev/null || echo -1)
+CB_NO_QUORUM=$(count_prefix "$NODE_B_URL" "$KEY_B" "$PREFIX" 2>/dev/null || echo -1)
+CC_NO_QUORUM=$(count_prefix "$NODE_C_URL" "$KEY_C" "$PREFIX" 2>/dev/null || echo -1)
+if [ "$CA_NO_QUORUM" -eq 0 ] && [ "$CB_NO_QUORUM" -eq 0 ] && [ "$CC_NO_QUORUM" -eq 0 ]; then
+    pass "Rejected no-quorum write did not leak after recovery"
+else
+    fail "No-quorum write leaked into recovered state" "A=$CA_NO_QUORUM B=$CB_NO_QUORUM C=$CC_NO_QUORUM"
+fi
+
+# ============================================================
+echo ""
+echo -e "${BOLD}Test 9: Rolling Raft Restarts Preserve Availability${NC}"
+# ============================================================
+
+PREFIX="raft-rolling-restart-$(date +%s)"
+ROLLING_ACCEPTED=0
+
+echo "  Rolling restart: Node A down..."
+docker stop docker-node-p0a-1 > /dev/null 2>&1
+sleep 5
+if write_to_either_survivor "$PREFIX" "while-a-down" \
+    "$NODE_B_URL" "$KEY_B" \
+    "$NODE_C_URL" "$KEY_C"; then
+    ROLLING_ACCEPTED=$((ROLLING_ACCEPTED + 1))
+    pass "Write accepted while Node A was down"
+else
+    fail "No write accepted while Node A was down"
+fi
+docker start docker-node-p0a-1 > /dev/null 2>&1
+wait_for_node "$NODE_A_URL" || fail "Node A did not recover during rolling restart"
+refresh_keys
+sleep 3
+
+echo "  Rolling restart: Node B down..."
+docker stop docker-node-p0b-1 > /dev/null 2>&1
+sleep 5
+if write_to_either_survivor "$PREFIX" "while-b-down" \
+    "$NODE_A_URL" "$KEY_A" \
+    "$NODE_C_URL" "$KEY_C"; then
+    ROLLING_ACCEPTED=$((ROLLING_ACCEPTED + 1))
+    pass "Write accepted while Node B was down"
+else
+    fail "No write accepted while Node B was down"
+fi
+docker start docker-node-p0b-1 > /dev/null 2>&1
+wait_for_node "$NODE_B_URL" || fail "Node B did not recover during rolling restart"
+refresh_keys
+sleep 3
+
+echo "  Rolling restart: Node C down..."
+docker stop docker-node-p0c-1 > /dev/null 2>&1
+sleep 5
+if write_to_either_survivor "$PREFIX" "while-c-down" \
+    "$NODE_A_URL" "$KEY_A" \
+    "$NODE_B_URL" "$KEY_B"; then
+    ROLLING_ACCEPTED=$((ROLLING_ACCEPTED + 1))
+    pass "Write accepted while Node C was down"
+else
+    fail "No write accepted while Node C was down"
+fi
+docker start docker-node-p0c-1 > /dev/null 2>&1
+wait_for_node "$NODE_C_URL" || fail "Node C did not recover during rolling restart"
+refresh_keys
+sleep 5
+
+if wait_for_prefix_count "$NODE_A_URL" "$KEY_A" "$PREFIX" "$ROLLING_ACCEPTED" \
+    && wait_for_prefix_count "$NODE_B_URL" "$KEY_B" "$PREFIX" "$ROLLING_ACCEPTED" \
+    && wait_for_prefix_count "$NODE_C_URL" "$KEY_C" "$PREFIX" "$ROLLING_ACCEPTED"; then
+    pass "Rolling restart writes converged on all three nodes"
+else
+    CA_ROLLING=$(count_prefix "$NODE_A_URL" "$KEY_A" "$PREFIX" 2>/dev/null || echo -1)
+    CB_ROLLING=$(count_prefix "$NODE_B_URL" "$KEY_B" "$PREFIX" 2>/dev/null || echo -1)
+    CC_ROLLING=$(count_prefix "$NODE_C_URL" "$KEY_C" "$PREFIX" 2>/dev/null || echo -1)
+    fail "Rolling restart writes did not converge" "A=$CA_ROLLING B=$CB_ROLLING C=$CC_ROLLING expected=$ROLLING_ACCEPTED"
+fi
+
+# ============================================================
+echo ""
+echo -e "${BOLD}Test 10: Lagging Follower Burst Catch-Up${NC}"
+# ============================================================
+
+PREFIX="raft-lagging-burst-$(date +%s)"
+echo "  Stopping Node C before a burst of writes..."
+docker stop docker-node-p0c-1 > /dev/null 2>&1
+sleep 5
+
+BURST_ACCEPTED=0
+for i in $(seq 1 25); do
+    if write_to_either_survivor "$PREFIX" "burst-$i" \
+        "$NODE_A_URL" "$KEY_A" \
+        "$NODE_B_URL" "$KEY_B"; then
+        BURST_ACCEPTED=$((BURST_ACCEPTED + 1))
+    fi
+done
+
+[ "$BURST_ACCEPTED" -eq 25 ] \
+    && pass "Majority accepted burst writes while follower lagged" \
+    || fail "Majority did not accept full burst while follower lagged" "accepted=$BURST_ACCEPTED expected=25"
+
+echo "  Restarting Node C and waiting for catch-up..."
+docker start docker-node-p0c-1 > /dev/null 2>&1
+wait_for_node "$NODE_C_URL" || fail "Node C did not recover after lagging-burst test"
+refresh_keys
+if wait_for_prefix_count "$NODE_C_URL" "$KEY_C" "$PREFIX" "$BURST_ACCEPTED"; then
+    pass "Lagging follower caught up with burst writes"
+else
+    CC_BURST=$(count_prefix "$NODE_C_URL" "$KEY_C" "$PREFIX" 2>/dev/null || echo -1)
+    fail "Lagging follower did not catch up with burst writes" "C=$CC_BURST expected=$BURST_ACCEPTED"
+fi
+
+if wait_for_prefix_count "$NODE_A_URL" "$KEY_A" "$PREFIX" "$BURST_ACCEPTED" \
+    && wait_for_prefix_count "$NODE_B_URL" "$KEY_B" "$PREFIX" "$BURST_ACCEPTED"; then
+    pass "All voters agree after lagging follower catch-up"
+else
+    CA_BURST=$(count_prefix "$NODE_A_URL" "$KEY_A" "$PREFIX" 2>/dev/null || echo -1)
+    CB_BURST=$(count_prefix "$NODE_B_URL" "$KEY_B" "$PREFIX" 2>/dev/null || echo -1)
+    CC_BURST=$(count_prefix "$NODE_C_URL" "$KEY_C" "$PREFIX" 2>/dev/null || echo -1)
+    fail "Voters diverged after lagging follower catch-up" "A=$CA_BURST B=$CB_BURST C=$CC_BURST expected=$BURST_ACCEPTED"
+fi
 
 # ============================================================
 echo ""

--- a/self-hosted/docker/test-write-scaling.sh
+++ b/self-hosted/docker/test-write-scaling.sh
@@ -8,12 +8,16 @@
 #   1. Cross-Partition Data Verification (Vitess VDiff)
 #   2. Bank Invariant — Single Table (CockroachDB Jepsen bank)
 #   3. Bank Invariant — Multi-Table (TiDB bank-multitable)
-#   4. Partition Enforcement (Vitess Single mode)
+#   4. Transparent Partition Routing (topology hiding)
+#   4b. All Replica Entrypoint Routing (cluster-wide topology hiding)
+#   4c. Six-Entrypoint Read-After-Write (session/topology hiding)
 #   5. Concurrent Write Scaling (CockroachDB KV)
 #   6. Monotonic Reads (TiDB monotonic)
 #   7. Node Restart Recovery (TiDB kill -9 / CockroachDB nemesis)
 #   8. Idempotent Re-Run (CockroachDB workload check)
 #   9. Two-Phase Commit Cross-Partition (Vitess 2PC)
+#   9f. 2PC Atomicity During NATS Outage
+#   9g. 2PC Atomicity During Participant Restart
 #  10. Rapid-Fire Writes Under Load (Jepsen stress)
 #  11. Write-Then-Immediate-Read Consistency (stale read detection)
 #  12. Double Node Restart (crash recovery stress)
@@ -25,6 +29,9 @@
 #  18. Interleaved Cross-Partition Reads (read skew detection)
 #  19. Large Batch Write Atomicity
 #  20. Kill Both Nodes Sequentially (full cluster restart)
+#  20b. Writes Through Followers During Raft Leader Outage
+#  20c. Lagging Follower Catch-Up After Cross-Partition Writes
+#  20d. Cross-Partition 2PC During Participant Leader Outage
 #  21. Sustained Writes 30s (long-running replication)
 #  22. Duplicate Insert Idempotency
 #  23. Final Exhaustive Invariant Check
@@ -42,6 +49,7 @@
 #  35. Single Document Read-Modify-Write (register)
 #  36. Write Skew Detection (G2 anomaly)
 #  37. Ultimate Final Invariant Check
+#  38. Sync Route Authority Guard
 #
 # Prerequisites:
 #   docker compose --profile cluster up
@@ -54,8 +62,14 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 
-NODE_A_URL="http://127.0.0.1:3210"
-NODE_B_URL="http://127.0.0.1:3310"
+NODE_P0A_URL="http://127.0.0.1:3210"
+NODE_P0B_URL="http://127.0.0.1:3220"
+NODE_P0C_URL="http://127.0.0.1:3230"
+NODE_P1A_URL="http://127.0.0.1:3310"
+NODE_P1B_URL="http://127.0.0.1:3320"
+NODE_P1C_URL="http://127.0.0.1:3330"
+NODE_A_URL="$NODE_P0A_URL"
+NODE_B_URL="$NODE_P1A_URL"
 
 RED='\033[0;31m'
 GREEN='\033[0;32m'
@@ -82,7 +96,7 @@ fail() {
 echo ""
 echo -e "${BOLD}Preflight checks${NC}"
 
-for name in docker-node-p0a-1 docker-node-p1a-1; do
+for name in docker-node-p0a-1 docker-node-p0b-1 docker-node-p0c-1 docker-node-p1a-1 docker-node-p1b-1 docker-node-p1c-1; do
     if ! docker inspect "$name" > /dev/null 2>&1; then
         echo -e "${RED}Container $name not running. Start the deployment first:${NC}"
         echo "  docker compose --profile cluster up"
@@ -91,8 +105,14 @@ for name in docker-node-p0a-1 docker-node-p1a-1; do
 done
 echo "  Containers running."
 
-NODE_A_KEY=$(docker exec docker-node-p0a-1 ./generate_admin_key.sh 2>&1 | tail -1)
-NODE_B_KEY=$(docker exec docker-node-p1a-1 ./generate_admin_key.sh 2>&1 | tail -1)
+NODE_P0A_KEY=$(docker exec docker-node-p0a-1 ./generate_admin_key.sh 2>&1 | tail -1)
+NODE_P0B_KEY=$(docker exec docker-node-p0b-1 ./generate_admin_key.sh 2>&1 | tail -1)
+NODE_P0C_KEY=$(docker exec docker-node-p0c-1 ./generate_admin_key.sh 2>&1 | tail -1)
+NODE_P1A_KEY=$(docker exec docker-node-p1a-1 ./generate_admin_key.sh 2>&1 | tail -1)
+NODE_P1B_KEY=$(docker exec docker-node-p1b-1 ./generate_admin_key.sh 2>&1 | tail -1)
+NODE_P1C_KEY=$(docker exec docker-node-p1c-1 ./generate_admin_key.sh 2>&1 | tail -1)
+NODE_A_KEY="$NODE_P0A_KEY"
+NODE_B_KEY="$NODE_P1A_KEY"
 echo "  Admin keys generated."
 
 # --- Deploy test functions ---
@@ -234,6 +254,22 @@ export const readOrdered = query({
   },
 });
 
+export const countMessagesByAuthorChannel = query({
+  args: { author: v.string(), channel: v.string() },
+  handler: async (ctx, args) => {
+    const rows = await ctx.db.query("messages").collect();
+    return rows.filter((r: any) => r.author === args.author && r.channel === args.channel).length;
+  },
+});
+
+export const countTasksByTitle = query({
+  args: { title: v.string() },
+  handler: async (ctx, args) => {
+    const rows = await ctx.db.query("tasks").collect();
+    return rows.filter((r: any) => r.title === args.title).length;
+  },
+});
+
 // Concurrent counter: multiple increments, verify total.
 export const incrementCounter = mutation({
   args: { name: v.string() },
@@ -344,11 +380,25 @@ mutate() {
         -d "{\"path\":\"$3\",\"args\":$4}"
 }
 
+mutation_response() {
+    curl -s "$1/api/mutation" \
+        -H "Authorization: Convex $2" \
+        -H "Content-Type: application/json" \
+        -d "{\"path\":\"$3\",\"args\":$4}"
+}
+
 query_api() {
     curl -sf "$1/api/query" \
         -H "Authorization: Convex $2" \
         -H "Content-Type: application/json" \
         -d "{\"path\":\"$3\",\"args\":{}}"
+}
+
+query_with_args() {
+    curl -sf "$1/api/query" \
+        -H "Authorization: Convex $2" \
+        -H "Content-Type: application/json" \
+        -d "{\"path\":\"$3\",\"args\":$4}"
 }
 
 jval() { python3 -c "import sys,json; print(int(json.load(sys.stdin)['value']['$1']))" <<< "$2"; }
@@ -461,46 +511,167 @@ EXPECTED_COMP=$((BASE_COMP + EXPECTED_DELTA + SALARY_DELTA))
     && pass "Cross-node multi-table invariant: both agree on \$$CA_TOTAL" \
     || fail "Cross-node multi-table invariant violated" "A=\$$CA_TOTAL vs B=\$$CB_TOTAL"
 
+# Test 3 adds two salary-bearing user documents. Keep the running table-count
+# baseline aligned so later topology-hiding checks assert the exact deltas they
+# introduce, not stale pre-compensation counts.
+AU=$((AU + 2))
+
 # ============================================================
 echo ""
-echo -e "${BOLD}Test 4: Partition Enforcement (Vitess Single Mode)${NC}"
+echo -e "${BOLD}Test 4: Transparent Partition Routing (Topology Hiding)${NC}"
 # ============================================================
 
-# Node A → projects (partition 1): must fail
+# Node A → projects (partition 1): should route/coordinate transparently.
 R=$(curl -s "$NODE_A_URL/api/mutation" -H "Authorization: Convex $NODE_A_KEY" -H "Content-Type: application/json" \
     -d '{"path":"messages:createProject","args":{"name":"X","status":"x","budget":0}}')
-echo "$R" | grep -q "InternalServerError" \
-    && pass "Node A rejected write to 'projects' (partition 1)" \
-    || fail "Node A should reject projects write" "$R"
+echo "$R" | grep -q '"status":"success"' \
+    && pass "Node A transparently routed write to 'projects' (partition 1)" \
+    || fail "Node A should route projects write" "$R"
 
-# Node B → messages (partition 0): must fail
+# Node B → messages (partition 0): should route/coordinate transparently.
 R=$(curl -s "$NODE_B_URL/api/mutation" -H "Authorization: Convex $NODE_B_KEY" -H "Content-Type: application/json" \
     -d '{"path":"messages:send","args":{"text":"x","author":"x","channel":"x"}}')
-echo "$R" | grep -q "InternalServerError" \
-    && pass "Node B rejected write to 'messages' (partition 0)" \
-    || fail "Node B should reject messages write" "$R"
+echo "$R" | grep -q '"status":"success"' \
+    && pass "Node B transparently routed write to 'messages' (partition 0)" \
+    || fail "Node B should route messages write" "$R"
 
-# Node A → tasks (partition 1): must fail
+# Node A → tasks (partition 1): should route/coordinate transparently.
 R=$(curl -s "$NODE_A_URL/api/mutation" -H "Authorization: Convex $NODE_A_KEY" -H "Content-Type: application/json" \
     -d '{"path":"messages:createTask","args":{"title":"x","assignee":"x","project":"x","status":"x"}}')
-echo "$R" | grep -q "InternalServerError" \
-    && pass "Node A rejected write to 'tasks' (partition 1)" \
-    || fail "Node A should reject tasks write" "$R"
+echo "$R" | grep -q '"status":"success"' \
+    && pass "Node A transparently routed write to 'tasks' (partition 1)" \
+    || fail "Node A should route tasks write" "$R"
 
-# Node B → users (partition 0): must fail
+# Node B → users (partition 0): should route/coordinate transparently.
 R=$(curl -s "$NODE_B_URL/api/mutation" -H "Authorization: Convex $NODE_B_KEY" -H "Content-Type: application/json" \
     -d '{"path":"messages:createUser","args":{"name":"x","role":"x"}}')
-echo "$R" | grep -q "InternalServerError" \
-    && pass "Node B rejected write to 'users' (partition 0)" \
-    || fail "Node B should reject users write" "$R"
+echo "$R" | grep -q '"status":"success"' \
+    && pass "Node B transparently routed write to 'users' (partition 0)" \
+    || fail "Node B should route users write" "$R"
 
-# Verify no phantom data — counts should match post-test1 values
+# Verify the transparently routed writes converged on both nodes.
 sleep 1
 DC=$(query_api "$NODE_A_URL" "$NODE_A_KEY" "messages:dashboard")
-CP=$(jval projects "$DC"); CM=$(jval messages "$DC")
-[ "$CP" -eq "$AP" ] && [ "$CM" -eq "$AM" ] \
-    && pass "No phantom data from rejected writes (proj=$CP msgs=$CM unchanged)" \
-    || fail "Phantom data detected" "proj=$CP (expected $AP) msgs=$CM (expected $AM)"
+DD=$(query_api "$NODE_B_URL" "$NODE_B_KEY" "messages:dashboard")
+CM=$(jval messages "$DC"); CU=$(jval users "$DC"); CP=$(jval projects "$DC"); CT=$(jval tasks "$DC")
+DM_B=$(jval messages "$DD"); DU_B=$(jval users "$DD"); DP_B=$(jval projects "$DD"); DT_B=$(jval tasks "$DD")
+EXPECTED_M=$((AM + 1)); EXPECTED_U=$((AU + 1)); EXPECTED_P=$((AP + 1)); EXPECTED_T=$((AT + 1))
+[ "$CM" -eq "$EXPECTED_M" ] && [ "$CU" -eq "$EXPECTED_U" ] && [ "$CP" -eq "$EXPECTED_P" ] && [ "$CT" -eq "$EXPECTED_T" ] \
+    && [ "$CM" -eq "$DM_B" ] && [ "$CU" -eq "$DU_B" ] && [ "$CP" -eq "$DP_B" ] && [ "$CT" -eq "$DT_B" ] \
+    && pass "Transparent routing converged (msgs=$CM users=$CU proj=$CP tasks=$CT)" \
+    || fail "Transparent routing did not converge" "A: $CM,$CU,$CP,$CT expected $EXPECTED_M,$EXPECTED_U,$EXPECTED_P,$EXPECTED_T; B: $DM_B,$DU_B,$DP_B,$DT_B"
+
+AM=$CM; AU=$CU; AP=$CP; AT=$CT
+
+# ============================================================
+echo ""
+echo -e "${BOLD}Test 4b: All Replica Entrypoint Routing (Cluster-Wide Topology Hiding)${NC}"
+# ============================================================
+
+# Public traffic should not need to know either the table owner or the current
+# Raft leader. Exercise non-leader entrypoints in both partitions and require
+# the system to forward/coordinate the write internally.
+R=$(mutate "$NODE_P0B_URL" "$NODE_P0B_KEY" "messages:createProject" '{"name":"follower-p0b-project","status":"x","budget":0}')
+echo "$R" | grep -q '"status":"success"' \
+    && pass "p0 follower B routed write to 'projects' (partition 1)" \
+    || fail "p0 follower B should route projects write" "$R"
+
+R=$(mutate "$NODE_P0C_URL" "$NODE_P0C_KEY" "messages:createUser" '{"name":"follower-p0c-user","role":"x"}')
+echo "$R" | grep -q '"status":"success"' \
+    && pass "p0 follower C routed write to 'users' (partition 0)" \
+    || fail "p0 follower C should route users write" "$R"
+
+R=$(mutate "$NODE_P1B_URL" "$NODE_P1B_KEY" "messages:send" '{"text":"follower-p1b-message","author":"x","channel":"x"}')
+echo "$R" | grep -q '"status":"success"' \
+    && pass "p1 follower B routed write to 'messages' (partition 0)" \
+    || fail "p1 follower B should route messages write" "$R"
+
+R=$(mutate "$NODE_P1C_URL" "$NODE_P1C_KEY" "messages:createTask" '{"title":"follower-p1c-task","assignee":"x","project":"x","status":"x"}')
+echo "$R" | grep -q '"status":"success"' \
+    && pass "p1 follower C routed write to 'tasks' (partition 1)" \
+    || fail "p1 follower C should route tasks write" "$R"
+
+sleep 2
+EXPECTED_M=$((AM + 1)); EXPECTED_U=$((AU + 1)); EXPECTED_P=$((AP + 1)); EXPECTED_T=$((AT + 1))
+ALL_NODE_COUNTS=()
+ALL_NODE_COUNTS+=("p0a=$(query_api "$NODE_P0A_URL" "$NODE_P0A_KEY" "messages:dashboard")")
+ALL_NODE_COUNTS+=("p0b=$(query_api "$NODE_P0B_URL" "$NODE_P0B_KEY" "messages:dashboard")")
+ALL_NODE_COUNTS+=("p0c=$(query_api "$NODE_P0C_URL" "$NODE_P0C_KEY" "messages:dashboard")")
+ALL_NODE_COUNTS+=("p1a=$(query_api "$NODE_P1A_URL" "$NODE_P1A_KEY" "messages:dashboard")")
+ALL_NODE_COUNTS+=("p1b=$(query_api "$NODE_P1B_URL" "$NODE_P1B_KEY" "messages:dashboard")")
+ALL_NODE_COUNTS+=("p1c=$(query_api "$NODE_P1C_URL" "$NODE_P1C_KEY" "messages:dashboard")")
+
+ALL_NODES_OK=true
+DETAILS=""
+for entry in "${ALL_NODE_COUNTS[@]}"; do
+    node="${entry%%=*}"
+    payload="${entry#*=}"
+    NM=$(jval messages "$payload"); NU=$(jval users "$payload"); NP=$(jval projects "$payload"); NT=$(jval tasks "$payload")
+    DETAILS="$DETAILS $node:$NM,$NU,$NP,$NT"
+    if [ "$NM" -ne "$EXPECTED_M" ] || [ "$NU" -ne "$EXPECTED_U" ] || [ "$NP" -ne "$EXPECTED_P" ] || [ "$NT" -ne "$EXPECTED_T" ]; then
+        ALL_NODES_OK=false
+    fi
+done
+
+$ALL_NODES_OK \
+    && pass "All six node entrypoints converged (msgs=$EXPECTED_M users=$EXPECTED_U proj=$EXPECTED_P tasks=$EXPECTED_T)" \
+    || fail "All six node entrypoints did not converge" "$DETAILS expected $EXPECTED_M,$EXPECTED_U,$EXPECTED_P,$EXPECTED_T"
+
+AM=$EXPECTED_M; AU=$EXPECTED_U; AP=$EXPECTED_P; AT=$EXPECTED_T
+
+# ============================================================
+echo ""
+echo -e "${BOLD}Test 4c: Six-Entrypoint Read-After-Write (Session/Topology Hiding)${NC}"
+# ============================================================
+
+# Each public node should be usable as an entrypoint. Write one unique message
+# through every node, then require every node to read every unique message back.
+ENTRYPOINT_LABELS=(p0a p0b p0c p1a p1b p1c)
+ENTRYPOINT_URLS=("$NODE_P0A_URL" "$NODE_P0B_URL" "$NODE_P0C_URL" "$NODE_P1A_URL" "$NODE_P1B_URL" "$NODE_P1C_URL")
+ENTRYPOINT_KEYS=("$NODE_P0A_KEY" "$NODE_P0B_KEY" "$NODE_P0C_KEY" "$NODE_P1A_KEY" "$NODE_P1B_KEY" "$NODE_P1C_KEY")
+SIX_RAR_AUTHORS=()
+SIX_RAR_ACCEPTED=0
+SIX_RAR_RUN="six-rar-$(date +%s)"
+
+for i in "${!ENTRYPOINT_LABELS[@]}"; do
+    label="${ENTRYPOINT_LABELS[$i]}"
+    author="$SIX_RAR_RUN-$label"
+    SIX_RAR_AUTHORS+=("$author")
+    R=$(mutation_response "${ENTRYPOINT_URLS[$i]}" "${ENTRYPOINT_KEYS[$i]}" "messages:send" \
+        "{\"text\":\"$author\",\"author\":\"$author\",\"channel\":\"six-entrypoint-rar\"}")
+    if echo "$R" | grep -q '"status":"success"'; then
+        SIX_RAR_ACCEPTED=$((SIX_RAR_ACCEPTED + 1))
+        pass "$label accepted routed read-after-write seed"
+    else
+        fail "$label rejected routed read-after-write seed" "$R"
+    fi
+done
+
+sleep 4
+SIX_RAR_OK=true
+SIX_RAR_DETAILS=""
+for read_i in "${!ENTRYPOINT_LABELS[@]}"; do
+    read_label="${ENTRYPOINT_LABELS[$read_i]}"
+    read_url="${ENTRYPOINT_URLS[$read_i]}"
+    read_key="${ENTRYPOINT_KEYS[$read_i]}"
+    for author in "${SIX_RAR_AUTHORS[@]}"; do
+        PAYLOAD=$(query_with_args "$read_url" "$read_key" "messages:countMessagesByAuthorChannel" \
+            "{\"author\":\"$author\",\"channel\":\"six-entrypoint-rar\"}" 2>/dev/null || echo '{"value":-1}')
+        COUNT=$(python3 -c "import sys,json; print(int(json.load(sys.stdin)['value']))" <<< "$PAYLOAD" 2>/dev/null || echo -1)
+        if [ "$COUNT" -ne 1 ]; then
+            SIX_RAR_OK=false
+            SIX_RAR_DETAILS="$SIX_RAR_DETAILS $read_label:$author=$COUNT"
+        fi
+    done
+done
+
+$SIX_RAR_OK \
+    && pass "All six nodes read all six routed writes" \
+    || fail "Six-entrypoint read-after-write failed" "$SIX_RAR_DETAILS"
+
+POST_SIX_RAR=$(query_api "$NODE_A_URL" "$NODE_A_KEY" "messages:dashboard")
+AM=$(jval messages "$POST_SIX_RAR"); AU=$(jval users "$POST_SIX_RAR")
+AP=$(jval projects "$POST_SIX_RAR"); AT=$(jval tasks "$POST_SIX_RAR")
 
 # ============================================================
 echo ""
@@ -591,14 +762,6 @@ if $MONO_OK; then
     pass "Monotonic reads: values never went backward (last=$LAST_SEEN)"
 fi
 
-# Override readLatestSeq to pass key arg
-query_with_args() {
-    curl -sf "$1/api/query" \
-        -H "Authorization: Convex $2" \
-        -H "Content-Type: application/json" \
-        -d "{\"path\":\"$3\",\"args\":$4}"
-}
-
 # ============================================================
 echo ""
 echo -e "${BOLD}Test 7: Node Restart Recovery (TiDB kill -9 / CockroachDB nemesis)${NC}"
@@ -626,7 +789,8 @@ for attempt in $(seq 1 30); do
 done
 
 # Re-generate Node B key (may have changed on restart)
-NODE_B_KEY=$(docker exec docker-node-p1a-1 ./generate_admin_key.sh 2>&1 | tail -1)
+NODE_P1A_KEY=$(docker exec docker-node-p1a-1 ./generate_admin_key.sh 2>&1 | tail -1)
+NODE_B_KEY="$NODE_P1A_KEY"
 
 # Re-deploy functions to Node B (modules are in-memory)
 echo "  Re-deploying functions to Node B..."
@@ -694,17 +858,22 @@ PRE_2PC_T=$(jval tasks "$PRE_2PC")
 # 9a: Atomic cross-partition write (Vitess atomic commit pattern).
 # A single mutation writes to messages (partition 0) AND tasks (partition 1).
 # With 2PC, both should be committed atomically.
-R=$(mutate "$NODE_A_URL" "$NODE_A_KEY" "messages:crossPartitionWrite" \
-    '{"text":"2pc-msg-1","taskTitle":"2pc-task-1"}' 2>&1)
-if echo "$R" | grep -q "success"; then
+R=$(mutation_response "$NODE_A_URL" "$NODE_A_KEY" "messages:crossPartitionWrite" \
+    '{"text":"2pc-msg-1","taskTitle":"2pc-task-1"}')
+if echo "$R" | grep -q '"status":"success"'; then
     pass "Cross-partition mutation accepted (2PC coordinator)"
 else
     fail "Cross-partition mutation rejected" "$R"
 fi
 
 # 9b: Write a second cross-partition mutation.
-mutate "$NODE_A_URL" "$NODE_A_KEY" "messages:crossPartitionWrite" \
-    '{"text":"2pc-msg-2","taskTitle":"2pc-task-2"}' > /dev/null 2>&1
+R=$(mutation_response "$NODE_A_URL" "$NODE_A_KEY" "messages:crossPartitionWrite" \
+    '{"text":"2pc-msg-2","taskTitle":"2pc-task-2"}')
+if echo "$R" | grep -q '"status":"success"'; then
+    pass "Second cross-partition mutation accepted (2PC coordinator)"
+else
+    fail "Second cross-partition mutation rejected" "$R"
+fi
 
 sleep 4
 
@@ -733,6 +902,101 @@ DELTA_T=$((POST_T_A - PRE_2PC_T))
 [ "$DELTA_M" -eq "$DELTA_T" ] \
     && pass "2PC invariant: msgs and tasks incremented equally (+$DELTA_M)" \
     || fail "2PC invariant violated" "msgs +$DELTA_M vs tasks +$DELTA_T"
+
+# ============================================================
+echo ""
+echo -e "${BOLD}Test 9f: 2PC Atomicity During NATS Outage${NC}"
+# ============================================================
+# NATS backs the TSO and 2PC decision log, so an outage may make the mutation
+# fail safely. What must never happen is a torn 2PC write.
+
+PRE_NATS_2PC=$(query_api "$NODE_A_URL" "$NODE_A_KEY" "messages:dashboard")
+PRE_NATS_2PC_M=$(jval messages "$PRE_NATS_2PC")
+PRE_NATS_2PC_T=$(jval tasks "$PRE_NATS_2PC")
+
+echo "  Pausing NATS and attempting one cross-partition mutation..."
+docker pause docker-nats-1 > /dev/null 2>&1
+NATS_2PC_RESPONSE=$(curl --max-time 10 -s "$NODE_A_URL/api/mutation" \
+    -H "Authorization: Convex $NODE_A_KEY" \
+    -H "Content-Type: application/json" \
+    -d '{"path":"messages:crossPartitionWrite","args":{"text":"2pc-nats-outage","taskTitle":"2pc-nats-outage-task"}}' \
+    || echo '{"status":"transport_error"}')
+sleep 2
+docker unpause docker-nats-1 > /dev/null 2>&1
+echo "  NATS resumed."
+
+sleep 6
+POST_NATS_2PC=$(query_api "$NODE_A_URL" "$NODE_A_KEY" "messages:dashboard")
+POST_NATS_2PC_M=$(jval messages "$POST_NATS_2PC")
+POST_NATS_2PC_T=$(jval tasks "$POST_NATS_2PC")
+NATS_2PC_DM=$((POST_NATS_2PC_M - PRE_NATS_2PC_M))
+NATS_2PC_DT=$((POST_NATS_2PC_T - PRE_NATS_2PC_T))
+
+if [ "$NATS_2PC_DM" -eq "$NATS_2PC_DT" ] && { [ "$NATS_2PC_DM" -eq 0 ] || [ "$NATS_2PC_DM" -eq 1 ]; }; then
+    pass "2PC under NATS outage was atomic/fail-closed (msgs +$NATS_2PC_DM tasks +$NATS_2PC_DT)"
+else
+    fail "2PC under NATS outage produced torn/non-idempotent result" "response=$NATS_2PC_RESPONSE msgs +$NATS_2PC_DM tasks +$NATS_2PC_DT"
+fi
+
+POST_NATS_2PC_B=$(query_api "$NODE_B_URL" "$NODE_B_KEY" "messages:dashboard")
+POST_NATS_2PC_BM=$(jval messages "$POST_NATS_2PC_B")
+POST_NATS_2PC_BT=$(jval tasks "$POST_NATS_2PC_B")
+[ "$POST_NATS_2PC_M" -eq "$POST_NATS_2PC_BM" ] && [ "$POST_NATS_2PC_T" -eq "$POST_NATS_2PC_BT" ] \
+    && pass "Nodes converged after NATS 2PC disruption" \
+    || fail "Nodes diverged after NATS 2PC disruption" "A: $POST_NATS_2PC_M,$POST_NATS_2PC_T vs B: $POST_NATS_2PC_BM,$POST_NATS_2PC_BT"
+
+# ============================================================
+echo ""
+echo -e "${BOLD}Test 9g: 2PC Atomicity During Participant Restart${NC}"
+# ============================================================
+# Race a cross-partition mutation with a partition-1 participant restart. The
+# client result may be ambiguous, but the persisted result must not be torn.
+
+PRE_RESTART_2PC=$(query_api "$NODE_A_URL" "$NODE_A_KEY" "messages:dashboard")
+PRE_RESTART_2PC_M=$(jval messages "$PRE_RESTART_2PC")
+PRE_RESTART_2PC_T=$(jval tasks "$PRE_RESTART_2PC")
+RESTART_2PC_RESPONSE_FILE=$(mktemp)
+
+(curl --max-time 20 -s "$NODE_A_URL/api/mutation" \
+    -H "Authorization: Convex $NODE_A_KEY" \
+    -H "Content-Type: application/json" \
+    -d '{"path":"messages:crossPartitionWrite","args":{"text":"2pc-participant-restart","taskTitle":"2pc-participant-restart-task"}}' \
+    > "$RESTART_2PC_RESPONSE_FILE" || echo '{"status":"transport_error"}' > "$RESTART_2PC_RESPONSE_FILE") &
+RESTART_2PC_PID=$!
+sleep 0.05
+docker restart docker-node-p1a-1 > /dev/null 2>&1
+wait "$RESTART_2PC_PID" || true
+
+echo "  Waiting for participant node p1a to recover..."
+for attempt in $(seq 1 60); do
+    curl -sf "$NODE_B_URL/version" > /dev/null 2>&1 && break
+    sleep 1
+done
+NODE_P1A_KEY=$(docker exec docker-node-p1a-1 ./generate_admin_key.sh 2>&1 | tail -1)
+NODE_B_KEY="$NODE_P1A_KEY"
+(cd "$DEPLOY_DIR" && npx convex deploy --admin-key "$NODE_B_KEY" --url "$NODE_B_URL" > /dev/null 2>&1)
+
+sleep 8
+POST_RESTART_2PC_A=$(query_api "$NODE_A_URL" "$NODE_A_KEY" "messages:dashboard")
+POST_RESTART_2PC_B=$(query_api "$NODE_B_URL" "$NODE_B_KEY" "messages:dashboard")
+POST_RESTART_2PC_M=$(jval messages "$POST_RESTART_2PC_A")
+POST_RESTART_2PC_T=$(jval tasks "$POST_RESTART_2PC_A")
+POST_RESTART_2PC_BM=$(jval messages "$POST_RESTART_2PC_B")
+POST_RESTART_2PC_BT=$(jval tasks "$POST_RESTART_2PC_B")
+RESTART_2PC_DM=$((POST_RESTART_2PC_M - PRE_RESTART_2PC_M))
+RESTART_2PC_DT=$((POST_RESTART_2PC_T - PRE_RESTART_2PC_T))
+RESTART_2PC_RESPONSE=$(cat "$RESTART_2PC_RESPONSE_FILE")
+rm -f "$RESTART_2PC_RESPONSE_FILE"
+
+if [ "$RESTART_2PC_DM" -eq "$RESTART_2PC_DT" ] && { [ "$RESTART_2PC_DM" -eq 0 ] || [ "$RESTART_2PC_DM" -eq 1 ]; }; then
+    pass "2PC during participant restart was atomic (msgs +$RESTART_2PC_DM tasks +$RESTART_2PC_DT)"
+else
+    fail "2PC during participant restart produced torn/non-idempotent result" "response=$RESTART_2PC_RESPONSE msgs +$RESTART_2PC_DM tasks +$RESTART_2PC_DT"
+fi
+
+[ "$POST_RESTART_2PC_M" -eq "$POST_RESTART_2PC_BM" ] && [ "$POST_RESTART_2PC_T" -eq "$POST_RESTART_2PC_BT" ] \
+    && pass "Nodes converged after participant restart 2PC race" \
+    || fail "Nodes diverged after participant restart 2PC race" "A: $POST_RESTART_2PC_M,$POST_RESTART_2PC_T vs B: $POST_RESTART_2PC_BM,$POST_RESTART_2PC_BT"
 
 # ============================================================
 echo ""
@@ -854,7 +1118,8 @@ for attempt in $(seq 1 30); do
     sleep 1
 done
 
-NODE_B_KEY=$(docker exec docker-node-p1a-1 ./generate_admin_key.sh 2>&1 | tail -1)
+NODE_P1A_KEY=$(docker exec docker-node-p1a-1 ./generate_admin_key.sh 2>&1 | tail -1)
+NODE_B_KEY="$NODE_P1A_KEY"
 (cd "$DEPLOY_DIR" && npx convex deploy --admin-key "$NODE_B_KEY" --url "$NODE_B_URL" > /dev/null 2>&1)
 
 sleep 4
@@ -1133,8 +1398,10 @@ for attempt in $(seq 1 60); do
     sleep 1
 done
 
-NODE_A_KEY=$(docker exec docker-node-p0a-1 ./generate_admin_key.sh 2>&1 | tail -1)
-NODE_B_KEY=$(docker exec docker-node-p1a-1 ./generate_admin_key.sh 2>&1 | tail -1)
+NODE_P0A_KEY=$(docker exec docker-node-p0a-1 ./generate_admin_key.sh 2>&1 | tail -1)
+NODE_A_KEY="$NODE_P0A_KEY"
+NODE_P1A_KEY=$(docker exec docker-node-p1a-1 ./generate_admin_key.sh 2>&1 | tail -1)
+NODE_B_KEY="$NODE_P1A_KEY"
 (cd "$DEPLOY_DIR" && npx convex deploy --admin-key "$NODE_A_KEY" --url "$NODE_A_URL" > /dev/null 2>&1)
 (cd "$DEPLOY_DIR" && npx convex deploy --admin-key "$NODE_B_KEY" --url "$NODE_B_URL" > /dev/null 2>&1)
 
@@ -1152,6 +1419,217 @@ POST_KILL_BM=$(jval messages "$POST_KILL_B")
 [ "$POST_KILL_AM" -eq "$POST_KILL_BM" ] \
     && pass "Both nodes converged after full restart" \
     || fail "Nodes diverged after restart" "A=$POST_KILL_AM vs B=$POST_KILL_BM"
+
+# ============================================================
+echo ""
+echo -e "${BOLD}Test 20b: Writes Through Followers During Raft Leader Outage${NC}"
+# ============================================================
+# Stop p0a and require every surviving public entrypoint to route a p0-owned
+# write through the new Raft leader. This catches stale leader/follower routing.
+
+PRE_P0_OUTAGE=$(query_api "$NODE_B_URL" "$NODE_B_KEY" "messages:dashboard")
+PRE_P0_OUTAGE_M=$(jval messages "$PRE_P0_OUTAGE")
+PRE_P0_OUTAGE_T=$(jval tasks "$PRE_P0_OUTAGE")
+
+echo "  Stopping p0a to force/hold a partition-0 leader change..."
+docker stop docker-node-p0a-1 > /dev/null 2>&1
+sleep 6
+
+OUTAGE_LABELS=(p0b p0c p1a p1b p1c)
+OUTAGE_URLS=("$NODE_P0B_URL" "$NODE_P0C_URL" "$NODE_P1A_URL" "$NODE_P1B_URL" "$NODE_P1C_URL")
+OUTAGE_KEYS=("$NODE_P0B_KEY" "$NODE_P0C_KEY" "$NODE_P1A_KEY" "$NODE_P1B_KEY" "$NODE_P1C_KEY")
+P0_OUTAGE_ACCEPTED=0
+P0_OUTAGE_RUN="p0-outage-$(date +%s)"
+
+for i in "${!OUTAGE_LABELS[@]}"; do
+    label="${OUTAGE_LABELS[$i]}"
+    R=$(mutation_response "${OUTAGE_URLS[$i]}" "${OUTAGE_KEYS[$i]}" "messages:send" \
+        "{\"text\":\"$P0_OUTAGE_RUN-$label\",\"author\":\"$P0_OUTAGE_RUN\",\"channel\":\"raft-outage\"}")
+    if echo "$R" | grep -q '"status":"success"'; then
+        P0_OUTAGE_ACCEPTED=$((P0_OUTAGE_ACCEPTED + 1))
+    else
+        fail "$label could not route write while p0a was down" "$R"
+    fi
+done
+
+[ "$P0_OUTAGE_ACCEPTED" -eq 5 ] \
+    && pass "All five surviving entrypoints accepted writes while p0a was down" \
+    || fail "Some entrypoints failed during p0a outage" "accepted=$P0_OUTAGE_ACCEPTED expected=5"
+
+P0_OUTAGE_2PC_LABELS=(p1a p1b p1c)
+P0_OUTAGE_2PC_URLS=("$NODE_P1A_URL" "$NODE_P1B_URL" "$NODE_P1C_URL")
+P0_OUTAGE_2PC_KEYS=("$NODE_P1A_KEY" "$NODE_P1B_KEY" "$NODE_P1C_KEY")
+P0_OUTAGE_2PC_ACCEPTED=0
+
+for i in "${!P0_OUTAGE_2PC_LABELS[@]}"; do
+    label="${P0_OUTAGE_2PC_LABELS[$i]}"
+    R=$(mutation_response "${P0_OUTAGE_2PC_URLS[$i]}" "${P0_OUTAGE_2PC_KEYS[$i]}" "messages:crossPartitionWrite" \
+        "{\"text\":\"$P0_OUTAGE_RUN-2pc-$label\",\"taskTitle\":\"$P0_OUTAGE_RUN-2pc-task-$label\"}")
+    if echo "$R" | grep -q '"status":"success"'; then
+        P0_OUTAGE_2PC_ACCEPTED=$((P0_OUTAGE_2PC_ACCEPTED + 1))
+    else
+        fail "$label could not route 2PC write while p0a was down" "$R"
+    fi
+done
+
+[ "$P0_OUTAGE_2PC_ACCEPTED" -eq 3 ] \
+    && pass "Surviving p1 entrypoints accepted 2PC writes while p0a was down" \
+    || fail "Some 2PC writes failed during p0a outage" "accepted=$P0_OUTAGE_2PC_ACCEPTED expected=3"
+
+echo "  Restarting p0a..."
+docker start docker-node-p0a-1 > /dev/null 2>&1
+for attempt in $(seq 1 60); do
+    curl -sf "$NODE_A_URL/version" > /dev/null 2>&1 && break
+    sleep 1
+done
+NODE_P0A_KEY=$(docker exec docker-node-p0a-1 ./generate_admin_key.sh 2>&1 | tail -1)
+NODE_A_KEY="$NODE_P0A_KEY"
+(cd "$DEPLOY_DIR" && npx convex deploy --admin-key "$NODE_A_KEY" --url "$NODE_A_URL" > /dev/null 2>&1)
+
+sleep 6
+POST_P0_OUTAGE_A=$(query_api "$NODE_A_URL" "$NODE_A_KEY" "messages:dashboard")
+POST_P0_OUTAGE_B=$(query_api "$NODE_B_URL" "$NODE_B_KEY" "messages:dashboard")
+POST_P0_OUTAGE_AM=$(jval messages "$POST_P0_OUTAGE_A")
+POST_P0_OUTAGE_BM=$(jval messages "$POST_P0_OUTAGE_B")
+POST_P0_OUTAGE_AT=$(jval tasks "$POST_P0_OUTAGE_A")
+POST_P0_OUTAGE_BT=$(jval tasks "$POST_P0_OUTAGE_B")
+P0_OUTAGE_DELTA=$((POST_P0_OUTAGE_AM - PRE_P0_OUTAGE_M))
+P0_OUTAGE_TASK_DELTA=$((POST_P0_OUTAGE_AT - PRE_P0_OUTAGE_T))
+P0_OUTAGE_EXPECTED_M=$((P0_OUTAGE_ACCEPTED + P0_OUTAGE_2PC_ACCEPTED))
+
+[ "$P0_OUTAGE_DELTA" -eq "$P0_OUTAGE_EXPECTED_M" ] \
+    && pass "All outage-window writes survived Raft leader outage (+$P0_OUTAGE_DELTA)" \
+    || fail "Lost/extra writes during Raft leader outage" "+$P0_OUTAGE_DELTA expected +$P0_OUTAGE_EXPECTED_M"
+
+[ "$P0_OUTAGE_TASK_DELTA" -eq "$P0_OUTAGE_2PC_ACCEPTED" ] \
+    && pass "2PC outage-window task halves survived Raft leader outage (+$P0_OUTAGE_TASK_DELTA)" \
+    || fail "Lost/extra 2PC task halves during Raft leader outage" "+$P0_OUTAGE_TASK_DELTA expected +$P0_OUTAGE_2PC_ACCEPTED"
+
+[ "$POST_P0_OUTAGE_AM" -eq "$POST_P0_OUTAGE_BM" ] && [ "$POST_P0_OUTAGE_AT" -eq "$POST_P0_OUTAGE_BT" ] \
+    && pass "Nodes converged after p0a leader outage" \
+    || fail "Nodes diverged after p0a leader outage" "p0a=$POST_P0_OUTAGE_AM,$POST_P0_OUTAGE_AT p1a=$POST_P0_OUTAGE_BM,$POST_P0_OUTAGE_BT"
+
+# ============================================================
+echo ""
+echo -e "${BOLD}Test 20c: Lagging Follower Catch-Up After Cross-Partition Writes${NC}"
+# ============================================================
+# Keep p1c offline while cross-partition writes commit, then require it to
+# catch up through Raft/NATS before serving a consistent dashboard.
+
+PRE_LAGGING=$(query_api "$NODE_A_URL" "$NODE_A_KEY" "messages:dashboard")
+PRE_LAGGING_M=$(jval messages "$PRE_LAGGING")
+PRE_LAGGING_T=$(jval tasks "$PRE_LAGGING")
+LAGGING_2PC_COUNT=4
+
+echo "  Stopping p1c before heavy cross-partition writes..."
+docker stop docker-node-p1c-1 > /dev/null 2>&1
+sleep 5
+
+LAGGING_ACCEPTED=0
+for i in $(seq 1 "$LAGGING_2PC_COUNT"); do
+    R=$(mutation_response "$NODE_A_URL" "$NODE_A_KEY" "messages:crossPartitionWrite" \
+        "{\"text\":\"lagging-2pc-$i\",\"taskTitle\":\"lagging-2pc-task-$i\"}")
+    if echo "$R" | grep -q '"status":"success"'; then
+        LAGGING_ACCEPTED=$((LAGGING_ACCEPTED + 1))
+    else
+        fail "Cross-partition write $i failed while p1c was offline" "$R"
+    fi
+done
+
+[ "$LAGGING_ACCEPTED" -eq "$LAGGING_2PC_COUNT" ] \
+    && pass "Cross-partition writes committed while p1c was offline ($LAGGING_ACCEPTED/$LAGGING_2PC_COUNT)" \
+    || fail "Some cross-partition writes failed while p1c was offline" "accepted=$LAGGING_ACCEPTED expected=$LAGGING_2PC_COUNT"
+
+echo "  Restarting p1c and waiting for catch-up..."
+docker start docker-node-p1c-1 > /dev/null 2>&1
+for attempt in $(seq 1 60); do
+    curl -sf "$NODE_P1C_URL/version" > /dev/null 2>&1 && break
+    sleep 1
+done
+NODE_P1C_KEY=$(docker exec docker-node-p1c-1 ./generate_admin_key.sh 2>&1 | tail -1)
+(cd "$DEPLOY_DIR" && npx convex deploy --admin-key "$NODE_P1C_KEY" --url "$NODE_P1C_URL" > /dev/null 2>&1)
+
+sleep 10
+POST_LAGGING_A=$(query_api "$NODE_A_URL" "$NODE_A_KEY" "messages:dashboard")
+POST_LAGGING_C=$(query_api "$NODE_P1C_URL" "$NODE_P1C_KEY" "messages:dashboard")
+POST_LAGGING_AM=$(jval messages "$POST_LAGGING_A")
+POST_LAGGING_AT=$(jval tasks "$POST_LAGGING_A")
+POST_LAGGING_CM=$(jval messages "$POST_LAGGING_C")
+POST_LAGGING_CT=$(jval tasks "$POST_LAGGING_C")
+LAGGING_DM=$((POST_LAGGING_AM - PRE_LAGGING_M))
+LAGGING_DT=$((POST_LAGGING_AT - PRE_LAGGING_T))
+
+[ "$LAGGING_DM" -eq "$LAGGING_ACCEPTED" ] && [ "$LAGGING_DT" -eq "$LAGGING_ACCEPTED" ] \
+    && pass "Heavy cross-partition writes remained atomic while follower lagged (+$LAGGING_ACCEPTED/+${LAGGING_ACCEPTED})" \
+    || fail "Unexpected heavy 2PC deltas while follower lagged" "msgs +$LAGGING_DM tasks +$LAGGING_DT expected +$LAGGING_ACCEPTED"
+
+[ "$POST_LAGGING_AM" -eq "$POST_LAGGING_CM" ] && [ "$POST_LAGGING_AT" -eq "$POST_LAGGING_CT" ] \
+    && pass "Lagging p1c caught up after cross-partition writes" \
+    || fail "Lagging p1c did not catch up" "p0a: $POST_LAGGING_AM,$POST_LAGGING_AT vs p1c: $POST_LAGGING_CM,$POST_LAGGING_CT"
+
+# ============================================================
+echo ""
+echo -e "${BOLD}Test 20d: Cross-Partition 2PC During Participant Leader Outage${NC}"
+# ============================================================
+# Stop the partition-1 leader and require every surviving public entrypoint to
+# coordinate cross-partition writes through the new partition-1 Raft leader.
+
+PRE_P1_OUTAGE=$(query_api "$NODE_A_URL" "$NODE_A_KEY" "messages:dashboard")
+PRE_P1_OUTAGE_M=$(jval messages "$PRE_P1_OUTAGE")
+PRE_P1_OUTAGE_T=$(jval tasks "$PRE_P1_OUTAGE")
+
+echo "  Stopping p1a to force/hold a partition-1 leader change..."
+docker stop docker-node-p1a-1 > /dev/null 2>&1
+sleep 6
+
+P1_OUTAGE_LABELS=(p0a p0b p0c p1b p1c)
+P1_OUTAGE_URLS=("$NODE_P0A_URL" "$NODE_P0B_URL" "$NODE_P0C_URL" "$NODE_P1B_URL" "$NODE_P1C_URL")
+P1_OUTAGE_KEYS=("$NODE_P0A_KEY" "$NODE_P0B_KEY" "$NODE_P0C_KEY" "$NODE_P1B_KEY" "$NODE_P1C_KEY")
+P1_OUTAGE_ACCEPTED=0
+P1_OUTAGE_RUN="p1-outage-$(date +%s)"
+
+for i in "${!P1_OUTAGE_LABELS[@]}"; do
+    label="${P1_OUTAGE_LABELS[$i]}"
+    R=$(mutation_response "${P1_OUTAGE_URLS[$i]}" "${P1_OUTAGE_KEYS[$i]}" "messages:crossPartitionWrite" \
+        "{\"text\":\"$P1_OUTAGE_RUN-$label\",\"taskTitle\":\"$P1_OUTAGE_RUN-task-$label\"}")
+    if echo "$R" | grep -q '"status":"success"'; then
+        P1_OUTAGE_ACCEPTED=$((P1_OUTAGE_ACCEPTED + 1))
+    else
+        fail "$label could not route 2PC write while p1a was down" "$R"
+    fi
+done
+
+[ "$P1_OUTAGE_ACCEPTED" -eq 5 ] \
+    && pass "All five surviving entrypoints accepted 2PC writes while p1a was down" \
+    || fail "Some 2PC writes failed during p1a outage" "accepted=$P1_OUTAGE_ACCEPTED expected=5"
+
+echo "  Restarting p1a..."
+docker start docker-node-p1a-1 > /dev/null 2>&1
+for attempt in $(seq 1 60); do
+    curl -sf "$NODE_B_URL/version" > /dev/null 2>&1 && break
+    sleep 1
+done
+NODE_P1A_KEY=$(docker exec docker-node-p1a-1 ./generate_admin_key.sh 2>&1 | tail -1)
+NODE_B_KEY="$NODE_P1A_KEY"
+(cd "$DEPLOY_DIR" && npx convex deploy --admin-key "$NODE_B_KEY" --url "$NODE_B_URL" > /dev/null 2>&1)
+
+sleep 8
+POST_P1_OUTAGE_A=$(query_api "$NODE_A_URL" "$NODE_A_KEY" "messages:dashboard")
+POST_P1_OUTAGE_B=$(query_api "$NODE_B_URL" "$NODE_B_KEY" "messages:dashboard")
+POST_P1_OUTAGE_AM=$(jval messages "$POST_P1_OUTAGE_A")
+POST_P1_OUTAGE_AT=$(jval tasks "$POST_P1_OUTAGE_A")
+POST_P1_OUTAGE_BM=$(jval messages "$POST_P1_OUTAGE_B")
+POST_P1_OUTAGE_BT=$(jval tasks "$POST_P1_OUTAGE_B")
+P1_OUTAGE_DM=$((POST_P1_OUTAGE_AM - PRE_P1_OUTAGE_M))
+P1_OUTAGE_DT=$((POST_P1_OUTAGE_AT - PRE_P1_OUTAGE_T))
+
+[ "$P1_OUTAGE_DM" -eq "$P1_OUTAGE_ACCEPTED" ] && [ "$P1_OUTAGE_DT" -eq "$P1_OUTAGE_ACCEPTED" ] \
+    && pass "2PC writes survived participant leader outage (+$P1_OUTAGE_ACCEPTED/+${P1_OUTAGE_ACCEPTED})" \
+    || fail "Lost/extra 2PC writes during participant leader outage" "msgs +$P1_OUTAGE_DM tasks +$P1_OUTAGE_DT expected +$P1_OUTAGE_ACCEPTED"
+
+[ "$POST_P1_OUTAGE_AM" -eq "$POST_P1_OUTAGE_BM" ] && [ "$POST_P1_OUTAGE_AT" -eq "$POST_P1_OUTAGE_BT" ] \
+    && pass "Nodes converged after p1a participant leader outage" \
+    || fail "Nodes diverged after p1a participant leader outage" "p0a=$POST_P1_OUTAGE_AM,$POST_P1_OUTAGE_AT p1a=$POST_P1_OUTAGE_BM,$POST_P1_OUTAGE_BT"
 
 # ============================================================
 echo ""
@@ -1338,15 +1816,18 @@ DJ_BT=$(jval tasks "$DJ_CHECK_B")
 echo ""
 echo -e "${BOLD}Test 26: NATS Partition Simulation${NC}"
 # ============================================================
-# Pause NATS briefly, write to Node A, unpause, verify Node B catches up.
+# Pause NATS briefly, write to Node A, unpause, verify accepted writes are
+# eventually visible on both partitions.
 
 echo "  Pausing NATS for 3 seconds..."
 docker pause docker-nats-1 > /dev/null 2>&1
 
-# Write during NATS outage (should succeed locally, publish will retry).
+# Write during NATS outage. It may fail closed if the TSO/decision path cannot
+# make progress, but if it is accepted then the Raft/NATS outbox must replay it
+# after recovery.
 NATS_KEY="nats-pause-$(date +%s)"
-mutate "$NODE_A_URL" "$NODE_A_KEY" "messages:send" \
-    "{\"text\":\"$NATS_KEY\",\"author\":\"nats-test\",\"channel\":\"test\"}" > /dev/null 2>&1 || true
+NATS_RESPONSE=$(mutation_response "$NODE_A_URL" "$NODE_A_KEY" "messages:send" \
+    "{\"text\":\"$NATS_KEY\",\"author\":\"$NATS_KEY\",\"channel\":\"nats-outage\"}" 2>&1 || echo '{"status":"transport_error"}')
 
 sleep 3
 docker unpause docker-nats-1 > /dev/null 2>&1
@@ -1361,6 +1842,28 @@ curl -sf "$NODE_A_URL/version" > /dev/null 2>&1 \
 curl -sf "$NODE_B_URL/version" > /dev/null 2>&1 \
     && pass "Node B survived NATS partition" \
     || fail "Node B crashed during NATS partition"
+
+NATS_ACCEPTED=0
+if echo "$NATS_RESPONSE" | grep -q '"status":"success"'; then
+    NATS_ACCEPTED=1
+fi
+
+NATS_A_COUNT=$(query_with_args "$NODE_A_URL" "$NODE_A_KEY" "messages:countMessagesByAuthorChannel" \
+    "{\"author\":\"$NATS_KEY\",\"channel\":\"nats-outage\"}" \
+    | python3 -c "import sys,json; print(int(json.load(sys.stdin)['value']))" 2>/dev/null || echo -1)
+NATS_B_COUNT=$(query_with_args "$NODE_B_URL" "$NODE_B_KEY" "messages:countMessagesByAuthorChannel" \
+    "{\"author\":\"$NATS_KEY\",\"channel\":\"nats-outage\"}" \
+    | python3 -c "import sys,json; print(int(json.load(sys.stdin)['value']))" 2>/dev/null || echo -1)
+
+if [ "$NATS_ACCEPTED" -eq 1 ]; then
+    [ "$NATS_A_COUNT" -eq 1 ] && [ "$NATS_B_COUNT" -eq 1 ] \
+        && pass "Accepted write during NATS outage replayed to both partitions" \
+        || fail "Accepted write during NATS outage did not replay" "response=$NATS_RESPONSE p0a=$NATS_A_COUNT p1a=$NATS_B_COUNT"
+else
+    [ "$NATS_A_COUNT" -eq 0 ] && [ "$NATS_B_COUNT" -eq 0 ] \
+        && pass "Write during NATS outage failed closed without partial visibility" \
+        || fail "Failed NATS-outage write left partial visibility" "response=$NATS_RESPONSE p0a=$NATS_A_COUNT p1a=$NATS_B_COUNT"
+fi
 
 # ============================================================
 echo ""
@@ -1563,7 +2066,8 @@ for attempt in $(seq 1 30); do
     sleep 1
 done
 
-NODE_A_KEY=$(docker exec docker-node-p0a-1 ./generate_admin_key.sh 2>&1 | tail -1)
+NODE_P0A_KEY=$(docker exec docker-node-p0a-1 ./generate_admin_key.sh 2>&1 | tail -1)
+NODE_A_KEY="$NODE_P0A_KEY"
 (cd "$DEPLOY_DIR" && npx convex deploy --admin-key "$NODE_A_KEY" --url "$NODE_A_URL" > /dev/null 2>&1)
 
 # Write after restart — TSO must give a valid timestamp.
@@ -1653,7 +2157,7 @@ WS_RESULT=$(curl -sf "$NODE_A_URL/api/query" \
 echo ""
 echo -e "${BOLD}Test 37: Ultimate Final Invariant Check${NC}"
 # ============================================================
-# After ALL 36 tests including NATS partition, node restarts, deploys,
+# After ALL previous tests including NATS partition, node restarts, deploys,
 # 200-doc batches, and sustained writes — every invariant must hold.
 
 sleep 5
@@ -1680,6 +2184,38 @@ ULT_BB=$(jtotal "$(query_api "$NODE_B_URL" "$NODE_B_KEY" "messages:totalBudget")
 
 echo ""
 echo "  FINAL DATA: msgs=$ULT_AM users=$ULT_AU projects=$ULT_AP tasks=$ULT_AT budget=\$$ULT_BA"
+
+# ============================================================
+echo ""
+echo -e "${BOLD}Test 38: Sync Route Authority Guard${NC}"
+# ============================================================
+# Sync/subscription setup is coordinator-owner only. Non-coordinator partition
+# nodes must fail closed before WebSocket upgrade instead of hosting orphaned
+# subscription state.
+
+SYNC_OK=true
+SYNC_DETAILS=""
+for entry in "p1a|$NODE_P1A_URL" "p1b|$NODE_P1B_URL" "p1c|$NODE_P1C_URL"; do
+    label="${entry%%|*}"
+    url="${entry#*|}"
+    for path in "/api/sync" "/api/1.0.0/sync"; do
+        STATUS=$(curl -s -o /dev/null -w "%{http_code}" \
+            -H "Connection: Upgrade" \
+            -H "Upgrade: websocket" \
+            -H "Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==" \
+            -H "Sec-WebSocket-Version: 13" \
+            "$url$path" 2>/dev/null || echo "000")
+        STATUS="${STATUS: -3}"
+        if [ "$STATUS" -lt 400 ] || [ "$STATUS" -eq 101 ]; then
+            SYNC_OK=false
+            SYNC_DETAILS="$SYNC_DETAILS $label$path=$STATUS"
+        fi
+    done
+done
+
+$SYNC_OK \
+    && pass "Non-coordinator partition nodes reject sync/WebSocket routes" \
+    || fail "Sync route did not fail closed on non-coordinator nodes" "$SYNC_DETAILS"
 
 # ============================================================
 echo ""


### PR DESCRIPTION
## Summary
- add URL-keyed 2PC client pooling so prepare/commit/rollback reuse tonic channels across transactions
- add URL-keyed mutation/query forwarder pooling for replica, Raft follower, and selective query forwarding paths
- make 2PC participant routing try all known Raft peer addresses for a partition instead of a single static owner endpoint
- expand Rust Raft failover coverage for unquorumed proposal truncation, quorumed proposal survival, stale-leader step-down, majority isolation, and snapshot retry/catch-up
- expand Docker cluster coverage for 2PC through leader outages, fail-closed NATS outage behavior, follower routing, no-quorum rejection, rolling restarts, and lagging follower catch-up

## Why
The original issue was the reconnect-per-call behavior called out in #166. While validating the fix, we also found the Docker harness was not proving enough of the cluster failover surface: the write-scaling suite had grown, but the dedicated Raft shell suite was still a thin 10-assertion smoke test. This PR hardens the hot internal RPC paths and raises the end-to-end validation bar for Raft + 2PC behavior.

Closes #166
Closes #198

## Verification
- `git diff --check`
- `cargo test -p database raft_failover_tests -- --nocapture` → 14 passed
- `cargo test -p database raft_node::tests -- --nocapture` → 6 passed
- `cargo test -p database test_node_addresses -- --nocapture` → 3 passed
- rebuilt local Docker image `ghcr.io/martinkalema/convex-horizontal-scaling:backend-latest`
- verified all six backend containers used local image `sha256:13edc1bf2c6ece8334937ed3a9ed41a0da1293136f4187f422fbb7874df507ef`
- `bash self-hosted/docker/test-write-scaling.sh` → `ALL 107 TESTS PASSED`
- `bash self-hosted/docker/test-raft-failover.sh` → `ALL 24 TESTS PASSED`
- `bash self-hosted/docker/test.sh` → `ALL SUITES PASSED`
