### PR TITLE
feat(database): add cluster membership directory

### DIFF
--- a/crates/database/src/committer.rs
+++ b/crates/database/src/committer.rs
@@ -107,7 +107,10 @@ use futures::{
 };
 use indexing::index_registry::IndexRegistry;
 use itertools::Itertools;
-use parking_lot::Mutex;
+use parking_lot::{
+    Mutex,
+    RwLock,
+};
 use prometheus::VMHistogram;
 use rand::Rng;
 use search::{
@@ -846,6 +849,7 @@ impl<RT: Runtime> Committer<RT> {
         let placement_state =
             partition_map.map(crate::partition::PlacementState::from_partition_map);
         let client_placement_state = placement_state.clone();
+        let client_node_addresses = Arc::new(RwLock::new(node_addresses));
         let committer = Self {
             pending_writes: PendingWrites::new(),
             prepared_writes: PreparedWrites::new(),
@@ -886,7 +890,7 @@ impl<RT: Runtime> Committer<RT> {
             retention_validator,
             snapshot_reader,
             placement_state: client_placement_state,
-            node_addresses,
+            node_addresses: client_node_addresses,
             two_phase_decision_log,
             two_phase_client_pool: Arc::new(crate::two_phase::TwoPhaseCommitGrpcClientPool::new(
                 cluster_grpc_auth,
@@ -5394,7 +5398,7 @@ pub struct CommitterClient {
     retention_validator: Arc<dyn RetentionValidator>,
     snapshot_reader: Reader<SnapshotManager>,
     placement_state: Option<crate::partition::PlacementState>,
-    node_addresses: Option<crate::two_phase::NodeAddresses>,
+    node_addresses: Arc<RwLock<Option<crate::two_phase::NodeAddresses>>>,
     two_phase_decision_log: Arc<dyn crate::two_phase::TwoPhaseDecisionLog>,
     two_phase_client_pool: Arc<crate::two_phase::TwoPhaseCommitGrpcClientPool>,
 }
@@ -5538,8 +5542,8 @@ impl CommitterClient {
         self.persistence_reader.clone()
     }
 
-    pub(crate) fn node_addresses(&self) -> Option<&crate::two_phase::NodeAddresses> {
-        self.node_addresses.as_ref()
+    pub(crate) fn node_addresses(&self) -> Option<crate::two_phase::NodeAddresses> {
+        self.node_addresses.read().clone()
     }
 
     pub(crate) async fn two_phase_client(
@@ -5564,6 +5568,19 @@ impl CommitterClient {
             anyhow::bail!("Cannot refresh placement metadata in single-partition mode");
         };
         placement_state.refresh(metadata)
+    }
+
+    pub fn refresh_membership_snapshot(
+        &self,
+        snapshot: crate::membership::MembershipSnapshot,
+    ) -> anyhow::Result<()> {
+        let node_addresses = snapshot.to_node_addresses();
+        anyhow::ensure!(
+            !node_addresses.partitions().is_empty(),
+            "Cannot refresh membership from an empty node directory"
+        );
+        *self.node_addresses.write() = Some(node_addresses);
+        Ok(())
     }
 
     pub fn ensure_placement_version(

--- a/crates/database/src/lib.rs
+++ b/crates/database/src/lib.rs
@@ -19,6 +19,7 @@ mod database;
 mod database_index_workers;
 pub mod delta_interest;
 mod execution_size;
+pub mod membership;
 mod metrics;
 pub mod nats_distributed_log;
 pub mod partition;

--- a/crates/database/src/membership.rs
+++ b/crates/database/src/membership.rs
@@ -1,0 +1,374 @@
+//! Cluster membership directory for horizontal scaling.
+//!
+//! Placement answers "which partition owns this data?" Membership answers
+//! "which physical nodes can serve that partition right now?" Keeping these
+//! separate prevents placement metadata from turning into a hardcoded address
+//! book as the cluster grows.
+
+use std::{
+    collections::BTreeMap,
+    fmt,
+};
+
+use anyhow::Context;
+use async_trait::async_trait;
+use serde::{
+    Deserialize,
+    Serialize,
+};
+
+use crate::{
+    partition::PartitionId,
+    two_phase::NodeAddresses,
+};
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub struct MembershipVersion(u64);
+
+impl MembershipVersion {
+    pub const BOOTSTRAP: Self = Self(0);
+
+    pub fn new(version: u64) -> Self {
+        Self(version)
+    }
+}
+
+impl From<MembershipVersion> for u64 {
+    fn from(version: MembershipVersion) -> Self {
+        version.0
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub struct ClusterNodeId(String);
+
+impl ClusterNodeId {
+    pub fn new(node_id: impl Into<String>) -> anyhow::Result<Self> {
+        let node_id = node_id.into();
+        anyhow::ensure!(
+            !node_id.trim().is_empty(),
+            "cluster node id cannot be empty"
+        );
+        Ok(Self(node_id))
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl fmt::Display for ClusterNodeId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct NodeMembership {
+    pub node_id: ClusterNodeId,
+    pub partition: PartitionId,
+    pub grpc_addr: String,
+    pub http_origin: Option<String>,
+    pub raft_addr: Option<String>,
+    pub generation: u64,
+    pub draining: bool,
+}
+
+impl NodeMembership {
+    pub fn new(
+        node_id: ClusterNodeId,
+        partition: PartitionId,
+        grpc_addr: impl Into<String>,
+    ) -> anyhow::Result<Self> {
+        let grpc_addr = grpc_addr.into().trim().to_string();
+        anyhow::ensure!(
+            !grpc_addr.is_empty(),
+            "cluster membership node {node_id} cannot have an empty gRPC address"
+        );
+        Ok(Self {
+            node_id,
+            partition,
+            grpc_addr,
+            http_origin: None,
+            raft_addr: None,
+            generation: 0,
+            draining: false,
+        })
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct MembershipSnapshot {
+    version: MembershipVersion,
+    nodes: BTreeMap<ClusterNodeId, NodeMembership>,
+}
+
+impl MembershipSnapshot {
+    pub fn new(version: MembershipVersion, nodes: Vec<NodeMembership>) -> Self {
+        Self {
+            version,
+            nodes: nodes
+                .into_iter()
+                .map(|node| (node.node_id.clone(), node))
+                .collect(),
+        }
+    }
+
+    pub fn from_node_addresses(version: MembershipVersion, addresses: &NodeAddresses) -> Self {
+        let nodes = addresses
+            .to_entries()
+            .into_iter()
+            .flat_map(|(partition, addresses)| {
+                addresses
+                    .into_iter()
+                    .enumerate()
+                    .filter_map(move |(index, address)| {
+                        let node_id =
+                            ClusterNodeId::new(format!("partition-{}-peer-{index}", partition.0))
+                                .ok()?;
+                        NodeMembership::new(node_id, partition, address).ok()
+                    })
+            })
+            .collect();
+        Self::new(version, nodes)
+    }
+
+    pub fn version(&self) -> MembershipVersion {
+        self.version
+    }
+
+    pub fn nodes(&self) -> &BTreeMap<ClusterNodeId, NodeMembership> {
+        &self.nodes
+    }
+
+    pub fn to_node_addresses(&self) -> NodeAddresses {
+        let mut addresses: BTreeMap<PartitionId, Vec<String>> = BTreeMap::new();
+        for node in self.nodes.values() {
+            if node.draining {
+                continue;
+            }
+            addresses
+                .entry(node.partition)
+                .or_default()
+                .push(node.grpc_addr.clone());
+        }
+        NodeAddresses::from_entries(addresses)
+    }
+}
+
+#[derive(Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct SerializedMembershipSnapshot {
+    version: u64,
+    nodes: Vec<SerializedNodeMembership>,
+}
+
+#[derive(Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct SerializedNodeMembership {
+    node_id: String,
+    partition: u32,
+    grpc_addr: String,
+    #[serde(default)]
+    http_origin: Option<String>,
+    #[serde(default)]
+    raft_addr: Option<String>,
+    #[serde(default)]
+    generation: u64,
+    #[serde(default)]
+    draining: bool,
+}
+
+impl From<&MembershipSnapshot> for SerializedMembershipSnapshot {
+    fn from(snapshot: &MembershipSnapshot) -> Self {
+        Self {
+            version: u64::from(snapshot.version()),
+            nodes: snapshot
+                .nodes()
+                .values()
+                .map(|node| SerializedNodeMembership {
+                    node_id: node.node_id.as_str().to_string(),
+                    partition: node.partition.0,
+                    grpc_addr: node.grpc_addr.clone(),
+                    http_origin: node.http_origin.clone(),
+                    raft_addr: node.raft_addr.clone(),
+                    generation: node.generation,
+                    draining: node.draining,
+                })
+                .collect(),
+        }
+    }
+}
+
+impl TryFrom<SerializedMembershipSnapshot> for MembershipSnapshot {
+    type Error = anyhow::Error;
+
+    fn try_from(serialized: SerializedMembershipSnapshot) -> anyhow::Result<Self> {
+        let nodes = serialized
+            .nodes
+            .into_iter()
+            .map(|node| {
+                let node_id = ClusterNodeId::new(node.node_id)?;
+                let mut membership =
+                    NodeMembership::new(node_id, PartitionId(node.partition), node.grpc_addr)?;
+                membership.http_origin = node.http_origin;
+                membership.raft_addr = node.raft_addr;
+                membership.generation = node.generation;
+                membership.draining = node.draining;
+                Ok(membership)
+            })
+            .collect::<anyhow::Result<_>>()?;
+        Ok(MembershipSnapshot::new(
+            MembershipVersion::new(serialized.version),
+            nodes,
+        ))
+    }
+}
+
+const MEMBERSHIP_KV_BUCKET: &str = "convex_membership";
+const MEMBERSHIP_CURRENT_KEY: &str = "current";
+
+#[async_trait]
+pub trait MembershipStore: Send + Sync + 'static {
+    async fn load(&self) -> anyhow::Result<Option<MembershipSnapshot>>;
+    async fn ensure_initialized(
+        &self,
+        bootstrap_snapshot: MembershipSnapshot,
+    ) -> anyhow::Result<MembershipSnapshot>;
+}
+
+pub struct NatsMembershipStore {
+    kv: async_nats::jetstream::kv::Store,
+}
+
+impl NatsMembershipStore {
+    pub async fn connect(nats_url: &str) -> anyhow::Result<Self> {
+        let _ = rustls::crypto::ring::default_provider().install_default();
+        let client = async_nats::connect(nats_url)
+            .await
+            .with_context(|| format!("Membership: failed to connect to NATS at {nats_url}"))?;
+        let jetstream = async_nats::jetstream::new(client);
+        let kv = jetstream
+            .create_key_value(async_nats::jetstream::kv::Config {
+                bucket: MEMBERSHIP_KV_BUCKET.to_string(),
+                history: 16,
+                ..Default::default()
+            })
+            .await
+            .context("Membership: failed to create KV bucket")?;
+        Ok(Self { kv })
+    }
+
+    fn encode(snapshot: &MembershipSnapshot) -> anyhow::Result<Vec<u8>> {
+        serde_json::to_vec(&SerializedMembershipSnapshot::from(snapshot))
+            .context("Membership: failed to serialize snapshot")
+    }
+
+    fn decode(bytes: &[u8]) -> anyhow::Result<MembershipSnapshot> {
+        let serialized: SerializedMembershipSnapshot =
+            serde_json::from_slice(bytes).context("Membership: failed to parse snapshot")?;
+        serialized.try_into()
+    }
+}
+
+#[async_trait]
+impl MembershipStore for NatsMembershipStore {
+    async fn load(&self) -> anyhow::Result<Option<MembershipSnapshot>> {
+        let Some(entry) = self
+            .kv
+            .entry(MEMBERSHIP_CURRENT_KEY)
+            .await
+            .context("Membership: failed to read current snapshot")?
+        else {
+            return Ok(None);
+        };
+        Ok(Some(Self::decode(&entry.value)?))
+    }
+
+    async fn ensure_initialized(
+        &self,
+        bootstrap_snapshot: MembershipSnapshot,
+    ) -> anyhow::Result<MembershipSnapshot> {
+        if let Some(existing) = self.load().await? {
+            return Ok(existing);
+        }
+        let bytes = Self::encode(&bootstrap_snapshot)?;
+        match self.kv.create(MEMBERSHIP_CURRENT_KEY, bytes.into()).await {
+            Ok(_) => Ok(bootstrap_snapshot),
+            Err(_) => self
+                .load()
+                .await?
+                .context("Membership: failed to initialize and no current snapshot exists"),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_membership_snapshot_converts_to_node_addresses() -> anyhow::Result<()> {
+        let snapshot = MembershipSnapshot::new(
+            MembershipVersion::new(7),
+            vec![
+                NodeMembership::new(ClusterNodeId::new("p0a")?, PartitionId(0), "node-p0a:50051")?,
+                NodeMembership::new(ClusterNodeId::new("p0b")?, PartitionId(0), "node-p0b:50051")?,
+                {
+                    let mut node = NodeMembership::new(
+                        ClusterNodeId::new("p1-draining")?,
+                        PartitionId(1),
+                        "node-p1-old:50051",
+                    )?;
+                    node.draining = true;
+                    node
+                },
+                NodeMembership::new(ClusterNodeId::new("p1a")?, PartitionId(1), "node-p1a:50051")?,
+            ],
+        );
+
+        let addresses = snapshot.to_node_addresses();
+        assert_eq!(
+            addresses.address_for(PartitionId(0)),
+            Some("node-p0a:50051")
+        );
+        assert_eq!(
+            addresses.addresses_for(PartitionId(0)).unwrap(),
+            &["node-p0a:50051".to_string(), "node-p0b:50051".to_string(),],
+        );
+        assert_eq!(
+            addresses.address_for(PartitionId(1)),
+            Some("node-p1a:50051")
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn test_membership_snapshot_bootstraps_from_node_addresses() {
+        let addresses =
+            NodeAddresses::from_config("0=node-p0a:50051|node-p0b:50051,1=node-p1a:50051");
+
+        let snapshot =
+            MembershipSnapshot::from_node_addresses(MembershipVersion::BOOTSTRAP, &addresses);
+
+        assert_eq!(snapshot.version(), MembershipVersion::BOOTSTRAP);
+        assert_eq!(snapshot.nodes().len(), 3);
+        assert_eq!(snapshot.to_node_addresses(), addresses);
+    }
+
+    #[test]
+    fn test_membership_snapshot_serialization_round_trip() -> anyhow::Result<()> {
+        let mut node =
+            NodeMembership::new(ClusterNodeId::new("p0a")?, PartitionId(0), "node-p0a:50051")?;
+        node.http_origin = Some("http://node-p0a:3210".to_string());
+        node.raft_addr = Some("node-p0a:50061".to_string());
+        node.generation = 3;
+
+        let snapshot = MembershipSnapshot::new(MembershipVersion::new(11), vec![node]);
+        let bytes = NatsMembershipStore::encode(&snapshot)?;
+        let decoded = NatsMembershipStore::decode(&bytes)?;
+
+        assert_eq!(decoded, snapshot);
+        Ok(())
+    }
+}

--- a/crates/database/src/tests/write_scaling_tests.rs
+++ b/crates/database/src/tests/write_scaling_tests.rs
@@ -121,6 +121,12 @@ use crate::{
         CommitterClient,
         AFTER_PENDING_WRITE_SNAPSHOT,
     },
+    membership::{
+        ClusterNodeId,
+        MembershipSnapshot,
+        MembershipVersion,
+        NodeMembership,
+    },
     partition::{
         PartitionId,
         PartitionMap,
@@ -5857,6 +5863,51 @@ fn test_committer_client_refreshes_placement_metadata() -> anyhow::Result<()> {
         ))?;
 
         committer.ensure_placement_version(PlacementVersion::new(2))?;
+        Ok(())
+    })
+}
+
+#[test]
+fn test_committer_client_refreshes_membership_snapshot() -> anyhow::Result<()> {
+    let td = TestDriver::new();
+    let rt = td.rt();
+    td.run_until(async move {
+        let log = Arc::new(InMemoryDistributedLog::new());
+        let node = create_node(
+            &rt,
+            log,
+            Some(partitioned_map_with_version(
+                PartitionId(1),
+                PlacementVersion::new(1),
+            )),
+        )
+        .await?;
+        let committer = node.committer_for_test();
+        assert!(committer.node_addresses().is_none());
+
+        committer.refresh_membership_snapshot(MembershipSnapshot::new(
+            MembershipVersion::new(2),
+            vec![
+                NodeMembership::new(
+                    ClusterNodeId::new("node-p0a")?,
+                    PartitionId(0),
+                    "node-p0:50051",
+                )?,
+                NodeMembership::new(
+                    ClusterNodeId::new("node-p1a")?,
+                    PartitionId(1),
+                    "node-p1:50051",
+                )?,
+            ],
+        ))?;
+
+        let node_addresses = committer
+            .node_addresses()
+            .expect("membership refresh should install node addresses");
+        assert_eq!(
+            node_addresses.address_for(PartitionId(1)),
+            Some("node-p1:50051"),
+        );
         Ok(())
     })
 }

--- a/crates/database/src/two_phase.rs
+++ b/crates/database/src/two_phase.rs
@@ -1067,12 +1067,28 @@ impl TwoPhaseDecisionLog for NatsTwoPhaseDecisionLog {
 /// Partition-to-address mapping for gRPC communication.
 /// Each entry maps a partition ID to one or more gRPC addresses for that
 /// partition's Raft peers.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct NodeAddresses {
     addresses: BTreeMap<PartitionId, Vec<String>>,
 }
 
 impl NodeAddresses {
+    pub fn from_entries(addresses: BTreeMap<PartitionId, Vec<String>>) -> Self {
+        Self {
+            addresses: addresses
+                .into_iter()
+                .filter_map(|(partition, addresses)| {
+                    let addresses = addresses
+                        .into_iter()
+                        .map(|address| address.trim().to_string())
+                        .filter(|address| !address.is_empty())
+                        .collect::<Vec<_>>();
+                    (!addresses.is_empty()).then_some((partition, addresses))
+                })
+                .collect(),
+        }
+    }
+
     /// Parse from config string: "0=host:port|host:port,1=host:port|host:port".
     ///
     /// A partition can list multiple Raft peers with `|`, e.g.
@@ -1095,7 +1111,11 @@ impl NodeAddresses {
                 }
             }
         }
-        Self { addresses }
+        Self::from_entries(addresses)
+    }
+
+    pub fn to_entries(&self) -> BTreeMap<PartitionId, Vec<String>> {
+        self.addresses.clone()
     }
 
     /// Get the gRPC address for a partition.
@@ -1742,6 +1762,26 @@ mod tests {
     fn test_node_addresses_empty() {
         let addrs = NodeAddresses::from_config("");
         assert!(addrs.partitions().is_empty());
+    }
+
+    #[test]
+    fn test_node_addresses_round_trip_structured_entries() {
+        let addrs = NodeAddresses::from_entries(BTreeMap::from([
+            (
+                PartitionId(0),
+                vec![" node-p0a:50051 ".to_string(), "node-p0b:50051".to_string()],
+            ),
+            (
+                PartitionId(1),
+                vec!["".to_string(), "node-p1a:50051".to_string()],
+            ),
+            (PartitionId(2), vec!["".to_string()]),
+        ]));
+
+        assert_eq!(addrs.address_for(PartitionId(0)), Some("node-p0a:50051"));
+        assert_eq!(addrs.address_for(PartitionId(1)), Some("node-p1a:50051"));
+        assert_eq!(addrs.address_for(PartitionId(2)), None);
+        assert_eq!(NodeAddresses::from_entries(addrs.to_entries()), addrs);
     }
 
     #[test]

--- a/crates/database/src/two_phase_coordinator.rs
+++ b/crates/database/src/two_phase_coordinator.rs
@@ -989,7 +989,7 @@ pub(crate) async fn coordinate_two_phase_commit_with_mode(
             mut failures,
         } = prepare_participants(
             local_committer,
-            node_addresses,
+            node_addresses.as_ref(),
             partition_map,
             &txn_id,
             &stateful_participants,
@@ -1040,7 +1040,7 @@ pub(crate) async fn coordinate_two_phase_commit_with_mode(
             }
             rollback_prepared_participants(
                 local_committer,
-                node_addresses,
+                node_addresses.as_ref(),
                 partition_map,
                 &txn_id,
                 &participants_to_rollback,
@@ -1087,7 +1087,7 @@ pub(crate) async fn coordinate_two_phase_commit_with_mode(
 
                 let commit_results = match commit_participants(
                     local_committer,
-                    node_addresses,
+                    node_addresses.as_ref(),
                     partition_map,
                     &txn_id,
                     &prepared_participants,
@@ -1138,7 +1138,7 @@ pub(crate) async fn coordinate_two_phase_commit_with_mode(
                 verify_committed_decision(&txn_id, &recovered, prepare_ts, &prepared_participants)?;
                 spawn_parallel_commit_cleanup(
                     local_committer.clone(),
-                    node_addresses.cloned(),
+                    node_addresses.clone(),
                     partition_map.clone(),
                     txn_id.clone(),
                     prepared_participants.clone(),

--- a/crates/local_backend/src/lib.rs
+++ b/crates/local_backend/src/lib.rs
@@ -144,6 +144,7 @@ pub struct BackendAppState {
     pub mutation_forwarder_pool: mutation_forwarder::MutationForwarderGrpcClientPool,
     pub replica_mutation_forwarder: Option<Arc<mutation_forwarder::MutationForwarderGrpcClient>>,
     pub placement_metadata_store: Option<Arc<dyn database::partition::PlacementMetadataStore>>,
+    pub membership_store: Option<Arc<dyn database::membership::MembershipStore>>,
     /// Raft partition mailbox for receiving Raft messages from peers.
     /// None if Raft is not enabled.
     pub raft_mailbox_tx:
@@ -439,6 +440,11 @@ pub async fn make_app(
     } else {
         None
     };
+    let static_node_addresses = config
+        .node_addresses
+        .as_deref()
+        .map(database::two_phase::NodeAddresses::from_config);
+    let mut effective_node_addresses = static_node_addresses.clone();
     let static_placement_metadata = config.partition_id.map(|_| {
         let partition_map_str = config.partition_map.as_deref().unwrap_or("");
         let num_partitions = config.num_partitions.unwrap_or(1);
@@ -473,10 +479,7 @@ pub async fn make_app(
                 .expect("partitioned startup should have placement metadata")
                 .into_partition_map(database::partition::PartitionId(id))
         }),
-        config
-            .node_addresses
-            .as_deref()
-            .map(database::two_phase::NodeAddresses::from_config),
+        static_node_addresses.clone(),
         two_phase_decision_log,
         Some(cluster_grpc_auth.clone()),
         timestamp_oracle,
@@ -496,6 +499,35 @@ pub async fn make_app(
             database
                 .committer_client()
                 .refresh_placement_metadata(authoritative_metadata)?;
+            Some(store)
+        } else {
+            None
+        };
+    let membership_store: Option<Arc<dyn database::membership::MembershipStore>> =
+        if let (Some(_), Some(nats_url)) = (config.partition_id, config.nats_url.as_deref()) {
+            let store: Arc<dyn database::membership::MembershipStore> =
+                Arc::new(database::membership::NatsMembershipStore::connect(nats_url).await?);
+            let authoritative_snapshot =
+                if let Some(static_node_addresses) = static_node_addresses.as_ref() {
+                    let bootstrap_snapshot =
+                        database::membership::MembershipSnapshot::from_node_addresses(
+                            database::membership::MembershipVersion::BOOTSTRAP,
+                            static_node_addresses,
+                        );
+                    store.ensure_initialized(bootstrap_snapshot).await?
+                } else {
+                    store.load().await?.ok_or_else(|| {
+                        anyhow::anyhow!(
+                            "Partitioned startup requires NODE_ADDRESSES until the shared \
+                             membership directory has been initialized"
+                        )
+                    })?
+                };
+            let membership_node_addresses = authoritative_snapshot.to_node_addresses();
+            database
+                .committer_client()
+                .refresh_membership_snapshot(authoritative_snapshot)?;
+            effective_node_addresses = Some(membership_node_addresses);
             Some(store)
         } else {
             None
@@ -671,10 +703,7 @@ pub async fn make_app(
     let origin = config.convex_origin_url()?;
     let instance_name = config.name();
     let partition_id = config.partition_id.map(database::partition::PartitionId);
-    let node_addresses = config
-        .node_addresses
-        .as_deref()
-        .map(database::two_phase::NodeAddresses::from_config);
+    let node_addresses = effective_node_addresses.clone();
     let mut raft_state_for_app = None;
     let mut raft_peer_http_origins = None;
     let mut raft_peer_grpc_urls = None;
@@ -829,10 +858,8 @@ pub async fn make_app(
                         .filter(|partition| partition.0 != local_partition)
                         .collect::<Vec<_>>()
                 } else {
-                    config
-                        .node_addresses
-                        .as_deref()
-                        .map(database::two_phase::NodeAddresses::from_config)
+                    effective_node_addresses
+                        .as_ref()
                         .map(|addresses| {
                             addresses
                                 .partitions()
@@ -1186,6 +1213,7 @@ pub async fn make_app(
         replica_mutation_forwarder,
         mutation_forwarder_pool,
         placement_metadata_store,
+        membership_store,
         raft_mailbox_tx,
         cluster_grpc_auth: Some(cluster_grpc_auth),
     };

--- a/docs/dynamic-placement.md
+++ b/docs/dynamic-placement.md
@@ -1,6 +1,6 @@
 # Dynamic Placement Control Plane
 
-Issue #104 is the path from startup-configured partitions to online placement
+Issue #130 is the path from startup-configured partitions to online placement
 changes. The current implementation is still static: nodes read
 `PARTITION_ID`, `PARTITION_MAP`, `NUM_PARTITIONS`, and `NODE_ADDRESSES` at
 startup. This document records the safety contract added before online
@@ -8,18 +8,22 @@ rebalancing is introduced.
 
 ## Current State
 
-Placement ownership is now represented in two layers in
-`crates/database/src/partition.rs`:
+Cluster routing state is now represented in three layers:
 
 - `PlacementMetadata` is the versioned control-plane model. It records where
   the metadata came from, how many partitions exist, and which logical targets
-  are owned by which partitions.
+  are owned by which partitions. Placement is logical only; it does not carry
+  node addresses.
 - `PartitionMap` is the runtime lookup object used by commit, routing, and 2PC
   paths.
 - `PlacementState` is the refreshable in-process holder shared by the committer
   and commit client. Each transaction snapshots the current `PartitionMap`
   before routing so a placement refresh cannot change ownership halfway through
   one commit.
+- `MembershipSnapshot` in `crates/database/src/membership.rs` is the physical
+  node directory. It records node IDs, partition membership, gRPC endpoints,
+  generation, and drain state. 2PC routing derives its `partition -> peer
+  addresses` view from this directory.
 
 The current metadata source is still static process config. Version `0` means
 the startup-configured map. Operators may now set `PARTITION_MAP_VERSION` and
@@ -30,6 +34,13 @@ When NATS is configured, startup now initializes or loads the shared
 that authoritative control-plane record. The static env map remains the
 bootstrap fallback so `Database::load` can start before any external placement
 source is available.
+
+When a partitioned node also has NATS, startup initializes or loads the shared
+`convex_membership/current` NATS KV record and refreshes the committer's 2PC
+routing addresses from that membership directory. `NODE_ADDRESSES` is now only a
+bootstrap seed for local/dev deployments or the first membership snapshot. Once
+the shared membership directory exists, a node can load physical endpoints from
+NATS instead of every process carrying the full topology in its env.
 
 Placement metadata is control-plane state, not an application API. Nodes,
 routers, and operators may reason about placement versions and ownership, but
@@ -53,18 +64,21 @@ When changing `PARTITION_MAP`, roll all nodes with the same
 that node fail fast with a placement-version mismatch instead of silently
 preparing against the wrong owner.
 
-## Remaining #104 Work
+## Remaining #130 Work
 
 - Store placement metadata in a replicated system table instead of env vars.
 - Add an authority/lease model for who may publish a new placement version.
 - Decide whether NATS KV remains the placement authority long term or becomes a
   bootstrap/transport layer for a replicated placement system table.
-- Add node membership metadata so new partitions can be added without editing
-  every node config by hand.
+- Move membership from a whole-snapshot KV record to per-node self-registration
+  with heartbeats, TTLs, and watch-driven in-process refresh.
+- Extend node membership use beyond 2PC gRPC routing: HTTP/deploy forwarding,
+  Raft peer discovery, liveness, role, generation/epoch, and drain state must
+  all converge on the same directory before automated add/remove/rebalance.
 - Add an online movement workflow: freeze source writes for the moved range or
   table, copy/catch up data, publish the new placement version, then unfreeze.
-- Add stale-map refresh behavior so clients/nodes retry after loading the newer
-  placement version.
+- Add stale-map refresh behavior across every routing surface; 2PC prepare
+  already refreshes from the placement store on version mismatch.
 - Add operational procedures for add-node, remove-node, and rebalance.
 
 Large distributed databases use the same shape at a larger scale: placement is


### PR DESCRIPTION
## Summary

- Adds a dedicated database membership directory separate from logical placement metadata.
- Introduces `MembershipSnapshot`, `NodeMembership`, and NATS-backed membership storage for physical node endpoints.
- Lets the committer refresh 2PC `NodeAddresses` from membership snapshots instead of coupling addresses to placement metadata.
- Seeds membership from static `NODE_ADDRESSES` only as bootstrap/local-dev input, then uses the shared membership snapshot as the effective routing view.
- Updates the dynamic placement docs to distinguish logical placement from physical membership and points live self-registration/heartbeat work to #234.

## Validation

- `cargo fmt --package database --package local_backend`
- `cargo test -p database membership -- --nocapture`
- `cargo test -p database placement_metadata -- --nocapture`
- `cargo test -p database test_committer_client_refreshes_membership_snapshot -- --nocapture`
- `cargo test -p database write_scaling_tests -- --nocapture` → 74/74
- `cargo check -p database`
- `cargo check -p local_backend`
- Rebuilt local backend image `sha256:892bb5f734627b6c1eaff5e18cc8013cdd598a25077820e558b436b7324ec97a`
- Verified all six backend containers used that exact local image ID with `BACKEND_PULL_POLICY=never`
- Clean full Docker harness: write-scaling 129/129, Raft failover 24/24, ALL SUITES PASSED

Refs #130
Refs #234