### PR TITLE
feat(membership): refresh live node endpoints

### DIFF
--- a/crates/database/src/committer.rs
+++ b/crates/database/src/committer.rs
@@ -5574,12 +5574,10 @@ impl CommitterClient {
         &self,
         snapshot: crate::membership::MembershipSnapshot,
     ) -> anyhow::Result<()> {
-        let node_addresses = snapshot.to_node_addresses();
-        anyhow::ensure!(
-            !node_addresses.partitions().is_empty(),
-            "Cannot refresh membership from an empty node directory"
-        );
-        *self.node_addresses.write() = Some(node_addresses);
+        let node_addresses =
+            snapshot.to_live_node_addresses(crate::membership::current_unix_timestamp_millis());
+        *self.node_addresses.write() =
+            (!node_addresses.partitions().is_empty()).then_some(node_addresses);
         Ok(())
     }
 

--- a/crates/database/src/membership.rs
+++ b/crates/database/src/membership.rs
@@ -8,6 +8,10 @@
 use std::{
     collections::BTreeMap,
     fmt,
+    time::{
+        SystemTime,
+        UNIX_EPOCH,
+    },
 };
 
 use anyhow::Context;
@@ -72,6 +76,7 @@ pub struct NodeMembership {
     pub raft_addr: Option<String>,
     pub generation: u64,
     pub draining: bool,
+    pub heartbeat_expires_at_ms: Option<u64>,
 }
 
 impl NodeMembership {
@@ -93,8 +98,26 @@ impl NodeMembership {
             raft_addr: None,
             generation: 0,
             draining: false,
+            heartbeat_expires_at_ms: None,
         })
     }
+
+    pub fn is_live_at(&self, now_ms: u64) -> bool {
+        if self.draining {
+            return false;
+        }
+        self.heartbeat_expires_at_ms
+            .is_none_or(|expires_at| expires_at > now_ms)
+    }
+}
+
+pub fn current_unix_timestamp_millis() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis()
+        .try_into()
+        .unwrap_or(u64::MAX)
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -154,9 +177,20 @@ impl MembershipSnapshot {
     }
 
     pub fn to_node_addresses(&self) -> NodeAddresses {
+        self.to_node_addresses_with_filter(|node| !node.draining)
+    }
+
+    pub fn to_live_node_addresses(&self, now_ms: u64) -> NodeAddresses {
+        self.to_node_addresses_with_filter(|node| node.is_live_at(now_ms))
+    }
+
+    fn to_node_addresses_with_filter(
+        &self,
+        keep: impl Fn(&NodeMembership) -> bool,
+    ) -> NodeAddresses {
         let mut addresses: BTreeMap<PartitionId, Vec<String>> = BTreeMap::new();
         for node in self.nodes.values() {
-            if node.draining {
+            if !keep(node) {
                 continue;
             }
             addresses
@@ -189,6 +223,8 @@ struct SerializedNodeMembership {
     generation: u64,
     #[serde(default)]
     draining: bool,
+    #[serde(default)]
+    heartbeat_expires_at_ms: Option<u64>,
 }
 
 impl From<&MembershipSnapshot> for SerializedMembershipSnapshot {
@@ -206,6 +242,7 @@ impl From<&MembershipSnapshot> for SerializedMembershipSnapshot {
                     raft_addr: node.raft_addr.clone(),
                     generation: node.generation,
                     draining: node.draining,
+                    heartbeat_expires_at_ms: node.heartbeat_expires_at_ms,
                 })
                 .collect(),
         }
@@ -227,6 +264,7 @@ impl TryFrom<SerializedMembershipSnapshot> for MembershipSnapshot {
                 membership.raft_addr = node.raft_addr;
                 membership.generation = node.generation;
                 membership.draining = node.draining;
+                membership.heartbeat_expires_at_ms = node.heartbeat_expires_at_ms;
                 Ok(membership)
             })
             .collect::<anyhow::Result<_>>()?;
@@ -461,6 +499,47 @@ mod tests {
         assert_eq!(
             updated.to_node_addresses().address_for(PartitionId(0)),
             Some("random-p0a-20260701:50051")
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn test_membership_live_addresses_filter_expired_and_draining_nodes() -> anyhow::Result<()> {
+        let mut live =
+            NodeMembership::new(ClusterNodeId::new("live")?, PartitionId(0), "live:50051")?;
+        live.heartbeat_expires_at_ms = Some(2_000);
+        let mut expired = NodeMembership::new(
+            ClusterNodeId::new("expired")?,
+            PartitionId(0),
+            "expired:50051",
+        )?;
+        expired.heartbeat_expires_at_ms = Some(999);
+        let mut draining = NodeMembership::new(
+            ClusterNodeId::new("draining")?,
+            PartitionId(1),
+            "draining:50051",
+        )?;
+        draining.heartbeat_expires_at_ms = Some(2_000);
+        draining.draining = true;
+        let static_bootstrap = NodeMembership::new(
+            ClusterNodeId::new("bootstrap")?,
+            PartitionId(1),
+            "bootstrap:50051",
+        )?;
+
+        let snapshot = MembershipSnapshot::new(
+            MembershipVersion::BOOTSTRAP,
+            vec![live, expired, draining, static_bootstrap],
+        );
+        let addresses = snapshot.to_live_node_addresses(1_000);
+
+        assert_eq!(
+            addresses.addresses_for(PartitionId(0)).unwrap(),
+            &["live:50051".to_string()]
+        );
+        assert_eq!(
+            addresses.addresses_for(PartitionId(1)).unwrap(),
+            &["bootstrap:50051".to_string()]
         );
         Ok(())
     }

--- a/crates/local_backend/src/config.rs
+++ b/crates/local_backend/src/config.rs
@@ -210,6 +210,11 @@ pub struct LocalConfig {
     #[clap(long, env = "CLUSTER_NODE_GENERATION", default_value = "0")]
     pub cluster_node_generation: u64,
 
+    /// Mark this node as draining in the membership directory. Draining nodes
+    /// continue running but are excluded from new routed work.
+    #[clap(long, env = "CLUSTER_NODE_DRAINING", default_value = "false")]
+    pub cluster_node_draining: bool,
+
     /// Raft node ID for this node. Each node in a Raft group must have
     /// a unique ID. When set, enables Raft consensus for the partition.
     /// Example: "1"

--- a/crates/local_backend/src/deploy_config.rs
+++ b/crates/local_backend/src/deploy_config.rs
@@ -196,11 +196,11 @@ fn metadata_owner_origin(st: &DeployRouterState) -> anyhow::Result<Option<String
     }
     let node_addresses = st
         .node_addresses
-        .as_ref()
-        .context("NODE_ADDRESSES is required to forward deploy metadata operations to the owner")?;
+        .get()
+        .context("Membership is required to forward deploy metadata operations to the owner")?;
     let owner_addr = node_addresses
         .address_for(PartitionId::DEFAULT)
-        .context("Missing NODE_ADDRESSES entry for deploy metadata owner partition-0")?;
+        .context("Missing live membership entry for deploy metadata owner partition-0")?;
     Ok(Some(http_origin_from_peer_addr(owner_addr)?))
 }
 

--- a/crates/local_backend/src/lib.rs
+++ b/crates/local_backend/src/lib.rs
@@ -76,6 +76,7 @@ use node_executor::{
     local::LocalNodeExecutor,
     Actions,
 };
+use parking_lot::RwLock;
 use runtime::prod::ProdRuntime;
 use search::{
     searcher::InProcessSearcher,
@@ -122,6 +123,27 @@ mod test_helpers;
 pub mod two_phase_service;
 
 pub const MAX_CONCURRENT_REQUESTS: usize = 128;
+const MEMBERSHIP_HEARTBEAT_INTERVAL: Duration = Duration::from_secs(2);
+const MEMBERSHIP_LEASE_TTL: Duration = Duration::from_secs(15);
+
+#[derive(Clone, Default)]
+pub struct SharedNodeAddresses(Arc<RwLock<Option<database::two_phase::NodeAddresses>>>);
+
+impl SharedNodeAddresses {
+    pub fn new(addresses: Option<database::two_phase::NodeAddresses>) -> Self {
+        Self(Arc::new(RwLock::new(addresses)))
+    }
+
+    pub fn get(&self) -> Option<database::two_phase::NodeAddresses> {
+        self.0.read().clone()
+    }
+
+    pub fn refresh_from_membership(&self, snapshot: &database::membership::MembershipSnapshot) {
+        let addresses =
+            snapshot.to_live_node_addresses(database::membership::current_unix_timestamp_millis());
+        *self.0.write() = (!addresses.partitions().is_empty()).then_some(addresses);
+    }
+}
 
 #[derive(Clone)]
 pub struct BackendAppState {
@@ -136,7 +158,7 @@ pub struct BackendAppState {
     pub zombify_rx: async_broadcast::Receiver<()>,
     pub replica_mode: bool,
     pub partition_id: Option<database::partition::PartitionId>,
-    pub node_addresses: Option<database::two_phase::NodeAddresses>,
+    pub node_addresses: SharedNodeAddresses,
     pub raft_state: Option<database::raft_partition::RaftPartitionState>,
     pub raft_peer_http_origins: Option<BTreeMap<u64, String>>,
     pub raft_peer_grpc_urls: Option<BTreeMap<u64, String>>,
@@ -191,7 +213,93 @@ fn advertised_membership_node(
     };
     node.raft_addr = config.advertise_raft_addr.clone();
     node.generation = config.cluster_node_generation;
+    node.draining = config.cluster_node_draining;
+    refresh_membership_lease(&mut node);
     Ok(Some(node))
+}
+
+fn refresh_membership_lease(node: &mut database::membership::NodeMembership) {
+    let now_ms = database::membership::current_unix_timestamp_millis();
+    let ttl_ms = MEMBERSHIP_LEASE_TTL
+        .as_millis()
+        .try_into()
+        .unwrap_or(u64::MAX);
+    node.heartbeat_expires_at_ms = Some(now_ms.saturating_add(ttl_ms));
+}
+
+fn apply_membership_snapshot(
+    database: &Database<ProdRuntime>,
+    shared_node_addresses: &SharedNodeAddresses,
+    snapshot: database::membership::MembershipSnapshot,
+) -> anyhow::Result<()> {
+    shared_node_addresses.refresh_from_membership(&snapshot);
+    database
+        .committer_client()
+        .refresh_membership_snapshot(snapshot)?;
+    Ok(())
+}
+
+fn start_membership_refresh_loop(
+    runtime: ProdRuntime,
+    database: Database<ProdRuntime>,
+    store: Arc<dyn database::membership::MembershipStore>,
+    shared_node_addresses: SharedNodeAddresses,
+    advertised_node: Option<database::membership::NodeMembership>,
+) {
+    let refresh_runtime = runtime.clone();
+    runtime.spawn_background("cluster_membership_refresh", async move {
+        let mut backoff = Duration::from_millis(250);
+        let mut last_live_addresses = None;
+        loop {
+            let refresh_result = async {
+                let snapshot = if let Some(base_node) = advertised_node.as_ref() {
+                    let mut node = base_node.clone();
+                    refresh_membership_lease(&mut node);
+                    let node_id = node.node_id.to_string();
+                    let grpc_addr = node.grpc_addr.clone();
+                    let snapshot = store.register_node(node).await?;
+                    tracing::debug!(
+                        node_id,
+                        grpc_addr,
+                        version = u64::from(snapshot.version()),
+                        "Refreshed cluster membership heartbeat"
+                    );
+                    snapshot
+                } else {
+                    store.load().await?.ok_or_else(|| {
+                        anyhow::anyhow!("Membership refresh found no current snapshot")
+                    })?
+                };
+                let live_addresses = snapshot
+                    .to_live_node_addresses(database::membership::current_unix_timestamp_millis());
+                if last_live_addresses.as_ref() != Some(&live_addresses) {
+                    tracing::info!(
+                        version = u64::from(snapshot.version()),
+                        ?live_addresses,
+                        "Refreshed cluster membership snapshot"
+                    );
+                    last_live_addresses = Some(live_addresses);
+                }
+                apply_membership_snapshot(&database, &shared_node_addresses, snapshot)
+            }
+            .await;
+
+            match refresh_result {
+                Ok(()) => {
+                    backoff = Duration::from_millis(250);
+                    refresh_runtime.wait(MEMBERSHIP_HEARTBEAT_INTERVAL).await;
+                },
+                Err(e) => {
+                    tracing::warn!(
+                        "Cluster membership refresh failed; retrying after {:?}: {e:#}",
+                        backoff
+                    );
+                    refresh_runtime.wait(backoff).await;
+                    backoff = (backoff * 2).min(Duration::from_secs(30));
+                },
+            }
+        }
+    });
 }
 
 // Contains state needed to serve most http routes. Similar to BackendAppState,
@@ -204,7 +312,7 @@ pub struct RouterState {
     pub runtime: ProdRuntime,
     pub replica_mode: bool,
     pub partition_id: Option<database::partition::PartitionId>,
-    pub node_addresses: Option<database::two_phase::NodeAddresses>,
+    pub node_addresses: SharedNodeAddresses,
     pub raft_state: Option<database::raft_partition::RaftPartitionState>,
     pub raft_peer_grpc_urls: Option<BTreeMap<u64, String>>,
     pub cluster_grpc_auth: Option<common::grpc::ClusterGrpcAuth>,
@@ -219,7 +327,7 @@ pub struct DeployRouterState {
     pub application: Application<ProdRuntime>,
     pub replica_mode: bool,
     pub partition_id: Option<database::partition::PartitionId>,
-    pub node_addresses: Option<database::two_phase::NodeAddresses>,
+    pub node_addresses: SharedNodeAddresses,
     pub raft_state: Option<database::raft_partition::RaftPartitionState>,
     pub raft_peer_http_origins: Option<BTreeMap<u64, String>>,
 }
@@ -479,6 +587,7 @@ pub async fn make_app(
         .node_addresses
         .as_deref()
         .map(database::two_phase::NodeAddresses::from_config);
+    let shared_node_addresses = SharedNodeAddresses::new(static_node_addresses.clone());
     let mut effective_node_addresses = static_node_addresses.clone();
     let static_placement_metadata = config.partition_id.map(|_| {
         let partition_map_str = config.partition_map.as_deref().unwrap_or("");
@@ -554,7 +663,7 @@ pub async fn make_app(
                 } else {
                     store.load().await?
                 };
-            let authoritative_snapshot = if let Some(advertised_node) = advertised_node {
+            let authoritative_snapshot = if let Some(advertised_node) = advertised_node.clone() {
                 let node_id = advertised_node.node_id.to_string();
                 let grpc_addr = advertised_node.grpc_addr.clone();
                 let snapshot = store.register_node(advertised_node).await?;
@@ -573,11 +682,19 @@ pub async fn make_app(
                     )
                 })?
             };
-            let membership_node_addresses = authoritative_snapshot.to_node_addresses();
-            database
-                .committer_client()
-                .refresh_membership_snapshot(authoritative_snapshot)?;
-            effective_node_addresses = Some(membership_node_addresses);
+            apply_membership_snapshot(
+                &database,
+                &shared_node_addresses,
+                authoritative_snapshot.clone(),
+            )?;
+            effective_node_addresses = shared_node_addresses.get();
+            start_membership_refresh_loop(
+                runtime.clone(),
+                database.clone(),
+                store.clone(),
+                shared_node_addresses.clone(),
+                advertised_node,
+            );
             Some(store)
         } else {
             None
@@ -753,7 +870,7 @@ pub async fn make_app(
     let origin = config.convex_origin_url()?;
     let instance_name = config.name();
     let partition_id = config.partition_id.map(database::partition::PartitionId);
-    let node_addresses = effective_node_addresses.clone();
+    let node_addresses = shared_node_addresses.clone();
     let mut raft_state_for_app = None;
     let mut raft_peer_http_origins = None;
     let mut raft_peer_grpc_urls = None;

--- a/crates/local_backend/src/query_forwarding_api.rs
+++ b/crates/local_backend/src/query_forwarding_api.rs
@@ -27,7 +27,6 @@ use common::{
 use database::{
     partition::PartitionId,
     raft_partition::RaftPartitionState,
-    two_phase::NodeAddresses,
     Database,
 };
 use errors::ErrorMetadata;
@@ -57,7 +56,10 @@ use value::{
     PublicDocumentId,
 };
 
-use crate::mutation_forwarder::MutationForwarderGrpcClientPool;
+use crate::{
+    mutation_forwarder::MutationForwarderGrpcClientPool,
+    SharedNodeAddresses,
+};
 
 const SELECTIVE_QUERY_AUTHORITY_PARTITION: PartitionId = PartitionId(0);
 const RECENT_QUERY_INTEREST_TTL: Duration = Duration::from_secs(60);
@@ -68,7 +70,7 @@ pub struct SelectiveQueryForwardingApi {
     database: Database<ProdRuntime>,
     replica_mode: bool,
     partition_id: Option<PartitionId>,
-    node_addresses: Option<NodeAddresses>,
+    node_addresses: SharedNodeAddresses,
     raft_state: Option<RaftPartitionState>,
     raft_peer_grpc_urls: Option<BTreeMap<u64, String>>,
     mutation_forwarder_pool: MutationForwarderGrpcClientPool,
@@ -80,7 +82,7 @@ impl SelectiveQueryForwardingApi {
         database: Database<ProdRuntime>,
         replica_mode: bool,
         partition_id: Option<PartitionId>,
-        node_addresses: Option<NodeAddresses>,
+        node_addresses: SharedNodeAddresses,
         raft_state: Option<RaftPartitionState>,
         raft_peer_grpc_urls: Option<BTreeMap<u64, String>>,
         cluster_grpc_auth: Option<ClusterGrpcAuth>,
@@ -135,15 +137,15 @@ impl SelectiveQueryForwardingApi {
     }
 
     fn authority_grpc_url(&self) -> anyhow::Result<String> {
-        let addresses = self.node_addresses.as_ref().context(
-            "Selective public query forwarding requires NODE_ADDRESSES to find the authoritative \
+        let addresses = self.node_addresses.get().context(
+            "Selective public query forwarding requires membership to find the authoritative \
              query node",
         )?;
         addresses
             .address_for(SELECTIVE_QUERY_AUTHORITY_PARTITION)
             .map(ToOwned::to_owned)
             .context(
-                "Selective public query forwarding requires a partition-0 NODE_ADDRESSES entry",
+                "Selective public query forwarding requires a live partition-0 membership entry",
             )
     }
 

--- a/docs/dynamic-placement.md
+++ b/docs/dynamic-placement.md
@@ -38,9 +38,19 @@ source is available.
 When a partitioned node also has NATS, startup initializes or loads the shared
 `convex_membership/current` NATS KV record and refreshes the committer's 2PC
 routing addresses from that membership directory. `NODE_ADDRESSES` is now only a
-bootstrap seed for local/dev deployments or the first membership snapshot. Once
-the shared membership directory exists, a node can load physical endpoints from
-NATS instead of every process carrying the full topology in its env.
+bootstrap seed for local/dev deployments or the first membership snapshot. Each
+node can also advertise its own gRPC/HTTP/Raft endpoints, generation, drain
+state, and heartbeat lease into that shared directory. A background refresh loop
+renews the local node's lease and refreshes in-process routing addresses from
+the live, non-draining membership entries. Once the shared membership directory
+exists, a node can load physical endpoints from NATS instead of every process
+carrying the full topology in its env.
+
+Bootstrap records without heartbeat leases are treated as live so a brand-new
+dev cluster can initialize before every node has self-registered. In the normal
+cluster path, each node overwrites its bootstrap entry with the same stable
+`node_id`, a fresh advertised endpoint, and a renewable lease. Operators should
+prefer a small seed/control-plane config over a hand-maintained full topology.
 
 Placement metadata is control-plane state, not an application API. Nodes,
 routers, and operators may reason about placement versions and ownership, but
@@ -70,11 +80,14 @@ preparing against the wrong owner.
 - Add an authority/lease model for who may publish a new placement version.
 - Decide whether NATS KV remains the placement authority long term or becomes a
   bootstrap/transport layer for a replicated placement system table.
-- Move membership from a whole-snapshot KV record to per-node self-registration
-  with heartbeats, TTLs, and watch-driven in-process refresh.
-- Extend node membership use beyond 2PC gRPC routing: HTTP/deploy forwarding,
-  Raft peer discovery, liveness, role, generation/epoch, and drain state must
-  all converge on the same directory before automated add/remove/rebalance.
+- Move membership from a whole-snapshot KV record to independent per-node keys
+  or another append/update-friendly control-plane representation. The current
+  implementation uses CAS on the whole snapshot, which is adequate for the
+  local harness but not the final large-cluster shape.
+- Extend node membership to dynamic Raft peer discovery and membership changes.
+  Recording `raft_addr` is not enough; adding/removing voters requires Raft
+  learner catch-up, promotion, and removal through consensus configuration
+  changes.
 - Add an online movement workflow: freeze source writes for the moved range or
   table, copy/catch up data, publish the new placement version, then unfreeze.
 - Add stale-map refresh behavior across every routing surface; 2PC prepare

--- a/self-hosted/docker/test-write-scaling.sh
+++ b/self-hosted/docker/test-write-scaling.sh
@@ -11,6 +11,7 @@
 #   4. Transparent Partition Routing (topology hiding)
 #   4b. All Replica Entrypoint Routing (cluster-wide topology hiding)
 #   4c. Six-Entrypoint Read-After-Write (session/topology hiding)
+#   4d. Live Membership Refresh After Node Readdress
 #   5. Concurrent Write Scaling (CockroachDB KV)
 #   6. Monotonic Reads (TiDB monotonic)
 #   7. Node Restart Recovery (TiDB kill -9 / CockroachDB nemesis)
@@ -767,6 +768,69 @@ $SIX_RAR_OK \
 POST_SIX_RAR=$(query_api "$NODE_A_URL" "$NODE_A_KEY" "messages:dashboard")
 AM=$(jval messages "$POST_SIX_RAR"); AU=$(jval users "$POST_SIX_RAR")
 AP=$(jval projects "$POST_SIX_RAR"); AT=$(jval tasks "$POST_SIX_RAR")
+
+# ============================================================
+echo ""
+echo -e "${BOLD}Test 4d: Live Membership Refresh After Node Readdress${NC}"
+# ============================================================
+
+# Recreate one participant with a different advertised address namespace. The
+# Compose service and host port stay stable for the harness, but the gRPC alias
+# advertised into membership changes. Other nodes must refresh from membership
+# without a process restart.
+READDR_RUN_ID="readdr-$(date +%s)"
+READDR_ADDR="node-p1a-${READDR_RUN_ID}:50051"
+echo "  Recreating p1a with advertised address $READDR_ADDR..."
+(
+    cd "$SCRIPT_DIR"
+    CLUSTER_RUN_ID="$READDR_RUN_ID" BACKEND_PULL_POLICY=never \
+        docker compose --profile cluster up -d --no-deps --force-recreate node-p1a > /dev/null
+)
+
+for _ in $(seq 1 40); do
+    curl -sf "$NODE_P1A_URL/version" > /dev/null 2>&1 && break
+    sleep 1
+done
+NODE_P1A_KEY=$(docker exec docker-node-p1a-1 ./generate_admin_key.sh 2>&1 | tail -1)
+NODE_B_KEY="$NODE_P1A_KEY"
+ENTRYPOINT_KEYS[3]="$NODE_P1A_KEY"
+
+P1A_ADVERTISED=$(docker exec docker-node-p1a-1 printenv ADVERTISE_GRPC_ADDR 2>/dev/null || true)
+[ "$P1A_ADVERTISED" = "$READDR_ADDR" ] \
+    && pass "p1a restarted with a new advertised gRPC address" \
+    || fail "p1a did not restart with the expected advertised address" "got=$P1A_ADVERTISED expected=$READDR_ADDR"
+
+OBSERVED_REFRESH=false
+for _ in $(seq 1 30); do
+    if docker logs docker-node-p0a-1 2>&1 | grep -F "Refreshed cluster membership snapshot" | grep -F "$READDR_ADDR" > /dev/null; then
+        OBSERVED_REFRESH=true
+        break
+    fi
+    sleep 1
+done
+$OBSERVED_REFRESH \
+    && pass "p0a refreshed membership and observed p1a's new advertised address" \
+    || fail "p0a did not observe p1a's new advertised address" "$READDR_ADDR"
+
+R=$(mutation_response "$NODE_A_URL" "$NODE_A_KEY" "messages:crossPartitionWrite" \
+    "{\"text\":\"membership-readdress-${READDR_RUN_ID}\",\"taskTitle\":\"membership-readdress-${READDR_RUN_ID}\"}")
+if echo "$R" | grep -q '"status":"success"'; then
+    sleep 2
+    MT=$(count_message_text "$NODE_A_URL" "$NODE_A_KEY" "membership-readdress-${READDR_RUN_ID}")
+    TT=$(count_task_title "$NODE_A_URL" "$NODE_A_KEY" "membership-readdress-${READDR_RUN_ID}")
+    if [ "$MT" -eq 1 ] && [ "$TT" -eq 1 ]; then
+        pass "Cross-partition routing worked after live membership readdress"
+        POST_READDR=$(query_api "$NODE_A_URL" "$NODE_A_KEY" "messages:dashboard")
+        AM=$(jval messages "$POST_READDR"); AU=$(jval users "$POST_READDR")
+        AP=$(jval projects "$POST_READDR"); AT=$(jval tasks "$POST_READDR")
+    else
+        fail "Readdress 2PC write did not appear exactly once" "messages=$MT tasks=$TT"
+    fi
+else
+    fail "Cross-partition routing failed after live membership readdress" "$R"
+fi
+
+export CLUSTER_RUN_ID="$READDR_RUN_ID"
 
 # ============================================================
 echo ""
@@ -1977,7 +2041,9 @@ echo ""
 echo -e "${BOLD}Test 20d: Cross-Partition 2PC During Participant Leader Outage${NC}"
 # ============================================================
 # Stop the partition-1 leader and require every surviving public entrypoint to
-# coordinate cross-partition writes through the new partition-1 Raft leader.
+# eventually coordinate cross-partition writes through the new partition-1 Raft
+# leader. Leader changes are asynchronous, so the test waits for bounded
+# readiness instead of relying on a fixed sleep to mean "new leader is routable."
 
 PRE_P1_OUTAGE=$(query_api "$NODE_A_URL" "$NODE_A_KEY" "messages:dashboard")
 PRE_P1_OUTAGE_M=$(jval messages "$PRE_P1_OUTAGE")
@@ -1992,20 +2058,35 @@ P1_OUTAGE_URLS=("$NODE_P0A_URL" "$NODE_P0B_URL" "$NODE_P0C_URL" "$NODE_P1B_URL" 
 P1_OUTAGE_KEYS=("$NODE_P0A_KEY" "$NODE_P0B_KEY" "$NODE_P0C_KEY" "$NODE_P1B_KEY" "$NODE_P1C_KEY")
 P1_OUTAGE_ACCEPTED=0
 P1_OUTAGE_RUN="p1-outage-$(date +%s)"
+P1_OUTAGE_TEXTS=()
+P1_OUTAGE_TASKS=()
 
 for i in "${!P1_OUTAGE_LABELS[@]}"; do
     label="${P1_OUTAGE_LABELS[$i]}"
-    R=$(mutation_response "${P1_OUTAGE_URLS[$i]}" "${P1_OUTAGE_KEYS[$i]}" "messages:crossPartitionWrite" \
-        "{\"text\":\"$P1_OUTAGE_RUN-$label\",\"taskTitle\":\"$P1_OUTAGE_RUN-task-$label\"}")
-    if echo "$R" | grep -q '"status":"success"'; then
-        P1_OUTAGE_ACCEPTED=$((P1_OUTAGE_ACCEPTED + 1))
-    else
-        fail "$label could not route 2PC write while p1a was down" "$R"
+    SUCCESS=false
+    LAST_R=""
+    for attempt in $(seq 1 30); do
+        text="$P1_OUTAGE_RUN-$label-attempt-$attempt"
+        task="$P1_OUTAGE_RUN-task-$label-attempt-$attempt"
+        R=$(mutation_response "${P1_OUTAGE_URLS[$i]}" "${P1_OUTAGE_KEYS[$i]}" "messages:crossPartitionWrite" \
+            "{\"text\":\"$text\",\"taskTitle\":\"$task\"}")
+        LAST_R="$R"
+        if echo "$R" | grep -q '"status":"success"'; then
+            P1_OUTAGE_ACCEPTED=$((P1_OUTAGE_ACCEPTED + 1))
+            P1_OUTAGE_TEXTS+=("$text")
+            P1_OUTAGE_TASKS+=("$task")
+            SUCCESS=true
+            break
+        fi
+        sleep 1
+    done
+    if [ "$SUCCESS" != "true" ]; then
+        fail "$label could not route 2PC write while p1a was down" "$LAST_R"
     fi
 done
 
 [ "$P1_OUTAGE_ACCEPTED" -eq 5 ] \
-    && pass "All five surviving entrypoints accepted 2PC writes while p1a was down" \
+    && pass "All five surviving entrypoints accepted 2PC writes after p1a leader failover" \
     || fail "Some 2PC writes failed during p1a outage" "accepted=$P1_OUTAGE_ACCEPTED expected=5"
 
 echo "  Restarting p1a..."
@@ -2025,6 +2106,25 @@ POST_P1_OUTAGE_AM=$(jval messages "$POST_P1_OUTAGE_A")
 POST_P1_OUTAGE_AT=$(jval tasks "$POST_P1_OUTAGE_A")
 POST_P1_OUTAGE_BM=$(jval messages "$POST_P1_OUTAGE_B")
 POST_P1_OUTAGE_BT=$(jval tasks "$POST_P1_OUTAGE_B")
+P1_OUTAGE_EXACT=true
+P1_OUTAGE_EXACT_DETAILS=""
+
+for i in "${!P1_OUTAGE_TEXTS[@]}"; do
+    text="${P1_OUTAGE_TEXTS[$i]}"
+    task="${P1_OUTAGE_TASKS[$i]}"
+    MSG_A=$(count_message_text "$NODE_A_URL" "$NODE_A_KEY" "$text")
+    MSG_B=$(count_message_text "$NODE_B_URL" "$NODE_B_KEY" "$text")
+    TASK_A=$(count_task_title "$NODE_A_URL" "$NODE_A_KEY" "$task")
+    TASK_B=$(count_task_title "$NODE_B_URL" "$NODE_B_KEY" "$task")
+    if [ "$MSG_A" -ne 1 ] || [ "$MSG_B" -ne 1 ] || [ "$TASK_A" -ne 1 ] || [ "$TASK_B" -ne 1 ]; then
+        P1_OUTAGE_EXACT=false
+        P1_OUTAGE_EXACT_DETAILS="$P1_OUTAGE_EXACT_DETAILS text=$text msgA=$MSG_A msgB=$MSG_B task=$task taskA=$TASK_A taskB=$TASK_B;"
+    fi
+done
+
+$P1_OUTAGE_EXACT \
+    && pass "Every participant-outage 2PC write appeared exactly once on both nodes" \
+    || fail "Participant-outage 2PC write exactness failed" "$P1_OUTAGE_EXACT_DETAILS"
 P1_OUTAGE_DM=$((POST_P1_OUTAGE_AM - PRE_P1_OUTAGE_M))
 P1_OUTAGE_DT=$((POST_P1_OUTAGE_AT - PRE_P1_OUTAGE_T))
 


### PR DESCRIPTION
## Summary

Part of #234.

This PR makes cluster routing consume live membership instead of only the startup `NODE_ADDRESSES` snapshot:

- Adds heartbeat lease metadata and drain filtering to membership entries.
- Adds a background membership refresh loop that renews this node's advertised endpoints and refreshes in-process routing state.
- Switches query/deploy routing and the committer's membership view to a shared, refreshable `NodeAddresses` handle.
- Adds `CLUSTER_NODE_DRAINING` wiring for nodes that should stay registered but not receive new routed traffic.
- Updates the dynamic placement docs to describe the current live-membership behavior and remaining control-plane work.
- Adds a Docker cluster test that recreates `p1a` with a new advertised gRPC alias, verifies another node observes the membership refresh, and proves cross-partition routing still works afterward.
- Hardens the participant-leader outage test to wait for bounded Raft readiness and verify every accepted outage-window 2PC write appears exactly once on both nodes.

## Validation

Local checks:

- `cargo fmt --package database --package local_backend`
- `cargo check -p local_backend`
- `cargo test -p database membership -- --nocapture`
- `bash -n self-hosted/docker/test-write-scaling.sh self-hosted/docker/test.sh self-hosted/docker/start-cluster.sh`
- `git diff --check`

Docker cluster proof:

- Rebuilt local backend image: `sha256:4c89003a1cf2aa7d28be7657ea9a2d478612dee5ce95bc7dc8d4bbb44a25a659`
- Confirmed all six backend containers used that exact image ID with `BACKEND_PULL_POLICY=never`.
- Fresh run ID: `run-1782918609`
- `BACKEND_PULL_POLICY=never bash self-hosted/docker/test.sh`
- Write-scaling suite: `134/134` passed
- Raft failover suite: `24/24` passed
- Final result: `ALL SUITES PASSED`

## Not included

This does not implement dynamic Raft voter add/remove or a final large-cluster membership store. `RAFT_PEERS` is still static, and membership is still published as a snapshot record. Those remain separate work items because safe Raft membership changes need consensus reconfiguration, not just endpoint refresh.
