### PR TITLE
feat(membership): advertise dynamic node endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,8 +182,10 @@ cd self-hosted/docker
 # 1 backend node for local development
 docker compose --profile single up
 
-# 2 partitions x 3 Raft nodes
-docker compose --profile cluster up
+# 2 partitions x 3 Raft nodes.
+# This wrapper gives each run a fresh advertised-address namespace so routing
+# uses membership discovery instead of only the static Compose service names.
+./start-cluster.sh
 ```
 
 Images are published to:

--- a/crates/database/src/membership.rs
+++ b/crates/database/src/membership.rs
@@ -141,6 +141,18 @@ impl MembershipSnapshot {
         &self.nodes
     }
 
+    pub fn with_registered_node(&self, node: NodeMembership) -> Self {
+        if self.nodes.get(&node.node_id) == Some(&node) {
+            return self.clone();
+        }
+        let mut nodes = self.nodes.clone();
+        nodes.insert(node.node_id.clone(), node);
+        MembershipSnapshot {
+            version: MembershipVersion::new(u64::from(self.version).saturating_add(1)),
+            nodes,
+        }
+    }
+
     pub fn to_node_addresses(&self) -> NodeAddresses {
         let mut addresses: BTreeMap<PartitionId, Vec<String>> = BTreeMap::new();
         for node in self.nodes.values() {
@@ -235,6 +247,7 @@ pub trait MembershipStore: Send + Sync + 'static {
         &self,
         bootstrap_snapshot: MembershipSnapshot,
     ) -> anyhow::Result<MembershipSnapshot>;
+    async fn register_node(&self, node: NodeMembership) -> anyhow::Result<MembershipSnapshot>;
 }
 
 pub struct NatsMembershipStore {
@@ -300,6 +313,57 @@ impl MembershipStore for NatsMembershipStore {
                 .await?
                 .context("Membership: failed to initialize and no current snapshot exists"),
         }
+    }
+
+    async fn register_node(&self, node: NodeMembership) -> anyhow::Result<MembershipSnapshot> {
+        for attempt in 0..10 {
+            if let Some(entry) = self
+                .kv
+                .entry(MEMBERSHIP_CURRENT_KEY)
+                .await
+                .context("Membership: failed to read current snapshot")?
+            {
+                let current = Self::decode(&entry.value)?;
+                let updated = current.with_registered_node(node.clone());
+                if updated == current {
+                    return Ok(current);
+                }
+                let bytes = Self::encode(&updated)?;
+                match self
+                    .kv
+                    .update(MEMBERSHIP_CURRENT_KEY, bytes.into(), entry.revision)
+                    .await
+                {
+                    Ok(_) => return Ok(updated),
+                    Err(_) => {
+                        tracing::debug!(
+                            attempt,
+                            node_id = %node.node_id,
+                            "Membership: CAS conflict while registering node"
+                        );
+                    },
+                }
+            } else {
+                let snapshot =
+                    MembershipSnapshot::new(MembershipVersion::BOOTSTRAP, vec![node.clone()]);
+                let bytes = Self::encode(&snapshot)?;
+                match self.kv.create(MEMBERSHIP_CURRENT_KEY, bytes.into()).await {
+                    Ok(_) => return Ok(snapshot),
+                    Err(_) => {
+                        tracing::debug!(
+                            attempt,
+                            node_id = %node.node_id,
+                            "Membership: create conflict while registering node"
+                        );
+                    },
+                }
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(1 << attempt)).await;
+        }
+        anyhow::bail!(
+            "Membership: failed to register node {} after CAS retries",
+            node.node_id
+        )
     }
 }
 
@@ -369,6 +433,35 @@ mod tests {
         let decoded = NatsMembershipStore::decode(&bytes)?;
 
         assert_eq!(decoded, snapshot);
+        Ok(())
+    }
+
+    #[test]
+    fn test_membership_snapshot_registration_replaces_advertised_address() -> anyhow::Result<()> {
+        let existing = NodeMembership::new(
+            ClusterNodeId::new("partition-0-peer-0")?,
+            PartitionId(0),
+            "node-p0a:50051",
+        )?;
+        let snapshot = MembershipSnapshot::new(MembershipVersion::BOOTSTRAP, vec![existing]);
+        let mut replacement = NodeMembership::new(
+            ClusterNodeId::new("partition-0-peer-0")?,
+            PartitionId(0),
+            "random-p0a-20260701:50051",
+        )?;
+        replacement.generation = 2;
+
+        let updated = snapshot.with_registered_node(replacement.clone());
+
+        assert_eq!(updated.version(), MembershipVersion::new(1));
+        assert_eq!(
+            updated.nodes().get(&replacement.node_id),
+            Some(&replacement)
+        );
+        assert_eq!(
+            updated.to_node_addresses().address_for(PartitionId(0)),
+            Some("random-p0a-20260701:50051")
+        );
         Ok(())
     }
 }

--- a/crates/local_backend/src/config.rs
+++ b/crates/local_backend/src/config.rs
@@ -182,6 +182,34 @@ pub struct LocalConfig {
     #[clap(long, env = "NODE_ADDRESSES")]
     pub node_addresses: Option<String>,
 
+    /// Stable logical node id used when this process registers itself in the
+    /// shared membership directory. If omitted in Raft mode, this defaults to
+    /// `partition-{PARTITION_ID}-peer-{RAFT_NODE_ID - 1}` so it replaces the
+    /// bootstrap NODE_ADDRESSES entry instead of creating a duplicate node.
+    #[clap(long, env = "CLUSTER_NODE_ID")]
+    pub cluster_node_id: Option<String>,
+
+    /// gRPC address this node advertises into the shared membership directory.
+    /// This may be different from the static Docker service name and can change
+    /// across runs.
+    #[clap(long, env = "ADVERTISE_GRPC_ADDR")]
+    pub advertise_grpc_addr: Option<String>,
+
+    /// Public HTTP origin this node advertises into membership.
+    #[clap(long, env = "ADVERTISE_HTTP_ORIGIN")]
+    pub advertise_http_origin: Option<String>,
+
+    /// Raft peer address this node advertises into membership. Dynamic Raft
+    /// reconfiguration is tracked separately; this is recorded now so the same
+    /// membership directory can carry physical endpoint data.
+    #[clap(long, env = "ADVERTISE_RAFT_ADDR")]
+    pub advertise_raft_addr: Option<String>,
+
+    /// Monotonic generation for this node advertisement. Operators and tests
+    /// can bump this when a node is recreated with a new physical address.
+    #[clap(long, env = "CLUSTER_NODE_GENERATION", default_value = "0")]
+    pub cluster_node_generation: u64,
+
     /// Raft node ID for this node. Each node in a Raft group must have
     /// a unique ID. When set, enables Raft consensus for the partition.
     /// Example: "1"

--- a/crates/local_backend/src/lib.rs
+++ b/crates/local_backend/src/lib.rs
@@ -159,6 +159,41 @@ impl BackendAppState {
     }
 }
 
+fn advertised_membership_node(
+    config: &LocalConfig,
+) -> anyhow::Result<Option<database::membership::NodeMembership>> {
+    let Some(partition_id) = config.partition_id else {
+        return Ok(None);
+    };
+    let Some(grpc_addr) = config.advertise_grpc_addr.as_deref() else {
+        return Ok(None);
+    };
+    let node_id = config
+        .cluster_node_id
+        .clone()
+        .or_else(|| {
+            config.raft_node_id.map(|raft_node_id| {
+                format!(
+                    "partition-{partition_id}-peer-{}",
+                    raft_node_id.saturating_sub(1)
+                )
+            })
+        })
+        .unwrap_or_else(|| config.name());
+    let mut node = database::membership::NodeMembership::new(
+        database::membership::ClusterNodeId::new(node_id)?,
+        database::partition::PartitionId(partition_id),
+        grpc_addr,
+    )?;
+    node.http_origin = match config.advertise_http_origin.clone() {
+        Some(origin) => Some(origin),
+        None => Some(config.convex_origin_url()?.to_string()),
+    };
+    node.raft_addr = config.advertise_raft_addr.clone();
+    node.generation = config.cluster_node_generation;
+    Ok(Some(node))
+}
+
 // Contains state needed to serve most http routes. Similar to BackendAppState,
 // but uses ApplicationApi instead of Application, which allows it to be used
 // in both Backend and Usher.
@@ -507,22 +542,37 @@ pub async fn make_app(
         if let (Some(_), Some(nats_url)) = (config.partition_id, config.nats_url.as_deref()) {
             let store: Arc<dyn database::membership::MembershipStore> =
                 Arc::new(database::membership::NatsMembershipStore::connect(nats_url).await?);
-            let authoritative_snapshot =
+            let advertised_node = advertised_membership_node(&config)?;
+            let seeded_snapshot =
                 if let Some(static_node_addresses) = static_node_addresses.as_ref() {
                     let bootstrap_snapshot =
                         database::membership::MembershipSnapshot::from_node_addresses(
                             database::membership::MembershipVersion::BOOTSTRAP,
                             static_node_addresses,
                         );
-                    store.ensure_initialized(bootstrap_snapshot).await?
+                    Some(store.ensure_initialized(bootstrap_snapshot).await?)
                 } else {
-                    store.load().await?.ok_or_else(|| {
-                        anyhow::anyhow!(
-                            "Partitioned startup requires NODE_ADDRESSES until the shared \
-                             membership directory has been initialized"
-                        )
-                    })?
+                    store.load().await?
                 };
+            let authoritative_snapshot = if let Some(advertised_node) = advertised_node {
+                let node_id = advertised_node.node_id.to_string();
+                let grpc_addr = advertised_node.grpc_addr.clone();
+                let snapshot = store.register_node(advertised_node).await?;
+                tracing::info!(
+                    node_id,
+                    grpc_addr,
+                    version = u64::from(snapshot.version()),
+                    "Registered cluster membership node"
+                );
+                snapshot
+            } else {
+                seeded_snapshot.ok_or_else(|| {
+                    anyhow::anyhow!(
+                        "Partitioned startup requires NODE_ADDRESSES or ADVERTISE_GRPC_ADDR until \
+                         the shared membership directory has been initialized"
+                    )
+                })?
+            };
             let membership_node_addresses = authoritative_snapshot.to_node_addresses();
             database
                 .committer_client()

--- a/docs/production-deployment.md
+++ b/docs/production-deployment.md
@@ -2,7 +2,7 @@
 
 How to deploy the Convex horizontally-scaled cluster on Kubernetes (GKE, EKS) and bare VMs (EC2). Based on how CockroachDB, TiDB, and YugabyteDB deploy in production.
 
-The Docker Compose setup (`docker compose --profile cluster up`) is for development only — the same pattern all three giants follow. Production uses Kubernetes StatefulSets or bare VM processes with persistent storage.
+The Docker Compose setup (`self-hosted/docker/start-cluster.sh`) is for development only — the same pattern all three giants follow. Compose still has stable service names for local orchestration and Raft bootstrap, but the wrapper gives each run a fresh advertised-address namespace so the routing path exercises membership discovery instead of treating the static Compose names as the source of truth. Production uses Kubernetes StatefulSets or bare VM processes with persistent storage.
 
 ## Kubernetes (GKE / EKS)
 

--- a/self-hosted/docker/docker-compose.yml
+++ b/self-hosted/docker/docker-compose.yml
@@ -88,8 +88,16 @@ services:
       CONVEX_SITE_ORIGIN: http://127.0.0.1:3211
       PARTITION_ID: "0"
       NUM_PARTITIONS: "1"
+      CLUSTER_NODE_ID: partition-0-peer-0
+      ADVERTISE_GRPC_ADDR: node-0-${CLUSTER_RUN_ID:-local}:50051
+      ADVERTISE_HTTP_ORIGIN: http://node-0-${CLUSTER_RUN_ID:-local}:3210
+      ADVERTISE_RAFT_ADDR: node-0-${CLUSTER_RUN_ID:-local}:50051
       RAFT_NODE_ID: "1"
       RAFT_PEERS: 1=http://node-0:50051
+    networks:
+      default:
+        aliases:
+          - node-0-${CLUSTER_RUN_ID:-local}
     depends_on:
       postgres:
         condition: service_healthy
@@ -125,8 +133,16 @@ services:
       PARTITION_MAP: messages=0,users=0,projects=1,tasks=1
       NUM_PARTITIONS: "2"
       NODE_ADDRESSES: 0=node-p0a:50051|node-p0b:50051|node-p0c:50051,1=node-p1a:50051|node-p1b:50051|node-p1c:50051
+      CLUSTER_NODE_ID: partition-0-peer-0
+      ADVERTISE_GRPC_ADDR: node-p0a-${CLUSTER_RUN_ID:-local}:50051
+      ADVERTISE_HTTP_ORIGIN: http://node-p0a-${CLUSTER_RUN_ID:-local}:3210
+      ADVERTISE_RAFT_ADDR: node-p0a-${CLUSTER_RUN_ID:-local}:50051
       RAFT_NODE_ID: "1"
       RAFT_PEERS: 1=http://node-p0a:50051,2=http://node-p0b:50051,3=http://node-p0c:50051
+    networks:
+      default:
+        aliases:
+          - node-p0a-${CLUSTER_RUN_ID:-local}
     depends_on:
       postgres:
         condition: service_healthy
@@ -152,9 +168,17 @@ services:
       PARTITION_MAP: messages=0,users=0,projects=1,tasks=1
       NUM_PARTITIONS: "2"
       NODE_ADDRESSES: 0=node-p0a:50051|node-p0b:50051|node-p0c:50051,1=node-p1a:50051|node-p1b:50051|node-p1c:50051
+      CLUSTER_NODE_ID: partition-0-peer-1
+      ADVERTISE_GRPC_ADDR: node-p0b-${CLUSTER_RUN_ID:-local}:50051
+      ADVERTISE_HTTP_ORIGIN: http://node-p0b-${CLUSTER_RUN_ID:-local}:3210
+      ADVERTISE_RAFT_ADDR: node-p0b-${CLUSTER_RUN_ID:-local}:50051
       RAFT_NODE_ID: "2"
       RAFT_PEERS: 1=http://node-p0a:50051,2=http://node-p0b:50051,3=http://node-p0c:50051
       REPLICA_STORAGE_PATH: /convex/data/storage
+    networks:
+      default:
+        aliases:
+          - node-p0b-${CLUSTER_RUN_ID:-local}
     depends_on:
       node-p0a:
         condition: service_healthy
@@ -180,9 +204,17 @@ services:
       PARTITION_MAP: messages=0,users=0,projects=1,tasks=1
       NUM_PARTITIONS: "2"
       NODE_ADDRESSES: 0=node-p0a:50051|node-p0b:50051|node-p0c:50051,1=node-p1a:50051|node-p1b:50051|node-p1c:50051
+      CLUSTER_NODE_ID: partition-0-peer-2
+      ADVERTISE_GRPC_ADDR: node-p0c-${CLUSTER_RUN_ID:-local}:50051
+      ADVERTISE_HTTP_ORIGIN: http://node-p0c-${CLUSTER_RUN_ID:-local}:3210
+      ADVERTISE_RAFT_ADDR: node-p0c-${CLUSTER_RUN_ID:-local}:50051
       RAFT_NODE_ID: "3"
       RAFT_PEERS: 1=http://node-p0a:50051,2=http://node-p0b:50051,3=http://node-p0c:50051
       REPLICA_STORAGE_PATH: /convex/data/storage
+    networks:
+      default:
+        aliases:
+          - node-p0c-${CLUSTER_RUN_ID:-local}
     depends_on:
       node-p0b:
         condition: service_healthy
@@ -210,8 +242,16 @@ services:
       PARTITION_MAP: messages=0,users=0,projects=1,tasks=1
       NUM_PARTITIONS: "2"
       NODE_ADDRESSES: 0=node-p0a:50051|node-p0b:50051|node-p0c:50051,1=node-p1a:50051|node-p1b:50051|node-p1c:50051
+      CLUSTER_NODE_ID: partition-1-peer-0
+      ADVERTISE_GRPC_ADDR: node-p1a-${CLUSTER_RUN_ID:-local}:50051
+      ADVERTISE_HTTP_ORIGIN: http://node-p1a-${CLUSTER_RUN_ID:-local}:3210
+      ADVERTISE_RAFT_ADDR: node-p1a-${CLUSTER_RUN_ID:-local}:50051
       RAFT_NODE_ID: "1"
       RAFT_PEERS: 1=http://node-p1a:50051,2=http://node-p1b:50051,3=http://node-p1c:50051
+    networks:
+      default:
+        aliases:
+          - node-p1a-${CLUSTER_RUN_ID:-local}
     depends_on:
       node-p0c:
         condition: service_healthy
@@ -237,9 +277,17 @@ services:
       PARTITION_MAP: messages=0,users=0,projects=1,tasks=1
       NUM_PARTITIONS: "2"
       NODE_ADDRESSES: 0=node-p0a:50051|node-p0b:50051|node-p0c:50051,1=node-p1a:50051|node-p1b:50051|node-p1c:50051
+      CLUSTER_NODE_ID: partition-1-peer-1
+      ADVERTISE_GRPC_ADDR: node-p1b-${CLUSTER_RUN_ID:-local}:50051
+      ADVERTISE_HTTP_ORIGIN: http://node-p1b-${CLUSTER_RUN_ID:-local}:3210
+      ADVERTISE_RAFT_ADDR: node-p1b-${CLUSTER_RUN_ID:-local}:50051
       RAFT_NODE_ID: "2"
       RAFT_PEERS: 1=http://node-p1a:50051,2=http://node-p1b:50051,3=http://node-p1c:50051
       REPLICA_STORAGE_PATH: /convex/data/storage
+    networks:
+      default:
+        aliases:
+          - node-p1b-${CLUSTER_RUN_ID:-local}
     depends_on:
       node-p1a:
         condition: service_healthy
@@ -265,9 +313,17 @@ services:
       PARTITION_MAP: messages=0,users=0,projects=1,tasks=1
       NUM_PARTITIONS: "2"
       NODE_ADDRESSES: 0=node-p0a:50051|node-p0b:50051|node-p0c:50051,1=node-p1a:50051|node-p1b:50051|node-p1c:50051
+      CLUSTER_NODE_ID: partition-1-peer-2
+      ADVERTISE_GRPC_ADDR: node-p1c-${CLUSTER_RUN_ID:-local}:50051
+      ADVERTISE_HTTP_ORIGIN: http://node-p1c-${CLUSTER_RUN_ID:-local}:3210
+      ADVERTISE_RAFT_ADDR: node-p1c-${CLUSTER_RUN_ID:-local}:50051
       RAFT_NODE_ID: "3"
       RAFT_PEERS: 1=http://node-p1a:50051,2=http://node-p1b:50051,3=http://node-p1c:50051
       REPLICA_STORAGE_PATH: /convex/data/storage
+    networks:
+      default:
+        aliases:
+          - node-p1c-${CLUSTER_RUN_ID:-local}
     depends_on:
       node-p1b:
         condition: service_healthy

--- a/self-hosted/docker/start-cluster.sh
+++ b/self-hosted/docker/start-cluster.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+#
+# Start the local cluster with a fresh advertised-address namespace.
+#
+# Compose service names remain stable for the test harness and for the static
+# Raft bootstrap peers, but nodes advertise per-run DNS aliases into the
+# membership directory. This lets the Docker setup exercise production-style
+# endpoint discovery instead of relying on a baked-in NODE_ADDRESSES map.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+export CLUSTER_RUN_ID="${CLUSTER_RUN_ID:-run-$(date +%s)-$$}"
+
+echo "Starting cluster with CLUSTER_RUN_ID=$CLUSTER_RUN_ID"
+echo "Backend pull policy: ${BACKEND_PULL_POLICY:-missing}"
+
+cd "$SCRIPT_DIR"
+docker compose --profile cluster up -d "$@"

--- a/self-hosted/docker/test-raft-failover.sh
+++ b/self-hosted/docker/test-raft-failover.sh
@@ -11,7 +11,7 @@
 #   - YugabyteDB Jepsen nightly resilience benchmarks
 #
 # Prerequisites:
-#   docker compose --profile cluster up
+#   ./start-cluster.sh
 #
 # Usage:
 #   cd self-hosted/docker && ./test-raft-failover.sh
@@ -52,7 +52,7 @@ echo -e "${BOLD}Preflight checks${NC}"
 for name in docker-node-p0a-1 docker-node-p0b-1 docker-node-p0c-1; do
     if ! docker inspect "$name" > /dev/null 2>&1; then
         echo -e "${RED}Container $name not running. Start:${NC}"
-        echo "  docker compose --profile cluster up"
+        echo "  ./start-cluster.sh"
         exit 1
     fi
 done

--- a/self-hosted/docker/test-write-scaling.sh
+++ b/self-hosted/docker/test-write-scaling.sh
@@ -57,9 +57,10 @@
 #  36. Write Skew Detection (G2 anomaly)
 #  37. Ultimate Final Invariant Check
 #  38. Sync Route Authority Guard
+#  39. Dynamic Membership Advertisement
 #
 # Prerequisites:
-#   docker compose --profile cluster up
+#   ./start-cluster.sh
 #
 # Usage:
 #   cd self-hosted/docker && ./test-write-scaling.sh
@@ -116,6 +117,39 @@ parallel_commit_log_count() {
     echo "$count"
 }
 
+assert_dynamic_membership_advertisements() {
+    local run_id="${CLUSTER_RUN_ID:-local}"
+    local details=""
+    local specs=(
+        "docker-node-p0a-1 node-p0a"
+        "docker-node-p0b-1 node-p0b"
+        "docker-node-p0c-1 node-p0c"
+        "docker-node-p1a-1 node-p1a"
+        "docker-node-p1b-1 node-p1b"
+        "docker-node-p1c-1 node-p1c"
+    )
+
+    for spec in "${specs[@]}"; do
+        read -r container base <<< "$spec"
+        local expected="${base}-${run_id}:50051"
+        local configured
+        configured=$(docker exec "$container" printenv ADVERTISE_GRPC_ADDR 2>/dev/null || true)
+        if [ "$configured" != "$expected" ]; then
+            details="$details $container env=$configured expected=$expected;"
+            continue
+        fi
+        if ! docker logs "$container" 2>&1 | grep -F "Registered cluster membership node" | grep -F "$expected" > /dev/null; then
+            details="$details $container did not log membership registration for $expected;"
+        fi
+    done
+
+    if [ -z "$details" ]; then
+        pass "Cluster membership registered per-run advertised gRPC aliases"
+    else
+        fail "Cluster membership advertised-address registration missing" "$details"
+    fi
+}
+
 # --- Preflight ---
 
 echo ""
@@ -124,11 +158,13 @@ echo -e "${BOLD}Preflight checks${NC}"
 for name in "${BACKEND_CONTAINERS[@]}"; do
     if ! docker inspect "$name" > /dev/null 2>&1; then
         echo -e "${RED}Container $name not running. Start the deployment first:${NC}"
-        echo "  docker compose --profile cluster up"
+        echo "  ./start-cluster.sh"
         exit 1
     fi
 done
 echo "  Containers running."
+
+assert_dynamic_membership_advertisements
 
 if [ "${EXPECT_PARALLEL_2PC_EARLY_ACK:-false}" = "true" ]; then
     EARLY_ACK_ENV_OK=true

--- a/self-hosted/docker/test.sh
+++ b/self-hosted/docker/test.sh
@@ -12,7 +12,7 @@
 #   ./test.sh parallel     # Write scaling with parallel-2PC early ack required
 #
 # Prerequisites:
-#   docker compose --profile cluster up
+#   ./start-cluster.sh
 
 set -euo pipefail
 


### PR DESCRIPTION
## Summary

Part of #234. This moves the Docker cluster one step away from static topology by letting each backend register its own advertised endpoint into the NATS-backed membership directory.

- Add `CLUSTER_NODE_ID`, `ADVERTISE_GRPC_ADDR`, `ADVERTISE_HTTP_ORIGIN`, `ADVERTISE_RAFT_ADDR`, and `CLUSTER_NODE_GENERATION` config.
- Add CAS-based `MembershipStore::register_node` so a stable logical node can replace its physical advertised address.
- Start Docker clusters through `self-hosted/docker/start-cluster.sh`, which generates a fresh `CLUSTER_RUN_ID` and advertises per-run DNS aliases like `node-p0a-run-...:50051`.
- Keep static `NODE_ADDRESSES` only as the bootstrap seed; membership self-registration overwrites the node's own endpoint.
- Add a counted Docker harness preflight proving all backends registered the per-run advertised aliases.

Raft peer discovery is intentionally unchanged in this PR. Dynamic Raft membership requires add-learner/promote-voter/remove-peer semantics and should remain a separate consensus reconfiguration task.

## Validation

- `cargo fmt --package database --package local_backend`
- `cargo test -p database membership -- --nocapture`
- `cargo check -p local_backend`
- `bash -n self-hosted/docker/start-cluster.sh self-hosted/docker/test-write-scaling.sh self-hosted/docker/test-raft-failover.sh self-hosted/docker/test.sh`
- `docker compose -f self-hosted/docker/docker-compose.yml --profile cluster config`
- Rebuilt local backend image: `sha256:48edf39b84e85efdd36437562bd534a2b797cf9abce47fd9b6be19ac201306f9`
- Started clean cluster with `CLUSTER_RUN_ID=run-1782914182 BACKEND_PULL_POLICY=never ./start-cluster.sh`
- Confirmed all six backend containers used image `sha256:48edf39b84e85efdd36437562bd534a2b797cf9abce47fd9b6be19ac201306f9`
- `CLUSTER_RUN_ID=run-1782914182 BACKEND_PULL_POLICY=never bash self-hosted/docker/test.sh`
  - Write scaling: `130/130`
  - Raft failover: `24/24`
  - `ALL SUITES PASSED`
