### PR TITLE
fix(database): harden 2pc commit hot-path timestamp ordering

### DIFF
--- a/crates/database/src/committer.rs
+++ b/crates/database/src/committer.rs
@@ -2063,7 +2063,7 @@ impl<RT: Runtime> Committer<RT> {
         let local_commit_floor = if allow_explicit_ts_rewrite {
             self.replayed_prepare_commit_floor()?
         } else {
-            cmp::max(self.log.max_ts(), *self.snapshot_manager.read().latest_ts()).succ()?
+            self.explicit_prepare_commit_floor()?
         };
 
         if let Some(existing) = self.prepared_transactions.get(&transaction_id) {
@@ -5001,6 +5001,15 @@ impl<RT: Runtime> Committer<RT> {
         Ok(cmp::max(
             log_floor,
             cmp::max(latest_ts.succ()?, self.last_assigned_ts.succ()?),
+        ))
+    }
+
+    fn explicit_prepare_commit_floor(&self) -> anyhow::Result<Timestamp> {
+        let log_floor = self.log.max_ts().succ()?;
+        let latest_ts = self.snapshot_manager.read().latest_ts();
+        Ok(cmp::max(
+            log_floor,
+            cmp::max(latest_ts.succ()?, self.last_assigned_ts),
         ))
     }
 

--- a/crates/database/src/committer.rs
+++ b/crates/database/src/committer.rs
@@ -4979,7 +4979,16 @@ impl<RT: Runtime> Committer<RT> {
     fn replayed_prepare_commit_floor(&self) -> anyhow::Result<Timestamp> {
         let log_floor = self.log.max_ts().succ()?;
         let latest_ts = self.snapshot_manager.read().latest_ts();
-        Ok(cmp::max(log_floor, latest_ts.succ()?))
+        let prepared_floor = self
+            .prepared_writes
+            .max_ts()
+            .map(|ts| ts.succ())
+            .transpose()?
+            .unwrap_or(Timestamp::MIN);
+        Ok(cmp::max(
+            prepared_floor,
+            cmp::max(log_floor, latest_ts.succ()?),
+        ))
     }
 
     fn next_max_repeatable_ts(&mut self) -> anyhow::Result<Timestamp> {

--- a/crates/database/src/committer.rs
+++ b/crates/database/src/committer.rs
@@ -349,6 +349,22 @@ fn stale_replica_frontiers(
         .collect()
 }
 
+fn merge_partition_timestamp_max(
+    current: &BTreeMap<crate::partition::PartitionId, Timestamp>,
+    proposed: BTreeMap<crate::partition::PartitionId, Timestamp>,
+) -> BTreeMap<crate::partition::PartitionId, Timestamp> {
+    let mut merged = current.clone();
+    for (partition, ts) in proposed {
+        if merged
+            .get(&partition)
+            .is_none_or(|current_ts| *current_ts < ts)
+        {
+            merged.insert(partition, ts);
+        }
+    }
+    merged
+}
+
 fn compact_checkpoint_documents(checkpoint: &CheckpointData) -> Vec<DocumentLogEntry> {
     let mut latest_documents = BTreeMap::new();
     for entry in &checkpoint.documents {
@@ -1247,6 +1263,10 @@ impl<RT: Runtime> Committer<RT> {
                                 self.log.append(commit_ts, writes, write_source);
                             }
                             if let Some(frontiers) = applied_delta_watermarks {
+                                let frontiers = merge_partition_timestamp_max(
+                                    &self.applied_delta_watermarks,
+                                    frontiers,
+                                );
                                 self.persistence
                                     .write_persistence_global(
                                         PersistenceGlobalKey::AppliedDeltaWatermarks,
@@ -1256,6 +1276,10 @@ impl<RT: Runtime> Committer<RT> {
                                 self.applied_delta_watermarks = frontiers;
                             }
                             if let Some(frontiers) = applied_data_delta_watermarks {
+                                let frontiers = merge_partition_timestamp_max(
+                                    &self.applied_data_delta_watermarks,
+                                    frontiers,
+                                );
                                 self.persistence
                                     .write_persistence_global(
                                         PersistenceGlobalKey::AppliedDataDeltaWatermarks,
@@ -1321,6 +1345,10 @@ impl<RT: Runtime> Committer<RT> {
                             result,
                             ..
                         } => {
+                            let applied_delta_watermarks = merge_partition_timestamp_max(
+                                &self.applied_delta_watermarks,
+                                applied_delta_watermarks,
+                            );
                             self.persistence
                                 .write_persistence_global(
                                     PersistenceGlobalKey::AppliedDeltaWatermarks,

--- a/crates/database/src/committer.rs
+++ b/crates/database/src/committer.rs
@@ -5007,9 +5007,14 @@ impl<RT: Runtime> Committer<RT> {
     fn explicit_prepare_commit_floor(&self) -> anyhow::Result<Timestamp> {
         let log_floor = self.log.max_ts().succ()?;
         let latest_ts = self.snapshot_manager.read().latest_ts();
+        let queued_floor = self
+            .latest_queued_snapshot()
+            .map(|(ts, _)| ts.succ())
+            .transpose()?
+            .unwrap_or(Timestamp::MIN);
         Ok(cmp::max(
             log_floor,
-            cmp::max(latest_ts.succ()?, self.last_assigned_ts),
+            cmp::max(latest_ts.succ()?, queued_floor),
         ))
     }
 

--- a/crates/database/src/tests/write_scaling_tests.rs
+++ b/crates/database/src/tests/write_scaling_tests.rs
@@ -3198,7 +3198,7 @@ async fn test_raft_prepared_redo_rewrite_allocates_unique_local_prepare_timestam
 }
 
 #[convex_macro::test_runtime]
-async fn test_live_prepare_rejects_timestamp_below_last_assigned(
+async fn test_live_prepare_rejects_timestamp_below_local_write_floor(
     rt: TestRuntime,
 ) -> anyhow::Result<()> {
     let log = Arc::new(InMemoryDistributedLog::new());
@@ -3267,19 +3267,12 @@ async fn test_live_prepare_rejects_timestamp_below_last_assigned(
     let txn_id = TwoPhaseTransactionId::new();
     let prepare_ts = source.committer_for_test().allocate_commit_ts().await?;
 
-    participant
-        .committer_for_test()
-        .apply_replica_delta(CommitDelta {
-            ts: prepare_ts.succ()?,
-            document_writes: Arc::new(Vec::new()),
-            document_updates: Vec::new(),
-            index_writes: Arc::new(Vec::new()),
-            write_source: WriteSource::new("live_prepare_floor_heartbeat_test"),
-            write_bytes: 0,
-            tablet_id_to_table_name: Default::default(),
-            source_partition: Some(PartitionId(0)),
-        })
-        .await?;
+    insert_doc(
+        &participant,
+        "projects",
+        assert_obj!("name" => "live-prepare-local-floor-advancer"),
+    )
+    .await?;
 
     let err = participant
         .committer_for_test()
@@ -3291,11 +3284,83 @@ async fn test_live_prepare_rejects_timestamp_below_last_assigned(
             vec![PartitionId(1)],
         )
         .await
-        .expect_err("live prepare should reject a timestamp below the local assigned floor");
+        .expect_err("live prepare should reject a timestamp below the local write floor");
     assert!(
         format!("{err:#}").contains("2PC Prepare assigned ts="),
         "unexpected error: {err:#}",
     );
+
+    Ok(())
+}
+
+#[convex_macro::test_runtime]
+async fn test_live_prepare_allows_timestamp_below_uncommitted_reservation(
+    rt: TestRuntime,
+) -> anyhow::Result<()> {
+    let log = Arc::new(InMemoryDistributedLog::new());
+    let table_number_allocator = Arc::new(InMemoryTableNumberAllocator::default());
+    let node = create_node_with_persistence_and_table_number_allocator(
+        &rt,
+        Arc::new(TestPersistence::new()),
+        log.clone(),
+        Some(partitioned_map(PartitionId(1))),
+        None,
+        Arc::new(NoopTwoPhaseDecisionLog),
+        None,
+        table_number_allocator,
+    )
+    .await?;
+
+    insert_doc(
+        &node,
+        "projects",
+        assert_obj!("name" => "seed-before-concurrent-prepare-floor"),
+    )
+    .await?;
+
+    let mut tx = node.begin(Identity::system()).await?;
+    TestFacingModel::new(&mut tx)
+        .insert(
+            &"projects".parse()?,
+            assert_obj!("name" => "live-prepare-below-reserved-timestamp"),
+        )
+        .await?;
+    let final_tx = tx.finalize()?;
+    let write_indexes: Vec<_> = final_tx
+        .writes
+        .coalesced_writes()
+        .enumerate()
+        .map(|(index, _)| index)
+        .collect();
+    let write_source = WriteSource::new("live_prepare_below_reserved_timestamp_test");
+    let participant_tx = ParticipantTransaction::from_final_transaction(
+        &final_tx,
+        PartitionId(1),
+        &write_indexes,
+        &partitioned_map(PartitionId(1)),
+        &write_source,
+    )?;
+    let txn_id = TwoPhaseTransactionId::new();
+    let prepare_ts = node.committer_for_test().allocate_commit_ts().await?;
+    let later_reserved_ts = node.committer_for_test().allocate_commit_ts().await?;
+    assert!(
+        later_reserved_ts > prepare_ts,
+        "test setup expected a later reserved timestamp",
+    );
+
+    let result = node
+        .committer_for_test()
+        .prepare_remote(
+            txn_id.clone(),
+            participant_tx,
+            write_source,
+            prepare_ts,
+            vec![PartitionId(1)],
+        )
+        .await?;
+    assert_eq!(result.prepare_ts, prepare_ts);
+
+    node.committer_for_test().rollback_prepared(txn_id).await?;
 
     Ok(())
 }

--- a/crates/database/src/tests/write_scaling_tests.rs
+++ b/crates/database/src/tests/write_scaling_tests.rs
@@ -3065,6 +3065,139 @@ async fn test_raft_prepared_redo_rewrites_when_follower_floor_advanced_by_replic
 }
 
 #[convex_macro::test_runtime]
+async fn test_raft_prepared_redo_rewrite_allocates_unique_local_prepare_timestamps(
+    rt: TestRuntime,
+) -> anyhow::Result<()> {
+    let log = Arc::new(InMemoryDistributedLog::new());
+    let table_number_allocator = Arc::new(InMemoryTableNumberAllocator::default());
+    let source = create_node_with_persistence_and_table_number_allocator(
+        &rt,
+        Arc::new(TestPersistence::new()),
+        log.clone(),
+        Some(partitioned_map(PartitionId(1))),
+        None,
+        Arc::new(NoopTwoPhaseDecisionLog),
+        None,
+        table_number_allocator.clone(),
+    )
+    .await?;
+    let follower = create_node_with_persistence_and_table_number_allocator(
+        &rt,
+        Arc::new(TestPersistence::new()),
+        log.clone(),
+        Some(partitioned_map(PartitionId(1))),
+        None,
+        Arc::new(NoopTwoPhaseDecisionLog),
+        None,
+        table_number_allocator.clone(),
+    )
+    .await?;
+    let foreign = create_node_with_persistence_and_table_number_allocator(
+        &rt,
+        Arc::new(TestPersistence::new()),
+        log.clone(),
+        Some(partitioned_map(PartitionId(0))),
+        None,
+        Arc::new(NoopTwoPhaseDecisionLog),
+        None,
+        table_number_allocator,
+    )
+    .await?;
+
+    insert_doc(
+        &source,
+        "projects",
+        assert_obj!("name" => "seed-before-concurrent-replay"),
+    )
+    .await?;
+    let seed_delta = log
+        .deltas()
+        .into_iter()
+        .last()
+        .context("seed insert should publish a delta")?;
+    follower
+        .committer_for_test()
+        .apply_replica_delta(seed_delta)
+        .await?;
+
+    let mut redos = Vec::new();
+    for i in 0..2 {
+        let mut tx = source.begin(Identity::system()).await?;
+        TestFacingModel::new(&mut tx)
+            .insert(
+                &"projects".parse()?,
+                assert_obj!("name" => format!("concurrent-raft-prepare-replay-{i}")),
+            )
+            .await?;
+        let final_tx = tx.finalize()?;
+        let write_indexes: Vec<_> = final_tx
+            .writes
+            .coalesced_writes()
+            .enumerate()
+            .map(|(index, _)| index)
+            .collect();
+        let write_source = WriteSource::new(format!("raft_prepare_unique_rewrite_test_{i}"));
+        let participant_tx = ParticipantTransaction::from_final_transaction(
+            &final_tx,
+            PartitionId(1),
+            &write_indexes,
+            &partitioned_map(PartitionId(1)),
+            &write_source,
+        )?;
+        let txn_id = TwoPhaseTransactionId::new();
+        let prepare_ts = source.committer_for_test().allocate_commit_ts().await?;
+        let redo = TwoPhaseRedoEntry::new(
+            &txn_id,
+            prepare_ts,
+            PartitionId(1),
+            participant_tx,
+            &write_source,
+        )?;
+        redos.push((txn_id, prepare_ts, redo));
+    }
+    let max_prepare_ts = redos
+        .iter()
+        .map(|(_, prepare_ts, _)| *prepare_ts)
+        .max()
+        .context("expected prepared redo entries")?;
+
+    insert_doc(
+        &foreign,
+        "messages",
+        assert_obj!("text" => "advance-follower-floor-before-concurrent-prepare-replay"),
+    )
+    .await?;
+    let mut foreign_delta = log
+        .deltas()
+        .into_iter()
+        .last()
+        .context("foreign insert should publish a delta")?;
+    if foreign_delta.ts <= max_prepare_ts {
+        foreign_delta.ts = max_prepare_ts.succ()?;
+    }
+    follower
+        .committer_for_test()
+        .apply_replica_delta(foreign_delta)
+        .await?;
+
+    for (_, prepare_ts, redo) in redos.iter().cloned() {
+        let prepare_result = follower
+            .committer_for_test()
+            .apply_raft_prepared_redo(redo)
+            .await?;
+        assert_eq!(prepare_result.prepare_ts, prepare_ts);
+    }
+
+    for (txn_id, ..) in redos {
+        follower
+            .committer_for_test()
+            .rollback_prepared(txn_id)
+            .await?;
+    }
+    Ok(())
+}
+
+#[convex_macro::test_runtime]
 async fn test_raft_prepared_redo_rewrites_when_pre_replay_heartbeat_advances_retention_floor(
     rt: TestRuntime,
 ) -> anyhow::Result<()> {

--- a/crates/database/src/tests/write_scaling_tests.rs
+++ b/crates/database/src/tests/write_scaling_tests.rs
@@ -3198,6 +3198,109 @@ async fn test_raft_prepared_redo_rewrite_allocates_unique_local_prepare_timestam
 }
 
 #[convex_macro::test_runtime]
+async fn test_live_prepare_rejects_timestamp_below_last_assigned(
+    rt: TestRuntime,
+) -> anyhow::Result<()> {
+    let log = Arc::new(InMemoryDistributedLog::new());
+    let table_number_allocator = Arc::new(InMemoryTableNumberAllocator::default());
+    let source = create_node_with_persistence_and_table_number_allocator(
+        &rt,
+        Arc::new(TestPersistence::new()),
+        log.clone(),
+        Some(partitioned_map(PartitionId(1))),
+        None,
+        Arc::new(NoopTwoPhaseDecisionLog),
+        None,
+        table_number_allocator.clone(),
+    )
+    .await?;
+    let participant = create_node_with_persistence_and_table_number_allocator(
+        &rt,
+        Arc::new(TestPersistence::new()),
+        log.clone(),
+        Some(partitioned_map(PartitionId(1))),
+        None,
+        Arc::new(NoopTwoPhaseDecisionLog),
+        None,
+        table_number_allocator,
+    )
+    .await?;
+
+    insert_doc(
+        &source,
+        "projects",
+        assert_obj!("name" => "seed-before-live-prepare-floor"),
+    )
+    .await?;
+    let seed_delta = log
+        .deltas()
+        .into_iter()
+        .last()
+        .context("seed insert should publish a delta")?;
+    participant
+        .committer_for_test()
+        .apply_replica_delta(seed_delta)
+        .await?;
+
+    let mut tx = source.begin(Identity::system()).await?;
+    TestFacingModel::new(&mut tx)
+        .insert(
+            &"projects".parse()?,
+            assert_obj!("name" => "live-prepare-below-last-assigned"),
+        )
+        .await?;
+    let final_tx = tx.finalize()?;
+    let write_indexes: Vec<_> = final_tx
+        .writes
+        .coalesced_writes()
+        .enumerate()
+        .map(|(index, _)| index)
+        .collect();
+    let write_source = WriteSource::new("live_prepare_below_last_assigned_test");
+    let participant_tx = ParticipantTransaction::from_final_transaction(
+        &final_tx,
+        PartitionId(1),
+        &write_indexes,
+        &partitioned_map(PartitionId(1)),
+        &write_source,
+    )?;
+    let txn_id = TwoPhaseTransactionId::new();
+    let prepare_ts = source.committer_for_test().allocate_commit_ts().await?;
+
+    participant
+        .committer_for_test()
+        .apply_replica_delta(CommitDelta {
+            ts: prepare_ts.succ()?,
+            document_writes: Arc::new(Vec::new()),
+            document_updates: Vec::new(),
+            index_writes: Arc::new(Vec::new()),
+            write_source: WriteSource::new("live_prepare_floor_heartbeat_test"),
+            write_bytes: 0,
+            tablet_id_to_table_name: Default::default(),
+            source_partition: Some(PartitionId(0)),
+        })
+        .await?;
+
+    let err = participant
+        .committer_for_test()
+        .prepare_remote(
+            txn_id,
+            participant_tx,
+            write_source,
+            prepare_ts,
+            vec![PartitionId(1)],
+        )
+        .await
+        .expect_err("live prepare should reject a timestamp below the local assigned floor");
+    assert!(
+        format!("{err:#}").contains("2PC Prepare assigned ts="),
+        "unexpected error: {err:#}",
+    );
+
+    Ok(())
+}
+
+#[convex_macro::test_runtime]
 async fn test_raft_prepared_redo_rewrites_when_pre_replay_heartbeat_advances_retention_floor(
     rt: TestRuntime,
 ) -> anyhow::Result<()> {

--- a/crates/database/src/write_log.rs
+++ b/crates/database/src/write_log.rs
@@ -849,6 +849,10 @@ impl PreparedWrites {
         self.by_ts.keys().next().copied()
     }
 
+    pub fn max_ts(&self) -> Option<Timestamp> {
+        self.by_ts.keys().next_back().copied()
+    }
+
     pub fn len(&self) -> usize {
         self.by_ts.len()
     }


### PR DESCRIPTION
## Summary

Closes #165.

This PR fixes the correctness blockers exposed while proving the commit hot path under concurrent 2PC load. The benchmark originally surfaced timestamp-ordering failures and replication watermark races before we could make a meaningful performance claim.

Changes included here:

- Preserve prepare ordering during Raft redo/recovery by avoiding timestamp collisions on replayed 2PC prepares.
- Merge queued replication watermarks monotonically so queued snapshots cannot rewind applied-frontier state.
- Reject stale live 2PC prepares only when a real local write/snapshot floor has advanced beyond the prepare timestamp.
- Allow concurrent 2PC timestamp reservations by not treating bare timestamp reservations as committed/queued writes.
- Add targeted Rust tests for replayed prepares, stale live prepares, concurrent timestamp reservations, and replica delta ordering.

## Why

The hot-path benchmark was failing before it could measure throughput reliably. Under concurrent 2PC, one coordinator could reserve a timestamp, another reservation could advance `last_assigned_ts`, and the first live prepare would then be rejected even though no conflicting committed/queued write existed. That made valid concurrent 2PC traffic fail with `2PC Prepare assigned ts=... but this participant requires ts>=...`.

The fix separates two concepts that had been conflated:

- committed or queued visibility floors, which must reject stale live prepares;
- uncommitted timestamp reservations, which must not invalidate earlier in-flight prepares.

## Validation

Rust/local validation:

- `cargo fmt -p database`
- `cargo test -p database test_live_prepare_ -- --nocapture` — 2 passed
- `cargo test -p database test_raft_prepared_redo -- --nocapture` — 6 passed
- `cargo test -p database test_replica_delta -- --nocapture` — 5 passed
- `cargo check -p database`

Image proof:

- Built official image with `self-hosted/docker-build/build_backend_image.sh ghcr.io/martinkalema/convex-horizontal-scaling:backend-latest`
- Image digest: `sha256:9e3558b883632db00342876e83a35e2c52a9fe8ca4c3dd7de7de14b08bf4a152`
- OCI revision label: `4d64d3583778ba9916505039abd27ae2f1f75051`
- `git rev-parse HEAD`: `4d64d3583778ba9916505039abd27ae2f1f75051`
- Cluster started with `BACKEND_PULL_POLICY=never`
- All six backend containers verified healthy and running image ID `sha256:9e3558b883632db00342876e83a35e2c52a9fe8ca4c3dd7de7de14b08bf4a152`

Cluster validation:

- `bash self-hosted/docker/benchmark-commit-hot-path.sh`
  - `local_p0`: 100 ops, 0 errors, 157.7 ops/sec
  - `local_p1`: 100 ops, 0 errors, 163.0 ops/sec
  - `two_pc`: 100 ops, 0 errors, 64.2 ops/sec
  - Verification: `messages=220/220`, `tasks=220/220`
- `bash self-hosted/docker/test.sh`
  - Write scaling suite: `ALL 107 TESTS PASSED`
  - Raft failover suite: `ALL 24 TESTS PASSED`
  - Overall: `ALL SUITES PASSED`

## Notes

This PR makes the benchmark reliable and removes the correctness failures it exposed. It does not yet remove the deeper stop-and-wait performance structure in the commit path; that remains the next optimization phase after the hot-path proof is stable.