### PR TITLE
fix(2pc): fence decision log writes

### DIFF
--- a/crates/database/src/two_phase.rs
+++ b/crates/database/src/two_phase.rs
@@ -632,17 +632,6 @@ pub mod testing {
 
     #[async_trait]
     impl TwoPhaseDecisionLog for InMemoryTwoPhaseDecisionLog {
-        async fn write_decision(
-            &self,
-            transaction_id: &TwoPhaseTransactionId,
-            decision: &TwoPhaseDecision,
-        ) -> anyhow::Result<()> {
-            self.decisions
-                .lock()
-                .insert(transaction_id.0.clone(), decision.clone());
-            Ok(())
-        }
-
         async fn write_decision_if_absent(
             &self,
             transaction_id: &TwoPhaseTransactionId,
@@ -733,26 +722,41 @@ pub fn two_phase_decision_key(transaction_id: &TwoPhaseTransactionId) -> String 
 
 #[async_trait]
 pub trait TwoPhaseDecisionLog: Send + Sync + 'static {
-    async fn write_decision(
-        &self,
-        transaction_id: &TwoPhaseTransactionId,
-        decision: &TwoPhaseDecision,
-    ) -> anyhow::Result<()>;
-
     async fn write_decision_if_absent(
         &self,
         transaction_id: &TwoPhaseTransactionId,
         decision: &TwoPhaseDecision,
-    ) -> anyhow::Result<bool> {
-        self.write_decision(transaction_id, decision).await?;
-        Ok(true)
-    }
+    ) -> anyhow::Result<bool>;
 
     async fn get_decision(
         &self,
         _transaction_id: &TwoPhaseTransactionId,
     ) -> anyhow::Result<Option<TwoPhaseDecision>> {
         Ok(None)
+    }
+
+    async fn write_decision(
+        &self,
+        transaction_id: &TwoPhaseTransactionId,
+        decision: &TwoPhaseDecision,
+    ) -> anyhow::Result<()> {
+        if self
+            .write_decision_if_absent(transaction_id, decision)
+            .await?
+        {
+            return Ok(());
+        }
+        let existing = self.get_decision(transaction_id).await?.with_context(|| {
+            format!("2PC: decision for {transaction_id} already existed but could not be read")
+        })?;
+        anyhow::ensure!(
+            existing == *decision,
+            "2PC: durable decision for {} is already {:?}, cannot overwrite with {:?}",
+            transaction_id,
+            existing,
+            decision,
+        );
+        Ok(())
     }
 
     async fn mark_participant_resolved(
@@ -779,14 +783,6 @@ pub struct NoopTwoPhaseDecisionLog;
 
 #[async_trait]
 impl TwoPhaseDecisionLog for NoopTwoPhaseDecisionLog {
-    async fn write_decision(
-        &self,
-        _transaction_id: &TwoPhaseTransactionId,
-        _decision: &TwoPhaseDecision,
-    ) -> anyhow::Result<()> {
-        Ok(())
-    }
-
     async fn write_decision_if_absent(
         &self,
         _transaction_id: &TwoPhaseTransactionId,
@@ -862,20 +858,6 @@ fn parse_nats_decision_entry(
 
 #[async_trait]
 impl TwoPhaseDecisionLog for NatsTwoPhaseDecisionLog {
-    async fn write_decision(
-        &self,
-        transaction_id: &TwoPhaseTransactionId,
-        decision: &TwoPhaseDecision,
-    ) -> anyhow::Result<()> {
-        let payload = serde_json::to_vec(decision)
-            .with_context(|| format!("2PC: Failed to serialize decision for {transaction_id}"))?;
-        self.kv
-            .put(two_phase_decision_key(transaction_id), payload.into())
-            .await
-            .with_context(|| format!("2PC: Failed to write decision for {transaction_id}"))?;
-        Ok(())
-    }
-
     async fn write_decision_if_absent(
         &self,
         transaction_id: &TwoPhaseTransactionId,
@@ -2086,6 +2068,42 @@ mod tests {
                 .await
                 .unwrap());
             assert_eq!(log.get_decision(&txn_id).await.unwrap(), Some(staging));
+        });
+    }
+
+    #[test]
+    fn test_decision_log_write_decision_is_idempotent_for_same_decision() {
+        futures::executor::block_on(async {
+            let log = testing::InMemoryTwoPhaseDecisionLog::new();
+            let txn_id = TwoPhaseTransactionId("same-decision-idempotent".to_string());
+            let decision = TwoPhaseDecision::committed(12345, vec![0, 1]);
+
+            log.write_decision(&txn_id, &decision).await.unwrap();
+            log.write_decision(&txn_id, &decision).await.unwrap();
+
+            assert_eq!(log.get_decision(&txn_id).await.unwrap(), Some(decision));
+        });
+    }
+
+    #[test]
+    fn test_decision_log_write_decision_rejects_conflicting_existing_decision() {
+        futures::executor::block_on(async {
+            let log = testing::InMemoryTwoPhaseDecisionLog::new();
+            let txn_id = TwoPhaseTransactionId("commit-after-timeout-rollback".to_string());
+            let rollback =
+                TwoPhaseDecision::rolled_back("prepare timed out".to_string(), vec![0, 1]);
+            let committed = TwoPhaseDecision::committed(12345, vec![0, 1]);
+
+            log.write_decision(&txn_id, &rollback).await.unwrap();
+            let err = log
+                .write_decision(&txn_id, &committed)
+                .await
+                .expect_err("a final commit must not overwrite an existing rollback");
+            assert!(
+                format!("{err:#}").contains("cannot overwrite"),
+                "unexpected error: {err:#}",
+            );
+            assert_eq!(log.get_decision(&txn_id).await.unwrap(), Some(rollback));
         });
     }
 

--- a/self-hosted/docker/test-write-scaling.sh
+++ b/self-hosted/docker/test-write-scaling.sh
@@ -494,12 +494,97 @@ query_with_args() {
 jval() { python3 -c "import sys,json; print(int(json.load(sys.stdin)['value']['$1']))" <<< "$2"; }
 jtotal() { python3 -c "import sys,json; print(int(json.load(sys.stdin)['value']))" <<< "$1"; }
 
+dashboard_message_task_counts_on_nodes() {
+    local dash_a
+    local dash_b
+    dash_a=$(query_api "$NODE_A_URL" "$NODE_A_KEY" "messages:dashboard")
+    dash_b=$(query_api "$NODE_B_URL" "$NODE_B_KEY" "messages:dashboard")
+    echo "$(jval messages "$dash_a") $(jval tasks "$dash_a") $(jval messages "$dash_b") $(jval tasks "$dash_b")"
+}
+
+wait_dashboard_message_task_convergence() {
+    local attempts="${1:-30}"
+    local counts="0 0 0 0"
+    local msg_a
+    local task_a
+    local msg_b
+    local task_b
+
+    for _ in $(seq 1 "$attempts"); do
+        counts=$(dashboard_message_task_counts_on_nodes 2>/dev/null || echo "$counts")
+        read -r msg_a task_a msg_b task_b <<< "$counts"
+        if [ "$msg_a" -eq "$msg_b" ] && [ "$task_a" -eq "$task_b" ]; then
+            echo "$counts"
+            return 0
+        fi
+        sleep 1
+    done
+
+    echo "$counts"
+    return 1
+}
+
 count_message_text() {
     jtotal "$(query_with_args "$1" "$2" "messages:countMessagesByText" "{\"text\":\"$3\"}")"
 }
 
 count_task_title() {
     jtotal "$(query_with_args "$1" "$2" "messages:countTasksByTitle" "{\"title\":\"$3\"}")"
+}
+
+count_2pc_pair_on_nodes() {
+    local text="$1"
+    local task="$2"
+    local msg_a
+    local msg_b
+    local task_a
+    local task_b
+    msg_a=$(count_message_text "$NODE_A_URL" "$NODE_A_KEY" "$text")
+    msg_b=$(count_message_text "$NODE_B_URL" "$NODE_B_KEY" "$text")
+    task_a=$(count_task_title "$NODE_A_URL" "$NODE_A_KEY" "$task")
+    task_b=$(count_task_title "$NODE_B_URL" "$NODE_B_KEY" "$task")
+    echo "$msg_a $msg_b $task_a $task_b"
+}
+
+two_pc_counts_match_response() {
+    local response="$1"
+    local msg_a="$2"
+    local msg_b="$3"
+    local task_a="$4"
+    local task_b="$5"
+
+    if echo "$response" | grep -q '"status":"success"'; then
+        [ "$msg_a" -eq 1 ] && [ "$msg_b" -eq 1 ] && [ "$task_a" -eq 1 ] && [ "$task_b" -eq 1 ]
+        return $?
+    fi
+
+    [ "$msg_a" -eq "$msg_b" ] && [ "$msg_a" -eq "$task_a" ] && [ "$msg_a" -eq "$task_b" ] \
+        && { [ "$msg_a" -eq 0 ] || [ "$msg_a" -eq 1 ]; }
+}
+
+wait_for_2pc_pair_exactness() {
+    local text="$1"
+    local task="$2"
+    local response="$3"
+    local attempts="${4:-30}"
+    local counts="0 0 0 0"
+    local msg_a
+    local msg_b
+    local task_a
+    local task_b
+
+    for _ in $(seq 1 "$attempts"); do
+        counts=$(count_2pc_pair_on_nodes "$text" "$task" 2>/dev/null || echo "$counts")
+        read -r msg_a msg_b task_a task_b <<< "$counts"
+        if two_pc_counts_match_response "$response" "$msg_a" "$msg_b" "$task_a" "$task_b"; then
+            echo "$counts"
+            return 0
+        fi
+        sleep 1
+    done
+
+    echo "$counts"
+    return 1
 }
 
 latest_membership_log() {
@@ -1388,12 +1473,8 @@ NODE_B_KEY="$NODE_P1A_KEY"
 (cd "$DEPLOY_DIR" && npx convex deploy --admin-key "$NODE_B_KEY" --url "$NODE_B_URL" > /dev/null 2>&1)
 
 sleep 8
-POST_RESTART_2PC_A=$(query_api "$NODE_A_URL" "$NODE_A_KEY" "messages:dashboard")
-POST_RESTART_2PC_B=$(query_api "$NODE_B_URL" "$NODE_B_KEY" "messages:dashboard")
-POST_RESTART_2PC_M=$(jval messages "$POST_RESTART_2PC_A")
-POST_RESTART_2PC_T=$(jval tasks "$POST_RESTART_2PC_A")
-POST_RESTART_2PC_BM=$(jval messages "$POST_RESTART_2PC_B")
-POST_RESTART_2PC_BT=$(jval tasks "$POST_RESTART_2PC_B")
+POST_RESTART_2PC_COUNTS=$(wait_dashboard_message_task_convergence || true)
+read -r POST_RESTART_2PC_M POST_RESTART_2PC_T POST_RESTART_2PC_BM POST_RESTART_2PC_BT <<< "$POST_RESTART_2PC_COUNTS"
 RESTART_2PC_DM=$((POST_RESTART_2PC_M - PRE_RESTART_2PC_M))
 RESTART_2PC_DT=$((POST_RESTART_2PC_T - PRE_RESTART_2PC_T))
 RESTART_2PC_RESPONSE=$(cat "$RESTART_2PC_RESPONSE_FILE")
@@ -1446,12 +1527,8 @@ NODE_A_KEY="$NODE_P0A_KEY"
 (cd "$DEPLOY_DIR" && npx convex deploy --admin-key "$NODE_A_KEY" --url "$NODE_A_URL" > /dev/null 2>&1)
 
 sleep 8
-POST_COORD_RESTART_2PC_A=$(query_api "$NODE_A_URL" "$NODE_A_KEY" "messages:dashboard")
-POST_COORD_RESTART_2PC_B=$(query_api "$NODE_B_URL" "$NODE_B_KEY" "messages:dashboard")
-POST_COORD_RESTART_2PC_M=$(jval messages "$POST_COORD_RESTART_2PC_A")
-POST_COORD_RESTART_2PC_T=$(jval tasks "$POST_COORD_RESTART_2PC_A")
-POST_COORD_RESTART_2PC_BM=$(jval messages "$POST_COORD_RESTART_2PC_B")
-POST_COORD_RESTART_2PC_BT=$(jval tasks "$POST_COORD_RESTART_2PC_B")
+POST_COORD_RESTART_2PC_COUNTS=$(wait_dashboard_message_task_convergence || true)
+read -r POST_COORD_RESTART_2PC_M POST_COORD_RESTART_2PC_T POST_COORD_RESTART_2PC_BM POST_COORD_RESTART_2PC_BT <<< "$POST_COORD_RESTART_2PC_COUNTS"
 COORD_RESTART_2PC_DM=$((POST_COORD_RESTART_2PC_M - PRE_COORD_RESTART_2PC_M))
 COORD_RESTART_2PC_DT=$((POST_COORD_RESTART_2PC_T - PRE_COORD_RESTART_2PC_T))
 COORD_RESTART_2PC_RESPONSE=$(cat "$COORD_RESTART_2PC_RESPONSE_FILE")
@@ -1487,20 +1564,15 @@ for i in "${!FAILURE_WINDOW_2PC_LABELS[@]}"; do
     task="${FAILURE_WINDOW_2PC_TASKS[$i]}"
     response="${FAILURE_WINDOW_2PC_RESPONSES[$i]}"
 
-    MSG_A=$(count_message_text "$NODE_A_URL" "$NODE_A_KEY" "$text")
-    MSG_B=$(count_message_text "$NODE_B_URL" "$NODE_B_KEY" "$text")
-    TASK_A=$(count_task_title "$NODE_A_URL" "$NODE_A_KEY" "$task")
-    TASK_B=$(count_task_title "$NODE_B_URL" "$NODE_B_KEY" "$task")
-    if echo "$response" | grep -q '"status":"success"'; then
-        if [ "$MSG_A" -ne 1 ] || [ "$MSG_B" -ne 1 ] || [ "$TASK_A" -ne 1 ] || [ "$TASK_B" -ne 1 ]; then
-            FAILURE_EXACTNESS_OK=false
-            FAILURE_EXACTNESS_DETAILS="$FAILURE_EXACTNESS_DETAILS [$label success msgA=$MSG_A msgB=$MSG_B taskA=$TASK_A taskB=$TASK_B]"
-        fi
-    elif [ "$MSG_A" -eq "$MSG_B" ] && [ "$MSG_A" -eq "$TASK_A" ] && [ "$MSG_A" -eq "$TASK_B" ] && { [ "$MSG_A" -eq 0 ] || [ "$MSG_A" -eq 1 ]; }; then
-        :
-    else
+    COUNTS=$(wait_for_2pc_pair_exactness "$text" "$task" "$response" || true)
+    read -r MSG_A MSG_B TASK_A TASK_B <<< "$COUNTS"
+    if ! two_pc_counts_match_response "$response" "$MSG_A" "$MSG_B" "$TASK_A" "$TASK_B"; then
         FAILURE_EXACTNESS_OK=false
-        FAILURE_EXACTNESS_DETAILS="$FAILURE_EXACTNESS_DETAILS [$label ambiguous msgA=$MSG_A msgB=$MSG_B taskA=$TASK_A taskB=$TASK_B response=$response]"
+        if echo "$response" | grep -q '"status":"success"'; then
+            FAILURE_EXACTNESS_DETAILS="$FAILURE_EXACTNESS_DETAILS [$label success msgA=$MSG_A msgB=$MSG_B taskA=$TASK_A taskB=$TASK_B]"
+        else
+            FAILURE_EXACTNESS_DETAILS="$FAILURE_EXACTNESS_DETAILS [$label ambiguous msgA=$MSG_A msgB=$MSG_B taskA=$TASK_A taskB=$TASK_B response=$response]"
+        fi
     fi
 done
 
@@ -1580,20 +1652,15 @@ for i in "${!NATS_FLAP_LABELS[@]}"; do
     task="${NATS_FLAP_TASKS[$i]}"
     response="${NATS_FLAP_RESPONSES[$i]}"
 
-    MSG_A=$(count_message_text "$NODE_A_URL" "$NODE_A_KEY" "$text")
-    MSG_B=$(count_message_text "$NODE_B_URL" "$NODE_B_KEY" "$text")
-    TASK_A=$(count_task_title "$NODE_A_URL" "$NODE_A_KEY" "$task")
-    TASK_B=$(count_task_title "$NODE_B_URL" "$NODE_B_KEY" "$task")
-    if echo "$response" | grep -q '"status":"success"'; then
-        if [ "$MSG_A" -ne 1 ] || [ "$MSG_B" -ne 1 ] || [ "$TASK_A" -ne 1 ] || [ "$TASK_B" -ne 1 ]; then
-            NATS_FLAP_EXACTNESS_OK=false
-            NATS_FLAP_EXACTNESS_DETAILS="$NATS_FLAP_EXACTNESS_DETAILS [$label success msgA=$MSG_A msgB=$MSG_B taskA=$TASK_A taskB=$TASK_B]"
-        fi
-    elif [ "$MSG_A" -eq "$MSG_B" ] && [ "$MSG_A" -eq "$TASK_A" ] && [ "$MSG_A" -eq "$TASK_B" ] && { [ "$MSG_A" -eq 0 ] || [ "$MSG_A" -eq 1 ]; }; then
-        :
-    else
+    COUNTS=$(wait_for_2pc_pair_exactness "$text" "$task" "$response" || true)
+    read -r MSG_A MSG_B TASK_A TASK_B <<< "$COUNTS"
+    if ! two_pc_counts_match_response "$response" "$MSG_A" "$MSG_B" "$TASK_A" "$TASK_B"; then
         NATS_FLAP_EXACTNESS_OK=false
-        NATS_FLAP_EXACTNESS_DETAILS="$NATS_FLAP_EXACTNESS_DETAILS [$label ambiguous msgA=$MSG_A msgB=$MSG_B taskA=$TASK_A taskB=$TASK_B response=$response]"
+        if echo "$response" | grep -q '"status":"success"'; then
+            NATS_FLAP_EXACTNESS_DETAILS="$NATS_FLAP_EXACTNESS_DETAILS [$label success msgA=$MSG_A msgB=$MSG_B taskA=$TASK_A taskB=$TASK_B]"
+        else
+            NATS_FLAP_EXACTNESS_DETAILS="$NATS_FLAP_EXACTNESS_DETAILS [$label ambiguous msgA=$MSG_A msgB=$MSG_B taskA=$TASK_A taskB=$TASK_B response=$response]"
+        fi
     fi
 done
 
@@ -1646,10 +1713,8 @@ NODE_B_KEY="$NODE_P1A_KEY"
 (cd "$DEPLOY_DIR" && npx convex deploy --admin-key "$NODE_B_KEY" --url "$NODE_B_URL" > /dev/null 2>&1)
 
 sleep 8
-POST_ACK_MSG_A=$(count_message_text "$NODE_A_URL" "$NODE_A_KEY" "$POST_ACK_TEXT")
-POST_ACK_MSG_B=$(count_message_text "$NODE_B_URL" "$NODE_B_KEY" "$POST_ACK_TEXT")
-POST_ACK_TASK_A=$(count_task_title "$NODE_A_URL" "$NODE_A_KEY" "$POST_ACK_TASK")
-POST_ACK_TASK_B=$(count_task_title "$NODE_B_URL" "$NODE_B_KEY" "$POST_ACK_TASK")
+POST_ACK_COUNTS=$(wait_for_2pc_pair_exactness "$POST_ACK_TEXT" "$POST_ACK_TASK" "$POST_ACK_RESPONSE" || true)
+read -r POST_ACK_MSG_A POST_ACK_MSG_B POST_ACK_TASK_A POST_ACK_TASK_B <<< "$POST_ACK_COUNTS"
 
 [ "$POST_ACK_MSG_A" -eq 1 ] && [ "$POST_ACK_MSG_B" -eq 1 ] && \
     [ "$POST_ACK_TASK_A" -eq 1 ] && [ "$POST_ACK_TASK_B" -eq 1 ] \


### PR DESCRIPTION
## Summary
- make `TwoPhaseDecisionLog::write_decision` CAS-backed by requiring `write_decision_if_absent` implementations
- allow idempotent rewrites only when the existing durable decision is identical
- reject conflicting durable decisions instead of allowing a commit/rollback overwrite
- make failure-window 2PC exactness checks wait on the same strict invariant after forced restarts

## Validation
- `rustfmt --edition 2024 --check crates/database/src/two_phase.rs`
- `bash -n self-hosted/docker/test-write-scaling.sh`
- `git diff --check`
- `env PROTOC=/Users/martin/Desktop/convex-horizontal-scaling/crates/pb_build/protoc/protoc-macos-universal cargo test --target-dir /tmp/convex-target-issue239 -p database two_phase::tests -- --nocapture`
- rebuilt backend image locally: `sha256:b679994d3a6befeae3a903dfe73792109e0b39c61b287b2ee3a1bf92b2653676`
- proved all six backend containers used that local image with `BACKEND_PULL_POLICY=never`
- `CLUSTER_RUN_ID=run-1782954251 BACKEND_PULL_POLICY=never bash self-hosted/docker/test.sh` -> write-scaling `143/143`, Raft failover `24/24`, all suites passed

Fixes #239