### PR TITLE
test(cluster): verify per-write 2pc exactness

### DIFF
--- a/self-hosted/docker/test-write-scaling.sh
+++ b/self-hosted/docker/test-write-scaling.sh
@@ -34,6 +34,7 @@
 #  20c. Lagging Follower Catch-Up After Cross-Partition Writes
 #  20d. Cross-Partition 2PC During Participant Leader Outage
 #  20e. Repeated Raft Leadership Churn During Cross-Partition 2PC
+#  20f. Per-Write 2PC Exactness During Leadership Churn
 #  21. Sustained Writes 30s (long-running replication)
 #  22. Duplicate Insert Idempotency
 #  23. Final Exhaustive Invariant Check
@@ -261,6 +262,14 @@ export const countMessagesByAuthorChannel = query({
   handler: async (ctx, args) => {
     const rows = await ctx.db.query("messages").collect();
     return rows.filter((r: any) => r.author === args.author && r.channel === args.channel).length;
+  },
+});
+
+export const countMessagesByText = query({
+  args: { text: v.string() },
+  handler: async (ctx, args) => {
+    const rows = await ctx.db.query("messages").collect();
+    return rows.filter((r: any) => r.text === args.text).length;
   },
 });
 
@@ -1703,6 +1712,8 @@ CHURN_2PC_RUN="churn-2pc-$(date +%s)"
 CHURN_2PC_ACCEPTED=0
 CHURN_2PC_REJECTED=0
 CHURN_2PC_ATTEMPTED=0
+CHURN_2PC_ACCEPTED_TEXTS=()
+CHURN_2PC_ACCEPTED_TASKS=()
 
 for round in 1 2 3 4; do
     case "$round" in
@@ -1752,11 +1763,15 @@ for round in 1 2 3 4; do
     for i in "${!survivor_labels[@]}"; do
         label="${survivor_labels[$i]}"
         CHURN_2PC_ATTEMPTED=$((CHURN_2PC_ATTEMPTED + 1))
+        write_text="$CHURN_2PC_RUN-r${round}-$label"
+        task_title="$CHURN_2PC_RUN-r${round}-task-$label"
         R=$(mutation_response "${survivor_urls[$i]}" "${survivor_keys[$i]}" "messages:crossPartitionWrite" \
-            "{\"text\":\"$CHURN_2PC_RUN-r${round}-$label\",\"taskTitle\":\"$CHURN_2PC_RUN-r${round}-task-$label\"}")
+            "{\"text\":\"$write_text\",\"taskTitle\":\"$task_title\"}")
         if echo "$R" | grep -q '"status":"success"'; then
             CHURN_2PC_ACCEPTED=$((CHURN_2PC_ACCEPTED + 1))
             ROUND_ACCEPTED=$((ROUND_ACCEPTED + 1))
+            CHURN_2PC_ACCEPTED_TEXTS+=("$write_text")
+            CHURN_2PC_ACCEPTED_TASKS+=("$task_title")
         else
             CHURN_2PC_REJECTED=$((CHURN_2PC_REJECTED + 1))
             echo -e "  ${YELLOW}WARN${NC} $label 2PC write rejected during $stopped_label outage (fail-closed): $R"
@@ -1828,6 +1843,34 @@ CHURN_2PC_DT=$((POST_CHURN_2PC_T - PRE_CHURN_2PC_T))
 [ "$POST_CHURN_2PC_M" -eq "$POST_CHURN_2PC_BM" ] && [ "$POST_CHURN_2PC_T" -eq "$POST_CHURN_2PC_BT" ] \
     && pass "Nodes converged after repeated Raft leadership churn" \
     || fail "Nodes diverged after repeated Raft leadership churn" "p0a=$POST_CHURN_2PC_M,$POST_CHURN_2PC_T p1a=$POST_CHURN_2PC_BM,$POST_CHURN_2PC_BT"
+
+# ============================================================
+echo ""
+echo -e "${BOLD}Test 20f: Per-Write 2PC Exactness During Leadership Churn${NC}"
+# ============================================================
+# Aggregate counts alone can miss a bad parallel-commit recovery pattern where
+# one accepted cross-partition operation is duplicated while another is lost.
+# Verify every accepted 2PC write from the churn window appears exactly once in
+# both halves and on both serving nodes.
+
+CHURN_EXACTNESS_OK=true
+CHURN_EXACTNESS_DETAILS=""
+for i in "${!CHURN_2PC_ACCEPTED_TEXTS[@]}"; do
+    text="${CHURN_2PC_ACCEPTED_TEXTS[$i]}"
+    task="${CHURN_2PC_ACCEPTED_TASKS[$i]}"
+    MSG_A=$(jtotal "$(query_with_args "$NODE_A_URL" "$NODE_A_KEY" "messages:countMessagesByText" "{\"text\":\"$text\"}")")
+    MSG_B=$(jtotal "$(query_with_args "$NODE_B_URL" "$NODE_B_KEY" "messages:countMessagesByText" "{\"text\":\"$text\"}")")
+    TASK_A=$(jtotal "$(query_with_args "$NODE_A_URL" "$NODE_A_KEY" "messages:countTasksByTitle" "{\"title\":\"$task\"}")")
+    TASK_B=$(jtotal "$(query_with_args "$NODE_B_URL" "$NODE_B_KEY" "messages:countTasksByTitle" "{\"title\":\"$task\"}")")
+    if [ "$MSG_A" -ne 1 ] || [ "$MSG_B" -ne 1 ] || [ "$TASK_A" -ne 1 ] || [ "$TASK_B" -ne 1 ]; then
+        CHURN_EXACTNESS_OK=false
+        CHURN_EXACTNESS_DETAILS="$CHURN_EXACTNESS_DETAILS [$text/$task msgA=$MSG_A msgB=$MSG_B taskA=$TASK_A taskB=$TASK_B]"
+    fi
+done
+
+$CHURN_EXACTNESS_OK \
+    && pass "Every accepted churn-window 2PC write appeared exactly once on both nodes" \
+    || fail "Churn-window 2PC exactness violated" "$CHURN_EXACTNESS_DETAILS"
 
 # ============================================================
 echo ""


### PR DESCRIPTION
## Summary

Refs #210.

Adds a cluster-level adversarial check for repeated Raft leadership churn during cross-partition 2PC. The existing churn test verified aggregate message/task deltas, but aggregate counts can miss a dangerous parallel-commit recovery pattern where one accepted transaction is duplicated while another accepted transaction is lost.

This PR strengthens the Docker harness by:

- adding a `countMessagesByText` query to the deployed test app;
- tracking every accepted churn-window 2PC operation by its unique message text and task title;
- verifying each accepted operation appears exactly once in both the message half and the task half;
- verifying the exact rows are visible from both serving nodes after leadership churn.

## Why this matters

Convex’s core guarantees are not just “roughly the right number of rows.” For horizontal write scaling we need each accepted cross-partition mutation to remain atomically visible, exactly once, even while Raft leaders are changing. This catches the class of bug where aggregate counts balance out but individual operations are duplicated, lost, or torn.

## Validation

Syntax/hygiene:

- `bash -n self-hosted/docker/test-write-scaling.sh`
- `git diff --check`

Image/runtime note:

- No backend image rebuild was needed because this PR changes only the Docker test harness and deployed test functions.
- Clean validation used `BACKEND_PULL_POLICY=never` and a recreated cluster with volumes wiped.
- Running backend container image ID matched local tag: `sha256:cd2532f97ae514af6a99fa549c239dd48e7ccbf44a2b681a35543e9e93ca99f2`.
- Local image label revision: `794be18be61b65e3a93b48c0a19cbc26ec82518f`.

Docker validation:

- First run on a reused/dirty cluster exposed old convergence noise before the new check; the new Test 20f itself passed, but the suite was not used as final validation.
- Reset with `BACKEND_PULL_POLICY=never docker compose -f self-hosted/docker/docker-compose.yml --profile cluster down -v --remove-orphans`.
- Recreated with `BACKEND_PULL_POLICY=never docker compose -f self-hosted/docker/docker-compose.yml --profile cluster up -d`.
- Ran `BACKEND_PULL_POLICY=never bash self-hosted/docker/test.sh` from a clean zero-data baseline.
- Write scaling suite: `ALL 121 TESTS PASSED`.
- Raft failover suite: `ALL 24 TESTS PASSED`.
- Full harness: `ALL SUITES PASSED`.
