### PR TITLE
test(database): cover staged 2pc recovery edge cases

### DIFF
--- a/crates/database/src/tests/write_scaling_tests.rs
+++ b/crates/database/src/tests/write_scaling_tests.rs
@@ -5042,6 +5042,171 @@ async fn test_watcher_recovers_complete_staging_decision_and_commits_prepared_wr
     Ok(())
 }
 
+#[convex_macro::test_runtime]
+async fn test_watcher_leaves_partial_staging_hidden_until_all_participants_stage(
+    rt: TestRuntime,
+) -> anyhow::Result<()> {
+    let log = Arc::new(InMemoryDistributedLog::new());
+    let decision_log = Arc::new(InMemoryTwoPhaseDecisionLog::new());
+    let node = create_node_with_options_and_decision_log(
+        &rt,
+        log,
+        Some(partitioned_map(PartitionId(1))),
+        None,
+        None,
+        decision_log.clone(),
+    )
+    .await?;
+
+    let mut tx = node.begin(Identity::system()).await?;
+    TestFacingModel::new(&mut tx)
+        .insert(
+            &"projects".parse()?,
+            assert_obj!("name" => "partial-staging-hidden"),
+        )
+        .await?;
+    let final_tx = tx.finalize()?;
+    let write_indexes: Vec<_> = final_tx
+        .writes
+        .coalesced_writes()
+        .enumerate()
+        .map(|(index, _)| index)
+        .collect();
+    let write_source = WriteSource::new("partial_staging_recovery_test");
+    let participant_tx = ParticipantTransaction::from_final_transaction(
+        &final_tx,
+        PartitionId(1),
+        &write_indexes,
+        &partitioned_map(PartitionId(1)),
+        &write_source,
+    )?;
+    let txn_id = TwoPhaseTransactionId::new();
+    let prepare_ts = node.committer_for_test().allocate_commit_ts().await?;
+    node.committer_for_test()
+        .prepare_remote(
+            txn_id.clone(),
+            participant_tx,
+            write_source,
+            prepare_ts,
+            vec![PartitionId(0), PartitionId(1)],
+        )
+        .await?;
+
+    let redo_records = node.committer_for_test().two_phase_redo_records().await?;
+    let redo_entry = redo_records
+        .values()
+        .next()
+        .context("prepare should persist a redo entry")?;
+    let staging = TwoPhaseDecision::staging(
+        u64::from(prepare_ts),
+        vec![0, 1],
+        vec![TwoPhaseParticipantIntent::from_redo_entry(redo_entry)],
+    );
+    assert!(
+        !staging.all_participants_staged(),
+        "test setup should represent an incomplete parallel-commit staging record",
+    );
+    decision_log.write_decision(&txn_id, &staging).await?;
+
+    let resolved = crate::two_phase_watcher::resolve_decision_for_local_partition(
+        &node.committer_for_test(),
+        PartitionId(1),
+        txn_id.clone(),
+        staging.clone(),
+    )
+    .await?;
+    assert!(
+        !resolved,
+        "watcher must not resolve or expose a transaction before all participants stage",
+    );
+
+    let projects_before_recovery = run_query(
+        node.clone(),
+        TableNamespace::root_component(),
+        Query::full_table_scan("projects".parse()?, Order::Asc),
+    )
+    .await?;
+    assert!(
+        !projects_before_recovery.iter().any(|project| {
+            project.value().0.get("name") == Some(&assert_val!("partial-staging-hidden"))
+        }),
+        "partial staged writes must stay hidden while the staging decision is pending",
+    );
+    assert!(
+        !decision_log
+            .get_decision(&txn_id)
+            .await?
+            .context("pending staging decision should remain durable")?
+            .all_participants_staged(),
+        "missing participant proof should keep the decision in staging",
+    );
+    assert_eq!(
+        node.committer_for_test()
+            .two_phase_redo_records()
+            .await?
+            .len(),
+        1,
+        "pending staging should keep the local prepared redo for later recovery",
+    );
+
+    decision_log
+        .mark_participant_staged(
+            &txn_id,
+            TwoPhaseParticipantIntent {
+                partition_id: 0,
+                prepare_ts: u64::from(prepare_ts),
+                participant_transaction_digest: "remote-participant-digest".to_string(),
+            },
+        )
+        .await?;
+
+    let resolved = crate::two_phase_watcher::resolve_decision_for_local_partition(
+        &node.committer_for_test(),
+        PartitionId(1),
+        txn_id.clone(),
+        staging,
+    )
+    .await?;
+    assert!(
+        resolved,
+        "watcher may recover the local participant once every participant proof exists",
+    );
+
+    let projects_after_recovery = run_query(
+        node.clone(),
+        TableNamespace::root_component(),
+        Query::full_table_scan("projects".parse()?, Order::Asc),
+    )
+    .await?;
+    assert!(
+        projects_after_recovery.iter().any(|project| {
+            project.value().0.get("name") == Some(&assert_val!("partial-staging-hidden"))
+        }),
+        "complete staged decision should make the recovered local write visible",
+    );
+    assert!(
+        node.committer_for_test()
+            .two_phase_redo_records()
+            .await?
+            .is_empty(),
+        "local recovery should clean up the participant redo after commit",
+    );
+    let Some(TwoPhaseDecision::Committed {
+        resolved_participants,
+        ..
+    }) = decision_log.get_decision(&txn_id).await?
+    else {
+        anyhow::bail!("complete staging recovery should promote the decision to committed");
+    };
+    assert_eq!(
+        resolved_participants,
+        vec![1],
+        "local watcher should mark only this participant resolved and leave the decision for \
+         other participants",
+    );
+    Ok(())
+}
+
 #[test]
 fn test_rollback_decision_survives_failed_rollback_rpc_for_watcher() -> anyhow::Result<()> {
     let td = TestDriver::new_with_io();

--- a/crates/database/src/tests/write_scaling_tests.rs
+++ b/crates/database/src/tests/write_scaling_tests.rs
@@ -2176,6 +2176,49 @@ async fn test_raft_apply_records_nats_outbox_when_publish_unavailable(
 }
 
 #[convex_macro::test_runtime]
+async fn test_partitioned_commit_records_nats_outbox_when_publish_unavailable(
+    rt: TestRuntime,
+) -> anyhow::Result<()> {
+    let replay_log = Arc::new(SwitchableDistributedLog::failing());
+    let persistence = Arc::new(TestPersistence::new());
+    let db = create_node_with_custom_distributed_log(
+        &rt,
+        persistence.clone(),
+        replay_log.clone(),
+        Some(partitioned_map(PartitionId(0))),
+        Arc::new(InMemoryTableNumberAllocator::default()),
+    )
+    .await?;
+
+    let commit_ts = insert_doc(
+        &db,
+        "messages",
+        assert_obj!("body" => "accepted while nats is unavailable"),
+    )
+    .await?;
+
+    let outbox = persistence
+        .reader()
+        .get_persistence_global(PersistenceGlobalKey::RaftNatsOutbox)
+        .await?
+        .context("partitioned local commit should record a Raft->NATS outbox entry")?;
+    let records: std::collections::BTreeMap<String, serde_json::Value> =
+        serde_json::from_value(outbox)?;
+    assert_eq!(
+        records.len(),
+        1,
+        "failed NATS publish should leave the accepted local commit in the outbox",
+    );
+    assert!(records.contains_key(&u64::from(commit_ts).to_string()));
+    assert!(
+        replay_log.published().is_empty(),
+        "the failing log must not observe a successful publish",
+    );
+
+    Ok(())
+}
+
+#[convex_macro::test_runtime]
 async fn test_frontier_heartbeat_does_not_dedupe_later_data_delta(
     rt: TestRuntime,
 ) -> anyhow::Result<()> {

--- a/crates/database/src/tests/write_scaling_tests.rs
+++ b/crates/database/src/tests/write_scaling_tests.rs
@@ -62,7 +62,10 @@ use common::{
         Timestamp,
     },
 };
-use futures::TryStreamExt;
+use futures::{
+    stream::BoxStream,
+    TryStreamExt,
+};
 use keybroker::Identity;
 use parking_lot::Mutex;
 use pb::replication::{
@@ -104,6 +107,8 @@ use crate::{
     commit_delta::{
         testing::InMemoryDistributedLog,
         CommitDelta,
+        DistributedLog,
+        ReplicationMessage,
     },
     committer::{
         CommitterClient,
@@ -270,6 +275,78 @@ async fn create_node_with_persistence_and_table_number_allocator(
     let handle = db.start_search_and_vector_bootstrap();
     handle.join().await?;
     Ok(db)
+}
+
+async fn create_node_with_custom_distributed_log(
+    rt: &TestRuntime,
+    tp: Arc<TestPersistence>,
+    distributed_log: Arc<dyn DistributedLog>,
+    partition_map: Option<PartitionMap>,
+    table_number_allocator: Arc<dyn TableNumberAllocator>,
+) -> anyhow::Result<Database<TestRuntime>> {
+    let searcher: Arc<dyn search::Searcher> = Arc::new(SearcherStub {});
+    let (deleted_tablet_sender, _) = tokio::sync::mpsc::channel(100);
+    let db = Database::load(
+        tp,
+        rt.clone(),
+        searcher,
+        ShutdownSignal::panic(),
+        Default::default(),
+        None,
+        Arc::new(new_unlimited_rate_limiter(rt.clone())),
+        deleted_tablet_sender,
+        distributed_log,
+        false,
+        partition_map,
+        None,
+        Arc::new(NoopTwoPhaseDecisionLog),
+        None,
+        None,
+        table_number_allocator,
+        None,
+    )
+    .await?;
+    db.set_search_storage(Arc::new(LocalDirStorage::new(rt.clone())?));
+    let handle = db.start_search_and_vector_bootstrap();
+    handle.join().await?;
+    Ok(db)
+}
+
+#[derive(Default)]
+struct SwitchableDistributedLog {
+    fail_publishes: AtomicBool,
+    published: Mutex<Vec<Timestamp>>,
+}
+
+impl SwitchableDistributedLog {
+    fn failing() -> Self {
+        Self {
+            fail_publishes: AtomicBool::new(true),
+            published: Mutex::new(Vec::new()),
+        }
+    }
+
+    fn published(&self) -> Vec<Timestamp> {
+        self.published.lock().clone()
+    }
+}
+
+#[async_trait]
+impl DistributedLog for SwitchableDistributedLog {
+    async fn publish(&self, delta: CommitDelta) -> anyhow::Result<()> {
+        if self.fail_publishes.load(Ordering::SeqCst) {
+            anyhow::bail!("injected replication publish failure");
+        }
+        self.published.lock().push(delta.ts);
+        Ok(())
+    }
+
+    async fn subscribe(
+        &self,
+        _from_ts: Timestamp,
+    ) -> anyhow::Result<BoxStream<'static, anyhow::Result<ReplicationMessage>>> {
+        Ok(Box::pin(futures::stream::pending()))
+    }
 }
 
 fn partitioned_map(local_partition: PartitionId) -> PartitionMap {
@@ -2033,6 +2110,66 @@ async fn test_replica_delta_redelivery_is_idempotent(rt: TestRuntime) -> anyhow:
         persisted_document_log_count(&node_a_persistence).await?,
         docs_after_first_apply,
         "redelivered delta after restart must not append duplicate document log entries",
+    );
+
+    Ok(())
+}
+
+#[convex_macro::test_runtime]
+async fn test_raft_apply_records_nats_outbox_when_publish_unavailable(
+    rt: TestRuntime,
+) -> anyhow::Result<()> {
+    let source_log = Arc::new(InMemoryDistributedLog::new());
+    let table_numbers = Arc::new(InMemoryTableNumberAllocator::default());
+    let source = create_node_with_table_number_allocator(
+        &rt,
+        source_log.clone(),
+        Some(partitioned_map(PartitionId(1))),
+        table_numbers.clone(),
+    )
+    .await?;
+
+    insert_doc(&source, "projects", assert_obj!("name" => "raft-outbox")).await?;
+    let delta = source_log
+        .deltas()
+        .into_iter()
+        .last()
+        .expect("source partition insert should publish a delta");
+    assert_eq!(delta.source_partition, Some(PartitionId(1)));
+    let delta_ts = delta.ts;
+
+    let replay_log = Arc::new(SwitchableDistributedLog::failing());
+    let follower_persistence = Arc::new(TestPersistence::new());
+    let follower = create_node_with_custom_distributed_log(
+        &rt,
+        follower_persistence.clone(),
+        replay_log.clone(),
+        Some(partitioned_map(PartitionId(1))),
+        table_numbers,
+    )
+    .await?;
+
+    follower
+        .committer_for_test()
+        .apply_raft_commit_delta(delta)
+        .await?;
+
+    let outbox = follower_persistence
+        .reader()
+        .get_persistence_global(PersistenceGlobalKey::RaftNatsOutbox)
+        .await?
+        .context("Raft follower apply should record the delta before NATS publish")?;
+    let records: std::collections::BTreeMap<String, serde_json::Value> =
+        serde_json::from_value(outbox)?;
+    assert_eq!(
+        records.len(),
+        1,
+        "failed NATS publish should leave the Raft-applied delta in the outbox",
+    );
+    assert!(records.contains_key(&u64::from(delta_ts).to_string()));
+    assert!(
+        replay_log.published().is_empty(),
+        "the failing log must not observe a successful publish before recovery",
     );
 
     Ok(())

--- a/crates/database/src/tests/write_scaling_tests.rs
+++ b/crates/database/src/tests/write_scaling_tests.rs
@@ -5043,6 +5043,133 @@ async fn test_watcher_recovers_complete_staging_decision_and_commits_prepared_wr
 }
 
 #[convex_macro::test_runtime]
+async fn test_watcher_recovers_complete_staging_after_participant_restart(
+    rt: TestRuntime,
+) -> anyhow::Result<()> {
+    let log = Arc::new(InMemoryDistributedLog::new());
+    let persistence = Arc::new(TestPersistence::new());
+    let decision_log = Arc::new(InMemoryTwoPhaseDecisionLog::new());
+    let node = create_node_with_persistence(
+        &rt,
+        persistence.clone(),
+        log.clone(),
+        Some(partitioned_map(PartitionId(1))),
+        None,
+        decision_log.clone(),
+        None,
+    )
+    .await?;
+
+    let mut tx = node.begin(Identity::system()).await?;
+    TestFacingModel::new(&mut tx)
+        .insert(
+            &"projects".parse()?,
+            assert_obj!("name" => "staged-before-participant-restart"),
+        )
+        .await?;
+    let final_tx = tx.finalize()?;
+    let write_indexes: Vec<_> = final_tx
+        .writes
+        .coalesced_writes()
+        .enumerate()
+        .map(|(index, _)| index)
+        .collect();
+    let write_source = WriteSource::new("complete_staging_restart_recovery_test");
+    let participant_tx = ParticipantTransaction::from_final_transaction(
+        &final_tx,
+        PartitionId(1),
+        &write_indexes,
+        &partitioned_map(PartitionId(1)),
+        &write_source,
+    )?;
+    let txn_id = TwoPhaseTransactionId::new();
+    let prepare_ts = node.committer_for_test().allocate_commit_ts().await?;
+    node.committer_for_test()
+        .prepare_remote(
+            txn_id.clone(),
+            participant_tx,
+            write_source,
+            prepare_ts,
+            vec![PartitionId(1)],
+        )
+        .await?;
+
+    let projects_before_restart = run_query(
+        node.clone(),
+        TableNamespace::root_component(),
+        Query::full_table_scan("projects".parse()?, Order::Asc),
+    )
+    .await?;
+    assert!(
+        !projects_before_restart.iter().any(|project| {
+            project.value().0.get("name") == Some(&assert_val!("staged-before-participant-restart"))
+        }),
+        "prepared staged writes must stay hidden before participant restart",
+    );
+
+    let redo_records = node.committer_for_test().two_phase_redo_records().await?;
+    let redo_entry = redo_records
+        .values()
+        .next()
+        .context("prepare should persist a redo entry before restart")?;
+    let staging = TwoPhaseDecision::staging(
+        u64::from(prepare_ts),
+        vec![1],
+        vec![TwoPhaseParticipantIntent::from_redo_entry(redo_entry)],
+    );
+    decision_log.write_decision(&txn_id, &staging).await?;
+    node.shutdown().await?;
+
+    let restarted = create_node_with_persistence(
+        &rt,
+        persistence.clone(),
+        log,
+        Some(partitioned_map(PartitionId(1))),
+        None,
+        decision_log.clone(),
+        None,
+    )
+    .await?;
+    let resolved = crate::two_phase_watcher::resolve_decision_for_local_partition(
+        &restarted.committer_for_test(),
+        PartitionId(1),
+        txn_id,
+        staging,
+    )
+    .await?;
+    assert!(
+        resolved,
+        "watcher should recover complete staging from durable redo after participant restart",
+    );
+
+    let projects_after_recovery = run_query(
+        restarted.clone(),
+        TableNamespace::root_component(),
+        Query::full_table_scan("projects".parse()?, Order::Asc),
+    )
+    .await?;
+    assert!(
+        projects_after_recovery.iter().any(|project| {
+            project.value().0.get("name") == Some(&assert_val!("staged-before-participant-restart"))
+        }),
+        "staging recovery after restart should make the committed write visible",
+    );
+    assert!(
+        decision_log.decisions().is_empty(),
+        "single-participant recovered staging decision should be deleted after restart cleanup",
+    );
+    assert!(
+        restarted
+            .committer_for_test()
+            .two_phase_redo_records()
+            .await?
+            .is_empty(),
+        "restart recovery should delete the participant redo record after commit",
+    );
+    Ok(())
+}
+
+#[convex_macro::test_runtime]
 async fn test_watcher_leaves_partial_staging_hidden_until_all_participants_stage(
     rt: TestRuntime,
 ) -> anyhow::Result<()> {

--- a/crates/database/src/tests/write_scaling_tests.rs
+++ b/crates/database/src/tests/write_scaling_tests.rs
@@ -135,6 +135,7 @@ use crate::{
         TwoPhaseCommitGrpcClient,
         TwoPhaseDecision,
         TwoPhaseDecisionLog,
+        TwoPhaseParticipantIntent,
         TwoPhaseRedoEntry,
         TwoPhaseTransactionId,
     },
@@ -4745,6 +4746,119 @@ async fn test_watcher_rolls_back_abandoned_prepare_without_decision(
     )
     .await
     .context("timed-out prepare should no longer block conflicting writes")?;
+    Ok(())
+}
+
+#[convex_macro::test_runtime]
+async fn test_watcher_recovers_complete_staging_decision_and_commits_prepared_write(
+    rt: TestRuntime,
+) -> anyhow::Result<()> {
+    let log = Arc::new(InMemoryDistributedLog::new());
+    let decision_log = Arc::new(InMemoryTwoPhaseDecisionLog::new());
+    let node = create_node_with_options_and_decision_log(
+        &rt,
+        log,
+        Some(partitioned_map(PartitionId(1))),
+        None,
+        None,
+        decision_log.clone(),
+    )
+    .await?;
+
+    let mut tx = node.begin(Identity::system()).await?;
+    TestFacingModel::new(&mut tx)
+        .insert(
+            &"projects".parse()?,
+            assert_obj!("name" => "staged-before-coordinator-crash"),
+        )
+        .await?;
+    let final_tx = tx.finalize()?;
+    let write_indexes: Vec<_> = final_tx
+        .writes
+        .coalesced_writes()
+        .enumerate()
+        .map(|(index, _)| index)
+        .collect();
+    let write_source = WriteSource::new("complete_staging_recovery_test");
+    let participant_tx = ParticipantTransaction::from_final_transaction(
+        &final_tx,
+        PartitionId(1),
+        &write_indexes,
+        &partitioned_map(PartitionId(1)),
+        &write_source,
+    )?;
+    let txn_id = TwoPhaseTransactionId::new();
+    let prepare_ts = node.committer_for_test().allocate_commit_ts().await?;
+    node.committer_for_test()
+        .prepare_remote(
+            txn_id.clone(),
+            participant_tx,
+            write_source,
+            prepare_ts,
+            vec![PartitionId(1)],
+        )
+        .await?;
+
+    let projects_before_recovery = run_query(
+        node.clone(),
+        TableNamespace::root_component(),
+        Query::full_table_scan("projects".parse()?, Order::Asc),
+    )
+    .await?;
+    assert!(
+        !projects_before_recovery.iter().any(|project| {
+            project.value().0.get("name") == Some(&assert_val!("staged-before-coordinator-crash"))
+        }),
+        "abortable staged writes must stay hidden before status recovery",
+    );
+
+    let redo_records = node.committer_for_test().two_phase_redo_records().await?;
+    let redo_entry = redo_records
+        .values()
+        .next()
+        .context("prepare should persist a redo entry")?;
+    let staging = TwoPhaseDecision::staging(
+        u64::from(prepare_ts),
+        vec![1],
+        vec![TwoPhaseParticipantIntent::from_redo_entry(redo_entry)],
+    );
+    decision_log.write_decision(&txn_id, &staging).await?;
+
+    let resolved = crate::two_phase_watcher::resolve_decision_for_local_partition(
+        &node.committer_for_test(),
+        PartitionId(1),
+        txn_id,
+        staging,
+    )
+    .await?;
+    assert!(
+        resolved,
+        "complete staged decision should recover to a committed decision",
+    );
+
+    let projects_after_recovery = run_query(
+        node.clone(),
+        TableNamespace::root_component(),
+        Query::full_table_scan("projects".parse()?, Order::Asc),
+    )
+    .await?;
+    assert!(
+        projects_after_recovery.iter().any(|project| {
+            project.value().0.get("name") == Some(&assert_val!("staged-before-coordinator-crash"))
+        }),
+        "watcher recovery should make the recovered committed write visible",
+    );
+    assert!(
+        decision_log.decisions().is_empty(),
+        "single-participant recovered staging decision should be deleted after cleanup",
+    );
+    assert!(
+        node.committer_for_test()
+            .two_phase_redo_records()
+            .await?
+            .is_empty(),
+        "committing the recovered staged transaction should delete the participant redo record",
+    );
     Ok(())
 }
 

--- a/crates/database/src/two_phase.rs
+++ b/crates/database/src/two_phase.rs
@@ -339,7 +339,10 @@ impl TwoPhaseDecision {
         Some(Duration::from_millis(now.saturating_sub(*staged_at)))
     }
 
-    pub fn mark_participant_staged(&mut self, intent: TwoPhaseParticipantIntent) {
+    pub fn mark_participant_staged(
+        &mut self,
+        intent: TwoPhaseParticipantIntent,
+    ) -> anyhow::Result<()> {
         let Self::Staging {
             participants,
             participant_intents,
@@ -347,7 +350,7 @@ impl TwoPhaseDecision {
             ..
         } = self
         else {
-            return;
+            return Ok(());
         };
         if !participants.contains(&intent.partition_id) {
             participants.push(intent.partition_id);
@@ -358,13 +361,19 @@ impl TwoPhaseDecision {
             .iter_mut()
             .find(|existing| existing.partition_id == intent.partition_id)
         {
-            *existing = intent;
+            anyhow::ensure!(
+                *existing == intent,
+                "2PC staging proof for participant {} conflicts with the existing staged intent",
+                intent.partition_id,
+            );
+            return Ok(());
         } else {
             participant_intents.push(intent);
         }
         participant_intents.sort_by_key(|intent| intent.partition_id);
         *transaction_digest =
             TwoPhaseTransactionDigest::from_staging_record(participants, participant_intents);
+        Ok(())
     }
 
     pub fn all_participants_staged(&self) -> bool {
@@ -671,7 +680,7 @@ pub mod testing {
             let Some(decision) = decisions.get_mut(&transaction_id.0) else {
                 return Ok(None);
             };
-            decision.mark_participant_staged(intent);
+            decision.mark_participant_staged(intent)?;
             Ok(Some(decision.clone()))
         }
 
@@ -959,7 +968,7 @@ impl TwoPhaseDecisionLog for NatsTwoPhaseDecisionLog {
             else {
                 return Ok(None);
             };
-            decision.mark_participant_staged(intent.clone());
+            decision.mark_participant_staged(intent.clone())?;
             let payload = serde_json::to_vec(&decision).with_context(|| {
                 format!("2PC: Failed to serialize decision for {transaction_id}")
             })?;
@@ -1810,7 +1819,9 @@ mod tests {
         assert!(!decision.all_participants_staged());
 
         let digest_before = decision.transaction_digest().cloned();
-        decision.mark_participant_staged(participant_intent(1, 12345, "participant-one"));
+        decision
+            .mark_participant_staged(participant_intent(1, 12345, "participant-one"))
+            .unwrap();
         assert!(decision.all_participants_staged());
         assert_ne!(digest_before.as_ref(), decision.transaction_digest());
         assert_eq!(
@@ -1826,11 +1837,34 @@ mod tests {
     fn test_staging_mark_participant_staged_is_idempotent() {
         let mut decision = TwoPhaseDecision::staging(12345, vec![0], vec![]);
         let intent = participant_intent(0, 12345, "participant-zero");
-        decision.mark_participant_staged(intent.clone());
+        decision.mark_participant_staged(intent.clone()).unwrap();
         let digest_after_first = decision.transaction_digest().cloned();
-        decision.mark_participant_staged(intent);
+        decision.mark_participant_staged(intent).unwrap();
         assert_eq!(decision.transaction_digest(), digest_after_first.as_ref());
         assert_eq!(decision.participant_intents().len(), 1);
+    }
+
+    #[test]
+    fn test_staging_rejects_conflicting_duplicate_participant_intent() {
+        let mut decision = TwoPhaseDecision::staging(
+            12345,
+            vec![0],
+            vec![participant_intent(0, 12345, "participant-zero")],
+        );
+        let digest_before = decision.transaction_digest().cloned();
+        let err = decision
+            .mark_participant_staged(participant_intent(0, 12345, "different-transaction"))
+            .expect_err("conflicting duplicate stage proof should fail closed");
+
+        assert!(
+            format!("{err:#}").contains("conflicts with the existing staged intent"),
+            "unexpected error: {err:#}",
+        );
+        assert_eq!(decision.transaction_digest(), digest_before.as_ref());
+        assert_eq!(
+            decision.participant_intents(),
+            &[participant_intent(0, 12345, "participant-zero")],
+        );
     }
 
     #[test]
@@ -2005,6 +2039,33 @@ mod tests {
                     participant_intent(1, 12345, "participant-one"),
                 ],
             );
+        });
+    }
+
+    #[test]
+    fn test_in_memory_decision_log_rejects_conflicting_duplicate_stage_proof() {
+        futures::executor::block_on(async {
+            let log = testing::InMemoryTwoPhaseDecisionLog::new();
+            let txn_id = TwoPhaseTransactionId("staging-conflict".to_string());
+            let staging = TwoPhaseDecision::staging(
+                12345,
+                vec![0],
+                vec![participant_intent(0, 12345, "participant-zero")],
+            );
+            log.write_decision(&txn_id, &staging).await.unwrap();
+
+            let err = log
+                .mark_participant_staged(
+                    &txn_id,
+                    participant_intent(0, 12345, "different-transaction"),
+                )
+                .await
+                .expect_err("conflicting duplicate stage proof should fail closed");
+            assert!(
+                format!("{err:#}").contains("conflicts with the existing staged intent"),
+                "unexpected error: {err:#}",
+            );
+            assert_eq!(log.get_decision(&txn_id).await.unwrap(), Some(staging));
         });
     }
 

--- a/self-hosted/docker/test-write-scaling.sh
+++ b/self-hosted/docker/test-write-scaling.sh
@@ -33,6 +33,7 @@
 #  20b. Writes Through Followers During Raft Leader Outage
 #  20c. Lagging Follower Catch-Up After Cross-Partition Writes
 #  20d. Cross-Partition 2PC During Participant Leader Outage
+#  20e. Repeated Raft Leadership Churn During Cross-Partition 2PC
 #  21. Sustained Writes 30s (long-running replication)
 #  22. Duplicate Insert Idempotency
 #  23. Final Exhaustive Invariant Check
@@ -1685,6 +1686,134 @@ P1_OUTAGE_DT=$((POST_P1_OUTAGE_AT - PRE_P1_OUTAGE_T))
 [ "$POST_P1_OUTAGE_AM" -eq "$POST_P1_OUTAGE_BM" ] && [ "$POST_P1_OUTAGE_AT" -eq "$POST_P1_OUTAGE_BT" ] \
     && pass "Nodes converged after p1a participant leader outage" \
     || fail "Nodes diverged after p1a participant leader outage" "p0a=$POST_P1_OUTAGE_AM,$POST_P1_OUTAGE_AT p1a=$POST_P1_OUTAGE_BM,$POST_P1_OUTAGE_BT"
+
+# ============================================================
+echo ""
+echo -e "${BOLD}Test 20e: Repeated Raft Leadership Churn During Cross-Partition 2PC${NC}"
+# ============================================================
+# Alternate partition-0 and partition-1 node outages while issuing
+# cross-partition 2PC writes through surviving entrypoints. This is a
+# deterministic precursor to randomized nemesis testing: every accepted write
+# must remain atomic and every restarted node must converge.
+
+PRE_CHURN_2PC=$(query_api "$NODE_A_URL" "$NODE_A_KEY" "messages:dashboard")
+PRE_CHURN_2PC_M=$(jval messages "$PRE_CHURN_2PC")
+PRE_CHURN_2PC_T=$(jval tasks "$PRE_CHURN_2PC")
+CHURN_2PC_RUN="churn-2pc-$(date +%s)"
+CHURN_2PC_ACCEPTED=0
+CHURN_2PC_REJECTED=0
+CHURN_2PC_ATTEMPTED=0
+
+for round in 1 2 3 4; do
+    case "$round" in
+        1)
+            stopped_container="docker-node-p0a-1"
+            stopped_url="$NODE_P0A_URL"
+            stopped_label="p0a"
+            survivor_labels=(p1a p1b p1c)
+            survivor_urls=("$NODE_P1A_URL" "$NODE_P1B_URL" "$NODE_P1C_URL")
+            survivor_keys=("$NODE_P1A_KEY" "$NODE_P1B_KEY" "$NODE_P1C_KEY")
+            ;;
+        2)
+            stopped_container="docker-node-p1a-1"
+            stopped_url="$NODE_P1A_URL"
+            stopped_label="p1a"
+            survivor_labels=(p0a p0b p0c)
+            survivor_urls=("$NODE_P0A_URL" "$NODE_P0B_URL" "$NODE_P0C_URL")
+            survivor_keys=("$NODE_P0A_KEY" "$NODE_P0B_KEY" "$NODE_P0C_KEY")
+            ;;
+        3)
+            stopped_container="docker-node-p0b-1"
+            stopped_url="$NODE_P0B_URL"
+            stopped_label="p0b"
+            survivor_labels=(p1a p1b p1c)
+            survivor_urls=("$NODE_P1A_URL" "$NODE_P1B_URL" "$NODE_P1C_URL")
+            survivor_keys=("$NODE_P1A_KEY" "$NODE_P1B_KEY" "$NODE_P1C_KEY")
+            ;;
+        4)
+            stopped_container="docker-node-p1b-1"
+            stopped_url="$NODE_P1B_URL"
+            stopped_label="p1b"
+            survivor_labels=(p0a p0b p0c)
+            survivor_urls=("$NODE_P0A_URL" "$NODE_P0B_URL" "$NODE_P0C_URL")
+            survivor_keys=("$NODE_P0A_KEY" "$NODE_P0B_KEY" "$NODE_P0C_KEY")
+            ;;
+    esac
+
+    echo "  Round $round: stopping $stopped_label and issuing 2PC writes through surviving entrypoints..."
+    docker stop "$stopped_container" > /dev/null 2>&1
+    sleep 6
+
+    ROUND_ACCEPTED=0
+    for i in "${!survivor_labels[@]}"; do
+        label="${survivor_labels[$i]}"
+        CHURN_2PC_ATTEMPTED=$((CHURN_2PC_ATTEMPTED + 1))
+        R=$(mutation_response "${survivor_urls[$i]}" "${survivor_keys[$i]}" "messages:crossPartitionWrite" \
+            "{\"text\":\"$CHURN_2PC_RUN-r${round}-$label\",\"taskTitle\":\"$CHURN_2PC_RUN-r${round}-task-$label\"}")
+        if echo "$R" | grep -q '"status":"success"'; then
+            CHURN_2PC_ACCEPTED=$((CHURN_2PC_ACCEPTED + 1))
+            ROUND_ACCEPTED=$((ROUND_ACCEPTED + 1))
+        else
+            CHURN_2PC_REJECTED=$((CHURN_2PC_REJECTED + 1))
+            echo -e "  ${YELLOW}WARN${NC} $label 2PC write rejected during $stopped_label outage (fail-closed): $R"
+        fi
+    done
+
+    [ "$ROUND_ACCEPTED" -gt 0 ] \
+        && pass "Round $round accepted at least one 2PC write during $stopped_label outage ($ROUND_ACCEPTED/3)" \
+        || fail "Round $round accepted no 2PC writes during $stopped_label outage" "all three attempts failed closed"
+
+    echo "  Restarting $stopped_label..."
+    docker start "$stopped_container" > /dev/null 2>&1
+    for attempt in $(seq 1 60); do
+        curl -sf "$stopped_url/version" > /dev/null 2>&1 && break
+        sleep 1
+    done
+
+    case "$round" in
+        1)
+            NODE_P0A_KEY=$(docker exec docker-node-p0a-1 ./generate_admin_key.sh 2>&1 | tail -1)
+            NODE_A_KEY="$NODE_P0A_KEY"
+            (cd "$DEPLOY_DIR" && npx convex deploy --admin-key "$NODE_P0A_KEY" --url "$NODE_P0A_URL" > /dev/null 2>&1)
+            ;;
+        2)
+            NODE_P1A_KEY=$(docker exec docker-node-p1a-1 ./generate_admin_key.sh 2>&1 | tail -1)
+            NODE_B_KEY="$NODE_P1A_KEY"
+            (cd "$DEPLOY_DIR" && npx convex deploy --admin-key "$NODE_P1A_KEY" --url "$NODE_P1A_URL" > /dev/null 2>&1)
+            ;;
+        3)
+            NODE_P0B_KEY=$(docker exec docker-node-p0b-1 ./generate_admin_key.sh 2>&1 | tail -1)
+            (cd "$DEPLOY_DIR" && npx convex deploy --admin-key "$NODE_P0B_KEY" --url "$NODE_P0B_URL" > /dev/null 2>&1)
+            ;;
+        4)
+            NODE_P1B_KEY=$(docker exec docker-node-p1b-1 ./generate_admin_key.sh 2>&1 | tail -1)
+            (cd "$DEPLOY_DIR" && npx convex deploy --admin-key "$NODE_P1B_KEY" --url "$NODE_P1B_URL" > /dev/null 2>&1)
+            ;;
+    esac
+    sleep 4
+done
+
+[ "$CHURN_2PC_ATTEMPTED" -eq $((CHURN_2PC_ACCEPTED + CHURN_2PC_REJECTED)) ] \
+    && pass "Repeated-churn 2PC attempts were all accounted for (accepted=$CHURN_2PC_ACCEPTED rejected=$CHURN_2PC_REJECTED)" \
+    || fail "Repeated-churn 2PC accounting mismatch" "attempted=$CHURN_2PC_ATTEMPTED accepted=$CHURN_2PC_ACCEPTED rejected=$CHURN_2PC_REJECTED"
+
+sleep 10
+POST_CHURN_2PC_A=$(query_api "$NODE_A_URL" "$NODE_A_KEY" "messages:dashboard")
+POST_CHURN_2PC_B=$(query_api "$NODE_B_URL" "$NODE_B_KEY" "messages:dashboard")
+POST_CHURN_2PC_M=$(jval messages "$POST_CHURN_2PC_A")
+POST_CHURN_2PC_T=$(jval tasks "$POST_CHURN_2PC_A")
+POST_CHURN_2PC_BM=$(jval messages "$POST_CHURN_2PC_B")
+POST_CHURN_2PC_BT=$(jval tasks "$POST_CHURN_2PC_B")
+CHURN_2PC_DM=$((POST_CHURN_2PC_M - PRE_CHURN_2PC_M))
+CHURN_2PC_DT=$((POST_CHURN_2PC_T - PRE_CHURN_2PC_T))
+
+[ "$CHURN_2PC_DM" -eq "$CHURN_2PC_ACCEPTED" ] && [ "$CHURN_2PC_DT" -eq "$CHURN_2PC_ACCEPTED" ] \
+    && pass "Repeated-churn 2PC writes remained atomic (+$CHURN_2PC_ACCEPTED/+${CHURN_2PC_ACCEPTED})" \
+    || fail "Lost/extra 2PC writes during repeated leadership churn" "msgs +$CHURN_2PC_DM tasks +$CHURN_2PC_DT expected +$CHURN_2PC_ACCEPTED"
+
+[ "$POST_CHURN_2PC_M" -eq "$POST_CHURN_2PC_BM" ] && [ "$POST_CHURN_2PC_T" -eq "$POST_CHURN_2PC_BT" ] \
+    && pass "Nodes converged after repeated Raft leadership churn" \
+    || fail "Nodes diverged after repeated Raft leadership churn" "p0a=$POST_CHURN_2PC_M,$POST_CHURN_2PC_T p1a=$POST_CHURN_2PC_BM,$POST_CHURN_2PC_BT"
 
 # ============================================================
 echo ""

--- a/self-hosted/docker/test-write-scaling.sh
+++ b/self-hosted/docker/test-write-scaling.sh
@@ -18,6 +18,7 @@
 #   9. Two-Phase Commit Cross-Partition (Vitess 2PC)
 #   9f. 2PC Atomicity During NATS Outage
 #   9g. 2PC Atomicity During Participant Restart
+#   9h. 2PC Atomicity During Coordinator Restart
 #  10. Rapid-Fire Writes Under Load (Jepsen stress)
 #  11. Write-Then-Immediate-Read Consistency (stale read detection)
 #  12. Double Node Restart (crash recovery stress)
@@ -997,6 +998,60 @@ fi
 [ "$POST_RESTART_2PC_M" -eq "$POST_RESTART_2PC_BM" ] && [ "$POST_RESTART_2PC_T" -eq "$POST_RESTART_2PC_BT" ] \
     && pass "Nodes converged after participant restart 2PC race" \
     || fail "Nodes diverged after participant restart 2PC race" "A: $POST_RESTART_2PC_M,$POST_RESTART_2PC_T vs B: $POST_RESTART_2PC_BM,$POST_RESTART_2PC_BT"
+
+# ============================================================
+echo ""
+echo -e "${BOLD}Test 9h: 2PC Atomicity During Coordinator Restart${NC}"
+# ============================================================
+# Race a cross-partition mutation with a partition-0 coordinator restart. This
+# is the coordinator-crash window: after staging/decision work starts, the
+# persisted outcome must still be either fully absent or fully present.
+
+PRE_COORD_RESTART_2PC=$(query_api "$NODE_A_URL" "$NODE_A_KEY" "messages:dashboard")
+PRE_COORD_RESTART_2PC_M=$(jval messages "$PRE_COORD_RESTART_2PC")
+PRE_COORD_RESTART_2PC_T=$(jval tasks "$PRE_COORD_RESTART_2PC")
+COORD_RESTART_2PC_RESPONSE_FILE=$(mktemp)
+
+(curl --max-time 20 -s "$NODE_A_URL/api/mutation" \
+    -H "Authorization: Convex $NODE_A_KEY" \
+    -H "Content-Type: application/json" \
+    -d '{"path":"messages:crossPartitionWrite","args":{"text":"2pc-coordinator-restart","taskTitle":"2pc-coordinator-restart-task"}}' \
+    > "$COORD_RESTART_2PC_RESPONSE_FILE" || echo '{"status":"transport_error"}' > "$COORD_RESTART_2PC_RESPONSE_FILE") &
+COORD_RESTART_2PC_PID=$!
+sleep 0.05
+docker restart docker-node-p0a-1 > /dev/null 2>&1
+wait "$COORD_RESTART_2PC_PID" || true
+
+echo "  Waiting for coordinator node p0a to recover..."
+for attempt in $(seq 1 60); do
+    curl -sf "$NODE_A_URL/version" > /dev/null 2>&1 && break
+    sleep 1
+done
+NODE_P0A_KEY=$(docker exec docker-node-p0a-1 ./generate_admin_key.sh 2>&1 | tail -1)
+NODE_A_KEY="$NODE_P0A_KEY"
+(cd "$DEPLOY_DIR" && npx convex deploy --admin-key "$NODE_A_KEY" --url "$NODE_A_URL" > /dev/null 2>&1)
+
+sleep 8
+POST_COORD_RESTART_2PC_A=$(query_api "$NODE_A_URL" "$NODE_A_KEY" "messages:dashboard")
+POST_COORD_RESTART_2PC_B=$(query_api "$NODE_B_URL" "$NODE_B_KEY" "messages:dashboard")
+POST_COORD_RESTART_2PC_M=$(jval messages "$POST_COORD_RESTART_2PC_A")
+POST_COORD_RESTART_2PC_T=$(jval tasks "$POST_COORD_RESTART_2PC_A")
+POST_COORD_RESTART_2PC_BM=$(jval messages "$POST_COORD_RESTART_2PC_B")
+POST_COORD_RESTART_2PC_BT=$(jval tasks "$POST_COORD_RESTART_2PC_B")
+COORD_RESTART_2PC_DM=$((POST_COORD_RESTART_2PC_M - PRE_COORD_RESTART_2PC_M))
+COORD_RESTART_2PC_DT=$((POST_COORD_RESTART_2PC_T - PRE_COORD_RESTART_2PC_T))
+COORD_RESTART_2PC_RESPONSE=$(cat "$COORD_RESTART_2PC_RESPONSE_FILE")
+rm -f "$COORD_RESTART_2PC_RESPONSE_FILE"
+
+if [ "$COORD_RESTART_2PC_DM" -eq "$COORD_RESTART_2PC_DT" ] && { [ "$COORD_RESTART_2PC_DM" -eq 0 ] || [ "$COORD_RESTART_2PC_DM" -eq 1 ]; }; then
+    pass "2PC during coordinator restart was atomic (msgs +$COORD_RESTART_2PC_DM tasks +$COORD_RESTART_2PC_DT)"
+else
+    fail "2PC during coordinator restart produced torn/non-idempotent result" "response=$COORD_RESTART_2PC_RESPONSE msgs +$COORD_RESTART_2PC_DM tasks +$COORD_RESTART_2PC_DT"
+fi
+
+[ "$POST_COORD_RESTART_2PC_M" -eq "$POST_COORD_RESTART_2PC_BM" ] && [ "$POST_COORD_RESTART_2PC_T" -eq "$POST_COORD_RESTART_2PC_BT" ] \
+    && pass "Nodes converged after coordinator restart 2PC race" \
+    || fail "Nodes diverged after coordinator restart 2PC race" "A: $POST_COORD_RESTART_2PC_M,$POST_COORD_RESTART_2PC_T vs B: $POST_COORD_RESTART_2PC_BM,$POST_COORD_RESTART_2PC_BT"
 
 # ============================================================
 echo ""


### PR DESCRIPTION
## Summary

Refs #210.

This adds an adversarial staged/parallel-commit correctness slice before true parallel commits are enabled:

- rejects conflicting duplicate participant staging proofs instead of silently overwriting the original staged intent
- proves duplicate identical stage proofs remain idempotent
- adds watcher-level recovery tests for coordinator-crash and participant-restart windows after staged prepare
- proves partial staging remains hidden/pending until every participant proof exists, then recovery may commit the local participant
- proves complete staging can recover after the participant restarts with only durable redo state and no in-memory prepared transaction
- proves abortable staged writes stay hidden before recovery, then become visible only after recovered commit cleanup
- adds Docker harness `Test 9h`, racing a cross-partition 2PC mutation with a partition-0 coordinator restart and asserting the result is either fully absent or fully present with convergence
- adds Docker harness `Test 20e`, alternating partition-0 and partition-1 node outages while issuing cross-partition 2PC writes through surviving entrypoints
- adds database-level Raft/NATS outbox tests proving both accepted local commits and Raft-applied deltas are durably recorded for later NATS replay when the publish plane is unavailable

`20e` intentionally treats election-window client errors as fail-closed retryable outcomes, not correctness failures. It still fails if a round accepts no writes, if accepted writes produce torn/extra deltas, or if nodes diverge.

This is still not the entire #210 adversarial matrix, but it now covers duplicate staging/recovery corruption, partial and complete staged watcher recovery, participant restart from durable redo, NATS outage, coordinator restart, repeated Raft leadership churn, accepted-commit NATS publish failure, and Raft/NATS outbox persistence.

## Local image proof

Built locally with `self-hosted/docker-build/build_backend_image.sh ghcr.io/martinkalema/convex-horizontal-scaling:backend-latest` at this PR branch HEAD.

- branch commit: `3d5116e6382675a30847b043e4621d57e59c47ba`
- image ID: `sha256:2a734785b827a4e24e1b6536f8a6692fef8e9e31426217aec37a8b6659720f4b`
- OCI revision: `3d5116e6382675a30847b043e4621d57e59c47ba`
- all six backend containers inspected with `.Image == sha256:2a734785b827a4e24e1b6536f8a6692fef8e9e31426217aec37a8b6659720f4b`
- cluster recreated with `BACKEND_PULL_POLICY=never`

## Validation

- `cargo fmt -p database --check`
- `git diff --check`
- `bash -n self-hosted/docker/test-write-scaling.sh`
- `env PROTOC=/Users/martin/Desktop/convex-horizontal-scaling/crates/pb_build/protoc/protoc-macos-universal cargo test -p database two_phase -- --nocapture` (`28/28`)
- `env PROTOC=/Users/martin/Desktop/convex-horizontal-scaling/crates/pb_build/protoc/protoc-macos-universal cargo test -p database nats_outbox -- --nocapture` (`4/4`)
- `env PROTOC=/Users/martin/Desktop/convex-horizontal-scaling/crates/pb_build/protoc/protoc-macos-universal cargo test -p database write_scaling_tests -- --nocapture` (`60/60`)
- `env PROTOC=/Users/martin/Desktop/convex-horizontal-scaling/crates/pb_build/protoc/protoc-macos-universal cargo check -p database`
- clean cluster reset with `BACKEND_PULL_POLICY=never`
- `bash self-hosted/docker/test.sh scaling` (`116/116`, `ALL SUITES PASSED`)
- `bash self-hosted/docker/test.sh failover` (`24/24`, `ALL SUITES PASSED`)
