### PR TITLE
feat(database): add validation-only 2pc read resolvers

### DIFF
--- a/crates/database/src/committer.rs
+++ b/crates/database/src/committer.rs
@@ -1636,6 +1636,21 @@ impl<RT: Runtime> Committer<RT> {
                             .await;
                             let _ = result.send(r);
                         },
+                        Some(CommitterMessage::ValidateRemoteReads {
+                            transaction_id,
+                            transaction,
+                            write_source,
+                            validate_ts,
+                            result,
+                        }) => {
+                            let r = self.handle_validate_remote_reads(
+                                transaction_id,
+                                transaction,
+                                write_source,
+                                validate_ts,
+                            );
+                            let _ = result.send(r);
+                        },
                         Some(CommitterMessage::AllocateCommitTs { result }) => {
                             let r = self
                                 .ensure_leader_for_writes()
@@ -2099,6 +2114,47 @@ impl<RT: Runtime> Committer<RT> {
                     partition_map.local_partition(),
                 );
             }
+        }
+        Ok(())
+    }
+
+    fn ensure_read_ownership(
+        &self,
+        reads: &ReadSet,
+        table_mapping: &TableMapping,
+        write_source: &WriteSource,
+    ) -> anyhow::Result<()> {
+        let Some(placement_state) = self.placement_state.as_ref() else {
+            return Ok(());
+        };
+        let partition_map = placement_state.partition_map();
+
+        let validate_tablet = |tablet_id| -> anyhow::Result<()> {
+            let table_name = table_mapping
+                .tablet_name(tablet_id)
+                .with_context(|| format!("Missing table mapping for validated read {tablet_id}"))?;
+            if let Some(partition) = crate::partition::routed_partition_for_table(
+                &table_name,
+                &partition_map,
+                write_source,
+            ) && partition != partition_map.local_partition()
+            {
+                anyhow::bail!(
+                    "Read validation for table '{}' rejected: owned by {}, not this node ({}). \
+                     Coordinator routed this read set to the wrong participant.",
+                    table_name,
+                    partition,
+                    partition_map.local_partition(),
+                );
+            }
+            Ok(())
+        };
+
+        for (index_name, _) in reads.iter_indexed() {
+            validate_tablet(*index_name.table())?;
+        }
+        for (index_name, _) in reads.iter_search() {
+            validate_tablet(*index_name.table())?;
         }
         Ok(())
     }
@@ -3990,6 +4046,65 @@ impl<RT: Runtime> Committer<RT> {
         )
     }
 
+    fn validate_participant_reads(
+        &mut self,
+        transaction_id: crate::two_phase::TwoPhaseTransactionId,
+        transaction: crate::two_phase::ParticipantTransaction,
+        write_source: WriteSource,
+        validate_ts: Timestamp,
+    ) -> anyhow::Result<()> {
+        let mut table_mapping = self
+            .snapshot_manager
+            .read()
+            .latest_snapshot()
+            .table_mapping()
+            .clone();
+        transaction.augment_table_mapping(&mut table_mapping)?;
+        self.ensure_leader_for_writes()?;
+        anyhow::ensure!(
+            transaction.writes.is_empty(),
+            "2PC ValidateReads txn={} received {} writes; write participants must use Prepare",
+            transaction_id,
+            transaction.writes.len(),
+        );
+        self.ensure_read_ownership(&transaction.reads, &table_mapping, &write_source)?;
+        self.validate_remote_read_frontiers(
+            *transaction.begin_timestamp,
+            &transaction.reads,
+            &table_mapping,
+            &write_source,
+        )?;
+
+        let local_commit_floor = self.explicit_prepare_commit_floor()?;
+        if validate_ts < local_commit_floor {
+            anyhow::bail!(
+                "2PC Prepare assigned ts={} but this participant requires ts>={}",
+                validate_ts,
+                local_commit_floor,
+            );
+        }
+
+        let timer = metrics::commit_is_stale_timer();
+        if let Some(conflicting_read) = self.commit_has_conflict(
+            &transaction.reads,
+            *transaction.begin_timestamp,
+            validate_ts,
+        )? {
+            anyhow::bail!(conflicting_read.into_error(&table_mapping, &write_source));
+        }
+        timer.finish();
+
+        if validate_ts > self.last_assigned_ts {
+            self.last_assigned_ts = validate_ts;
+        }
+        tracing::info!(
+            "2PC ValidateReads: txn={}, validate_ts={}",
+            transaction_id,
+            u64::from(validate_ts),
+        );
+        Ok(())
+    }
+
     fn remap_participant_system_table_writes(
         writes: Vec<DocumentUpdateWithPrevTs>,
         source_mapping: &TableMapping,
@@ -4430,6 +4545,22 @@ impl<RT: Runtime> Committer<RT> {
             raft_state.mark_applied(raft_applied_index).await?;
         }
         Ok(result)
+    }
+
+    fn handle_validate_remote_reads(
+        &mut self,
+        transaction_id: crate::two_phase::TwoPhaseTransactionId,
+        transaction: crate::two_phase::ParticipantTransaction,
+        write_source: WriteSource,
+        validate_ts: Timestamp,
+    ) -> anyhow::Result<()> {
+        tracing::info!(
+            "2PC ValidateReads: txn={}, {} indexed reads, validate_ts={}",
+            transaction_id,
+            transaction.reads.iter_indexed().count(),
+            u64::from(validate_ts),
+        );
+        self.validate_participant_reads(transaction_id, transaction, write_source, validate_ts)
     }
 
     /// Start committing a previously prepared transaction without blocking the
@@ -5669,6 +5800,34 @@ impl CommitterClient {
         rx.await.map_err(|_| metrics::shutdown_error())?
     }
 
+    pub async fn validate_remote_reads(
+        &self,
+        transaction_id: crate::two_phase::TwoPhaseTransactionId,
+        transaction: crate::two_phase::ParticipantTransaction,
+        write_source: WriteSource,
+        validate_ts: Timestamp,
+    ) -> anyhow::Result<()> {
+        self.wait_for_remote_read_frontiers(
+            *transaction.begin_timestamp,
+            &transaction.reads,
+            &write_source,
+        )
+        .await?;
+        let (tx, rx) = oneshot::channel();
+        let message = CommitterMessage::ValidateRemoteReads {
+            transaction_id,
+            transaction,
+            write_source,
+            validate_ts,
+            result: tx,
+        };
+        self.sender.try_send(message).map_err(|e| match e {
+            TrySendError::Full(..) => metrics::committer_full_error().into(),
+            TrySendError::Closed(..) => metrics::shutdown_error(),
+        })?;
+        rx.await.map_err(|_| metrics::shutdown_error())?
+    }
+
     /// 2PC CommitPrepared: finalize a prepared transaction.
     pub async fn commit_prepared(
         &self,
@@ -5876,6 +6035,13 @@ enum CommitterMessage {
         prepare_ts: Timestamp,
         participants: Vec<crate::partition::PartitionId>,
         result: oneshot::Sender<anyhow::Result<crate::two_phase::PrepareResult>>,
+    },
+    ValidateRemoteReads {
+        transaction_id: crate::two_phase::TwoPhaseTransactionId,
+        transaction: crate::two_phase::ParticipantTransaction,
+        write_source: WriteSource,
+        validate_ts: Timestamp,
+        result: oneshot::Sender<anyhow::Result<()>>,
     },
     AllocateCommitTs {
         result: oneshot::Sender<anyhow::Result<Timestamp>>,

--- a/crates/database/src/tests/write_scaling_tests.rs
+++ b/crates/database/src/tests/write_scaling_tests.rs
@@ -9,6 +9,7 @@ use std::{
     sync::{
         atomic::{
             AtomicBool,
+            AtomicUsize,
             Ordering,
         },
         Arc,
@@ -78,6 +79,8 @@ use pb::replication::{
     TwoPcPrepareResponse,
     TwoPcRollbackRequest,
     TwoPcRollbackResponse,
+    TwoPcValidateReadsRequest,
+    TwoPcValidateReadsResponse,
 };
 use rand::{
     Rng,
@@ -461,11 +464,29 @@ async fn global_table_scan_or_empty(
 
 struct TestTwoPhaseCommitGrpcService {
     committer: CommitterClient,
+    prepare_calls: Arc<AtomicUsize>,
+    validate_reads_calls: Arc<AtomicUsize>,
 }
 
 impl TestTwoPhaseCommitGrpcService {
     fn new(committer: CommitterClient) -> Self {
-        Self { committer }
+        Self::with_counters(
+            committer,
+            Arc::new(AtomicUsize::new(0)),
+            Arc::new(AtomicUsize::new(0)),
+        )
+    }
+
+    fn with_counters(
+        committer: CommitterClient,
+        prepare_calls: Arc<AtomicUsize>,
+        validate_reads_calls: Arc<AtomicUsize>,
+    ) -> Self {
+        Self {
+            committer,
+            prepare_calls,
+            validate_reads_calls,
+        }
     }
 }
 
@@ -475,6 +496,7 @@ impl TwoPhaseCommitService for TestTwoPhaseCommitGrpcService {
         &self,
         request: Request<TwoPcPrepareRequest>,
     ) -> Result<Response<TwoPcPrepareResponse>, Status> {
+        self.prepare_calls.fetch_add(1, Ordering::SeqCst);
         let req = request.into_inner();
         let txn_id = TwoPhaseTransactionId(req.transaction_id);
         let transaction = req
@@ -505,6 +527,34 @@ impl TwoPhaseCommitService for TestTwoPhaseCommitGrpcService {
         Ok(Response::new(TwoPcPrepareResponse {
             prepare_ts: u64::from(result.prepare_ts),
         }))
+    }
+
+    async fn validate_reads(
+        &self,
+        request: Request<TwoPcValidateReadsRequest>,
+    ) -> Result<Response<TwoPcValidateReadsResponse>, Status> {
+        self.validate_reads_calls.fetch_add(1, Ordering::SeqCst);
+        let req = request.into_inner();
+        let txn_id = TwoPhaseTransactionId(req.transaction_id);
+        let transaction = req
+            .transaction
+            .ok_or_else(|| Status::invalid_argument("ValidateReads missing transaction payload"))?;
+        let transaction = ParticipantTransaction::try_from(transaction).map_err(|e| {
+            Status::invalid_argument(format!("Invalid ValidateReads payload: {e:#}"))
+        })?;
+        let validate_ts: Timestamp = req.validate_ts.try_into().map_err(|e| {
+            Status::invalid_argument(format!("Invalid ValidateReads timestamp: {e:#}"))
+        })?;
+        self.committer
+            .ensure_placement_version(PlacementVersion::from(req.placement_version))
+            .map_err(|e| Status::failed_precondition(format!("ValidateReads rejected: {e:#}")))?;
+
+        self.committer
+            .validate_remote_reads(txn_id, transaction, req.write_source.into(), validate_ts)
+            .await
+            .map_err(|e| Status::internal(format!("ValidateReads failed: {e:#}")))?;
+
+        Ok(Response::new(TwoPcValidateReadsResponse {}))
     }
 
     async fn commit_prepared(
@@ -545,6 +595,13 @@ impl TwoPhaseCommitService for FailingPrepareGrpcService {
         _request: Request<TwoPcPrepareRequest>,
     ) -> Result<Response<TwoPcPrepareResponse>, Status> {
         Err(Status::internal("forced prepare failure"))
+    }
+
+    async fn validate_reads(
+        &self,
+        _request: Request<TwoPcValidateReadsRequest>,
+    ) -> Result<Response<TwoPcValidateReadsResponse>, Status> {
+        Err(Status::internal("forced validate reads failure"))
     }
 
     async fn commit_prepared(
@@ -677,6 +734,15 @@ impl TwoPhaseCommitService for AmbiguousPrepareAfterLocalPrepareGrpcService {
         ))
     }
 
+    async fn validate_reads(
+        &self,
+        _request: Request<TwoPcValidateReadsRequest>,
+    ) -> Result<Response<TwoPcValidateReadsResponse>, Status> {
+        Err(Status::failed_precondition(
+            "validate_reads should not be called during ambiguous prepare test",
+        ))
+    }
+
     async fn commit_prepared(
         &self,
         _request: Request<TwoPcCommitRequest>,
@@ -757,6 +823,15 @@ impl TwoPhaseCommitService for FailingCommitAfterLocalPrepareGrpcService {
         Ok(Response::new(TwoPcPrepareResponse {
             prepare_ts: u64::from(result.prepare_ts),
         }))
+    }
+
+    async fn validate_reads(
+        &self,
+        _request: Request<TwoPcValidateReadsRequest>,
+    ) -> Result<Response<TwoPcValidateReadsResponse>, Status> {
+        Err(Status::failed_precondition(
+            "validate_reads should not be called during commit failure test",
+        ))
     }
 
     async fn commit_prepared(
@@ -850,6 +925,15 @@ impl TwoPhaseCommitService for FailingRollbackAfterPrepareGrpcService {
         Ok(Response::new(TwoPcPrepareResponse {
             prepare_ts: u64::from(result.prepare_ts),
         }))
+    }
+
+    async fn validate_reads(
+        &self,
+        _request: Request<TwoPcValidateReadsRequest>,
+    ) -> Result<Response<TwoPcValidateReadsResponse>, Status> {
+        Err(Status::failed_precondition(
+            "validate_reads should not be called during rollback failure test",
+        ))
     }
 
     async fn commit_prepared(
@@ -1557,7 +1641,7 @@ async fn test_prepare_participants_include_remote_read_owner(
 }
 
 #[convex_macro::test_runtime]
-async fn test_read_owner_prepare_rejects_conflicting_owner_write(
+async fn test_read_owner_validation_rejects_conflicting_owner_write(
     rt: TestRuntime,
 ) -> anyhow::Result<()> {
     let log = Arc::new(InMemoryDistributedLog::new());
@@ -1618,18 +1702,25 @@ async fn test_read_owner_prepare_rejects_conflicting_owner_write(
     let prepare_ts = node_b.committer_for_test().allocate_commit_ts().await?;
     let err = node_b
         .committer_for_test()
-        .prepare_remote(
+        .validate_remote_reads(
             TwoPhaseTransactionId::new(),
             read_owner_tx,
             write_source,
             prepare_ts,
-            vec![PartitionId(0), PartitionId(1)],
         )
         .await
         .expect_err("read owner should reject a read set made stale by its own write log");
     assert!(
         format!("{err:#}").contains("changed while this mutation was being run"),
         "expected read-owner OCC conflict, got {err:#}",
+    );
+    assert!(
+        node_b
+            .committer_for_test()
+            .two_phase_redo_records()
+            .await?
+            .is_empty(),
+        "validation-only read owners must not persist 2PC redo records",
     );
 
     Ok(())
@@ -1951,8 +2042,12 @@ fn test_local_commit_with_remote_read_routes_to_read_owner() -> anyhow::Result<(
             Some(tso.clone()),
         )
         .await?;
-        let server = start_two_pc_server(TestTwoPhaseCommitGrpcService::new(
+        let prepare_calls = Arc::new(AtomicUsize::new(0));
+        let validate_reads_calls = Arc::new(AtomicUsize::new(0));
+        let server = start_two_pc_server(TestTwoPhaseCommitGrpcService::with_counters(
             node_b.committer_for_test(),
+            prepare_calls.clone(),
+            validate_reads_calls.clone(),
         ))
         .await?;
         let node_a = create_node_with_options(
@@ -1994,6 +2089,16 @@ fn test_local_commit_with_remote_read_routes_to_read_owner() -> anyhow::Result<(
         assert!(
             commit_ts > initial_delta_ts,
             "resolver-routed commit should use a timestamp after the remote seed",
+        );
+        assert_eq!(
+            validate_reads_calls.load(Ordering::SeqCst),
+            1,
+            "remote read owner should receive a validation-only resolver RPC",
+        );
+        assert_eq!(
+            prepare_calls.load(Ordering::SeqCst),
+            0,
+            "read-only resolver participants should not stage prepared writes",
         );
         server.shutdown().await?;
         Ok(())

--- a/crates/database/src/two_phase.rs
+++ b/crates/database/src/two_phase.rs
@@ -59,6 +59,7 @@ use pb::{
         TwoPcSearchRead,
         TwoPcTabletMetadata,
         TwoPcTextQueryTermRead,
+        TwoPcValidateReadsRequest,
     },
     searchlight,
 };
@@ -1644,6 +1645,29 @@ impl TwoPhaseCommitGrpcClient {
         Ok(PrepareResult {
             prepare_ts: prepare_ts.try_into()?,
         })
+    }
+
+    pub async fn validate_reads(
+        &self,
+        transaction_id: &TwoPhaseTransactionId,
+        transaction: ParticipantTransaction,
+        write_source: WriteSource,
+        validate_ts: Timestamp,
+        placement_version: crate::partition::PlacementVersion,
+    ) -> anyhow::Result<()> {
+        let request = TwoPcValidateReadsRequest {
+            transaction_id: transaction_id.0.clone(),
+            transaction: Some(transaction.try_into()?),
+            write_source: write_source.as_str().unwrap_or_default().to_string(),
+            validate_ts: u64::from(validate_ts),
+            placement_version: u64::from(placement_version),
+        };
+        self.client
+            .clone()
+            .validate_reads(self.request(request))
+            .await
+            .context("gRPC ValidateReads failed")?;
+        Ok(())
     }
 
     pub async fn commit_prepared(

--- a/crates/database/src/two_phase_coordinator.rs
+++ b/crates/database/src/two_phase_coordinator.rs
@@ -264,22 +264,36 @@ async fn prepare_participant(
     node_addresses: Option<&NodeAddresses>,
     partition_map: &PartitionMap,
     transaction_id: &TwoPhaseTransactionId,
-    all_participants: &[PartitionId],
+    stateful_participants: &[PartitionId],
     participant: PartitionId,
     participant_tx: ParticipantTransaction,
     write_source: &WriteSource,
     prepare_ts: Timestamp,
-) -> anyhow::Result<()> {
-    let result = if participant == partition_map.local_partition() {
+) -> anyhow::Result<bool> {
+    let stages_writes = !participant_tx.writes.is_empty();
+    if participant == partition_map.local_partition() {
+        if stages_writes {
+            let result = local_committer
+                .prepare_remote(
+                    transaction_id.clone(),
+                    participant_tx,
+                    write_source.clone(),
+                    prepare_ts,
+                    stateful_participants.to_vec(),
+                )
+                .await?;
+            verify_prepare_result(participant, prepare_ts, result)?;
+            return Ok(true);
+        }
         local_committer
-            .prepare_remote(
+            .validate_remote_reads(
                 transaction_id.clone(),
                 participant_tx,
                 write_source.clone(),
                 prepare_ts,
-                all_participants.to_vec(),
             )
-            .await?
+            .await?;
+        return Ok(false);
     } else {
         let node_addresses = node_addresses.with_context(|| {
             format!(
@@ -295,30 +309,56 @@ async fn prepare_participant(
         for addr in addresses {
             match local_committer.two_phase_client(addr).await {
                 Ok(client) => {
-                    match client
-                        .prepare(
-                            transaction_id,
-                            participant_tx.clone(),
-                            write_source.clone(),
-                            prepare_ts,
-                            partition_map.placement_version(),
-                            all_participants,
-                        )
-                        .await
-                    {
-                        Ok(result) => {
-                            return verify_prepare_result(participant, prepare_ts, result)
-                        },
-                        Err(err) if should_try_next_participant_address(&err) => {
-                            tracing::warn!(
-                                "2PC Coordinator: prepare to participant {} via {} failed, trying \
-                                 next address: {err:#}",
-                                participant,
-                                addr,
-                            );
-                            last_err = Some(err);
-                        },
-                        Err(err) => return Err(err),
+                    if stages_writes {
+                        match client
+                            .prepare(
+                                transaction_id,
+                                participant_tx.clone(),
+                                write_source.clone(),
+                                prepare_ts,
+                                partition_map.placement_version(),
+                                stateful_participants,
+                            )
+                            .await
+                        {
+                            Ok(result) => {
+                                verify_prepare_result(participant, prepare_ts, result)?;
+                                return Ok(true);
+                            },
+                            Err(err) if should_try_next_participant_address(&err) => {
+                                tracing::warn!(
+                                    "2PC Coordinator: prepare to participant {} via {} failed, \
+                                     trying next address: {err:#}",
+                                    participant,
+                                    addr,
+                                );
+                                last_err = Some(err);
+                            },
+                            Err(err) => return Err(err),
+                        }
+                    } else {
+                        match client
+                            .validate_reads(
+                                transaction_id,
+                                participant_tx.clone(),
+                                write_source.clone(),
+                                prepare_ts,
+                                partition_map.placement_version(),
+                            )
+                            .await
+                        {
+                            Ok(()) => return Ok(false),
+                            Err(err) if should_try_next_participant_address(&err) => {
+                                tracing::warn!(
+                                    "2PC Coordinator: read validation on participant {} via {} \
+                                     failed, trying next address: {err:#}",
+                                    participant,
+                                    addr,
+                                );
+                                last_err = Some(err);
+                            },
+                            Err(err) => return Err(err),
+                        }
                     }
                 },
                 Err(err) if should_try_next_participant_address(&err) => {
@@ -336,9 +376,7 @@ async fn prepare_participant(
         return Err(last_err.unwrap_or_else(|| {
             anyhow!("2PC: No usable NODE_ADDRESSES entry for participant {participant}")
         }));
-    };
-
-    verify_prepare_result(participant, prepare_ts, result)
+    }
 }
 
 async fn prepare_participants(
@@ -346,7 +384,7 @@ async fn prepare_participants(
     node_addresses: Option<&NodeAddresses>,
     partition_map: &PartitionMap,
     transaction_id: &TwoPhaseTransactionId,
-    all_participants: &[PartitionId],
+    stateful_participants: &[PartitionId],
     participants: &[(PartitionId, ParticipantTransaction)],
     write_source: &WriteSource,
     prepare_ts: Timestamp,
@@ -359,7 +397,7 @@ async fn prepare_participants(
                 node_addresses,
                 partition_map,
                 transaction_id,
-                all_participants,
+                stateful_participants,
                 *participant,
                 participant_tx.clone(),
                 write_source,
@@ -374,7 +412,8 @@ async fn prepare_participants(
     let mut failures = Vec::new();
     while let Some((participant, result)) = prepares.next().await {
         match result {
-            Ok(()) => prepared.push(participant),
+            Ok(true) => prepared.push(participant),
+            Ok(false) => {},
             Err(err) => failures.push(PrepareParticipantFailure { participant, err }),
         }
     }
@@ -918,9 +957,16 @@ pub(crate) async fn coordinate_two_phase_commit_with_mode(
             ))
         })
         .collect::<anyhow::Result<_>>()?;
-    let all_participants: Vec<_> = participants
+    let stateful_participants: Vec<_> = participants
         .iter()
-        .map(|(participant, _)| *participant)
+        .filter_map(|(participant, transaction)| {
+            (!transaction.writes.is_empty()).then_some(*participant)
+        })
+        .collect();
+    let stateful_participant_transactions: Vec<_> = participants
+        .iter()
+        .filter(|(_, transaction)| !transaction.writes.is_empty())
+        .cloned()
         .collect();
     metrics::log_two_phase_participants(participants.len());
 
@@ -946,7 +992,7 @@ pub(crate) async fn coordinate_two_phase_commit_with_mode(
             node_addresses,
             partition_map,
             &txn_id,
-            &all_participants,
+            &stateful_participants,
             &participants,
             &write_source,
             prepare_ts,
@@ -967,7 +1013,7 @@ pub(crate) async fn coordinate_two_phase_commit_with_mode(
                 .iter()
                 .any(|failure| is_ambiguous_prepare_error(&failure.err));
             let participants_to_rollback = if has_ambiguous_prepare {
-                all_participants.clone()
+                stateful_participants.clone()
             } else {
                 prepared_participants.clone()
             };
@@ -1083,8 +1129,8 @@ pub(crate) async fn coordinate_two_phase_commit_with_mode(
                     local_committer,
                     &txn_id,
                     prepare_ts,
-                    &all_participants,
-                    &participants,
+                    &stateful_participants,
+                    &stateful_participant_transactions,
                     &write_source,
                 )
                 .await?;

--- a/crates/local_backend/src/two_phase_service.rs
+++ b/crates/local_backend/src/two_phase_service.rs
@@ -38,6 +38,8 @@ use pb::replication::{
     TwoPcPrepareResponse,
     TwoPcRollbackRequest,
     TwoPcRollbackResponse,
+    TwoPcValidateReadsRequest,
+    TwoPcValidateReadsResponse,
 };
 use tonic::{
     Request,
@@ -219,6 +221,47 @@ impl TwoPhaseCommitService for TwoPhaseCommitGrpcService {
         Ok(Response::new(TwoPcPrepareResponse {
             prepare_ts: u64::from(result.prepare_ts),
         }))
+    }
+
+    async fn validate_reads(
+        &self,
+        request: Request<TwoPcValidateReadsRequest>,
+    ) -> Result<Response<TwoPcValidateReadsResponse>, Status> {
+        self.authenticate(&request)?;
+        let req = request.into_inner();
+        let txn_id = TwoPhaseTransactionId(req.transaction_id);
+        let transaction = req
+            .transaction
+            .ok_or_else(|| Status::invalid_argument("ValidateReads missing transaction payload"))?;
+        let transaction = ParticipantTransaction::try_from(transaction).map_err(|e| {
+            Status::invalid_argument(format!("Invalid ValidateReads payload: {e:#}"))
+        })?;
+        let validate_ts = req.validate_ts.try_into().map_err(|e| {
+            Status::invalid_argument(format!("Invalid ValidateReads timestamp: {e:#}"))
+        })?;
+        let placement_version = PlacementVersion::from(req.placement_version);
+        self.ensure_placement_version(placement_version).await?;
+
+        if let Some(client) = self.leader_client().await? {
+            client
+                .validate_reads(
+                    &txn_id,
+                    transaction,
+                    req.write_source.into(),
+                    validate_ts,
+                    placement_version,
+                )
+                .await
+                .map_err(|e| Status::internal(format!("Leader ValidateReads failed: {e:#}")))?;
+            return Ok(Response::new(TwoPcValidateReadsResponse {}));
+        }
+
+        self.committer
+            .validate_remote_reads(txn_id, transaction, req.write_source.into(), validate_ts)
+            .await
+            .map_err(|e| Status::internal(format!("ValidateReads failed: {e:#}")))?;
+
+        Ok(Response::new(TwoPcValidateReadsResponse {}))
     }
 
     async fn commit_prepared(

--- a/crates/pb/protos/replication.proto
+++ b/crates/pb/protos/replication.proto
@@ -129,6 +129,7 @@ message QueryError {
 // to remote partitions, then CommitPrepared or RollbackPrepared.
 service TwoPhaseCommitService {
   rpc Prepare(TwoPcPrepareRequest) returns (TwoPcPrepareResponse);
+  rpc ValidateReads(TwoPcValidateReadsRequest) returns (TwoPcValidateReadsResponse);
   rpc CommitPrepared(TwoPcCommitRequest) returns (TwoPcCommitResponse);
   rpc RollbackPrepared(TwoPcRollbackRequest) returns (TwoPcRollbackResponse);
 }
@@ -161,6 +162,29 @@ message TwoPcPrepareRequest {
 message TwoPcPrepareResponse {
   // The prepare timestamp assigned by the participant's TSO.
   uint64 prepare_ts = 1;
+}
+
+message TwoPcValidateReadsRequest {
+  // Globally unique 2PC transaction ID, used only for tracing validation
+  // failures. Read-only validators do not stage durable participant state.
+  string transaction_id = 1;
+
+  // The participant's read subset. The writes field must be empty; write
+  // owners still use Prepare so they can stage a durable participant intent.
+  TwoPcParticipantTransaction transaction = 2;
+
+  // Write source for logging.
+  string write_source = 3;
+
+  // Globally assigned prepare/commit timestamp chosen by the coordinator.
+  uint64 validate_ts = 4;
+
+  // Placement metadata version used by the coordinator to route this
+  // validation request.
+  uint64 placement_version = 5;
+}
+
+message TwoPcValidateReadsResponse {
 }
 
 message TwoPcParticipantTransaction {


### PR DESCRIPTION
## Summary

- Add a `ValidateReads` 2PC RPC for read-only resolver participants.
- Keep write owners on the stateful `Prepare` / `CommitPrepared` path, while read owners validate OCC at the coordinator timestamp without staging empty prepared transactions.
- Fence successful read validation by advancing the participant timestamp floor, so later local commits cannot slip below the validated commit timestamp.
- Keep durable decisions, rollback, parallel cleanup, and watcher recovery scoped to participants that actually staged writes.

## Validation

- `cargo test -p database read_owner -- --nocapture`
- `cargo test -p database write_scaling_tests -- --nocapture` → 70/70
- `cargo test -p database two_phase_coordinator::tests -- --nocapture` → 7/7
- `cargo check -p database`
- `cargo check -p local_backend` with Node v20.19.5 pinned
- Rebuilt backend image locally: `sha256:7ab8f20b3b8ea9ac34b7d7d4e419d502bb95cdd061107e8e3b456d433ec335f5`
- Verified all six backend containers ran that exact local image ID
- `BACKEND_PULL_POLICY=never bash self-hosted/docker/test.sh` → write-scaling 129/129, Raft failover 24/24, all suites passed

Part of #131.