### PR TITLE
feat(database): gate parallel 2pc early ack

### DIFF
--- a/crates/common/src/knobs.rs
+++ b/crates/common/src/knobs.rs
@@ -400,6 +400,16 @@ pub static REMOTE_READ_FRONTIER_WAIT_TIMEOUT: LazyLock<Duration> = LazyLock::new
     Duration::from_millis(env_config("REMOTE_READ_FRONTIER_WAIT_TIMEOUT_MS", 5000))
 });
 
+/// Enable true 2PC parallel-commit early acknowledgement.
+///
+/// When false, cross-partition 2PC uses the conservative durable-decision path:
+/// the coordinator acknowledges the client only after participant cleanup makes
+/// writes visible. When true, the coordinator may acknowledge after it has a
+/// durable staging record plus every participant's Raft-replicated intent
+/// proof, and cleanup proceeds asynchronously.
+pub static ENABLE_PARALLEL_2PC_EARLY_ACK: LazyLock<bool> =
+    LazyLock::new(|| env_config("ENABLE_PARALLEL_2PC_EARLY_ACK", false));
+
 /// This is the max duration between a Commit and bumping max_repeatable_ts.
 /// When reading from a follower persistence, we can only read commits at
 /// timestamps <= max_repeatable_ts (because commits > max_repeatable_ts are

--- a/crates/common/src/persistence.rs
+++ b/crates/common/src/persistence.rs
@@ -170,8 +170,13 @@ pub enum PersistenceGlobalKey {
     /// Latest origin commit timestamp for a non-empty data delta durably
     /// applied per source partition. Unlike `AppliedDeltaWatermarks`, this
     /// must not advance on frontier-only heartbeats because it is used for
-    /// transport redelivery idempotency.
+    /// transport lag/diagnostics, not exact redelivery idempotency.
     AppliedDataDeltaWatermarks,
+
+    /// Exact set of non-empty data delta origin timestamps durably applied per
+    /// source partition. This is separate from the max watermark because
+    /// Raft->NATS outbox recovery can replay older deltas after newer ones.
+    AppliedDataDeltaIds,
 
     /// Latest snapshot of all tables' summaries, cached to speed up startup.
     TableSummary,
@@ -216,6 +221,7 @@ impl From<PersistenceGlobalKey> for String {
             PersistenceGlobalKey::AppliedDataDeltaWatermarks => {
                 "applied_data_delta_watermarks".to_string()
             },
+            PersistenceGlobalKey::AppliedDataDeltaIds => "applied_data_delta_ids".to_string(),
             PersistenceGlobalKey::TableSummary => "table_summary".to_string(),
             PersistenceGlobalKey::TwoPhaseRedoRecords => "two_phase_redo_records".to_string(),
             PersistenceGlobalKey::RaftNatsOutbox => "raft_nats_outbox".to_string(),
@@ -240,6 +246,7 @@ impl FromStr for PersistenceGlobalKey {
             "replication_frontiers" => Ok(Self::ReplicationFrontiers),
             "applied_delta_watermarks" => Ok(Self::AppliedDeltaWatermarks),
             "applied_data_delta_watermarks" => Ok(Self::AppliedDataDeltaWatermarks),
+            "applied_data_delta_ids" => Ok(Self::AppliedDataDeltaIds),
             "table_summary" => Ok(Self::TableSummary),
             "two_phase_redo_records" => Ok(Self::TwoPhaseRedoRecords),
             "raft_nats_outbox" => Ok(Self::RaftNatsOutbox),

--- a/crates/database/src/committer.rs
+++ b/crates/database/src/committer.rs
@@ -197,6 +197,7 @@ const MAX_PERSISTENCE_WRITES_BACKOFF: Duration = Duration::from_secs(60);
 const RAFT_NATS_OUTBOX_REPLAY_INTERVAL: Duration = Duration::from_secs(1);
 
 type RaftNatsOutboxRecords = BTreeMap<String, serde_json::Value>;
+pub(crate) type AppliedDataDeltaIds = BTreeMap<crate::partition::PartitionId, BTreeSet<Timestamp>>;
 
 /// State held for a 2PC-prepared transaction awaiting commit/rollback.
 struct PreparedTransaction {
@@ -262,6 +263,7 @@ enum PersistenceWrite {
         source_partition: Option<crate::partition::PartitionId>,
         applied_delta_watermarks: Option<BTreeMap<crate::partition::PartitionId, Timestamp>>,
         applied_data_delta_watermarks: Option<BTreeMap<crate::partition::PartitionId, Timestamp>>,
+        applied_data_delta_ids: Option<AppliedDataDeltaIds>,
         raft_nats_outbox_delta: Option<CommitDelta>,
         result: oneshot::Sender<anyhow::Result<Timestamp>>,
         commit_id: usize,
@@ -279,6 +281,7 @@ enum PersistenceWrite {
         replication_frontiers: BTreeMap<crate::partition::PartitionId, Timestamp>,
         applied_delta_watermarks: BTreeMap<crate::partition::PartitionId, Timestamp>,
         applied_data_delta_watermarks: BTreeMap<crate::partition::PartitionId, Timestamp>,
+        applied_data_delta_ids: AppliedDataDeltaIds,
         result: oneshot::Sender<anyhow::Result<Timestamp>>,
         commit_id: usize,
     },
@@ -363,6 +366,60 @@ fn merge_partition_timestamp_max(
         }
     }
     merged
+}
+
+fn merge_applied_data_delta_ids(
+    current: &AppliedDataDeltaIds,
+    proposed: AppliedDataDeltaIds,
+) -> AppliedDataDeltaIds {
+    let mut merged = current.clone();
+    for (partition, timestamps) in proposed {
+        merged.entry(partition).or_default().extend(timestamps);
+    }
+    merged
+}
+
+fn applied_data_delta_ids_to_json(ids: &AppliedDataDeltaIds) -> serde_json::Value {
+    let mut object = serde_json::Map::new();
+    for (partition, timestamps) in ids {
+        object.insert(
+            partition.0.to_string(),
+            serde_json::Value::Array(
+                timestamps
+                    .iter()
+                    .map(|ts| serde_json::Value::from(u64::from(*ts)))
+                    .collect(),
+            ),
+        );
+    }
+    serde_json::Value::Object(object)
+}
+
+pub(crate) fn applied_data_delta_ids_from_json(
+    value: serde_json::Value,
+) -> anyhow::Result<AppliedDataDeltaIds> {
+    let object = value
+        .as_object()
+        .context("applied data delta ids should be an object")?;
+    let mut ids = AppliedDataDeltaIds::new();
+    for (partition, timestamps) in object {
+        let partition_id = partition
+            .parse::<u32>()
+            .with_context(|| format!("invalid applied data delta ids partition {partition:?}"))?;
+        let timestamps = timestamps
+            .as_array()
+            .context("applied data delta ids entries should be arrays")?
+            .iter()
+            .map(|value| {
+                let ts = value
+                    .as_u64()
+                    .context("applied data delta id should be a u64 timestamp")?;
+                Timestamp::try_from(ts)
+            })
+            .collect::<anyhow::Result<BTreeSet<_>>>()?;
+        ids.insert(crate::partition::PartitionId(partition_id), timestamps);
+    }
+    Ok(ids)
 }
 
 fn compact_checkpoint_documents(checkpoint: &CheckpointData) -> Vec<DocumentLogEntry> {
@@ -685,8 +742,15 @@ pub struct Committer<RT: Runtime> {
     applied_delta_watermarks: BTreeMap<crate::partition::PartitionId, Timestamp>,
 
     // Durable origin-timestamp idempotency frontier for non-empty replicated
-    // data deltas only. Heartbeats must never advance this map.
+    // data deltas only. Heartbeats must never advance this map. This is only a
+    // max watermark; exact idempotency lives in `applied_data_delta_ids` because
+    // Raft->NATS outbox replay can deliver older origin timestamps after newer
+    // ones.
     applied_data_delta_watermarks: BTreeMap<crate::partition::PartitionId, Timestamp>,
+
+    // Exact durable origin ids for non-empty replicated data deltas. Keyed by
+    // source partition and origin commit timestamp.
+    applied_data_delta_ids: AppliedDataDeltaIds,
 
     // Sender for requeueing internal work that must wait for earlier state
     // machine timestamps to become visible without blocking the committer loop.
@@ -766,6 +830,7 @@ impl<RT: Runtime> Committer<RT> {
         raft_state: Option<crate::raft_partition::RaftPartitionState>,
         applied_delta_watermarks: BTreeMap<crate::partition::PartitionId, Timestamp>,
         applied_data_delta_watermarks: BTreeMap<crate::partition::PartitionId, Timestamp>,
+        applied_data_delta_ids: AppliedDataDeltaIds,
     ) -> CommitterClient {
         let persistence_reader = persistence.reader();
         let (tx, rx) = mpsc::channel(*COMMITTER_QUEUE_SIZE);
@@ -794,6 +859,7 @@ impl<RT: Runtime> Committer<RT> {
             raft_state,
             applied_delta_watermarks,
             applied_data_delta_watermarks,
+            applied_data_delta_ids,
             sender: tx.clone(),
         };
         let handle = runtime.spawn("committer", async move {
@@ -1248,6 +1314,7 @@ impl<RT: Runtime> Committer<RT> {
                             source_partition,
                             applied_delta_watermarks,
                             applied_data_delta_watermarks,
+                            applied_data_delta_ids,
                             raft_nats_outbox_delta,
                             result,
                             ..
@@ -1287,6 +1354,20 @@ impl<RT: Runtime> Committer<RT> {
                                     )
                                     .await?;
                                 self.applied_data_delta_watermarks = frontiers;
+                            }
+                            if let Some(applied_ids) = applied_data_delta_ids {
+                                self.applied_data_delta_ids = merge_applied_data_delta_ids(
+                                    &self.applied_data_delta_ids,
+                                    applied_ids,
+                                );
+                                let applied_data_delta_ids_json =
+                                    applied_data_delta_ids_to_json(&self.applied_data_delta_ids);
+                                self.persistence
+                                    .write_persistence_global(
+                                        PersistenceGlobalKey::AppliedDataDeltaIds,
+                                        applied_data_delta_ids_json,
+                                    )
+                                    .await?;
                             }
                             if let Some(delta) = raft_nats_outbox_delta.as_ref() {
                                 Self::add_raft_nats_outbox_delta(
@@ -1386,6 +1467,7 @@ impl<RT: Runtime> Committer<RT> {
                             replication_frontiers,
                             applied_delta_watermarks,
                             applied_data_delta_watermarks,
+                            applied_data_delta_ids,
                             result,
                             ..
                         } => {
@@ -1397,6 +1479,7 @@ impl<RT: Runtime> Committer<RT> {
                             self.last_assigned_ts = snapshot_ts;
                             self.applied_delta_watermarks = applied_delta_watermarks.clone();
                             self.applied_data_delta_watermarks = applied_data_delta_watermarks;
+                            self.applied_data_delta_ids = applied_data_delta_ids;
                             self.snapshot_manager.write().replace(
                                 snapshot_ts,
                                 snapshot,
@@ -3061,6 +3144,17 @@ impl<RT: Runtime> Committer<RT> {
                         )
                         .await?;
                 }
+                if !checkpoint
+                    .globals
+                    .contains_key(&String::from(PersistenceGlobalKey::AppliedDataDeltaIds))
+                {
+                    persistence
+                        .write_persistence_global(
+                            PersistenceGlobalKey::AppliedDataDeltaIds,
+                            serde_json::json!({}),
+                        )
+                        .await?;
+                }
 
                 let replication_frontiers = checkpoint
                     .globals
@@ -3102,6 +3196,12 @@ impl<RT: Runtime> Committer<RT> {
                     })
                     .transpose()?
                     .unwrap_or_default();
+                let applied_data_delta_ids = checkpoint
+                    .globals
+                    .get(&String::from(PersistenceGlobalKey::AppliedDataDeltaIds))
+                    .map(|value| applied_data_delta_ids_from_json(value.clone()))
+                    .transpose()?
+                    .unwrap_or_default();
 
                 Ok(PersistenceWrite::InstallSnapshot {
                     snapshot_ts: checkpoint_ts,
@@ -3109,6 +3209,7 @@ impl<RT: Runtime> Committer<RT> {
                     replication_frontiers,
                     applied_delta_watermarks,
                     applied_data_delta_watermarks,
+                    applied_data_delta_ids,
                     result,
                     commit_id,
                 })
@@ -3423,9 +3524,9 @@ impl<RT: Runtime> Committer<RT> {
         if let Some(source_partition) = delta.source_partition
             && local_prepared_commit_ts.is_none()
             && self
-                .applied_data_delta_watermarks
+                .applied_data_delta_ids
                 .get(&source_partition)
-                .is_some_and(|frontier| *frontier >= remote_ts)
+                .is_some_and(|timestamps| timestamps.contains(&remote_ts))
         {
             tracing::info!(
                 "Skipping duplicate non-empty replica delta: source_partition={}, remote_ts={}",
@@ -3672,6 +3773,11 @@ impl<RT: Runtime> Committer<RT> {
                 }
                 frontiers
             });
+        let updated_applied_data_delta_ids = delta.source_partition.map(|source_partition| {
+            let mut ids = self.applied_data_delta_ids.clone();
+            ids.entry(source_partition).or_default().insert(remote_ts);
+            ids
+        });
         if let Some(source_partition) = delta.source_partition {
             if self
                 .applied_delta_watermarks
@@ -3689,6 +3795,10 @@ impl<RT: Runtime> Committer<RT> {
                 self.applied_data_delta_watermarks
                     .insert(source_partition, remote_ts);
             }
+            self.applied_data_delta_ids
+                .entry(source_partition)
+                .or_default()
+                .insert(remote_ts);
         }
         let raft_nats_outbox_delta = (mode == ReplicaDeltaApplyMode::FullRaftState
             && delta.source_partition.is_some())
@@ -3703,6 +3813,7 @@ impl<RT: Runtime> Committer<RT> {
             let replication_frontiers = updated_replication_frontiers.clone();
             let applied_delta_watermarks = updated_applied_delta_watermarks.clone();
             let applied_data_delta_watermarks = updated_applied_data_delta_watermarks.clone();
+            let applied_data_delta_ids = updated_applied_data_delta_ids.clone();
             let source_partition = delta.source_partition;
             async move {
                 // Write to persistence (so function runner can load modules).
@@ -3737,6 +3848,7 @@ impl<RT: Runtime> Committer<RT> {
                     source_partition,
                     applied_delta_watermarks,
                     applied_data_delta_watermarks,
+                    applied_data_delta_ids,
                     raft_nats_outbox_delta,
                     result,
                     commit_id,

--- a/crates/database/src/database.rs
+++ b/crates/database/src/database.rs
@@ -1071,6 +1071,13 @@ impl<RT: Runtime> Database<RT> {
             },
             None => BTreeMap::new(),
         };
+        let applied_data_delta_ids = match reader
+            .get_persistence_global(PersistenceGlobalKey::AppliedDataDeltaIds)
+            .await?
+        {
+            Some(value) => crate::committer::applied_data_delta_ids_from_json(value)?,
+            None => BTreeMap::new(),
+        };
 
         let snapshot_manager = SnapshotManager::new(
             *ts,
@@ -1135,6 +1142,7 @@ impl<RT: Runtime> Database<RT> {
             raft_state,
             applied_delta_watermarks,
             applied_data_delta_watermarks,
+            applied_data_delta_ids,
         );
         let table_mapping_snapshot_cache =
             AsyncLru::new(runtime.clone(), 20, 2, "table_mapping_snapshot");

--- a/crates/database/src/tests/write_scaling_tests.rs
+++ b/crates/database/src/tests/write_scaling_tests.rs
@@ -2743,6 +2743,139 @@ async fn test_frontier_heartbeat_does_not_dedupe_later_data_delta(
     Ok(())
 }
 
+#[convex_macro::test_runtime]
+async fn test_late_outbox_replay_data_delta_not_deduped_by_newer_data_watermark(
+    rt: TestRuntime,
+) -> anyhow::Result<()> {
+    let log = Arc::new(InMemoryDistributedLog::new());
+    let target_persistence = Arc::new(TestPersistence::new());
+    let table_numbers = Arc::new(InMemoryTableNumberAllocator::default());
+    let source = create_node_with_table_number_allocator(
+        &rt,
+        log.clone(),
+        Some(partitioned_map(PartitionId(1))),
+        table_numbers.clone(),
+    )
+    .await?;
+    let mut target = create_node_with_persistence_and_table_number_allocator(
+        &rt,
+        target_persistence.clone(),
+        log.clone(),
+        Some(partitioned_map(PartitionId(0))),
+        None,
+        Arc::new(NoopTwoPhaseDecisionLog),
+        None,
+        table_numbers.clone(),
+    )
+    .await?;
+
+    insert_doc(&source, "projects", assert_obj!("name" => "schema-seed")).await?;
+    let schema_delta = latest_delta_for_partition(&log, PartitionId(1))?;
+    target
+        .committer_for_test()
+        .apply_replica_delta(schema_delta)
+        .await?;
+
+    insert_doc(
+        &source,
+        "projects",
+        assert_obj!("name" => "older-outbox-replay"),
+    )
+    .await?;
+    let older_delta = latest_delta_for_partition(&log, PartitionId(1))?;
+    insert_doc(
+        &source,
+        "projects",
+        assert_obj!("name" => "newer-outbox-replay"),
+    )
+    .await?;
+    let newer_delta = latest_delta_for_partition(&log, PartitionId(1))?;
+    anyhow::ensure!(
+        older_delta.ts < newer_delta.ts,
+        "test setup should create an older origin delta before the newer one",
+    );
+
+    target
+        .committer_for_test()
+        .apply_replica_delta(newer_delta.clone())
+        .await?;
+    let data_watermarks = target_persistence
+        .reader()
+        .get_persistence_global(PersistenceGlobalKey::AppliedDataDeltaWatermarks)
+        .await?
+        .context("newer data delta should persist the max data watermark")?;
+    let data_watermarks =
+        partition_timestamp_map_from_json(data_watermarks, "applied data delta watermarks")?;
+    assert_eq!(
+        data_watermarks.get(&PartitionId(1)).copied(),
+        Some(newer_delta.ts),
+        "newer delta should advance the diagnostic max data watermark",
+    );
+
+    let older_apply_ts = target
+        .committer_for_test()
+        .apply_replica_delta(older_delta.clone())
+        .await?;
+    assert!(
+        older_apply_ts > newer_delta.ts,
+        "older origin delta should still apply at a fresh local timestamp after a newer watermark",
+    );
+
+    let projects = run_query(
+        target.clone(),
+        TableNamespace::root_component(),
+        Query::full_table_scan("projects".parse()?, Order::Asc),
+    )
+    .await?;
+    for name in ["schema-seed", "older-outbox-replay", "newer-outbox-replay"] {
+        let matches = projects
+            .iter()
+            .filter(|project| project.value().0.get("name") == Some(&assert_val!(name)))
+            .count();
+        assert_eq!(
+            matches, 1,
+            "replicated project {name:?} should appear exactly once",
+        );
+    }
+
+    target.shutdown().await?;
+    target = create_node_with_persistence_and_table_number_allocator(
+        &rt,
+        target_persistence.clone(),
+        log,
+        Some(partitioned_map(PartitionId(0))),
+        None,
+        Arc::new(NoopTwoPhaseDecisionLog),
+        None,
+        table_numbers,
+    )
+    .await?;
+
+    let document_log_count_before_duplicate =
+        persisted_document_log_count(&target_persistence).await?;
+    let snapshot_ts_before_duplicate = *target.now_ts_for_reads();
+    let duplicate_apply_ts = target
+        .committer_for_test()
+        .apply_replica_delta(older_delta.clone())
+        .await?;
+    assert_eq!(
+        duplicate_apply_ts, older_delta.ts,
+        "post-restart duplicate should ACK as skipped at its origin timestamp",
+    );
+    assert_eq!(
+        persisted_document_log_count(&target_persistence).await?,
+        document_log_count_before_duplicate,
+        "post-restart duplicate must not append document log entries",
+    );
+    assert_eq!(
+        *target.now_ts_for_reads(),
+        snapshot_ts_before_duplicate,
+        "post-restart duplicate must not publish a new snapshot",
+    );
+
+    Ok(())
+}
+
 fn rewrite_index_document_ids(mut delta: CommitDelta) -> anyhow::Result<CommitDelta> {
     let mut rewritten = 1u8;
     for update in &mut delta.document_updates {

--- a/crates/database/src/tests/write_scaling_tests.rs
+++ b/crates/database/src/tests/write_scaling_tests.rs
@@ -150,6 +150,10 @@ use crate::{
         TwoPhaseRedoEntry,
         TwoPhaseTransactionId,
     },
+    two_phase_coordinator::{
+        coordinate_two_phase_commit_with_mode,
+        TwoPhaseCommitMode,
+    },
     Database,
     SystemMetadataModel,
     TableModel,
@@ -5251,6 +5255,155 @@ fn test_cross_partition_commit_uses_remote_prepare_over_grpc() -> anyhow::Result
             assert_obj!("name" => "follow-up-remote"),
         )
         .await?;
+
+        server.shutdown().await?;
+        Ok(())
+    })
+}
+
+#[test]
+fn test_parallel_early_ack_recovers_staging_before_async_cleanup() -> anyhow::Result<()> {
+    let td = TestDriver::new_with_io();
+    let rt = td.rt();
+    td.run_until(async move {
+        let log = Arc::new(InMemoryDistributedLog::new());
+        let decision_log = Arc::new(InMemoryTwoPhaseDecisionLog::new());
+        let tso: Arc<dyn TimestampOracle> = Arc::new(InMemoryTimestampOracle::new());
+        let node_b_map = partitioned_map(PartitionId(1));
+        let node_b = create_node_with_options_and_decision_log(
+            &rt,
+            log.clone(),
+            Some(node_b_map),
+            None,
+            Some(tso.clone()),
+            decision_log.clone(),
+        )
+        .await?;
+        let server = start_two_pc_server(TestTwoPhaseCommitGrpcService::new(
+            node_b.committer_for_test(),
+        ))
+        .await?;
+
+        let node_a_map = partitioned_map(PartitionId(0));
+        let node_a = create_node_with_options_and_decision_log(
+            &rt,
+            log.clone(),
+            Some(node_a_map.clone()),
+            Some(NodeAddresses::from_config(&format!("1={}", server.addr()))),
+            Some(tso),
+            decision_log.clone(),
+        )
+        .await?;
+
+        insert_doc(&node_b, "projects", assert_obj!("name" => "seed")).await?;
+        let remote_seed_delta = log
+            .deltas()
+            .into_iter()
+            .last()
+            .expect("seed project should publish a delta");
+        node_a
+            .committer_for_test()
+            .apply_replica_delta(remote_seed_delta)
+            .await?;
+        insert_doc(&node_a, "messages", assert_obj!("text" => "seed")).await?;
+        let heartbeat_ts = node_b.bump_max_repeatable_ts().await?;
+        node_a
+            .committer_for_test()
+            .apply_replica_delta(CommitDelta {
+                ts: heartbeat_ts,
+                document_writes: Arc::new(Vec::new()),
+                document_updates: Vec::new(),
+                index_writes: Arc::new(Vec::new()),
+                write_source: WriteSource::new("parallel_early_ack_test"),
+                write_bytes: 0,
+                tablet_id_to_table_name: Default::default(),
+                source_partition: Some(PartitionId(1)),
+            })
+            .await?;
+
+        let initial_delta_count = log.deltas().len();
+        let mut tx = node_a.begin(Identity::system()).await?;
+        let mut model = TestFacingModel::new(&mut tx);
+        model
+            .insert(
+                &"messages".parse()?,
+                assert_obj!("text" => "parallel-local"),
+            )
+            .await?;
+        model
+            .insert(
+                &"projects".parse()?,
+                assert_obj!("name" => "parallel-remote"),
+            )
+            .await?;
+        let final_tx = tx.finalize()?;
+
+        let outcome = coordinate_two_phase_commit_with_mode(
+            &node_a.committer_for_test(),
+            final_tx,
+            WriteSource::new("parallel_early_ack_test"),
+            &node_a_map,
+            TwoPhaseCommitMode::ParallelEarlyAck,
+        )
+        .await?;
+
+        let decisions = decision_log.decisions();
+        assert_eq!(decisions.len(), 1);
+        assert!(
+            decisions.values().any(|decision| matches!(
+                decision,
+                TwoPhaseDecision::Committed {
+                    commit_ts,
+                    participants,
+                    ..
+                } if *commit_ts == u64::from(outcome.ts)
+                    && participants == &vec![PartitionId(0).0, PartitionId(1).0]
+            )),
+            "parallel early ACK should recover the durable staging proof into a committed decision"
+        );
+
+        let mut commit_deltas = Vec::new();
+        for _ in 0..50 {
+            let deltas = log.deltas();
+            commit_deltas = deltas[initial_delta_count..]
+                .iter()
+                .filter(|delta| delta.ts == outcome.ts)
+                .cloned()
+                .collect();
+            if commit_deltas.len() == 2 {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+        assert_eq!(
+            commit_deltas.len(),
+            2,
+            "parallel cleanup should eventually publish one committed delta per participant",
+        );
+        let mut sources: Vec<_> = commit_deltas
+            .iter()
+            .map(|delta| delta.source_partition)
+            .collect();
+        sources.sort();
+        assert_eq!(sources, vec![Some(PartitionId(0)), Some(PartitionId(1))]);
+
+        for _ in 0..50 {
+            if decision_log
+                .decisions()
+                .values()
+                .any(TwoPhaseDecision::all_participants_resolved)
+            {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+        assert!(
+            decision_log
+                .decisions()
+                .values()
+                .any(TwoPhaseDecision::all_participants_resolved),
+            "async cleanup should mark every participant resolved",
+        );
 
         server.shutdown().await?;
         Ok(())

--- a/crates/database/src/two_phase_coordinator.rs
+++ b/crates/database/src/two_phase_coordinator.rs
@@ -32,6 +32,8 @@ use common::{
         ParseDocument,
         ResolvedDocument,
     },
+    knobs::ENABLE_PARALLEL_2PC_EARLY_ACK,
+    runtime::tokio_spawn,
     types::Timestamp,
 };
 use futures::{
@@ -54,13 +56,32 @@ use crate::{
     two_phase::{
         NodeAddresses,
         ParticipantTransaction,
+        StagingRecoveryResult,
         TwoPhaseDecision,
+        TwoPhaseParticipantIntent,
+        TwoPhaseRedoEntry,
         TwoPhaseTransactionId,
     },
     write_log::WriteSource,
 };
 
 const MAX_PREPARE_TS_RETRIES: usize = 8;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum TwoPhaseCommitMode {
+    DurableDecision,
+    ParallelEarlyAck,
+}
+
+impl TwoPhaseCommitMode {
+    fn from_knob() -> Self {
+        if *ENABLE_PARALLEL_2PC_EARLY_ACK {
+            Self::ParallelEarlyAck
+        } else {
+            Self::DurableDecision
+        }
+    }
+}
 
 struct PrepareParticipantFailure {
     participant: PartitionId,
@@ -555,6 +576,151 @@ async fn write_decision_record(
     Ok(())
 }
 
+fn participant_intents_for_staging(
+    transaction_id: &TwoPhaseTransactionId,
+    prepare_ts: Timestamp,
+    all_participants: &[PartitionId],
+    participants: &[(PartitionId, ParticipantTransaction)],
+    write_source: &WriteSource,
+) -> anyhow::Result<Vec<TwoPhaseParticipantIntent>> {
+    let mut intents = participants
+        .iter()
+        .map(|(participant, transaction)| {
+            let redo = TwoPhaseRedoEntry::new_with_participants(
+                transaction_id,
+                prepare_ts,
+                *participant,
+                all_participants,
+                transaction.clone(),
+                write_source,
+            )?;
+            Ok(TwoPhaseParticipantIntent::from_redo_entry(&redo))
+        })
+        .collect::<anyhow::Result<Vec<_>>>()?;
+    intents.sort_by_key(|intent| intent.partition_id);
+    Ok(intents)
+}
+
+async fn write_complete_staging_decision(
+    local_committer: &CommitterClient,
+    transaction_id: &TwoPhaseTransactionId,
+    prepare_ts: Timestamp,
+    all_participants: &[PartitionId],
+    participants: &[(PartitionId, ParticipantTransaction)],
+    write_source: &WriteSource,
+) -> anyhow::Result<TwoPhaseDecision> {
+    let decision = TwoPhaseDecision::staging(
+        u64::from(prepare_ts),
+        all_participants
+            .iter()
+            .map(|participant| participant.0)
+            .collect(),
+        participant_intents_for_staging(
+            transaction_id,
+            prepare_ts,
+            all_participants,
+            participants,
+            write_source,
+        )?,
+    );
+    anyhow::ensure!(
+        decision.all_participants_staged(),
+        "2PC Coordinator: constructed incomplete staging decision for txn={transaction_id}",
+    );
+    write_decision_record(local_committer, transaction_id, &decision)
+        .await
+        .with_context(|| {
+            format!("2PC Coordinator: failed to write staging decision for txn={transaction_id}")
+        })?;
+    Ok(decision)
+}
+
+async fn recover_complete_staging_decision(
+    local_committer: &CommitterClient,
+    transaction_id: &TwoPhaseTransactionId,
+) -> anyhow::Result<TwoPhaseDecision> {
+    let decision_log = local_committer.two_phase_decision_log();
+    let recovered = decision_log
+        .recover_staging_decision(transaction_id)
+        .await
+        .with_context(|| {
+            format!(
+                "2PC Coordinator: failed to recover complete staging decision for \
+                 txn={transaction_id}"
+            )
+        })?;
+    match recovered {
+        StagingRecoveryResult::Committed(decision)
+        | StagingRecoveryResult::AlreadyFinal(decision @ TwoPhaseDecision::Committed { .. }) => {
+            Ok(decision)
+        },
+        StagingRecoveryResult::Pending(decision) => {
+            anyhow::bail!(
+                "2PC Coordinator: staging decision for txn={} is still pending: {:?}",
+                transaction_id,
+                decision,
+            )
+        },
+        StagingRecoveryResult::AlreadyFinal(decision) => {
+            anyhow::bail!(
+                "2PC Coordinator: staging decision for txn={} recovered to non-committed final \
+                 state: {:?}",
+                transaction_id,
+                decision,
+            )
+        },
+        StagingRecoveryResult::Missing => {
+            anyhow::bail!(
+                "2PC Coordinator: staging decision for txn={} disappeared before recovery",
+                transaction_id,
+            )
+        },
+    }
+}
+
+fn spawn_parallel_commit_cleanup(
+    local_committer: CommitterClient,
+    node_addresses: Option<NodeAddresses>,
+    partition_map: PartitionMap,
+    transaction_id: TwoPhaseTransactionId,
+    prepared_participants: Vec<PartitionId>,
+    prepare_ts: Timestamp,
+) {
+    tokio_spawn("two_phase_parallel_commit_cleanup", async move {
+        match commit_participants(
+            &local_committer,
+            node_addresses.as_ref(),
+            &partition_map,
+            &transaction_id,
+            &prepared_participants,
+        )
+        .await
+        {
+            Ok(commit_results) => {
+                for (participant, commit_ts) in &commit_results {
+                    if *commit_ts != prepare_ts {
+                        tracing::error!(
+                            "2PC parallel cleanup: participant {} committed txn={} at ts={} but \
+                             coordinator assigned ts={}",
+                            participant,
+                            transaction_id,
+                            commit_ts,
+                            prepare_ts,
+                        );
+                    }
+                }
+            },
+            Err(err) => {
+                tracing::warn!(
+                    "2PC parallel cleanup for txn={} did not finish; watcher will retry from the \
+                     durable decision: {err:#}",
+                    transaction_id,
+                );
+            },
+        }
+    });
+}
+
 async fn mark_participant_resolved(
     local_committer: &CommitterClient,
     transaction_id: &TwoPhaseTransactionId,
@@ -606,6 +772,51 @@ fn is_unknown_rollback_error(err: &anyhow::Error) -> bool {
     format!("{err:#}").contains("unknown transaction")
 }
 
+fn verify_committed_decision(
+    transaction_id: &TwoPhaseTransactionId,
+    decision: &TwoPhaseDecision,
+    expected_ts: Timestamp,
+    expected_participants: &[PartitionId],
+) -> anyhow::Result<()> {
+    let TwoPhaseDecision::Committed {
+        commit_ts,
+        participants,
+        ..
+    } = decision
+    else {
+        anyhow::bail!(
+            "2PC Coordinator: expected committed decision for txn={} but found {:?}",
+            transaction_id,
+            decision,
+        );
+    };
+    anyhow::ensure!(
+        *commit_ts == u64::from(expected_ts),
+        "2PC Coordinator: recovered commit decision for txn={} at ts={} but expected ts={}",
+        transaction_id,
+        commit_ts,
+        u64::from(expected_ts),
+    );
+    let mut actual_participants = participants.clone();
+    actual_participants.sort_unstable();
+    actual_participants.dedup();
+    let mut expected_participants: Vec<_> = expected_participants
+        .iter()
+        .map(|participant| participant.0)
+        .collect();
+    expected_participants.sort_unstable();
+    expected_participants.dedup();
+    anyhow::ensure!(
+        actual_participants == expected_participants,
+        "2PC Coordinator: recovered commit decision for txn={} has participants {:?} but expected \
+         {:?}",
+        transaction_id,
+        actual_participants,
+        expected_participants,
+    );
+    Ok(())
+}
+
 /// Execute the 2PC protocol for a transaction that cannot commit on the local
 /// fast path.
 pub async fn coordinate_two_phase_commit(
@@ -613,6 +824,23 @@ pub async fn coordinate_two_phase_commit(
     transaction: FinalTransaction,
     write_source: WriteSource,
     partition_map: &PartitionMap,
+) -> anyhow::Result<CommitOutcome> {
+    coordinate_two_phase_commit_with_mode(
+        local_committer,
+        transaction,
+        write_source,
+        partition_map,
+        TwoPhaseCommitMode::from_knob(),
+    )
+    .await
+}
+
+pub(crate) async fn coordinate_two_phase_commit_with_mode(
+    local_committer: &CommitterClient,
+    transaction: FinalTransaction,
+    write_source: WriteSource,
+    partition_map: &PartitionMap,
+    commit_mode: TwoPhaseCommitMode,
 ) -> anyhow::Result<CommitOutcome> {
     let timer = metrics::two_phase_coordinator_timer();
     let source_partition = match classify_transaction(&transaction, partition_map, &write_source) {
@@ -755,54 +983,93 @@ pub async fn coordinate_two_phase_commit(
             continue;
         }
 
-        let decision = TwoPhaseDecision::committed(
-            u64::from(prepare_ts),
-            prepared_participants.iter().map(|p| p.0).collect(),
-        );
-        write_decision_record(local_committer, &txn_id, &decision)
-            .await
-            .with_context(|| {
-                format!("2PC Coordinator: failed to write commit decision for txn={txn_id}")
-            })?;
+        match commit_mode {
+            TwoPhaseCommitMode::DurableDecision => {
+                let decision = TwoPhaseDecision::committed(
+                    u64::from(prepare_ts),
+                    prepared_participants.iter().map(|p| p.0).collect(),
+                );
+                write_decision_record(local_committer, &txn_id, &decision)
+                    .await
+                    .with_context(|| {
+                        format!("2PC Coordinator: failed to write commit decision for txn={txn_id}")
+                    })?;
 
-        let commit_results = match commit_participants(
-            local_committer,
-            node_addresses,
-            partition_map,
-            &txn_id,
-            &prepared_participants,
-        )
-        .await
-        {
-            Ok(commit_results) => commit_results,
-            Err(err) => {
-                metrics::log_two_phase_error("commit");
-                return Err(err);
+                let commit_results = match commit_participants(
+                    local_committer,
+                    node_addresses,
+                    partition_map,
+                    &txn_id,
+                    &prepared_participants,
+                )
+                .await
+                {
+                    Ok(commit_results) => commit_results,
+                    Err(err) => {
+                        metrics::log_two_phase_error("commit");
+                        return Err(err);
+                    },
+                };
+
+                for (participant, commit_ts) in &commit_results {
+                    anyhow::ensure!(
+                        *commit_ts == prepare_ts,
+                        "Participant {} committed at ts={} but coordinator assigned ts={}",
+                        participant,
+                        commit_ts,
+                        prepare_ts,
+                    );
+                }
+
+                tracing::info!(
+                    "2PC Coordinator: committed txn={} at ts={}",
+                    txn_id,
+                    u64::from(prepare_ts),
+                );
+                metrics::log_two_phase_prepare_attempts(prepare_attempts);
+                metrics::log_two_phase_decision("commit");
+                timer.finish();
+                return Ok(CommitOutcome {
+                    ts: prepare_ts,
+                    source_partition,
+                });
             },
-        };
+            TwoPhaseCommitMode::ParallelEarlyAck => {
+                write_complete_staging_decision(
+                    local_committer,
+                    &txn_id,
+                    prepare_ts,
+                    &all_participants,
+                    &participants,
+                    &write_source,
+                )
+                .await?;
+                let recovered = recover_complete_staging_decision(local_committer, &txn_id).await?;
+                verify_committed_decision(&txn_id, &recovered, prepare_ts, &prepared_participants)?;
+                spawn_parallel_commit_cleanup(
+                    local_committer.clone(),
+                    node_addresses.cloned(),
+                    partition_map.clone(),
+                    txn_id.clone(),
+                    prepared_participants.clone(),
+                    prepare_ts,
+                );
 
-        for (participant, commit_ts) in &commit_results {
-            anyhow::ensure!(
-                *commit_ts == prepare_ts,
-                "Participant {} committed at ts={} but coordinator assigned ts={}",
-                participant,
-                commit_ts,
-                prepare_ts,
-            );
+                tracing::info!(
+                    "2PC Coordinator: parallel-committed txn={} at ts={} with asynchronous \
+                     participant cleanup",
+                    txn_id,
+                    u64::from(prepare_ts),
+                );
+                metrics::log_two_phase_prepare_attempts(prepare_attempts);
+                metrics::log_two_phase_decision("parallel_commit");
+                timer.finish();
+                return Ok(CommitOutcome {
+                    ts: prepare_ts,
+                    source_partition,
+                });
+            },
         }
-
-        tracing::info!(
-            "2PC Coordinator: committed txn={} at ts={}",
-            txn_id,
-            u64::from(prepare_ts),
-        );
-        metrics::log_two_phase_prepare_attempts(prepare_attempts);
-        metrics::log_two_phase_decision("commit");
-        timer.finish();
-        return Ok(CommitOutcome {
-            ts: prepare_ts,
-            source_partition,
-        });
     }
 
     metrics::log_two_phase_error("prepare");
@@ -818,10 +1085,40 @@ pub async fn coordinate_two_phase_commit(
 
 #[cfg(test)]
 mod tests {
+    use std::collections::BTreeMap;
+
+    use common::types::{
+        RepeatableTimestamp,
+        Timestamp,
+    };
+
     use super::{
         is_ambiguous_prepare_error,
         is_retryable_prepare_ts_error,
+        participant_intents_for_staging,
+        verify_committed_decision,
     };
+    use crate::{
+        partition::PartitionId,
+        reads::ReadSet,
+        two_phase::{
+            ParticipantTransaction,
+            TwoPhaseDecision,
+            TwoPhaseParticipantIntent,
+            TwoPhaseRedoEntry,
+            TwoPhaseTransactionId,
+        },
+        write_log::WriteSource,
+    };
+
+    fn empty_participant_transaction() -> ParticipantTransaction {
+        ParticipantTransaction {
+            begin_timestamp: RepeatableTimestamp::MIN,
+            tablet_metadata: BTreeMap::new(),
+            reads: ReadSet::empty(),
+            writes: Vec::new(),
+        }
+    }
 
     #[test]
     fn retryable_prepare_ts_error_detects_wrapped_grpc_status() {
@@ -860,5 +1157,81 @@ mod tests {
             "gRPC Prepare failed: status: Internal, message: \"forced prepare failure\""
         );
         assert!(!is_ambiguous_prepare_error(&err));
+    }
+
+    #[test]
+    fn staging_intents_match_participant_redo_records() -> anyhow::Result<()> {
+        let transaction_id = TwoPhaseTransactionId::new();
+        let prepare_ts = Timestamp::try_from(12345u64)?;
+        let write_source = WriteSource::unknown();
+        let all_participants = vec![PartitionId(0), PartitionId(1)];
+        let participant_tx = empty_participant_transaction();
+        let participants = vec![
+            (PartitionId(1), participant_tx.clone()),
+            (PartitionId(0), participant_tx.clone()),
+        ];
+
+        let intents = participant_intents_for_staging(
+            &transaction_id,
+            prepare_ts,
+            &all_participants,
+            &participants,
+            &write_source,
+        )?;
+
+        let mut expected_intents = participants
+            .iter()
+            .map(|(participant, transaction)| {
+                let redo = TwoPhaseRedoEntry::new_with_participants(
+                    &transaction_id,
+                    prepare_ts,
+                    *participant,
+                    &all_participants,
+                    transaction.clone(),
+                    &write_source,
+                )?;
+                Ok(TwoPhaseParticipantIntent::from_redo_entry(&redo))
+            })
+            .collect::<anyhow::Result<Vec<_>>>()?;
+        expected_intents.sort_by_key(|intent| intent.partition_id);
+
+        assert_eq!(intents, expected_intents);
+        Ok(())
+    }
+
+    #[test]
+    fn committed_decision_verifier_rejects_wrong_timestamp_or_participants() -> anyhow::Result<()> {
+        let transaction_id = TwoPhaseTransactionId::new();
+        let prepare_ts = Timestamp::try_from(12345u64)?;
+        let committed = TwoPhaseDecision::committed(
+            u64::from(prepare_ts),
+            vec![PartitionId(1).0, PartitionId(0).0],
+        );
+
+        verify_committed_decision(
+            &transaction_id,
+            &committed,
+            prepare_ts,
+            &[PartitionId(0), PartitionId(1)],
+        )?;
+
+        let wrong_ts = TwoPhaseDecision::committed(u64::from(prepare_ts) + 1, vec![0, 1]);
+        assert!(verify_committed_decision(
+            &transaction_id,
+            &wrong_ts,
+            prepare_ts,
+            &[PartitionId(0), PartitionId(1)],
+        )
+        .is_err());
+
+        let wrong_participants = TwoPhaseDecision::committed(u64::from(prepare_ts), vec![0]);
+        assert!(verify_committed_decision(
+            &transaction_id,
+            &wrong_participants,
+            prepare_ts,
+            &[PartitionId(0), PartitionId(1)],
+        )
+        .is_err());
+        Ok(())
     }
 }

--- a/docs/issue-journal.md
+++ b/docs/issue-journal.md
@@ -850,6 +850,28 @@ own for distributed changes.
   - `cargo test -p common test_persistence_global_roundtrips -- --nocapture`
   - `cargo check -p database -p local_backend`
 
+### 2026-06 — Added guarded 2PC parallel-commit early acknowledgement
+
+- **Status:** complete behind feature flag
+- **Related issue:** `#69`
+- **What this fixes:** the 2PC coordinator had accumulated the staged decision,
+  participant intent, recovery, and adversarial-test prerequisites for
+  CockroachDB-style parallel commits, but the live coordinator still always
+  waited for participant `CommitPrepared` cleanup before acknowledging the
+  client. That kept the safe durable-decision semantics but did not exercise
+  the true early-ack path.
+- **Behavior:** `ENABLE_PARALLEL_2PC_EARLY_ACK` now selects an explicit
+  parallel-commit coordinator mode. The default remains the conservative
+  durable-decision path. When enabled, the coordinator writes a complete
+  durable `Staging` record, recovers it into `Committed`, acknowledges at the
+  assigned commit timestamp, and schedules ordinary participant cleanup
+  asynchronously. Cleanup remains retriable through the retained decision log
+  and watcher if the background task fails.
+- **Validation:**
+  - `cargo test -p database two_phase -- --nocapture`
+  - `cargo test -p database test_parallel_early_ack_recovers_staging_before_async_cleanup -- --nocapture`
+  - `cargo test -p database test_cross_partition_commit_uses_remote_prepare_over_grpc -- --nocapture`
+
 ## Open Issues
 
 - `#74` is no longer blocked on follower self-sufficiency. The current

--- a/docs/parallel-commits-design.md
+++ b/docs/parallel-commits-design.md
@@ -2,17 +2,25 @@
 
 ## Status
 
-Design for issue `#206`.
+Design and rollout notes for issue `#69`.
 
 This document is intentionally conservative. It describes what is required to
 turn `#69` into true CockroachDB-style parallel commits without weakening the
 properties that make Convex feel like Convex.
 
 The current codebase already has durable-decision 2PC, Raft-backed participant
-prepare records, abandoned-prepare rollback, retained decision records, and
-same-partition Raft failover. PR `#205` adds safe parallel participant fanout
-inside that existing protocol. That is useful, but it is not yet true parallel
-commit.
+prepare records, abandoned-prepare rollback, retained decision records,
+same-partition Raft failover, staged decision metadata, staged status recovery,
+and staged read/subscription policy hooks. The default runtime path remains the
+conservative durable-decision protocol.
+
+Issue `#69` now has a guarded early-ack implementation behind
+`ENABLE_PARALLEL_2PC_EARLY_ACK=false` by default. When enabled, the coordinator
+acknowledges a cross-partition transaction after it writes a complete durable
+`Staging` record, recovers that proof into `Committed`, and schedules ordinary
+participant cleanup asynchronously. This preserves the durable-decision path as
+the production fallback while we continue hardening the staged cleanup and
+read-after-write windows.
 
 ## Summary
 
@@ -186,9 +194,10 @@ database: an acknowledged mutation is commonly followed immediately by a query
 or subscription update. Therefore, early ACK is allowed only after the read and
 subscription paths can handle committed-but-not-cleaned-up staged writes.
 
-Until issue `#209` is complete, true early ACK must stay disabled. The system
-may still use the staging machinery internally but should wait for normal
-`CommitPrepared` visibility before returning success.
+The production default remains disabled. The system can use the staging
+machinery internally, but ordinary clusters should continue waiting for normal
+`CommitPrepared` visibility before returning success unless
+`ENABLE_PARALLEL_2PC_EARLY_ACK=true` is explicitly set for validation.
 
 ### Cleanup
 
@@ -293,11 +302,12 @@ state alone.
 ## Relationship To Existing Issues
 
 - `#69` remains the umbrella for CockroachDB-style parallel commits.
-- `#205` is a safe fanout improvement and can merge independently.
-- `#207` should add the durable `Staging` record and participant intent proof.
-- `#208` should add transaction status recovery.
-- `#209` should make reads, OCC, and subscriptions staged-write-aware.
-- `#210` should add the adversarial tests before enabling true early ACK.
+- `#205` added safe parallel participant fanout inside the durable-decision
+  protocol.
+- `#207` added the durable `Staging` record and participant intent proof.
+- `#208` added transaction status recovery.
+- `#209` made reads, OCC, and subscriptions staged-write-aware.
+- `#210` added adversarial tests for 2PC/Raft/NATS ambiguity windows.
 - `#131` remains the broader resolver-style conflict checking work. Parallel
   commits must not make current read validation weaker while that evolves.
 - `#134` remains the long-term deterministic simulation goal.
@@ -314,8 +324,9 @@ state alone.
    recovery mature.
 5. Teach read, OCC, and subscription paths to handle staged committed intents.
 6. Add cluster fault-injection tests for every ambiguous window.
-7. Enable early ACK behind a feature flag only after the tests prove no torn
-   visibility, stale read-after-write, or speculative subscription result.
+7. Enable early ACK behind `ENABLE_PARALLEL_2PC_EARLY_ACK` only after the tests
+   prove no torn visibility, stale read-after-write, or speculative
+   subscription result.
 
 ## Test Gates
 


### PR DESCRIPTION
## Summary
- Add a guarded `ENABLE_PARALLEL_2PC_EARLY_ACK` mode for 2PC parallel-commit style early acknowledgement after the committed decision is durable and every participant has durable complete-staging evidence.
- Keep the default path on durable-decision semantics so production behavior is unchanged unless the knob is enabled.
- Fix replica delta idempotency discovered during validation: exact non-empty data delta origin ids now drive duplicate suppression instead of the max data watermark, so older valid Raft->NATS outbox replays are not dropped after newer deltas.

## Why
Issue #69 is about moving toward CockroachDB-style parallel commits without weakening Convex semantics. The first slice is intentionally guarded: it proves the recovery invariant and cleanup path while keeping the default behavior conservative.

The full cluster run surfaced a real default-path replay bug: after coordinator restart, a newer partition-1 delta could advance the max applied-data watermark, then an older but still unapplied outbox replay was incorrectly treated as duplicate. That caused one task half to disappear from partition 0. The fix separates diagnostic/max watermarks from exact redelivery ids.

## Tests
- `cargo fmt -p common -p database`
- `git diff --check`
- `cargo test --target-dir /tmp/convex-target-issue69 -p database test_late_outbox_replay_data_delta_not_deduped_by_newer_data_watermark -- --nocapture`
- `cargo test --target-dir /tmp/convex-target-issue69 -p database test_replica_delta_redelivery_is_idempotent -- --nocapture`
- `cargo test --target-dir /tmp/convex-target-issue69 -p database test_frontier_heartbeat_does_not_dedupe_later_data_delta -- --nocapture`
- `cargo test --target-dir /tmp/convex-target-issue69 -p database test_seeded_replica_apply_simulation_preserves_frontier_and_idempotency_invariants -- --nocapture`
- `cargo test --target-dir /tmp/convex-target-issue69 -p database records_nats_outbox_when_publish_unavailable -- --nocapture`
- `cargo test --target-dir /tmp/convex-target-issue69 -p database write_scaling_tests -- --nocapture` = 68/68 passed
- `cargo test --target-dir /tmp/convex-target-issue69 -p database two_phase_coordinator::tests -- --nocapture` = 7/7 passed
- Built backend image locally: `sha256:a8d70ab722a8e001732b29fe32eda7930a31647fb3c60166aacbf877e38b3bf2`, revision `aa6b758831cf6d3a452fc63a81cc04d7993290a3`
- Verified all six backend containers ran that exact image/revision with `BACKEND_PULL_POLICY=never`
- `BACKEND_PULL_POLICY=never bash self-hosted/docker/test.sh` = write-scaling 129/129 passed, Raft failover 24/24 passed, all suites passed

Closes #69
