### PR TITLE
test(cluster): cover post-ack 2pc cleanup recovery

### DIFF
--- a/crates/database/src/two_phase.rs
+++ b/crates/database/src/two_phase.rs
@@ -2155,4 +2155,42 @@ mod tests {
             );
         });
     }
+
+    #[test]
+    fn test_final_decision_survives_duplicate_and_complete_cleanup_marks() {
+        futures::executor::block_on(async {
+            let log = testing::InMemoryTwoPhaseDecisionLog::new();
+            let txn_id = TwoPhaseTransactionId("post-ack-cleanup-recovery".to_string());
+            let committed = TwoPhaseDecision::committed(12345, vec![0, 1]);
+            log.write_decision(&txn_id, &committed).await.unwrap();
+
+            let partially_resolved = log
+                .mark_participant_resolved(&txn_id, PartitionId(0))
+                .await
+                .unwrap()
+                .expect("commit decision should remain after first cleanup mark");
+            assert_eq!(partially_resolved.resolved_participants(), &[0]);
+            assert!(!partially_resolved.all_participants_resolved());
+
+            let duplicate_resolution = log
+                .mark_participant_resolved(&txn_id, PartitionId(0))
+                .await
+                .unwrap()
+                .expect("duplicate cleanup mark must not delete the decision");
+            assert_eq!(duplicate_resolution.resolved_participants(), &[0]);
+
+            let fully_resolved = log
+                .mark_participant_resolved(&txn_id, PartitionId(1))
+                .await
+                .unwrap()
+                .expect("final cleanup mark must retain the decision for crash recovery");
+            assert_eq!(fully_resolved.resolved_participants(), &[0, 1]);
+            assert!(fully_resolved.all_participants_resolved());
+
+            assert_eq!(
+                log.recover_staging_decision(&txn_id).await.unwrap(),
+                StagingRecoveryResult::AlreadyFinal(fully_resolved),
+            );
+        });
+    }
 }

--- a/self-hosted/docker/test-write-scaling.sh
+++ b/self-hosted/docker/test-write-scaling.sh
@@ -21,6 +21,7 @@
 #   9h. 2PC Atomicity During Coordinator Restart
 #   9i. Per-Write 2PC Exactness During Failure Windows
 #   9j. 2PC Exactness During Repeated NATS Flaps
+#   9k. Post-Ack 2PC Exactness After Cleanup-Window Restarts
 #  10. Rapid-Fire Writes Under Load (Jepsen stress)
 #  11. Write-Then-Immediate-Read Consistency (stale read detection)
 #  12. Double Node Restart (crash recovery stress)
@@ -1219,6 +1220,73 @@ done
 $NATS_FLAP_EXACTNESS_OK \
     && pass "Every NATS-flap 2PC attempt was absent or appeared exactly once on both nodes" \
     || fail "NATS-flap 2PC exactness violated" "$NATS_FLAP_EXACTNESS_DETAILS"
+
+# ============================================================
+echo ""
+echo -e "${BOLD}Test 9k: Post-Ack 2PC Exactness After Cleanup-Window Restarts${NC}"
+# ============================================================
+# Once the client has observed success, recovery and cleanup may still be
+# racing in the background. Restart the coordinator and participant entrypoints
+# immediately after a successful cross-partition write, then prove that cleanup
+# recovery neither drops nor duplicates the committed pair.
+
+POST_ACK_RUN="post-ack-2pc-$(date +%s)"
+POST_ACK_TEXT="$POST_ACK_RUN-msg"
+POST_ACK_TASK="$POST_ACK_RUN-task"
+POST_ACK_RESPONSE=$(mutation_response "$NODE_A_URL" "$NODE_A_KEY" "messages:crossPartitionWrite" \
+    "{\"text\":\"$POST_ACK_TEXT\",\"taskTitle\":\"$POST_ACK_TASK\"}")
+
+if echo "$POST_ACK_RESPONSE" | grep -q '"status":"success"'; then
+    pass "Post-ack cleanup-window 2PC write returned success"
+else
+    fail "Post-ack cleanup-window 2PC write did not return success" "$POST_ACK_RESPONSE"
+fi
+
+echo "  Restarting coordinator and participant entrypoints immediately after success..."
+(docker restart docker-node-p0a-1 > /dev/null 2>&1) &
+POST_ACK_RESTART_P0_PID=$!
+(docker restart docker-node-p1a-1 > /dev/null 2>&1) &
+POST_ACK_RESTART_P1_PID=$!
+wait "$POST_ACK_RESTART_P0_PID" || true
+wait "$POST_ACK_RESTART_P1_PID" || true
+
+for attempt in $(seq 1 60); do
+    curl -sf "$NODE_A_URL/version" > /dev/null 2>&1 && break
+    sleep 1
+done
+for attempt in $(seq 1 60); do
+    curl -sf "$NODE_B_URL/version" > /dev/null 2>&1 && break
+    sleep 1
+done
+NODE_P0A_KEY=$(docker exec docker-node-p0a-1 ./generate_admin_key.sh 2>&1 | tail -1)
+NODE_P1A_KEY=$(docker exec docker-node-p1a-1 ./generate_admin_key.sh 2>&1 | tail -1)
+NODE_A_KEY="$NODE_P0A_KEY"
+NODE_B_KEY="$NODE_P1A_KEY"
+(cd "$DEPLOY_DIR" && npx convex deploy --admin-key "$NODE_A_KEY" --url "$NODE_A_URL" > /dev/null 2>&1)
+(cd "$DEPLOY_DIR" && npx convex deploy --admin-key "$NODE_B_KEY" --url "$NODE_B_URL" > /dev/null 2>&1)
+
+sleep 8
+POST_ACK_MSG_A=$(count_message_text "$NODE_A_URL" "$NODE_A_KEY" "$POST_ACK_TEXT")
+POST_ACK_MSG_B=$(count_message_text "$NODE_B_URL" "$NODE_B_KEY" "$POST_ACK_TEXT")
+POST_ACK_TASK_A=$(count_task_title "$NODE_A_URL" "$NODE_A_KEY" "$POST_ACK_TASK")
+POST_ACK_TASK_B=$(count_task_title "$NODE_B_URL" "$NODE_B_KEY" "$POST_ACK_TASK")
+
+[ "$POST_ACK_MSG_A" -eq 1 ] && [ "$POST_ACK_MSG_B" -eq 1 ] && \
+    [ "$POST_ACK_TASK_A" -eq 1 ] && [ "$POST_ACK_TASK_B" -eq 1 ] \
+    && pass "Post-ack 2PC write appeared exactly once after restart cleanup" \
+    || fail "Post-ack 2PC write was lost or duplicated after restart cleanup" \
+        "msgA=$POST_ACK_MSG_A msgB=$POST_ACK_MSG_B taskA=$POST_ACK_TASK_A taskB=$POST_ACK_TASK_B"
+
+POST_ACK_DASH_A=$(query_api "$NODE_A_URL" "$NODE_A_KEY" "messages:dashboard")
+POST_ACK_DASH_B=$(query_api "$NODE_B_URL" "$NODE_B_KEY" "messages:dashboard")
+POST_ACK_DASH_AM=$(jval messages "$POST_ACK_DASH_A")
+POST_ACK_DASH_AT=$(jval tasks "$POST_ACK_DASH_A")
+POST_ACK_DASH_BM=$(jval messages "$POST_ACK_DASH_B")
+POST_ACK_DASH_BT=$(jval tasks "$POST_ACK_DASH_B")
+[ "$POST_ACK_DASH_AM" -eq "$POST_ACK_DASH_BM" ] && [ "$POST_ACK_DASH_AT" -eq "$POST_ACK_DASH_BT" ] \
+    && pass "Nodes converged after post-ack 2PC cleanup-window restarts" \
+    || fail "Nodes diverged after post-ack 2PC cleanup-window restarts" \
+        "p0a=$POST_ACK_DASH_AM,$POST_ACK_DASH_AT p1a=$POST_ACK_DASH_BM,$POST_ACK_DASH_BT"
 
 # ============================================================
 echo ""

--- a/self-hosted/docker/test.sh
+++ b/self-hosted/docker/test.sh
@@ -7,8 +7,8 @@
 #
 # Usage:
 #   ./test.sh              # Run all tests (scaling + failover)
-#   ./test.sh scaling      # Write scaling only (77 tests)
-#   ./test.sh failover     # Raft failover only (10 tests)
+#   ./test.sh scaling      # Write scaling only
+#   ./test.sh failover     # Raft failover only
 #
 # Prerequisites:
 #   docker compose --profile cluster up
@@ -22,8 +22,8 @@ case "$SUITE" in
     *)
         echo "Usage: $0 [all|scaling|failover]"
         echo "  all       Run all tests (default)"
-        echo "  scaling   Write scaling tests only (77 tests)"
-        echo "  failover  Raft failover tests only (10 tests)"
+        echo "  scaling   Write scaling tests only"
+        echo "  failover  Raft failover tests only"
         exit 1
         ;;
 esac


### PR DESCRIPTION
## Summary

Closes part of #210.

Adds coverage for the post-ack 2PC cleanup/recovery window:

- adds `Test 9k` to the Docker write-scaling harness;
- performs a successful cross-partition 2PC write, immediately restarts the coordinator and participant entrypoints, then verifies the accepted write appears exactly once on both nodes;
- adds a unit-level guard that final 2PC decisions remain recoverable after partial, duplicate, and complete cleanup marks;
- removes stale hard-coded `77`/`10` suite counts from `self-hosted/docker/test.sh` so the wrapper does not drift as tests grow.

## Validation

- `cargo fmt --check -p database`
- `bash -n self-hosted/docker/test.sh && bash -n self-hosted/docker/test-write-scaling.sh`
- `git diff --check`
- `cargo test -p database test_final_decision_survives_duplicate_and_complete_cleanup_marks -- --nocapture`
- Clean Docker cluster reset with `BACKEND_PULL_POLICY=never`
- Verified all six backend containers used local image `sha256:cd2532f97ae514af6a99fa549c239dd48e7ccbf44a2b681a35543e9e93ca99f2`, revision `794be18be61b65e3a93b48c0a19cbc26ec82518f`
- `BACKEND_PULL_POLICY=never bash self-hosted/docker/test.sh`
  - Write scaling: `129/129`
  - Raft failover: `24/24`
  - Full harness: `ALL SUITES PASSED`
