### PR TITLE
feat(database): add resolver conflict metrics

### DIFF
--- a/crates/database/src/committer.rs
+++ b/crates/database/src/committer.rs
@@ -333,6 +333,14 @@ fn remote_read_partitions(
     partitions
 }
 
+fn resolver_read_set_interval_count(reads: &ReadSet) -> usize {
+    reads
+        .iter_indexed()
+        .map(|(_, reads)| reads.intervals.len())
+        .sum::<usize>()
+        + reads.iter_search().count()
+}
+
 fn stale_replica_frontiers(
     snapshot_manager: &SnapshotManager,
     begin_ts: Timestamp,
@@ -4053,30 +4061,68 @@ impl<RT: Runtime> Committer<RT> {
         write_source: WriteSource,
         validate_ts: Timestamp,
     ) -> anyhow::Result<()> {
+        let local_partition = self.local_partition_for_two_phase();
+        let timer = metrics::two_phase_resolver_validation_timer(local_partition);
+        metrics::log_two_phase_resolver_read_set_intervals(
+            local_partition,
+            resolver_read_set_interval_count(&transaction.reads),
+        );
+
         let mut table_mapping = self
             .snapshot_manager
             .read()
             .latest_snapshot()
             .table_mapping()
             .clone();
-        transaction.augment_table_mapping(&mut table_mapping)?;
-        self.ensure_leader_for_writes()?;
-        anyhow::ensure!(
-            transaction.writes.is_empty(),
-            "2PC ValidateReads txn={} received {} writes; write participants must use Prepare",
-            transaction_id,
-            transaction.writes.len(),
-        );
-        self.ensure_read_ownership(&transaction.reads, &table_mapping, &write_source)?;
-        self.validate_remote_read_frontiers(
+        if let Err(err) = transaction.augment_table_mapping(&mut table_mapping) {
+            metrics::log_two_phase_resolver_validation(local_partition, "metadata");
+            timer.finish_with("metadata");
+            return Err(err);
+        }
+        if let Err(err) = self.ensure_leader_for_writes() {
+            metrics::log_two_phase_resolver_validation(local_partition, "not_leader");
+            timer.finish_with("not_leader");
+            return Err(err);
+        }
+        if !transaction.writes.is_empty() {
+            metrics::log_two_phase_resolver_validation(local_partition, "invalid_request");
+            timer.finish_with("invalid_request");
+            anyhow::bail!(
+                "2PC ValidateReads txn={} received {} writes; write participants must use Prepare",
+                transaction_id,
+                transaction.writes.len(),
+            );
+        }
+        if let Err(err) =
+            self.ensure_read_ownership(&transaction.reads, &table_mapping, &write_source)
+        {
+            metrics::log_two_phase_resolver_validation(local_partition, "ownership");
+            timer.finish_with("ownership");
+            return Err(err);
+        }
+        if let Err(err) = self.validate_remote_read_frontiers(
             *transaction.begin_timestamp,
             &transaction.reads,
             &table_mapping,
             &write_source,
-        )?;
+        ) {
+            metrics::log_two_phase_resolver_validation(local_partition, "frontier");
+            timer.finish_with("frontier");
+            return Err(err);
+        }
 
-        let local_commit_floor = self.explicit_prepare_commit_floor()?;
+        let local_commit_floor = match self.explicit_prepare_commit_floor() {
+            Ok(local_commit_floor) => local_commit_floor,
+            Err(err) => {
+                metrics::log_two_phase_resolver_validation(local_partition, "error");
+                timer.finish_with("error");
+                return Err(err);
+            },
+        };
         if validate_ts < local_commit_floor {
+            metrics::log_two_phase_resolver_validation(local_partition, "timestamp_floor");
+            metrics::log_two_phase_resolver_timestamp_floor_rejection(local_partition);
+            timer.finish_with("timestamp_floor");
             anyhow::bail!(
                 "2PC Prepare assigned ts={} but this participant requires ts>={}",
                 validate_ts,
@@ -4084,19 +4130,32 @@ impl<RT: Runtime> Committer<RT> {
             );
         }
 
-        let timer = metrics::commit_is_stale_timer();
-        if let Some(conflicting_read) = self.commit_has_conflict(
+        let stale_timer = metrics::commit_is_stale_timer();
+        let conflicting_read = match self.commit_has_conflict(
             &transaction.reads,
             *transaction.begin_timestamp,
             validate_ts,
-        )? {
+        ) {
+            Ok(conflicting_read) => conflicting_read,
+            Err(err) => {
+                metrics::log_two_phase_resolver_validation(local_partition, "error");
+                timer.finish_with("error");
+                return Err(err);
+            },
+        };
+        if let Some(conflicting_read) = conflicting_read {
+            metrics::log_two_phase_resolver_validation(local_partition, "conflict");
+            metrics::log_two_phase_resolver_conflict(local_partition);
+            timer.finish_with("conflict");
             anyhow::bail!(conflicting_read.into_error(&table_mapping, &write_source));
         }
-        timer.finish();
+        stale_timer.finish();
 
         if validate_ts > self.last_assigned_ts {
             self.last_assigned_ts = validate_ts;
         }
+        metrics::log_two_phase_resolver_validation(local_partition, "success");
+        timer.finish();
         tracing::info!(
             "2PC ValidateReads: txn={}, validate_ts={}",
             transaction_id,

--- a/crates/database/src/metrics.rs
+++ b/crates/database/src/metrics.rs
@@ -42,6 +42,8 @@ use crate::{
 };
 
 const PARTITION_LABELS: [&str; 1] = ["partition"];
+const PARTITION_OUTCOME_LABELS: [&str; 2] = ["partition", "outcome"];
+const PARTITION_STATUS_LABELS: [&str; 2] = ["partition", "status"];
 const SOURCE_PARTITION_LABELS: [&str; 1] = ["source_partition"];
 const OUTCOME_LABELS: [&str; 1] = ["outcome"];
 const PHASE_LABELS: [&str; 1] = ["phase"];
@@ -66,6 +68,13 @@ fn outcome_label(outcome: &'static str) -> StaticMetricLabel {
 
 fn phase_label(phase: &'static str) -> StaticMetricLabel {
     StaticMetricLabel::new("phase", phase)
+}
+
+fn partition_outcome_labels(
+    partition: PartitionId,
+    outcome: &'static str,
+) -> Vec<StaticMetricLabel> {
+    vec![partition_label(partition), outcome_label(outcome)]
 }
 
 fn commit_path_label(path: &'static str) -> StaticMetricLabel {
@@ -501,6 +510,69 @@ pub fn log_two_phase_prepare_attempts(num_attempts: usize) {
     log_distribution(
         &DATABASE_TWO_PHASE_PREPARE_ATTEMPTS_TOTAL,
         num_attempts as f64,
+    );
+}
+
+register_convex_histogram!(
+    DATABASE_TWO_PHASE_RESOLVER_VALIDATION_SECONDS,
+    "Time to validate a read-only 2PC resolver participant by partition and status",
+    &PARTITION_STATUS_LABELS
+);
+pub fn two_phase_resolver_validation_timer(partition: PartitionId) -> StatusTimer {
+    let mut timer = StatusTimer::new(&DATABASE_TWO_PHASE_RESOLVER_VALIDATION_SECONDS);
+    timer.add_label(partition_label(partition));
+    timer
+}
+
+register_convex_counter!(
+    DATABASE_TWO_PHASE_RESOLVER_VALIDATIONS_TOTAL,
+    "Number of read-only 2PC resolver validations by partition and outcome",
+    &PARTITION_OUTCOME_LABELS
+);
+pub fn log_two_phase_resolver_validation(partition: PartitionId, outcome: &'static str) {
+    log_counter_with_labels(
+        &DATABASE_TWO_PHASE_RESOLVER_VALIDATIONS_TOTAL,
+        1,
+        partition_outcome_labels(partition, outcome),
+    );
+}
+
+register_convex_counter!(
+    DATABASE_TWO_PHASE_RESOLVER_CONFLICTS_TOTAL,
+    "Number of read-only 2PC resolver validations that rejected conflicting reads",
+    &PARTITION_LABELS
+);
+pub fn log_two_phase_resolver_conflict(partition: PartitionId) {
+    log_counter_with_labels(
+        &DATABASE_TWO_PHASE_RESOLVER_CONFLICTS_TOTAL,
+        1,
+        vec![partition_label(partition)],
+    );
+}
+
+register_convex_counter!(
+    DATABASE_TWO_PHASE_RESOLVER_TIMESTAMP_FLOOR_REJECTIONS_TOTAL,
+    "Number of read-only 2PC resolver validations rejected below the local timestamp floor",
+    &PARTITION_LABELS
+);
+pub fn log_two_phase_resolver_timestamp_floor_rejection(partition: PartitionId) {
+    log_counter_with_labels(
+        &DATABASE_TWO_PHASE_RESOLVER_TIMESTAMP_FLOOR_REJECTIONS_TOTAL,
+        1,
+        vec![partition_label(partition)],
+    );
+}
+
+register_convex_histogram!(
+    DATABASE_TWO_PHASE_RESOLVER_READ_SET_INTERVALS_TOTAL,
+    "Number of indexed and search read intervals checked by read-only 2PC resolver validation",
+    &PARTITION_LABELS
+);
+pub fn log_two_phase_resolver_read_set_intervals(partition: PartitionId, intervals: usize) {
+    log_distribution_with_labels(
+        &DATABASE_TWO_PHASE_RESOLVER_READ_SET_INTERVALS_TOTAL,
+        intervals as f64,
+        vec![partition_label(partition)],
     );
 }
 


### PR DESCRIPTION
## Summary

- Add per-partition latency and outcome metrics for validation-only 2PC read resolver checks.
- Count resolver conflicts and timestamp-floor rejections separately so we can see whether owner-side read validation is rejecting due to true OCC conflicts or stale coordinator timestamps.
- Record read-set interval/search load as a distribution to make resolver pressure visible before we tune or shard the resolver path further.

This is observability-only: it does not change resolver validation semantics.

## Validation

Rust/local checks:
- `cargo fmt --package database`
- `PROTOC=/Users/martin/Desktop/convex-horizontal-scaling/crates/pb_build/protoc/protoc-macos-universal cargo test -p database read_owner -- --nocapture`
- `PROTOC=/Users/martin/Desktop/convex-horizontal-scaling/crates/pb_build/protoc/protoc-macos-universal cargo test -p database write_scaling_tests -- --nocapture`
- `PROTOC=/Users/martin/Desktop/convex-horizontal-scaling/crates/pb_build/protoc/protoc-macos-universal cargo check -p database`
- `PATH="$HOME/.nvm/versions/node/v20.19.5/bin:$PATH" PROTOC=/Users/martin/Desktop/convex-horizontal-scaling/crates/pb_build/protoc/protoc-macos-universal cargo check -p local_backend`

Cluster proof:
- Built local backend image `ghcr.io/martinkalema/convex-horizontal-scaling:backend-latest`.
- Verified all six backend containers were healthy and running local image ID `sha256:5be99bab72924a1fb56a7449d734efd4120f29e0fe6b45ea75f3d2ebeae15d40`.
- Ran `BACKEND_PULL_POLICY=never bash self-hosted/docker/test.sh`.
- Result: write-scaling `129/129`, Raft failover `24/24`, `ALL SUITES PASSED`.

Refs #131
