### PR TITLE
feat(database): recover staged 2pc decisions

### DIFF
--- a/crates/database/src/metrics.rs
+++ b/crates/database/src/metrics.rs
@@ -1,3 +1,5 @@
+use std::time::Duration;
+
 use ::search::metrics::{
     SearchType,
     SEARCH_TYPE_LABEL,
@@ -500,6 +502,27 @@ pub fn log_two_phase_prepare_attempts(num_attempts: usize) {
         &DATABASE_TWO_PHASE_PREPARE_ATTEMPTS_TOTAL,
         num_attempts as f64,
     );
+}
+
+register_convex_counter!(
+    DATABASE_TWO_PHASE_STAGING_RECOVERY_TOTAL,
+    "Number of parallel-commit staging recovery attempts by outcome",
+    &OUTCOME_LABELS
+);
+pub fn log_two_phase_staging_recovery(outcome: &'static str) {
+    log_counter_with_labels(
+        &DATABASE_TWO_PHASE_STAGING_RECOVERY_TOTAL,
+        1,
+        vec![outcome_label(outcome)],
+    );
+}
+
+register_convex_histogram!(
+    DATABASE_TWO_PHASE_STAGING_AGE_SECONDS,
+    "Age of unresolved parallel-commit staging records observed by the watcher"
+);
+pub fn log_two_phase_staging_age(age: Duration) {
+    log_distribution(&DATABASE_TWO_PHASE_STAGING_AGE_SECONDS, age.as_secs_f64());
 }
 
 register_convex_histogram!(

--- a/crates/database/src/two_phase.rs
+++ b/crates/database/src/two_phase.rs
@@ -137,6 +137,8 @@ pub enum TwoPhaseDecision {
         participant_intents: Vec<TwoPhaseParticipantIntent>,
         transaction_digest: TwoPhaseTransactionDigest,
         #[serde(default)]
+        staged_at_unix_millis: Option<u64>,
+        #[serde(default)]
         resolved_participants: Vec<u32>,
     },
     /// All participants prepared successfully. Commit.
@@ -218,6 +220,7 @@ impl TwoPhaseDecision {
             participants,
             participant_intents,
             transaction_digest,
+            staged_at_unix_millis: Some(now_unix_millis()),
             resolved_participants: Vec::new(),
         }
     }
@@ -308,6 +311,34 @@ impl TwoPhaseDecision {
         }
     }
 
+    pub fn committed_from_staging(&self) -> Option<Self> {
+        match self {
+            Self::Staging {
+                commit_ts,
+                participants,
+                resolved_participants,
+                ..
+            } if self.all_participants_staged() => Some(Self::Committed {
+                commit_ts: *commit_ts,
+                participants: participants.clone(),
+                resolved_participants: resolved_participants.clone(),
+            }),
+            _ => None,
+        }
+    }
+
+    pub fn staged_age(&self) -> Option<Duration> {
+        let Self::Staging {
+            staged_at_unix_millis: Some(staged_at),
+            ..
+        } = self
+        else {
+            return None;
+        };
+        let now = now_unix_millis();
+        Some(Duration::from_millis(now.saturating_sub(*staged_at)))
+    }
+
     pub fn mark_participant_staged(&mut self, intent: TwoPhaseParticipantIntent) {
         let Self::Staging {
             participants,
@@ -356,6 +387,14 @@ impl TwoPhaseDecision {
             .iter()
             .all(|participant| self.resolved_participants().contains(participant))
     }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum StagingRecoveryResult {
+    Missing,
+    Pending(TwoPhaseDecision),
+    Committed(TwoPhaseDecision),
+    AlreadyFinal(TwoPhaseDecision),
 }
 
 /// Result from a successful Prepare on a participant.
@@ -567,6 +606,24 @@ pub mod testing {
             Ok(Some(decision.clone()))
         }
 
+        async fn recover_staging_decision(
+            &self,
+            transaction_id: &TwoPhaseTransactionId,
+        ) -> anyhow::Result<StagingRecoveryResult> {
+            let mut decisions = self.decisions.lock();
+            let Some(decision) = decisions.get_mut(&transaction_id.0) else {
+                return Ok(StagingRecoveryResult::Missing);
+            };
+            if !decision.is_staging() {
+                return Ok(StagingRecoveryResult::AlreadyFinal(decision.clone()));
+            }
+            let Some(committed) = decision.committed_from_staging() else {
+                return Ok(StagingRecoveryResult::Pending(decision.clone()));
+            };
+            *decision = committed.clone();
+            Ok(StagingRecoveryResult::Committed(committed))
+        }
+
         async fn delete_decision(
             &self,
             transaction_id: &TwoPhaseTransactionId,
@@ -626,6 +683,11 @@ pub trait TwoPhaseDecisionLog: Send + Sync + 'static {
         intent: TwoPhaseParticipantIntent,
     ) -> anyhow::Result<Option<TwoPhaseDecision>>;
 
+    async fn recover_staging_decision(
+        &self,
+        transaction_id: &TwoPhaseTransactionId,
+    ) -> anyhow::Result<StagingRecoveryResult>;
+
     async fn delete_decision(&self, transaction_id: &TwoPhaseTransactionId) -> anyhow::Result<()>;
 }
 
@@ -663,6 +725,13 @@ impl TwoPhaseDecisionLog for NoopTwoPhaseDecisionLog {
         _intent: TwoPhaseParticipantIntent,
     ) -> anyhow::Result<Option<TwoPhaseDecision>> {
         Ok(None)
+    }
+
+    async fn recover_staging_decision(
+        &self,
+        _transaction_id: &TwoPhaseTransactionId,
+    ) -> anyhow::Result<StagingRecoveryResult> {
+        Ok(StagingRecoveryResult::Missing)
     }
 
     async fn delete_decision(&self, _transaction_id: &TwoPhaseTransactionId) -> anyhow::Result<()> {
@@ -848,6 +917,57 @@ impl TwoPhaseDecisionLog for NatsTwoPhaseDecisionLog {
         anyhow::bail!(
             "2PC: Failed to mark participant {} staged for {transaction_id} after CAS retries",
             intent.partition_id,
+        )
+    }
+
+    async fn recover_staging_decision(
+        &self,
+        transaction_id: &TwoPhaseTransactionId,
+    ) -> anyhow::Result<StagingRecoveryResult> {
+        let key = two_phase_decision_key(transaction_id);
+        for _ in 0..10 {
+            let Some(entry) =
+                self.kv.entry(key.clone()).await.with_context(|| {
+                    format!("2PC: Failed to read decision for {transaction_id}")
+                })?
+            else {
+                return Ok(StagingRecoveryResult::Missing);
+            };
+            let Some(decision) =
+                parse_nats_decision_entry(transaction_id, entry.operation, &entry.value)?
+            else {
+                return Ok(StagingRecoveryResult::Missing);
+            };
+            if !decision.is_staging() {
+                return Ok(StagingRecoveryResult::AlreadyFinal(decision));
+            }
+            let Some(committed) = decision.committed_from_staging() else {
+                return Ok(StagingRecoveryResult::Pending(decision));
+            };
+            let payload = serde_json::to_vec(&committed).with_context(|| {
+                format!("2PC: Failed to serialize recovered decision for {transaction_id}")
+            })?;
+            match self
+                .kv
+                .update(key.clone(), payload.into(), entry.revision)
+                .await
+            {
+                Ok(_) => return Ok(StagingRecoveryResult::Committed(committed)),
+                Err(err)
+                    if err.kind()
+                        == async_nats::jetstream::kv::UpdateErrorKind::WrongLastRevision =>
+                {
+                    continue;
+                },
+                Err(err) => {
+                    anyhow::bail!(
+                        "2PC: Failed to recover staging decision for {transaction_id}: {err:#}"
+                    );
+                },
+            }
+        }
+        anyhow::bail!(
+            "2PC: Failed to recover staging decision for {transaction_id} after CAS retries"
         )
     }
 
@@ -1568,6 +1688,7 @@ mod tests {
                 participants,
                 participant_intents,
                 transaction_digest,
+                staged_at_unix_millis,
                 resolved_participants,
             } => {
                 assert_eq!(commit_ts, 12345);
@@ -1580,6 +1701,7 @@ mod tests {
                     ]
                 );
                 assert_eq!(Some(&transaction_digest), decision.transaction_digest(),);
+                assert!(staged_at_unix_millis.is_some());
                 assert!(resolved_participants.is_empty());
             },
             _ => panic!("Wrong variant"),
@@ -1734,6 +1856,82 @@ mod tests {
                     participant_intent(0, 12345, "participant-zero"),
                     participant_intent(1, 12345, "participant-one"),
                 ],
+            );
+        });
+    }
+
+    #[test]
+    fn test_in_memory_decision_log_recovers_complete_staging_to_committed() {
+        futures::executor::block_on(async {
+            let log = testing::InMemoryTwoPhaseDecisionLog::new();
+            let txn_id = TwoPhaseTransactionId("staging-recovery".to_string());
+            let staging = TwoPhaseDecision::staging(
+                12345,
+                vec![0, 1],
+                vec![
+                    participant_intent(0, 12345, "participant-zero"),
+                    participant_intent(1, 12345, "participant-one"),
+                ],
+            );
+            log.write_decision(&txn_id, &staging).await.unwrap();
+
+            let result = log.recover_staging_decision(&txn_id).await.unwrap();
+            let StagingRecoveryResult::Committed(TwoPhaseDecision::Committed {
+                commit_ts,
+                participants,
+                resolved_participants,
+            }) = result
+            else {
+                panic!("expected committed recovery");
+            };
+            assert_eq!(commit_ts, 12345);
+            assert_eq!(participants, vec![0, 1]);
+            assert!(resolved_participants.is_empty());
+            assert_eq!(
+                log.get_decision(&txn_id).await.unwrap(),
+                Some(TwoPhaseDecision::committed(12345, vec![0, 1])),
+            );
+        });
+    }
+
+    #[test]
+    fn test_in_memory_decision_log_leaves_incomplete_staging_pending() {
+        futures::executor::block_on(async {
+            let log = testing::InMemoryTwoPhaseDecisionLog::new();
+            let txn_id = TwoPhaseTransactionId("staging-pending".to_string());
+            let staging = TwoPhaseDecision::staging(
+                12345,
+                vec![0, 1],
+                vec![participant_intent(0, 12345, "participant-zero")],
+            );
+            log.write_decision(&txn_id, &staging).await.unwrap();
+
+            let result = log.recover_staging_decision(&txn_id).await.unwrap();
+            assert_eq!(result, StagingRecoveryResult::Pending(staging.clone()));
+            assert_eq!(log.get_decision(&txn_id).await.unwrap(), Some(staging));
+        });
+    }
+
+    #[test]
+    fn test_in_memory_decision_log_recovery_is_idempotent_after_final_decision() {
+        futures::executor::block_on(async {
+            let log = testing::InMemoryTwoPhaseDecisionLog::new();
+            let txn_id = TwoPhaseTransactionId("staging-idempotent-recovery".to_string());
+            let staging = TwoPhaseDecision::staging(
+                12345,
+                vec![0],
+                vec![participant_intent(0, 12345, "participant-zero")],
+            );
+            log.write_decision(&txn_id, &staging).await.unwrap();
+            assert!(matches!(
+                log.recover_staging_decision(&txn_id).await.unwrap(),
+                StagingRecoveryResult::Committed(_),
+            ));
+
+            let result = log.recover_staging_decision(&txn_id).await.unwrap();
+            assert_eq!(
+                result,
+                StagingRecoveryResult::AlreadyFinal(TwoPhaseDecision::committed(12345, vec![0])),
             );
         });
     }

--- a/crates/database/src/two_phase_watcher.rs
+++ b/crates/database/src/two_phase_watcher.rs
@@ -17,8 +17,10 @@ use common::runtime::Runtime;
 
 use crate::{
     committer::CommitterClient,
+    metrics,
     partition::PartitionId,
     two_phase::{
+        StagingRecoveryResult,
         TwoPhaseDecision,
         TwoPhaseTransactionId,
         PREPARE_TIMEOUT_SECS,
@@ -27,24 +29,14 @@ use crate::{
     },
 };
 
-/// Apply an existing durable 2PC decision to this local participant.
-pub async fn resolve_decision_for_local_partition(
+async fn apply_final_decision_for_local_partition(
     committer: &CommitterClient,
     local_partition: PartitionId,
-    txn_id: TwoPhaseTransactionId,
+    txn_id: &TwoPhaseTransactionId,
     decision: TwoPhaseDecision,
 ) -> anyhow::Result<bool> {
-    let resolved = match decision {
-        TwoPhaseDecision::Staging { .. } => {
-            // True parallel-commit status recovery is added in a follow-up
-            // issue. Until then, Staging is metadata-only and must not be
-            // interpreted as either commit or rollback by the legacy watcher.
-            tracing::debug!(
-                "2PC Watcher: staging txn={} needs transaction status recovery",
-                txn_id,
-            );
-            false
-        },
+    match decision {
+        TwoPhaseDecision::Staging { .. } => Ok(false),
         TwoPhaseDecision::Committed { participants, .. } => {
             if !participants.contains(&local_partition.0) {
                 return Ok(false);
@@ -59,7 +51,7 @@ pub async fn resolve_decision_for_local_partition(
                         txn_id,
                         u64::from(ts),
                     );
-                    true
+                    Ok(true)
                 },
                 Err(e) => {
                     // "unknown transaction" means it was already committed or
@@ -69,12 +61,12 @@ pub async fn resolve_decision_for_local_partition(
                             "2PC Watcher: committed txn={} already resolved locally",
                             txn_id,
                         );
-                        true
+                        Ok(true)
                     } else {
                         tracing::debug!(
                             "2PC Watcher: CommitPrepared for {txn_id} not ready: {e:#}"
                         );
-                        false
+                        Ok(false)
                     }
                 },
             }
@@ -90,20 +82,80 @@ pub async fn resolve_decision_for_local_partition(
                         "2PC Watcher: rolled back txn={} locally or it was already gone",
                         txn_id,
                     );
-                    true
+                    Ok(true)
                 },
                 Err(e) if e.to_string().contains("unknown transaction") => {
                     tracing::debug!(
                         "2PC Watcher: rollback txn={} already resolved locally",
                         txn_id,
                     );
-                    true
+                    Ok(true)
                 },
                 Err(e) => {
                     tracing::debug!("2PC Watcher: RollbackPrepared for {txn_id} not ready: {e:#}");
+                    Ok(false)
+                },
+            }
+        },
+    }
+}
+
+/// Apply an existing durable 2PC decision to this local participant.
+pub async fn resolve_decision_for_local_partition(
+    committer: &CommitterClient,
+    local_partition: PartitionId,
+    txn_id: TwoPhaseTransactionId,
+    decision: TwoPhaseDecision,
+) -> anyhow::Result<bool> {
+    let resolved = match decision {
+        TwoPhaseDecision::Staging { .. } => {
+            let decision_log = committer.two_phase_decision_log();
+            match decision_log.recover_staging_decision(&txn_id).await? {
+                StagingRecoveryResult::Committed(recovered) => {
+                    metrics::log_two_phase_staging_recovery("committed");
+                    apply_final_decision_for_local_partition(
+                        committer,
+                        local_partition,
+                        &txn_id,
+                        recovered,
+                    )
+                    .await?
+                },
+                StagingRecoveryResult::AlreadyFinal(recovered) => {
+                    metrics::log_two_phase_staging_recovery("already_final");
+                    apply_final_decision_for_local_partition(
+                        committer,
+                        local_partition,
+                        &txn_id,
+                        recovered,
+                    )
+                    .await?
+                },
+                StagingRecoveryResult::Pending(pending) => {
+                    metrics::log_two_phase_staging_recovery("pending");
+                    if let Some(age) = pending.staged_age() {
+                        metrics::log_two_phase_staging_age(age);
+                    }
+                    tracing::debug!(
+                        "2PC Watcher: staging txn={} still missing participant proofs",
+                        txn_id,
+                    );
+                    false
+                },
+                StagingRecoveryResult::Missing => {
+                    metrics::log_two_phase_staging_recovery("missing");
                     false
                 },
             }
+        },
+        final_decision => {
+            apply_final_decision_for_local_partition(
+                committer,
+                local_partition,
+                &txn_id,
+                final_decision,
+            )
+            .await?
         },
     };
 


### PR DESCRIPTION
## Summary

Refs #208. Replaces #213 after #212 was merged into `dev`.

This PR adds the first conservative transaction-status recovery path for parallel-commit staging records.

What changed:
- Adds `staged_at_unix_millis` to staging records for watcher age metrics.
- Adds `StagingRecoveryResult` and `TwoPhaseDecision::committed_from_staging()`.
- Adds `TwoPhaseDecisionLog::recover_staging_decision()` with CAS behavior for NATS KV.
- Updates the 2PC watcher to recover a complete `Staging` record to `Committed`, then reuse the existing final-decision cleanup path.
- Leaves incomplete staging records pending; it does not infer rollback from missing proofs.
- Adds metrics for staging recovery outcomes and unresolved staging age.
- Adds tests for complete recovery, incomplete/pending recovery, and idempotent repeated recovery.

Important scope note:
- This still does **not** enable true early ACK.
- This does **not** query participants for missing proofs yet.
- The current durable-decision 2PC path remains unchanged.

## Validation

- `cargo fmt -p database --check`
- `git diff --check`
- `env PROTOC=/Users/martin/Desktop/convex-horizontal-scaling/crates/pb_build/protoc/protoc-macos-universal cargo test -p database two_phase -- --nocapture` (`22/22`)
- `env PROTOC=/Users/martin/Desktop/convex-horizontal-scaling/crates/pb_build/protoc/protoc-macos-universal cargo check -p database`

No Docker rebuild was run because this is still inactive recovery plumbing and does not change the live clustered commit path.
