### PR TITLE
feat(database): validate cross-partition read owners

### DIFF
--- a/crates/database/src/tests/write_scaling_tests.rs
+++ b/crates/database/src/tests/write_scaling_tests.rs
@@ -29,7 +29,6 @@ use common::{
         ID_FIELD,
     },
     interval::Interval,
-    knobs::REMOTE_READ_FRONTIER_WAIT_TIMEOUT,
     maybe_val,
     pause::PauseController,
     persistence::{
@@ -1465,6 +1464,178 @@ async fn test_cross_partition_prepare_waits_for_remote_frontier(
 }
 
 #[convex_macro::test_runtime]
+async fn test_prepare_participants_include_remote_read_owner(
+    rt: TestRuntime,
+) -> anyhow::Result<()> {
+    let log = Arc::new(InMemoryDistributedLog::new());
+    let node_a = create_node(&rt, log.clone(), Some(partitioned_map(PartitionId(0)))).await?;
+    let node_b = create_node(&rt, log.clone(), Some(partitioned_map(PartitionId(1)))).await?;
+
+    insert_doc(&node_b, "projects", assert_obj!("name" => "seed")).await?;
+    let project_delta = log
+        .deltas()
+        .into_iter()
+        .last()
+        .expect("seed project should publish a delta");
+    node_a
+        .committer_for_test()
+        .apply_replica_delta(project_delta)
+        .await?;
+
+    let mut tx = node_a.begin(Identity::system()).await?;
+    TestFacingModel::new(&mut tx)
+        .insert(&"messages".parse()?, assert_obj!("text" => "local-write"))
+        .await?;
+    let mut final_tx = tx.finalize()?;
+    let project_tablet = final_tx
+        .table_mapping
+        .namespace(TableNamespace::Global)
+        .name_to_tablet()("projects".parse()?)?;
+    let project_read = TabletIndexName::by_id(project_tablet);
+    final_tx.reads.record_indexed_derived(
+        project_read.clone(),
+        IndexedFields::by_id(),
+        Interval::all(),
+    );
+
+    let write_source = WriteSource::new("remote_read_owner_prepare_test");
+    let partition_map = partitioned_map(PartitionId(0));
+    let classification = crate::two_phase_coordinator::classify_transaction(
+        &final_tx,
+        &partition_map,
+        &write_source,
+    );
+    assert!(
+        matches!(
+            classification,
+            crate::two_phase_coordinator::TransactionClassification::CrossPartition { .. }
+        ),
+        "a transaction that writes locally but reads a remote-owned table must use 2PC resolver \
+         validation",
+    );
+
+    let participant_indexes = crate::two_phase_coordinator::participant_prepare_indexes(
+        &final_tx,
+        &partition_map,
+        &write_source,
+    );
+    assert_eq!(
+        participant_indexes.keys().copied().collect::<Vec<_>>(),
+        vec![PartitionId(0), PartitionId(1)],
+    );
+    assert!(
+        !participant_indexes
+            .get(&PartitionId(0))
+            .expect("local write owner should participate")
+            .is_empty(),
+        "local write owner should receive the physical document and catalog writes",
+    );
+    assert!(
+        participant_indexes
+            .get(&PartitionId(1))
+            .expect("remote read owner should participate")
+            .is_empty(),
+        "read-owner participant validates conflicts without receiving writes",
+    );
+
+    let read_owner_tx = ParticipantTransaction::from_final_transaction(
+        &final_tx,
+        PartitionId(1),
+        participant_indexes
+            .get(&PartitionId(1))
+            .expect("remote read owner should participate"),
+        &partition_map,
+        &write_source,
+    )?;
+    assert!(read_owner_tx.writes.is_empty());
+    assert!(!read_owner_tx
+        .reads
+        .index_reads_for_test(&project_read)
+        .is_empty());
+
+    Ok(())
+}
+
+#[convex_macro::test_runtime]
+async fn test_read_owner_prepare_rejects_conflicting_owner_write(
+    rt: TestRuntime,
+) -> anyhow::Result<()> {
+    let log = Arc::new(InMemoryDistributedLog::new());
+    let node_a = create_node(&rt, log.clone(), Some(partitioned_map(PartitionId(0)))).await?;
+    let node_b = create_node(&rt, log.clone(), Some(partitioned_map(PartitionId(1)))).await?;
+
+    insert_doc(&node_b, "projects", assert_obj!("name" => "seed")).await?;
+    let seed_delta = log
+        .deltas()
+        .into_iter()
+        .last()
+        .expect("seed project should publish a delta");
+    node_a
+        .committer_for_test()
+        .apply_replica_delta(seed_delta)
+        .await?;
+
+    let mut tx = node_a.begin(Identity::system()).await?;
+    TestFacingModel::new(&mut tx)
+        .insert(&"messages".parse()?, assert_obj!("text" => "local-write"))
+        .await?;
+    let mut final_tx = tx.finalize()?;
+    let project_tablet = final_tx
+        .table_mapping
+        .namespace(TableNamespace::Global)
+        .name_to_tablet()("projects".parse()?)?;
+    final_tx.reads.record_indexed_derived(
+        TabletIndexName::by_id(project_tablet),
+        IndexedFields::by_id(),
+        Interval::all(),
+    );
+
+    insert_doc(
+        &node_b,
+        "projects",
+        assert_obj!("name" => "conflicting-owner-write"),
+    )
+    .await?;
+
+    let write_source = WriteSource::new("read_owner_conflict_prepare_test");
+    let source_map = partitioned_map(PartitionId(0));
+    let participant_indexes = crate::two_phase_coordinator::participant_prepare_indexes(
+        &final_tx,
+        &source_map,
+        &write_source,
+    );
+    let read_owner_tx = ParticipantTransaction::from_final_transaction(
+        &final_tx,
+        PartitionId(1),
+        participant_indexes
+            .get(&PartitionId(1))
+            .expect("remote read owner should participate"),
+        &source_map,
+        &write_source,
+    )?;
+    assert!(read_owner_tx.writes.is_empty());
+
+    let prepare_ts = node_b.committer_for_test().allocate_commit_ts().await?;
+    let err = node_b
+        .committer_for_test()
+        .prepare_remote(
+            TwoPhaseTransactionId::new(),
+            read_owner_tx,
+            write_source,
+            prepare_ts,
+            vec![PartitionId(0), PartitionId(1)],
+        )
+        .await
+        .expect_err("read owner should reject a read set made stale by its own write log");
+    assert!(
+        format!("{err:#}").contains("changed while this mutation was being run"),
+        "expected read-owner OCC conflict, got {err:#}",
+    );
+
+    Ok(())
+}
+
+#[convex_macro::test_runtime]
 async fn test_local_only_prepare_does_not_wait_for_remote_frontier(
     rt: TestRuntime,
 ) -> anyhow::Result<()> {
@@ -1765,71 +1936,72 @@ async fn test_prepare_retries_while_local_commit_is_pending(
     Ok(())
 }
 
-#[convex_macro::test_runtime]
-async fn test_local_commit_waits_for_remote_frontier(rt: TestRuntime) -> anyhow::Result<()> {
-    let log = Arc::new(InMemoryDistributedLog::new());
-    let node_a = create_node(&rt, log.clone(), Some(partitioned_map(PartitionId(0)))).await?;
-    let node_b = create_node(&rt, log.clone(), Some(partitioned_map(PartitionId(1)))).await?;
-
-    insert_doc(&node_b, "projects", assert_obj!("name" => "seed")).await?;
-    let initial_delta = log
-        .deltas()
-        .into_iter()
-        .last()
-        .expect("seed project should publish a delta");
-    node_a
-        .committer_for_test()
-        .apply_replica_delta(initial_delta)
+#[test]
+fn test_local_commit_with_remote_read_routes_to_read_owner() -> anyhow::Result<()> {
+    let td = TestDriver::new_with_io();
+    let rt = td.rt();
+    td.run_until(async move {
+        let log = Arc::new(InMemoryDistributedLog::new());
+        let tso: Arc<dyn TimestampOracle> = Arc::new(InMemoryTimestampOracle::new());
+        let node_b = create_node_with_options(
+            &rt,
+            log.clone(),
+            Some(partitioned_map(PartitionId(1))),
+            None,
+            Some(tso.clone()),
+        )
+        .await?;
+        let server = start_two_pc_server(TestTwoPhaseCommitGrpcService::new(
+            node_b.committer_for_test(),
+        ))
+        .await?;
+        let node_a = create_node_with_options(
+            &rt,
+            log.clone(),
+            Some(partitioned_map(PartitionId(0))),
+            Some(NodeAddresses::from_config(&format!("1={}", server.addr()))),
+            Some(tso),
+        )
         .await?;
 
-    // Advance node A's local snapshot without advancing partition 1's frontier.
-    insert_doc(&node_a, "messages", assert_obj!("text" => "lag-maker")).await?;
+        insert_doc(&node_b, "projects", assert_obj!("name" => "seed")).await?;
+        let initial_delta = log
+            .deltas()
+            .into_iter()
+            .last()
+            .expect("seed project should publish a delta");
+        let initial_delta_ts = initial_delta.ts;
+        node_a
+            .committer_for_test()
+            .apply_replica_delta(initial_delta)
+            .await?;
 
-    let mut tx = node_a.begin(Identity::system()).await?;
-    TestFacingModel::new(&mut tx)
-        .insert(&"messages".parse()?, assert_obj!("text" => "commit"))
-        .await?;
-    let remote_tablet = tx
-        .table_mapping()
-        .namespace(TableNamespace::Global)
-        .name_to_tablet()("projects".parse()?)?;
-    tx.reads.record_indexed_derived(
-        TabletIndexName::by_id(remote_tablet),
-        IndexedFields::by_id(),
-        Interval::all(),
-    );
+        let mut tx = node_a.begin(Identity::system()).await?;
+        TestFacingModel::new(&mut tx)
+            .insert(&"messages".parse()?, assert_obj!("text" => "commit"))
+            .await?;
+        let remote_tablet = tx
+            .table_mapping()
+            .namespace(TableNamespace::Global)
+            .name_to_tablet()("projects".parse()?)?;
+        tx.reads.record_indexed_derived(
+            TabletIndexName::by_id(remote_tablet),
+            IndexedFields::by_id(),
+            Interval::all(),
+        );
 
-    let node_a_for_commit = node_a.clone();
-    let commit = tokio::spawn(async move { node_a_for_commit.commit(tx).await });
-
-    tokio::time::sleep(Duration::from_millis(50)).await;
-    assert!(
-        !commit.is_finished(),
-        "commit should wait for the remote partition frontier to catch up",
-    );
-
-    let heartbeat_ts = node_b.bump_max_repeatable_ts().await?;
-    node_a
-        .committer_for_test()
-        .apply_replica_delta(CommitDelta {
-            ts: heartbeat_ts,
-            document_writes: Arc::new(Vec::new()),
-            document_updates: Vec::new(),
-            index_writes: Arc::new(Vec::new()),
-            write_source: WriteSource::new("remote_read_frontier_heartbeat_commit_test"),
-            write_bytes: 0,
-            tablet_id_to_table_name: Default::default(),
-            source_partition: Some(PartitionId(1)),
-        })
-        .await?;
-
-    let commit_result = tokio::time::timeout(Duration::from_secs(1), commit).await??;
-    commit_result?;
-    Ok(())
+        let commit_ts = node_a.commit(tx).await?;
+        assert!(
+            commit_ts > initial_delta_ts,
+            "resolver-routed commit should use a timestamp after the remote seed",
+        );
+        server.shutdown().await?;
+        Ok(())
+    })
 }
 
 #[convex_macro::test_runtime]
-async fn test_local_commit_times_out_waiting_for_remote_read_frontier(
+async fn test_local_commit_with_remote_read_fails_closed_without_owner_addresses(
     rt: TestRuntime,
 ) -> anyhow::Result<()> {
     let log = Arc::new(InMemoryDistributedLog::new());
@@ -1864,22 +2036,12 @@ async fn test_local_commit_times_out_waiting_for_remote_read_frontier(
         Interval::all(),
     );
 
-    let node_a_for_commit = node_a.clone();
-    let commit = tokio::spawn(async move { node_a_for_commit.commit(tx).await });
-
-    tokio::time::sleep(Duration::from_millis(50)).await;
+    let err = node_a
+        .commit(tx)
+        .await
+        .expect_err("remote read owner should be required when local writes use resolver 2PC");
     assert!(
-        !commit.is_finished(),
-        "commit should wait before the bounded remote read frontier timeout fires",
-    );
-
-    rt.advance_time(*REMOTE_READ_FRONTIER_WAIT_TIMEOUT + Duration::from_millis(1))
-        .await;
-
-    let commit_result = tokio::time::timeout(Duration::from_millis(100), commit).await??;
-    let err = commit_result.expect_err("stale remote frontier should time out");
-    assert!(
-        err.to_string().contains("Timed out after"),
+        format!("{err:#}").contains("NODE_ADDRESSES is required"),
         "unexpected error: {err:#}",
     );
     Ok(())

--- a/crates/database/src/two_phase_coordinator.rs
+++ b/crates/database/src/two_phase_coordinator.rs
@@ -10,7 +10,10 @@
 //! The coordinator runs on the node where the mutation was received.
 //! Remote partitions are reached via gRPC.
 
-use std::collections::BTreeMap;
+use std::collections::{
+    BTreeMap,
+    BTreeSet,
+};
 
 use anyhow::{
     anyhow,
@@ -115,21 +118,19 @@ pub fn classify_transaction(
     partition_map: &PartitionMap,
     write_source: &WriteSource,
 ) -> TransactionClassification {
-    let mut partitions: BTreeMap<PartitionId, Vec<usize>> = BTreeMap::new();
-
-    for (i, write) in transaction.writes.coalesced_writes().enumerate() {
-        if let Some(partition) =
-            routed_partition_for_write(transaction, write, partition_map, write_source)
-        {
-            partitions.entry(partition).or_default().push(i);
-        }
-    }
+    let partitions = participant_write_indexes(transaction, partition_map, write_source);
+    let mut prepare_participants: BTreeSet<_> = partitions.keys().copied().collect();
+    prepare_participants.extend(participant_read_owners(
+        transaction,
+        partition_map,
+        write_source,
+    ));
 
     if partitions.is_empty() {
         TransactionClassification::SinglePartition
-    } else if partitions.len() == 1 {
-        let owner = *partitions
-            .keys()
+    } else if prepare_participants.len() == 1 {
+        let owner = *prepare_participants
+            .iter()
             .next()
             .expect("single-partition classification should have one owner");
         if owner == partition_map.local_partition() {
@@ -163,6 +164,48 @@ pub(crate) fn participant_write_indexes(
 
     participant_indexes.retain(|_, indexes| !indexes.is_empty());
     participant_indexes
+}
+
+pub(crate) fn participant_prepare_indexes(
+    transaction: &FinalTransaction,
+    partition_map: &PartitionMap,
+    write_source: &WriteSource,
+) -> BTreeMap<PartitionId, Vec<usize>> {
+    let mut participant_indexes =
+        participant_write_indexes(transaction, partition_map, write_source);
+
+    for participant in participant_read_owners(transaction, partition_map, write_source) {
+        participant_indexes.entry(participant).or_default();
+    }
+
+    participant_indexes
+}
+
+fn participant_read_owners(
+    transaction: &FinalTransaction,
+    partition_map: &PartitionMap,
+    write_source: &WriteSource,
+) -> BTreeSet<PartitionId> {
+    let mut participants = BTreeSet::new();
+    let mut visit_tablet = |tablet_id| {
+        let Ok(table_name) = transaction.table_mapping.tablet_name(tablet_id) else {
+            return;
+        };
+        if let Some(partition) =
+            routed_partition_for_table(&table_name, partition_map, write_source)
+        {
+            participants.insert(partition);
+        }
+    };
+
+    for (index_name, _) in transaction.reads.read_set().iter_indexed() {
+        visit_tablet(*index_name.table());
+    }
+    for (index_name, _) in transaction.reads.read_set().iter_search() {
+        visit_tablet(*index_name.table());
+    }
+
+    participants
 }
 
 fn routed_partition_for_write(
@@ -857,7 +900,8 @@ pub(crate) async fn coordinate_two_phase_commit_with_mode(
         TransactionClassification::CrossPartition { partitions: _ } => None,
     };
 
-    let participant_indexes = participant_write_indexes(&transaction, partition_map, &write_source);
+    let participant_indexes =
+        participant_prepare_indexes(&transaction, partition_map, &write_source);
     let node_addresses = local_committer.node_addresses();
     let participants: Vec<_> = participant_indexes
         .iter()

--- a/docs/resolver-style-conflict-checking.md
+++ b/docs/resolver-style-conflict-checking.md
@@ -1,0 +1,79 @@
+# Resolver-Style Conflict Checking
+
+Issue: #131
+
+## Goal
+
+Convex's transaction contract is serializable ACID execution over arbitrary
+TypeScript mutations. Horizontal write scaling must preserve that contract even
+when a transaction reads data owned by one partition and writes data owned by
+another.
+
+The long-term direction is resolver-style conflict checking: route read/write
+set validation to the owner of the affected table/range/key, rather than relying
+only on a coordinator's local replica freshness.
+
+## Current Baseline
+
+The current system still uses the existing 2PC machinery for cross-partition
+transactions:
+
+1. The coordinator allocates one commit timestamp.
+2. Participants validate their local read set and stage prepared writes.
+3. A durable decision commits or rolls back the transaction.
+
+This is still a 2PC protocol, not a full FoundationDB-style resolver subsystem.
+The important change is that prepare participation is no longer based only on
+write ownership.
+
+## First Slice Implemented
+
+Prepare participants now include:
+
+- partitions that own one or more writes, and
+- partitions that own tables read by the transaction.
+
+That means a mutation that writes table `messages` on partition 0 but reads
+table `projects` on partition 1 is no longer treated as a local fast-path
+commit. Partition 1 participates as a read-owner resolver, receives no writes,
+and validates that its owned read ranges have not changed between the
+transaction begin timestamp and the assigned prepare timestamp.
+
+This closes a correctness gap where a coordinator could previously validate
+against its local replica and miss a concurrent owner-side write that had not
+arrived through replication yet.
+
+## Conservative Behavior
+
+Read-owner participants currently use the same prepare/commit/rollback path as
+write participants. They stage an empty prepared write and resolve through the
+normal 2PC cleanup path.
+
+This is intentionally conservative:
+
+- correctness comes first;
+- read-owner validation happens at the owner partition;
+- clusters without `NODE_ADDRESSES` fail closed instead of falling back to local
+  replica validation.
+
+The tradeoff is that read-only resolver participants briefly participate in the
+2PC lifecycle even though they do not write documents. A later optimization can
+replace this with a dedicated validation-only resolver RPC once the correctness
+contract is proven.
+
+## Remaining Work
+
+- Add a dedicated resolver/check-read-set RPC that does not stage empty writes.
+- Split resolver ownership from table-level write ownership once placement moves
+  beyond static table maps.
+- Track resolver latency, retry rate, and per-partition conflict load.
+- Extend cluster tests to cover concurrent owner-side writes racing with
+  cross-partition read/write mutations.
+- Keep 2PC as the durable apply protocol until the resolver layer has its own
+  recovery and duplicate-message semantics.
+
+## Non-Goals
+
+- Do not remove 2PC in this slice.
+- Do not allow application developers to choose or observe resolver shards.
+- Do not treat selective delivery as a substitute for conflict checking.


### PR DESCRIPTION
## Summary

Refs #131.

This PR adds the first resolver-style conflict-checking slice for distributed commits:

- includes read-owner partitions in the 2PC prepare participant set, even when they receive no writes;
- treats local-write + remote-read mutations as cross-partition resolver work instead of a local fast-path commit;
- fails closed when owner routing is required but `NODE_ADDRESSES` is missing;
- adds a design note for the broader resolver-style conflict-checking roadmap.

This does not complete #131. It keeps 2PC as the durable apply protocol and uses conservative read-only participants for now. A later slice should add a dedicated validation-only resolver RPC, metrics, and broader cluster adversarial coverage.

## Validation

- `cargo test -p database read_owner -- --nocapture`
- `cargo test -p database write_scaling_tests -- --nocapture` -> 70/70 passed
- `cargo test -p database two_phase_coordinator::tests -- --nocapture` -> 7/7 passed
- `cargo check -p database`
- Rebuilt local backend image `ghcr.io/martinkalema/convex-horizontal-scaling:backend-latest` -> image ID `sha256:47bd447392e970e09308a4777b5602ae2056499a30bdd8ead07c44845bf040d2`
- `BACKEND_PULL_POLICY=never bash self-hosted/docker/test.sh` -> write-scaling 129/129, Raft failover 24/24, all suites passed
