### PR TITLE
perf(database): instrument commit hot path stages

### DIFF
--- a/crates/database/src/committer.rs
+++ b/crates/database/src/committer.rs
@@ -918,6 +918,8 @@ impl<RT: Runtime> Committer<RT> {
                             };
                             drop(_guard);
                             if let Some(raft_applied_index) = raft_applied_index {
+                                let raft_mark_timer =
+                                    metrics::commit_hot_path_stage_timer("local", "raft_mark_applied");
                                 let Some(raft_state) = self.raft_state.as_ref() else {
                                     return Self::fail_committed_write(
                                         result,
@@ -939,13 +941,15 @@ impl<RT: Runtime> Committer<RT> {
                                         err,
                                     );
                                 }
+                                raft_mark_timer.finish();
                             }
                             let use_raft_nats_outbox =
                                 Self::should_record_raft_nats_outbox_delta(&published_commit.delta);
                             if use_raft_nats_outbox
-                                && let Err(err) = Self::add_raft_nats_outbox_delta(
+                                && let Err(err) = Self::record_raft_nats_outbox_delta(
                                     self.persistence.clone(),
                                     &published_commit.delta,
+                                    "local",
                                 )
                                 .await
                             {
@@ -959,6 +963,7 @@ impl<RT: Runtime> Committer<RT> {
                             if let Err(err) = Self::publish_commit_delta(
                                 self.distributed_log.clone(),
                                 published_commit.delta.clone(),
+                                "local",
                             )
                             .await
                             {
@@ -977,9 +982,10 @@ impl<RT: Runtime> Committer<RT> {
                                     );
                                 }
                             } else if use_raft_nats_outbox
-                                && let Err(err) = Self::delete_raft_nats_outbox_delta(
+                                && let Err(err) = Self::clear_raft_nats_outbox_delta(
                                     self.persistence.clone(),
                                     commit_ts,
+                                    "local",
                                 )
                                 .await
                             {
@@ -1349,6 +1355,10 @@ impl<RT: Runtime> Committer<RT> {
                             };
                             let commit_ts = published_commit.commit_ts;
                             if let Some(raft_applied_index) = published_commit.raft_applied_index {
+                                let raft_mark_timer = metrics::commit_hot_path_stage_timer(
+                                    "2pc_participant",
+                                    "raft_mark_applied",
+                                );
                                 let Some(raft_state) = self.raft_state.as_ref() else {
                                     return Self::fail_committed_write(
                                         result,
@@ -1370,13 +1380,15 @@ impl<RT: Runtime> Committer<RT> {
                                         err,
                                     );
                                 }
+                                raft_mark_timer.finish();
                             }
                             let use_raft_nats_outbox =
                                 Self::should_record_raft_nats_outbox_delta(&published_commit.delta);
                             if use_raft_nats_outbox
-                                && let Err(err) = Self::add_raft_nats_outbox_delta(
+                                && let Err(err) = Self::record_raft_nats_outbox_delta(
                                     self.persistence.clone(),
                                     &published_commit.delta,
+                                    "2pc_participant",
                                 )
                                 .await
                             {
@@ -1390,6 +1402,7 @@ impl<RT: Runtime> Committer<RT> {
                             if let Err(err) = Self::publish_commit_delta(
                                 self.distributed_log.clone(),
                                 published_commit.delta.clone(),
+                                "2pc_participant",
                             )
                             .await
                             {
@@ -1408,9 +1421,10 @@ impl<RT: Runtime> Committer<RT> {
                                     );
                                 }
                             } else if use_raft_nats_outbox
-                                && let Err(err) = Self::delete_raft_nats_outbox_delta(
+                                && let Err(err) = Self::clear_raft_nats_outbox_delta(
                                     self.persistence.clone(),
                                     commit_ts,
+                                    "2pc_participant",
                                 )
                                 .await
                             {
@@ -2296,12 +2310,17 @@ impl<RT: Runtime> Committer<RT> {
     async fn wait_for_raft_commit(
         raft_commit_waiter: RaftCommitWaiter,
         commit_ts: Timestamp,
+        path: &'static str,
     ) -> anyhow::Result<Option<u64>> {
         let Some(raft_commit_waiter) = raft_commit_waiter else {
             return Ok(None);
         };
+        let timer = metrics::commit_hot_path_stage_timer(path, "raft_quorum_wait");
         match raft_commit_waiter.await {
-            Ok(RaftProposalResult::Committed { index }) => Ok(Some(index)),
+            Ok(RaftProposalResult::Committed { index }) => {
+                timer.finish();
+                Ok(Some(index))
+            },
             Ok(RaftProposalResult::Rejected) => anyhow::bail!(
                 "Raft rejected commit at ts={} before quorum commit",
                 u64::from(commit_ts),
@@ -2365,14 +2384,20 @@ impl<RT: Runtime> Committer<RT> {
     async fn publish_commit_delta(
         distributed_log: Arc<dyn DistributedLog>,
         delta: CommitDelta,
+        path: &'static str,
     ) -> anyhow::Result<()> {
+        let timer = metrics::commit_hot_path_stage_timer(path, "replication_publish");
         let delta_ts = delta.ts;
-        distributed_log.publish(delta).await.with_context(|| {
+        let result = distributed_log.publish(delta).await.with_context(|| {
             format!(
                 "Failed to publish commit delta at ts={}",
                 u64::from(delta_ts)
             )
-        })
+        });
+        if result.is_ok() {
+            timer.finish();
+        }
+        result
     }
 
     fn raft_nats_outbox_key(ts: Timestamp) -> String {
@@ -2420,6 +2445,19 @@ impl<RT: Runtime> Committer<RT> {
         Self::write_raft_nats_outbox_records(persistence, &records).await
     }
 
+    async fn record_raft_nats_outbox_delta(
+        persistence: Arc<dyn Persistence>,
+        delta: &CommitDelta,
+        path: &'static str,
+    ) -> anyhow::Result<()> {
+        let timer = metrics::commit_hot_path_stage_timer(path, "raft_nats_outbox_record");
+        let result = Self::add_raft_nats_outbox_delta(persistence, delta).await;
+        if result.is_ok() {
+            timer.finish();
+        }
+        result
+    }
+
     async fn delete_raft_nats_outbox_delta(
         persistence: Arc<dyn Persistence>,
         ts: Timestamp,
@@ -2427,6 +2465,19 @@ impl<RT: Runtime> Committer<RT> {
         let mut records = Self::load_raft_nats_outbox_records(persistence.clone()).await?;
         records.remove(&Self::raft_nats_outbox_key(ts));
         Self::write_raft_nats_outbox_records(persistence, &records).await
+    }
+
+    async fn clear_raft_nats_outbox_delta(
+        persistence: Arc<dyn Persistence>,
+        ts: Timestamp,
+        path: &'static str,
+    ) -> anyhow::Result<()> {
+        let timer = metrics::commit_hot_path_stage_timer(path, "raft_nats_outbox_clear");
+        let result = Self::delete_raft_nats_outbox_delta(persistence, ts).await;
+        if result.is_ok() {
+            timer.finish();
+        }
+        result
     }
 
     async fn replay_raft_nats_outbox_once(
@@ -2442,8 +2493,14 @@ impl<RT: Runtime> Committer<RT> {
                 .to_delta()
                 .with_context(|| format!("Failed to decode Raft->NATS outbox delta {key}"))?;
             let delta_ts = delta.ts;
-            Self::publish_commit_delta(distributed_log.clone(), delta).await?;
-            Self::delete_raft_nats_outbox_delta(persistence.clone(), delta_ts).await?;
+            Self::publish_commit_delta(distributed_log.clone(), delta, "raft_nats_outbox_replay")
+                .await?;
+            Self::clear_raft_nats_outbox_delta(
+                persistence.clone(),
+                delta_ts,
+                "raft_nats_outbox_replay",
+            )
+            .await?;
             replayed += 1;
         }
         Ok(replayed)
@@ -2627,6 +2684,7 @@ impl<RT: Runtime> Committer<RT> {
             write_source,
             new_snapshot,
             delta,
+            "local",
         )
     }
 
@@ -2638,6 +2696,7 @@ impl<RT: Runtime> Committer<RT> {
         write_source: WriteSource,
         new_snapshot: Snapshot,
         delta: CommitDelta,
+        path: &'static str,
     ) -> anyhow::Result<PublishedCommit> {
         let apply_timer = metrics::commit_apply_timer();
         anyhow::ensure!(
@@ -2657,14 +2716,20 @@ impl<RT: Runtime> Committer<RT> {
 
         if let Some(ref tso) = self.timestamp_oracle {
             let tso = tso.clone();
-            if let Err(err) = block_in_place(|| {
+            let tso_advance_timer =
+                metrics::commit_hot_path_stage_timer(path, "tso_advance_committed");
+            let advance_result = block_in_place(|| {
                 let rt = tokio::runtime::Handle::current();
                 if rt.runtime_flavor() == tokio::runtime::RuntimeFlavor::CurrentThread {
                     futures::executor::block_on(tso.advance_committed_ts(commit_ts))
                 } else {
                     rt.block_on(tso.advance_committed_ts(commit_ts))
                 }
-            }) {
+            });
+            if advance_result.is_ok() {
+                tso_advance_timer.finish();
+            }
+            if let Err(err) = advance_result {
                 tracing::warn!(
                     "Failed to advance global max_committed to {} before publishing commit: \
                      {err:#}",
@@ -2674,6 +2739,7 @@ impl<RT: Runtime> Committer<RT> {
         }
 
         // Write transaction state at the commit ts to the document store.
+        let hot_path_apply_timer = metrics::commit_hot_path_stage_timer(path, "apply_visible");
         metrics::commit_rows(ordered_updates.len() as u64);
 
         let timer = metrics::pending_writes_to_write_log_timer();
@@ -2700,6 +2766,7 @@ impl<RT: Runtime> Committer<RT> {
         drop(snapshot_manager);
 
         apply_timer.finish();
+        hot_path_apply_timer.finish();
         Ok(PublishedCommit {
             commit_ts,
             delta,
@@ -4087,7 +4154,10 @@ impl<RT: Runtime> Committer<RT> {
         &mut self,
         transaction_id: crate::two_phase::TwoPhaseTransactionId,
     ) -> anyhow::Result<PublishedCommit> {
+        let redo_stage_timer =
+            metrics::commit_hot_path_stage_timer("2pc_participant", "two_phase_redo");
         self.stage_durable_two_phase_redo(&transaction_id, true)?;
+        redo_stage_timer.finish();
         let prepared = self
             .prepared_transactions
             .get(&transaction_id)
@@ -4129,7 +4199,8 @@ impl<RT: Runtime> Committer<RT> {
         );
         let raft_commit_waiter = self.propose_commit_to_raft(&delta)?;
         let raft_applied_index = block_in_place(|| {
-            let wait_future = Self::wait_for_raft_commit(raft_commit_waiter, commit_ts);
+            let wait_future =
+                Self::wait_for_raft_commit(raft_commit_waiter, commit_ts, "2pc_participant");
             let rt = tokio::runtime::Handle::current();
             if rt.runtime_flavor() == tokio::runtime::RuntimeFlavor::CurrentThread {
                 futures::executor::block_on(wait_future)
@@ -4139,7 +4210,9 @@ impl<RT: Runtime> Committer<RT> {
         })?;
 
         // Write to persistence (same as normal commit path).
-        block_in_place(|| {
+        let persistence_stage_timer =
+            metrics::commit_hot_path_stage_timer("2pc_participant", "persistence_write");
+        let persistence_result = block_in_place(|| {
             let write_future = async {
                 self.persistence
                     .write(&document_writes, &index_writes, ConflictStrategy::Error)
@@ -4151,7 +4224,11 @@ impl<RT: Runtime> Committer<RT> {
             } else {
                 rt.block_on(write_future)
             }
-        })?;
+        });
+        if persistence_result.is_ok() {
+            persistence_stage_timer.finish();
+        }
+        persistence_result?;
 
         let prepared = self
             .prepared_transactions
@@ -4185,6 +4262,7 @@ impl<RT: Runtime> Committer<RT> {
             write_source,
             snapshot,
             delta,
+            "2pc_participant",
         )?;
         published_commit.raft_applied_index = raft_applied_index;
         Ok(published_commit)
@@ -4415,19 +4493,26 @@ impl<RT: Runtime> Committer<RT> {
         let rt = self.runtime.clone();
         Some(
             async move {
-                let raft_applied_index =
-                    match Self::wait_for_raft_commit(raft_commit_waiter, commit_ts).await {
-                        Ok(index) => index,
-                        Err(err) => {
-                            return Ok(PersistenceWrite::RejectedBeforePersistence {
-                                pending_write,
-                                commit_timer,
-                                result,
-                                commit_id,
-                                err,
-                            });
-                        },
-                    };
+                let raft_applied_index = match Self::wait_for_raft_commit(
+                    raft_commit_waiter,
+                    commit_ts,
+                    "local",
+                )
+                .await
+                {
+                    Ok(index) => index,
+                    Err(err) => {
+                        return Ok(PersistenceWrite::RejectedBeforePersistence {
+                            pending_write,
+                            commit_timer,
+                            result,
+                            commit_id,
+                            err,
+                        });
+                    },
+                };
+                let persistence_stage_timer =
+                    metrics::commit_hot_path_stage_timer("local", "persistence_write");
                 let mut backoff = Backoff::new(
                     INITIAL_PERSISTENCE_WRITES_BACKOFF,
                     MAX_PERSISTENCE_WRITES_BACKOFF,
@@ -4458,6 +4543,7 @@ impl<RT: Runtime> Committer<RT> {
                         }
                     } else {
                         pause_client.wait(AFTER_PENDING_WRITE_SNAPSHOT).await;
+                        persistence_stage_timer.finish();
                         return Ok(PersistenceWrite::Commit {
                             pending_write,
                             commit_timer,
@@ -4584,12 +4670,19 @@ impl<RT: Runtime> Committer<RT> {
     fn next_commit_ts(&mut self) -> anyhow::Result<Timestamp> {
         let _timer = next_commit_ts_seconds();
         let local_floor = self.local_commit_floor()?;
+        let timestamp_stage_path = if self.timestamp_oracle.is_some() {
+            "tso"
+        } else {
+            "local"
+        };
+        let timestamp_stage_timer =
+            metrics::commit_hot_path_stage_timer(timestamp_stage_path, "timestamp_allocate");
 
         // When a global TSO is configured (TiDB PD pattern), draw timestamps
         // from it instead of the local clock. This ensures globally unique,
         // monotonically increasing timestamps across all nodes in the cluster.
-        // The BatchTimestampOracle's fast path is a local mutex increment
-        // (zero network calls), so block_in_place is safe here.
+        // The BatchTimestampOracle keeps range reservation batched, but still
+        // checks the global committed floor before assignment.
         if let Some(ref tso) = self.timestamp_oracle {
             let tso = tso.clone();
             let ts = block_in_place(|| {
@@ -4607,12 +4700,14 @@ impl<RT: Runtime> Committer<RT> {
                 local_floor,
             );
             self.last_assigned_ts = ts;
+            timestamp_stage_timer.finish();
             return Ok(ts);
         }
 
         // Single-node mode: existing behavior (local clock + monotonic counter).
         let max = cmp::max(local_floor, self.runtime.generate_timestamp()?);
         self.last_assigned_ts = max;
+        timestamp_stage_timer.finish();
         Ok(max)
     }
 
@@ -5623,7 +5718,8 @@ mod tests {
         tx.send(RaftProposalResult::Committed { index: 7 }).unwrap();
 
         let applied_index =
-            Committer::<TestRuntime>::wait_for_raft_commit(Some(rx), Timestamp::must(1)).await?;
+            Committer::<TestRuntime>::wait_for_raft_commit(Some(rx), Timestamp::must(1), "test")
+                .await?;
         assert_eq!(applied_index, Some(7));
         Ok(())
     }
@@ -5633,16 +5729,18 @@ mod tests {
         let (tx, rx) = oneshot::channel();
         tx.send(RaftProposalResult::Rejected).unwrap();
 
-        let err = Committer::<TestRuntime>::wait_for_raft_commit(Some(rx), Timestamp::must(1))
-            .await
-            .unwrap_err();
+        let err =
+            Committer::<TestRuntime>::wait_for_raft_commit(Some(rx), Timestamp::must(1), "test")
+                .await
+                .unwrap_err();
         assert!(format!("{err:#}").contains("Raft rejected commit"));
     }
 
     #[tokio::test]
     async fn raft_commit_waiter_allows_non_raft_commit() -> anyhow::Result<()> {
         let applied_index =
-            Committer::<TestRuntime>::wait_for_raft_commit(None, Timestamp::must(1)).await?;
+            Committer::<TestRuntime>::wait_for_raft_commit(None, Timestamp::must(1), "test")
+                .await?;
         assert_eq!(applied_index, None);
         Ok(())
     }

--- a/crates/database/src/metrics.rs
+++ b/crates/database/src/metrics.rs
@@ -43,6 +43,12 @@ const PARTITION_LABELS: [&str; 1] = ["partition"];
 const SOURCE_PARTITION_LABELS: [&str; 1] = ["source_partition"];
 const OUTCOME_LABELS: [&str; 1] = ["outcome"];
 const PHASE_LABELS: [&str; 1] = ["phase"];
+const COMMIT_PATH_LABEL: &str = "path";
+const COMMIT_STAGE_LABEL: &str = "stage";
+const TSO_OPERATION_LABEL: &str = "operation";
+const COMMIT_HOT_PATH_STAGE_LABELS: [&str; 3] =
+    [COMMIT_PATH_LABEL, COMMIT_STAGE_LABEL, STATUS_LABEL[0]];
+const TSO_OPERATION_LABELS: [&str; 2] = [TSO_OPERATION_LABEL, STATUS_LABEL[0]];
 
 fn partition_label(partition: PartitionId) -> StaticMetricLabel {
     StaticMetricLabel::new("partition", partition.0.to_string())
@@ -58,6 +64,18 @@ fn outcome_label(outcome: &'static str) -> StaticMetricLabel {
 
 fn phase_label(phase: &'static str) -> StaticMetricLabel {
     StaticMetricLabel::new("phase", phase)
+}
+
+fn commit_path_label(path: &'static str) -> StaticMetricLabel {
+    StaticMetricLabel::new(COMMIT_PATH_LABEL, path)
+}
+
+fn commit_stage_label(stage: &'static str) -> StaticMetricLabel {
+    StaticMetricLabel::new(COMMIT_STAGE_LABEL, stage)
+}
+
+fn tso_operation_label(operation: &'static str) -> StaticMetricLabel {
+    StaticMetricLabel::new(TSO_OPERATION_LABEL, operation)
 }
 
 register_convex_gauge!(
@@ -792,6 +810,29 @@ pub fn commit_timer() -> StatusTimer {
 }
 
 register_convex_histogram!(
+    DATABASE_COMMIT_HOT_PATH_STAGE_SECONDS,
+    "Foreground latency paid by individual database commit hot-path stages",
+    &COMMIT_HOT_PATH_STAGE_LABELS
+);
+pub fn commit_hot_path_stage_timer(path: &'static str, stage: &'static str) -> StatusTimer {
+    let mut timer = StatusTimer::new(&DATABASE_COMMIT_HOT_PATH_STAGE_SECONDS);
+    timer.add_label(commit_path_label(path));
+    timer.add_label(commit_stage_label(stage));
+    timer
+}
+
+register_convex_histogram!(
+    DATABASE_TSO_OPERATION_SECONDS,
+    "Latency of timestamp-oracle operations on the commit hot path",
+    &TSO_OPERATION_LABELS
+);
+pub fn tso_operation_timer(operation: &'static str) -> StatusTimer {
+    let mut timer = StatusTimer::new(&DATABASE_TSO_OPERATION_SECONDS);
+    timer.add_label(tso_operation_label(operation));
+    timer
+}
+
+register_convex_histogram!(
     DATABASE_COMMIT_ID_REUSE_SECONDS,
     "Time to check if IDs have been reused",
     &STATUS_LABEL
@@ -965,7 +1006,10 @@ pub fn bump_repeatable_ts_timer() -> Timer<VMHistogram> {
     Timer::new(&BUMP_REPEATABLE_TS_SECONDS)
 }
 
-register_convex_histogram!(NEXT_COMMIT_TS_SECONDS, "Time to bump max_repeatable_ts");
+register_convex_histogram!(
+    NEXT_COMMIT_TS_SECONDS,
+    "Time to allocate the next commit timestamp"
+);
 pub fn next_commit_ts_seconds() -> Timer<VMHistogram> {
     Timer::new(&NEXT_COMMIT_TS_SECONDS)
 }

--- a/crates/database/src/timestamp_oracle.rs
+++ b/crates/database/src/timestamp_oracle.rs
@@ -7,8 +7,9 @@
 //! ## Design (inspired by Vitess sequence tables)
 //!
 //! A central counter is stored in NATS KV. Each node reserves a batch of
-//! timestamps (e.g., 1000 at a time). Within the batch, timestamps are
-//! assigned locally with zero network calls. When the batch is exhausted,
+//! timestamps (e.g., 1000 at a time). Within the batch, the local counter can
+//! advance without reserving a new range, while still checking the global
+//! committed-timestamp floor before assignment. When the batch is exhausted,
 //! the node reserves another batch from the central counter.
 //!
 //! This gives the performance of local timestamp assignment with the
@@ -28,6 +29,8 @@ use common::{
     types::Timestamp,
 };
 use parking_lot::Mutex;
+
+use crate::metrics;
 
 /// Trait for assigning globally unique, monotonically increasing timestamps.
 ///
@@ -114,8 +117,9 @@ impl<RT: Runtime> TimestampOracle for LocalTimestampOracle<RT> {
 /// Batch timestamp oracle for multi-node deployments.
 ///
 /// Reserves ranges of timestamps from a central NATS KV counter.
-/// Within a range, timestamps are assigned locally with zero network calls.
-/// When the range is exhausted, a new range is reserved.
+/// Within a range, timestamps can advance without reserving a new range.
+/// Each allocation still reads the global committed-timestamp floor so a node
+/// with an older reserved batch does not continue below the cluster watermark.
 ///
 /// Example with batch_size=1000:
 /// - Node A reserves [1000, 1999]
@@ -124,8 +128,7 @@ impl<RT: Runtime> TimestampOracle for LocalTimestampOracle<RT> {
 /// - Node B assigns 2000, 2001, 2002... locally
 /// - No overlap, no coordination within a batch
 pub struct BatchTimestampOracle {
-    nats_client: async_nats::Client,
-    kv_bucket: String,
+    kv: async_nats::jetstream::kv::Store,
     batch_size: u64,
     state: Mutex<BatchState>,
 }
@@ -193,14 +196,12 @@ impl BatchTimestampOracle {
             Err(_) => tracing::info!("TSO: Counter already exists"),
         }
 
-        let bucket = "convex_tso".to_string();
         let batch_size = batch_size.unwrap_or(DEFAULT_BATCH_SIZE);
 
         tracing::info!("TSO: Connected to NATS KV, batch_size={batch_size}");
 
         Ok(Self {
-            nats_client: client,
-            kv_bucket: bucket,
+            kv,
             batch_size,
             state: Mutex::new(BatchState {
                 current: 0,
@@ -214,15 +215,11 @@ impl BatchTimestampOracle {
     /// Uses NATS KV atomic update (CAS) to ensure no two nodes get
     /// overlapping ranges.
     async fn reserve_batch_at_or_above(&self, min_next: u64) -> anyhow::Result<(u64, u64)> {
-        let jetstream = async_nats::jetstream::new(self.nats_client.clone());
-        let kv = jetstream
-            .get_key_value(&self.kv_bucket)
-            .await
-            .context("TSO: Failed to get KV bucket")?;
-
+        let timer = metrics::tso_operation_timer("batch_reserve");
         // Retry loop for CAS conflicts.
         for attempt in 0..10 {
-            let entry = kv
+            let entry = self
+                .kv
                 .entry(TSO_COUNTER_KEY)
                 .await
                 .context("TSO: Failed to read counter")?
@@ -244,7 +241,8 @@ impl BatchTimestampOracle {
 
             // Atomic compare-and-swap: only succeeds if no other node
             // modified the counter since we read it.
-            match kv
+            match self
+                .kv
                 .update(TSO_COUNTER_KEY, new_value.into(), entry.revision)
                 .await
             {
@@ -252,6 +250,7 @@ impl BatchTimestampOracle {
                     tracing::info!(
                         "TSO: Reserved batch [{new_lower}, {new_upper}) on attempt {attempt}"
                     );
+                    timer.finish();
                     return Ok((new_lower, new_upper));
                 },
                 Err(_) => {
@@ -269,120 +268,138 @@ impl BatchTimestampOracle {
 #[async_trait]
 impl TimestampOracle for BatchTimestampOracle {
     async fn next_ts_at_or_after(&self, min_ts: Timestamp) -> anyhow::Result<Timestamp> {
-        let committed_floor = self.max_committed_ts().await?;
-        let min_next_ts = std::cmp::max(min_ts, committed_floor.succ()?);
-        let min_next = u64::from(min_next_ts);
+        let timer = metrics::tso_operation_timer("next_ts_at_or_after");
+        let result = async {
+            let committed_floor = self.max_committed_ts().await?;
+            let min_next_ts = std::cmp::max(min_ts, committed_floor.succ()?);
+            let min_next = u64::from(min_next_ts);
 
-        loop {
-            let candidate = {
+            loop {
+                let candidate = {
+                    let mut state = self.state.lock();
+                    if committed_floor > state.max_committed {
+                        state.max_committed = committed_floor;
+                    }
+
+                    if let Some((ts, next_current)) =
+                        next_ts_from_reserved_batch(state.current, state.upper_bound, min_next)
+                    {
+                        state.current = next_current;
+                        Some(ts)
+                    } else {
+                        None
+                    }
+                };
+
+                if let Some(ts) = candidate {
+                    return Timestamp::try_from(ts);
+                }
+
+                let (lower, upper) = self.reserve_batch_at_or_above(min_next).await?;
                 let mut state = self.state.lock();
-                if committed_floor > state.max_committed {
-                    state.max_committed = committed_floor;
-                }
-
-                if let Some((ts, next_current)) =
-                    next_ts_from_reserved_batch(state.current, state.upper_bound, min_next)
-                {
-                    state.current = next_current;
-                    Some(ts)
-                } else {
-                    None
-                }
-            };
-
-            if let Some(ts) = candidate {
-                return Timestamp::try_from(ts);
+                state.current = lower;
+                state.upper_bound = upper;
             }
-
-            let (lower, upper) = self.reserve_batch_at_or_above(min_next).await?;
-            let mut state = self.state.lock();
-            state.current = lower;
-            state.upper_bound = upper;
         }
+        .await;
+        if result.is_ok() {
+            timer.finish();
+        }
+        result
     }
 
     async fn max_committed_ts(&self) -> anyhow::Result<Timestamp> {
-        // Read from NATS KV for cross-node consistency.
-        let jetstream = async_nats::jetstream::new(self.nats_client.clone());
-        let kv = jetstream
-            .get_key_value(&self.kv_bucket)
-            .await
-            .context("TSO: Failed to get KV bucket")?;
-
-        match kv.entry(TSO_MAX_COMMITTED_KEY).await? {
-            Some(entry) => {
-                let ts = u64::from_be_bytes(
-                    entry
-                        .value
-                        .as_ref()
-                        .try_into()
-                        .context("TSO: Invalid max_committed value")?,
-                );
-                Timestamp::try_from(ts)
-            },
-            None => Ok(Timestamp::MIN),
-        }
-    }
-
-    async fn advance_committed_ts(&self, ts: Timestamp) -> anyhow::Result<()> {
-        let ts_u64 = u64::from(ts);
-
-        // Update local state.
-        {
-            let mut state = self.state.lock();
-            if ts > state.max_committed {
-                state.max_committed = ts;
-            }
-        }
-
-        let jetstream = async_nats::jetstream::new(self.nats_client.clone());
-        let kv = jetstream
-            .get_key_value(&self.kv_bucket)
-            .await
-            .context("TSO: Failed to get KV bucket")?;
-
-        let value = ts_u64.to_be_bytes().to_vec();
-        for attempt in 0..10 {
-            match kv.entry(TSO_MAX_COMMITTED_KEY).await? {
+        let timer = metrics::tso_operation_timer("max_committed_read");
+        let result = async {
+            match self.kv.entry(TSO_MAX_COMMITTED_KEY).await? {
                 Some(entry) => {
-                    let current = u64::from_be_bytes(
+                    let ts = u64::from_be_bytes(
                         entry
                             .value
                             .as_ref()
                             .try_into()
                             .context("TSO: Invalid max_committed value")?,
                     );
-                    if current >= ts_u64 {
-                        return Ok(());
-                    }
+                    Timestamp::try_from(ts)
+                },
+                None => Ok(Timestamp::MIN),
+            }
+        }
+        .await;
+        if result.is_ok() {
+            timer.finish();
+        }
+        result
+    }
 
-                    match kv
-                        .update(TSO_MAX_COMMITTED_KEY, value.clone().into(), entry.revision)
+    async fn advance_committed_ts(&self, ts: Timestamp) -> anyhow::Result<()> {
+        let timer = metrics::tso_operation_timer("advance_committed");
+        let result = async {
+            let ts_u64 = u64::from(ts);
+
+            // Update local state.
+            {
+                let mut state = self.state.lock();
+                if ts > state.max_committed {
+                    state.max_committed = ts;
+                }
+            }
+
+            let value = ts_u64.to_be_bytes().to_vec();
+            for attempt in 0..10 {
+                match self.kv.entry(TSO_MAX_COMMITTED_KEY).await? {
+                    Some(entry) => {
+                        let current = u64::from_be_bytes(
+                            entry
+                                .value
+                                .as_ref()
+                                .try_into()
+                                .context("TSO: Invalid max_committed value")?,
+                        );
+                        if current >= ts_u64 {
+                            return Ok(());
+                        }
+
+                        match self
+                            .kv
+                            .update(TSO_MAX_COMMITTED_KEY, value.clone().into(), entry.revision)
+                            .await
+                        {
+                            Ok(_) => return Ok(()),
+                            Err(_) => {
+                                tracing::debug!(
+                                    "TSO: max_committed CAS conflict on attempt {attempt}, \
+                                     retrying"
+                                );
+                                tokio::time::sleep(std::time::Duration::from_millis(1 << attempt))
+                                    .await;
+                            },
+                        }
+                    },
+                    None => match self
+                        .kv
+                        .create(TSO_MAX_COMMITTED_KEY, value.clone().into())
                         .await
                     {
                         Ok(_) => return Ok(()),
                         Err(_) => {
                             tracing::debug!(
-                                "TSO: max_committed CAS conflict on attempt {attempt}, retrying"
+                                "TSO: max_committed create conflict on attempt {attempt}, retrying"
                             );
                             tokio::time::sleep(std::time::Duration::from_millis(1 << attempt))
                                 .await;
                         },
-                    }
-                },
-                None => match kv.create(TSO_MAX_COMMITTED_KEY, value.clone().into()).await {
-                    Ok(_) => return Ok(()),
-                    Err(_) => {
-                        tracing::debug!(
-                            "TSO: max_committed create conflict on attempt {attempt}, retrying"
-                        );
-                        tokio::time::sleep(std::time::Duration::from_millis(1 << attempt)).await;
                     },
-                },
+                }
             }
-        }
 
-        anyhow::bail!("TSO: Failed to advance max_committed after 10 attempts")
+            anyhow::bail!("TSO: Failed to advance max_committed after 10 attempts")
+        }
+        .await;
+        if result.is_ok() {
+            timer.finish();
+        }
+        result
     }
 }
 

--- a/docs/cluster-observability.md
+++ b/docs/cluster-observability.md
@@ -119,6 +119,20 @@ Two important scrape behaviors to know up front:
   coordinated by that node.
 - `database_two_phase_prepare_retries_total`
   Counter of 2PC prepare timestamp retries.
+- `database_commit_hot_path_stage_seconds{path="local|2pc_participant|tso|raft_nats_outbox_replay",stage="...",status="success|error"}`
+  Histogram of foreground latency paid by individual commit hot-path stages.
+  Important stage values include `timestamp_allocate`, `raft_quorum_wait`,
+  `persistence_write`, `tso_advance_committed`, `apply_visible`,
+  `raft_mark_applied`, `raft_nats_outbox_record`,
+  `raft_nats_outbox_clear`, `replication_publish`, and `two_phase_redo`.
+  Use this metric to identify which synchronous stage is dominating write
+  latency before changing the commit path.
+- `database_tso_operation_seconds{operation="...",status="success|error"}`
+  Histogram of timestamp-oracle operation latency. Important operation values
+  include `next_ts_at_or_after`, `max_committed_read`, `batch_reserve`, and
+  `advance_committed`. This is the first place to look when timestamp
+  allocation is slower than expected or batch allocation is falling back to
+  NATS KV too often.
 - `database_replication_transport_publish_seconds`
   Histogram of JetStream publish latency for replication messages.
 - `database_replication_transport_message_bytes{phase="publish|consume"}`
@@ -181,6 +195,12 @@ Two important scrape behaviors to know up front:
   `database_two_phase_participants_total`, or
   `database_two_phase_prepare_attempts_total` drifts upward because that often
   precedes visible write latency regressions.
+- Commit hot-path latency:
+  investigate when `database_commit_hot_path_stage_seconds` shifts upward for
+  `raft_quorum_wait`, `persistence_write`, `replication_publish`,
+  `tso_advance_committed`, or `timestamp_allocate`. Use
+  `database_tso_operation_seconds` to break timestamp allocation into TSO
+  sub-operations.
 
 ## Runbooks
 
@@ -258,14 +278,38 @@ Two important scrape behaviors to know up front:
 2. If `prepare` retries are climbing, inspect
    `database_two_phase_prepare_retries_total`; this usually means timestamp
    allocation pressure or stale participant state.
-3. Compare `database_two_phase_coordinator_seconds`,
+3. If 2PC commits are slow but not failing, inspect
+   `database_commit_hot_path_stage_seconds{path="2pc_participant"}` to split
+   the participant-side cost between `two_phase_redo`, `raft_quorum_wait`,
+   `persistence_write`, `apply_visible`, and `replication_publish`.
+4. Compare `database_two_phase_coordinator_seconds`,
    `database_two_phase_participants_total`, and
    `database_two_phase_prepare_attempts_total` to see whether the failures are
    tied to wider fanout or repeated prepare retries.
-4. If `commit` errors are climbing, inspect the participant logs and confirm
+5. If `commit` errors are climbing, inspect the participant logs and confirm
    which partition owner is failing.
-5. Treat repeated 2PC rollbacks as a correctness-risk signal even if retries
+6. Treat repeated 2PC rollbacks as a correctness-risk signal even if retries
    hide the issue from clients.
+
+### Commit Hot Path Latency
+
+1. Start with `database_commit_seconds{status="success"}` to confirm the
+   user-visible commit latency shift.
+2. Break that latency down with `database_commit_hot_path_stage_seconds`.
+   For normal single-partition writes, focus on `path="local"`. For
+   cross-partition participant cost, focus on `path="2pc_participant"`.
+3. If `stage="timestamp_allocate"` is high, inspect
+   `database_tso_operation_seconds`. A high `max_committed_read` points at the
+   per-allocation committed-floor read. A high `batch_reserve` points at TSO KV
+   range reservation or CAS contention.
+4. If `stage="raft_quorum_wait"` is high, correlate with
+   `database_raft_lagging_followers_info`,
+   `database_raft_max_follower_lag_entries_info`, and node/network logs.
+5. If `stage="replication_publish"` is high, compare against
+   `database_replication_transport_publish_seconds` and JetStream/NATS health.
+6. If `stage="persistence_write"` or `stage="apply_visible"` is high, inspect
+   persistence latency, snapshot size, and write-log/index update work before
+   making protocol changes.
 
 ## Scope Notes
 


### PR DESCRIPTION
## Summary
- add per-stage commit hot-path latency metrics for local commits, 2PC participants, Raft quorum wait, persistence, visibility, replication publish, and Raft->NATS outbox work
- add TSO operation latency metrics for timestamp allocation, committed-floor reads, batch reservation, and committed watermark advancement
- cache the BatchTimestampOracle NATS KV store handle so each TSO operation no longer refetches the bucket before touching keys
- document the new metrics and runbook flow for diagnosing commit latency regressions

## Validation
- `cargo test -p database timestamp_oracle -- --nocapture`
- `cargo test -p database raft_commit_waiter -- --nocapture`
- `cargo check -p database`
- `git diff --check`

Refs #165