### PR TITLE
fix(tso): discard stale leadership batches

### DIFF
--- a/crates/database/src/raft_partition.rs
+++ b/crates/database/src/raft_partition.rs
@@ -60,6 +60,7 @@ use crate::{
         RaftNode,
         RaftNodeConfig,
     },
+    timestamp_oracle::TimestampOracle,
 };
 
 /// Shared state for a Raft-enabled partition, accessible from the Committer
@@ -179,6 +180,7 @@ impl RaftPartitionManager {
         engine: Arc<raft_engine::Engine>,
         peer_senders: HashMap<u64, mpsc::UnboundedSender<Message>>,
         snapshot_provider: Option<Arc<dyn crate::raft_storage::RaftSnapshotProvider>>,
+        timestamp_oracle: Option<Arc<dyn TimestampOracle>>,
     ) -> anyhow::Result<Self> {
         let (mailbox_tx, mailbox_rx) = mpsc::unbounded_channel();
 
@@ -200,9 +202,13 @@ impl RaftPartitionManager {
         let serving_lease_refresh = leader_serving_lease_valid_until.clone();
         let serving_lease_duration_refresh = leader_serving_lease_duration;
         let partition_id = config.partition_id;
+        let tso_became_leader = timestamp_oracle.clone();
 
         node.set_leadership_callbacks(LeadershipCallbacks {
             on_became_leader: Box::new(move || {
+                if let Some(tso) = tso_became_leader.as_ref() {
+                    tso.discard_reserved_batch();
+                }
                 is_leader_cb.store(true, Ordering::SeqCst);
                 metrics::log_raft_is_leader(partition_id, true);
                 tracing::info!(
@@ -214,7 +220,11 @@ impl RaftPartitionManager {
                 let is_leader_lost = is_leader.clone();
                 let serving_lease_lost = leader_serving_lease_valid_until.clone();
                 let partition_id_lost = partition_id;
+                let tso_lost_leadership = timestamp_oracle.clone();
                 move || {
+                    if let Some(tso) = tso_lost_leadership.as_ref() {
+                        tso.discard_reserved_batch();
+                    }
                     is_leader_lost.store(false, Ordering::SeqCst);
                     *serving_lease_lost.lock() = None;
                     metrics::log_raft_is_leader(partition_id_lost, false);
@@ -286,8 +296,42 @@ impl RaftPartitionManager {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::{
+        atomic::{
+            AtomicUsize,
+            Ordering,
+        },
+        Arc,
+    };
+
+    use async_trait::async_trait;
+    use common::types::Timestamp;
+
     use super::*;
     use crate::raft_storage::ConvexRaftStorage;
+
+    struct RecordingTimestampOracle {
+        discards: Arc<AtomicUsize>,
+    }
+
+    #[async_trait]
+    impl TimestampOracle for RecordingTimestampOracle {
+        async fn next_ts_at_or_after(&self, _min_ts: Timestamp) -> anyhow::Result<Timestamp> {
+            Ok(Timestamp::must(1))
+        }
+
+        async fn max_committed_ts(&self) -> anyhow::Result<Timestamp> {
+            Ok(Timestamp::MIN)
+        }
+
+        async fn advance_committed_ts(&self, _ts: Timestamp) -> anyhow::Result<()> {
+            Ok(())
+        }
+
+        fn discard_reserved_batch(&self) {
+            self.discards.fetch_add(1, Ordering::SeqCst);
+        }
+    }
 
     fn test_engine() -> Arc<raft_engine::Engine> {
         let dir = tempfile::tempdir().unwrap();
@@ -305,7 +349,7 @@ mod tests {
         };
 
         let manager =
-            RaftPartitionManager::new(config, test_engine(), HashMap::new(), None).unwrap();
+            RaftPartitionManager::new(config, test_engine(), HashMap::new(), None, None).unwrap();
         let state = manager.state();
 
         assert!(!state.is_leader());
@@ -324,7 +368,7 @@ mod tests {
         };
 
         let mut manager =
-            RaftPartitionManager::new(config, test_engine(), HashMap::new(), None).unwrap();
+            RaftPartitionManager::new(config, test_engine(), HashMap::new(), None, None).unwrap();
         let state = manager.state();
 
         assert!(!state.is_leader());
@@ -346,6 +390,33 @@ mod tests {
         );
     }
 
+    #[tokio::test]
+    async fn test_became_leader_discards_tso_reserved_batch() {
+        let config = RaftNodeConfig {
+            node_id: 1,
+            partition_id: PartitionId(0),
+            peers: vec![1],
+            election_tick: 10,
+            heartbeat_tick: 3,
+        };
+        let discards = Arc::new(AtomicUsize::new(0));
+        let tso = Arc::new(RecordingTimestampOracle {
+            discards: discards.clone(),
+        });
+
+        let mut manager =
+            RaftPartitionManager::new(config, test_engine(), HashMap::new(), None, Some(tso))
+                .unwrap();
+
+        let mut node = manager.take_node().unwrap();
+        for _ in 0..20 {
+            node.raw_node.tick();
+        }
+        node.process_ready_test();
+
+        assert_eq!(discards.load(Ordering::SeqCst), 1);
+    }
+
     #[test]
     fn test_send_proposal() {
         let config = RaftNodeConfig {
@@ -356,7 +427,7 @@ mod tests {
         };
 
         let manager =
-            RaftPartitionManager::new(config, test_engine(), HashMap::new(), None).unwrap();
+            RaftPartitionManager::new(config, test_engine(), HashMap::new(), None, None).unwrap();
         let state = manager.state();
 
         // Should be able to send without error (node exists).

--- a/crates/database/src/timestamp_oracle.rs
+++ b/crates/database/src/timestamp_oracle.rs
@@ -61,6 +61,15 @@ pub trait TimestampOracle: Send + Sync + 'static {
 
     /// Advance the max committed timestamp. Called after a successful commit.
     async fn advance_committed_ts(&self, ts: Timestamp) -> anyhow::Result<()>;
+
+    /// Discard any node-local timestamp reservation after a leadership epoch
+    /// change.
+    ///
+    /// Batch-based TSOs must not carry an old local reservation across Raft
+    /// leadership changes. A re-elected leader should fence itself against the
+    /// latest global counter and committed floor before assigning more commit
+    /// timestamps.
+    fn discard_reserved_batch(&self) {}
 }
 
 /// Local timestamp oracle for single-node deployments.
@@ -140,6 +149,9 @@ struct BatchState {
     upper_bound: u64,
     /// Maximum committed timestamp seen.
     max_committed: Timestamp,
+    /// Force the next assignment to refresh the global committed floor before
+    /// reserving or consuming any batch.
+    refresh_committed_floor: bool,
 }
 
 const TSO_COUNTER_KEY: &str = "tso_counter";
@@ -165,6 +177,23 @@ fn should_read_committed_floor_before_assignment(
     local_min_next: u64,
 ) -> bool {
     next_ts_from_reserved_batch(current, upper_bound, local_min_next).is_some()
+}
+
+fn local_min_next_from_floor(min_ts: Timestamp, max_committed: Timestamp) -> anyhow::Result<u64> {
+    Ok(u64::from(std::cmp::max(min_ts, max_committed.succ()?)))
+}
+
+fn discard_batch_state_for_leadership_change(state: &mut BatchState) {
+    state.current = 0;
+    state.upper_bound = 0;
+    state.refresh_committed_floor = true;
+}
+
+fn refresh_committed_floor(state: &mut BatchState, committed_floor: Timestamp) {
+    if committed_floor > state.max_committed {
+        state.max_committed = committed_floor;
+    }
+    state.refresh_committed_floor = false;
 }
 
 impl BatchTimestampOracle {
@@ -215,6 +244,7 @@ impl BatchTimestampOracle {
                 current: 0,
                 upper_bound: 0,
                 max_committed: Timestamp::MIN,
+                refresh_committed_floor: false,
             }),
         })
     }
@@ -295,9 +325,15 @@ impl TimestampOracle for BatchTimestampOracle {
         let timer = metrics::tso_operation_timer("next_ts_at_or_after");
         let result = async {
             loop {
+                if self.state.lock().refresh_committed_floor {
+                    let committed_floor = self.max_committed_ts().await?;
+                    let mut state = self.state.lock();
+                    refresh_committed_floor(&mut state, committed_floor);
+                }
+
                 let local_min_next = {
                     let state = self.state.lock();
-                    u64::from(std::cmp::max(min_ts, state.max_committed.succ()?))
+                    local_min_next_from_floor(min_ts, state.max_committed)?
                 };
 
                 let reserved_batch_can_satisfy_local_floor = {
@@ -441,6 +477,11 @@ impl TimestampOracle for BatchTimestampOracle {
         }
         result
     }
+
+    fn discard_reserved_batch(&self) {
+        let mut state = self.state.lock();
+        discard_batch_state_for_leadership_change(&mut state);
+    }
 }
 
 #[cfg(any(test, feature = "testing"))]
@@ -495,10 +536,16 @@ pub mod testing {
 
 #[cfg(test)]
 mod tests {
+    use common::types::Timestamp;
+
     use super::{
         batch_lower_bound,
+        discard_batch_state_for_leadership_change,
+        local_min_next_from_floor,
         next_ts_from_reserved_batch,
+        refresh_committed_floor,
         should_read_committed_floor_before_assignment,
+        BatchState,
     };
 
     #[test]
@@ -544,5 +591,46 @@ mod tests {
         assert!(!should_read_committed_floor_before_assignment(
             100, 200, 250
         ));
+    }
+
+    #[test]
+    fn leadership_change_discards_reserved_batch() {
+        let mut state = BatchState {
+            current: 150,
+            upper_bound: 200,
+            max_committed: Timestamp::must(120),
+            refresh_committed_floor: false,
+        };
+
+        discard_batch_state_for_leadership_change(&mut state);
+
+        assert_eq!(state.current, 0);
+        assert_eq!(state.upper_bound, 0);
+        assert_eq!(state.max_committed, Timestamp::must(120));
+        assert!(state.refresh_committed_floor);
+    }
+
+    #[test]
+    fn leadership_floor_refresh_prevents_stale_batch_reuse() -> anyhow::Result<()> {
+        let mut state = BatchState {
+            current: 150,
+            upper_bound: 200,
+            max_committed: Timestamp::must(120),
+            refresh_committed_floor: false,
+        };
+
+        discard_batch_state_for_leadership_change(&mut state);
+        refresh_committed_floor(&mut state, Timestamp::must(250));
+
+        let min_next = local_min_next_from_floor(Timestamp::MIN, state.max_committed)?;
+
+        assert_eq!(min_next, 251);
+        assert!(!state.refresh_committed_floor);
+        assert!(
+            next_ts_from_reserved_batch(state.current, state.upper_bound, min_next).is_none(),
+            "a re-elected leader must not assign from the old leadership epoch's local batch",
+        );
+        assert_eq!(batch_lower_bound(200, min_next), 251);
+        Ok(())
     }
 }

--- a/crates/local_backend/src/lib.rs
+++ b/crates/local_backend/src/lib.rs
@@ -626,7 +626,7 @@ pub async fn make_app(
         static_node_addresses.clone(),
         two_phase_decision_log,
         Some(cluster_grpc_auth.clone()),
-        timestamp_oracle,
+        timestamp_oracle.clone(),
         table_number_allocator,
         None, // raft_state: set after Raft node starts, not during Database::load
     )
@@ -1236,6 +1236,7 @@ pub async fn make_app(
             raft_engine,
             peer_senders,
             Some(snapshot_provider),
+            timestamp_oracle.clone(),
         )?;
         let raft_state = manager.state();
         raft_state_for_app = Some(raft_state.clone());

--- a/self-hosted/docker/test-write-scaling.sh
+++ b/self-hosted/docker/test-write-scaling.sh
@@ -1448,6 +1448,9 @@ echo -e "${BOLD}Test 9g: 2PC Atomicity During Participant Restart${NC}"
 # Race a cross-partition mutation with a partition-1 participant restart. The
 # client result may be ambiguous, but the persisted result must not be torn.
 
+FAILURE_WINDOW_RUN="failure-window-2pc-$(date +%s)-$$"
+PARTICIPANT_RESTART_TEXT="$FAILURE_WINDOW_RUN-participant-restart-msg"
+PARTICIPANT_RESTART_TASK="$FAILURE_WINDOW_RUN-participant-restart-task"
 PRE_RESTART_2PC=$(query_api "$NODE_A_URL" "$NODE_A_KEY" "messages:dashboard")
 PRE_RESTART_2PC_M=$(jval messages "$PRE_RESTART_2PC")
 PRE_RESTART_2PC_T=$(jval tasks "$PRE_RESTART_2PC")
@@ -1456,7 +1459,7 @@ RESTART_2PC_RESPONSE_FILE=$(mktemp)
 (curl --max-time 20 -s "$NODE_A_URL/api/mutation" \
     -H "Authorization: Convex $NODE_A_KEY" \
     -H "Content-Type: application/json" \
-    -d '{"path":"messages:crossPartitionWrite","args":{"text":"2pc-participant-restart","taskTitle":"2pc-participant-restart-task"}}' \
+    -d "{\"path\":\"messages:crossPartitionWrite\",\"args\":{\"text\":\"$PARTICIPANT_RESTART_TEXT\",\"taskTitle\":\"$PARTICIPANT_RESTART_TASK\"}}" \
     > "$RESTART_2PC_RESPONSE_FILE" || echo '{"status":"transport_error"}' > "$RESTART_2PC_RESPONSE_FILE") &
 RESTART_2PC_PID=$!
 sleep 0.05
@@ -1480,8 +1483,8 @@ RESTART_2PC_DT=$((POST_RESTART_2PC_T - PRE_RESTART_2PC_T))
 RESTART_2PC_RESPONSE=$(cat "$RESTART_2PC_RESPONSE_FILE")
 rm -f "$RESTART_2PC_RESPONSE_FILE"
 FAILURE_WINDOW_2PC_LABELS+=("participant-restart")
-FAILURE_WINDOW_2PC_TEXTS+=("2pc-participant-restart")
-FAILURE_WINDOW_2PC_TASKS+=("2pc-participant-restart-task")
+FAILURE_WINDOW_2PC_TEXTS+=("$PARTICIPANT_RESTART_TEXT")
+FAILURE_WINDOW_2PC_TASKS+=("$PARTICIPANT_RESTART_TASK")
 FAILURE_WINDOW_2PC_RESPONSES+=("$RESTART_2PC_RESPONSE")
 
 if [ "$RESTART_2PC_DM" -eq "$RESTART_2PC_DT" ] && { [ "$RESTART_2PC_DM" -eq 0 ] || [ "$RESTART_2PC_DM" -eq 1 ]; }; then
@@ -1502,6 +1505,8 @@ echo -e "${BOLD}Test 9h: 2PC Atomicity During Coordinator Restart${NC}"
 # is the coordinator-crash window: after staging/decision work starts, the
 # persisted outcome must still be either fully absent or fully present.
 
+COORD_RESTART_TEXT="$FAILURE_WINDOW_RUN-coordinator-restart-msg"
+COORD_RESTART_TASK="$FAILURE_WINDOW_RUN-coordinator-restart-task"
 PRE_COORD_RESTART_2PC=$(query_api "$NODE_A_URL" "$NODE_A_KEY" "messages:dashboard")
 PRE_COORD_RESTART_2PC_M=$(jval messages "$PRE_COORD_RESTART_2PC")
 PRE_COORD_RESTART_2PC_T=$(jval tasks "$PRE_COORD_RESTART_2PC")
@@ -1510,7 +1515,7 @@ COORD_RESTART_2PC_RESPONSE_FILE=$(mktemp)
 (curl --max-time 20 -s "$NODE_A_URL/api/mutation" \
     -H "Authorization: Convex $NODE_A_KEY" \
     -H "Content-Type: application/json" \
-    -d '{"path":"messages:crossPartitionWrite","args":{"text":"2pc-coordinator-restart","taskTitle":"2pc-coordinator-restart-task"}}' \
+    -d "{\"path\":\"messages:crossPartitionWrite\",\"args\":{\"text\":\"$COORD_RESTART_TEXT\",\"taskTitle\":\"$COORD_RESTART_TASK\"}}" \
     > "$COORD_RESTART_2PC_RESPONSE_FILE" || echo '{"status":"transport_error"}' > "$COORD_RESTART_2PC_RESPONSE_FILE") &
 COORD_RESTART_2PC_PID=$!
 sleep 0.05
@@ -1534,8 +1539,8 @@ COORD_RESTART_2PC_DT=$((POST_COORD_RESTART_2PC_T - PRE_COORD_RESTART_2PC_T))
 COORD_RESTART_2PC_RESPONSE=$(cat "$COORD_RESTART_2PC_RESPONSE_FILE")
 rm -f "$COORD_RESTART_2PC_RESPONSE_FILE"
 FAILURE_WINDOW_2PC_LABELS+=("coordinator-restart")
-FAILURE_WINDOW_2PC_TEXTS+=("2pc-coordinator-restart")
-FAILURE_WINDOW_2PC_TASKS+=("2pc-coordinator-restart-task")
+FAILURE_WINDOW_2PC_TEXTS+=("$COORD_RESTART_TEXT")
+FAILURE_WINDOW_2PC_TASKS+=("$COORD_RESTART_TASK")
 FAILURE_WINDOW_2PC_RESPONSES+=("$COORD_RESTART_2PC_RESPONSE")
 
 if [ "$COORD_RESTART_2PC_DM" -eq "$COORD_RESTART_2PC_DT" ] && { [ "$COORD_RESTART_2PC_DM" -eq 0 ] || [ "$COORD_RESTART_2PC_DM" -eq 1 ]; }; then


### PR DESCRIPTION
## Summary

Fixes #241.

This prevents a node from carrying a stale node-local BatchTimestampOracle reservation across Raft leadership epochs. Whenever a partition node gains or loses Raft leadership, we now discard its reserved batch and force the next assignment to refresh the committed timestamp floor before reserving or consuming a batch.

Also tightens the Docker 2PC restart-window harness by making the 9g/9h marker values unique per run, so historical rows from earlier full-harness executions cannot contaminate the exactness check.

## Validation

- `rustfmt --edition 2024 --check crates/database/src/timestamp_oracle.rs crates/database/src/raft_partition.rs crates/local_backend/src/lib.rs`
- `git diff --check`
- `bash -n self-hosted/docker/test-write-scaling.sh`
- `env PROTOC=/Users/martin/Desktop/convex-horizontal-scaling/crates/pb_build/protoc/protoc-macos-universal cargo check --target-dir /tmp/convex-target-issue241 -p local_backend`
- `env PROTOC=/Users/martin/Desktop/convex-horizontal-scaling/crates/pb_build/protoc/protoc-macos-universal cargo test --target-dir /tmp/convex-target-issue241 -p database timestamp_oracle -- --nocapture` (`8/8` passed)
- `env PROTOC=/Users/martin/Desktop/convex-horizontal-scaling/crates/pb_build/protoc/protoc-macos-universal cargo test --target-dir /tmp/convex-target-issue241 -p database raft_partition -- --nocapture` (`4/4` passed)
- Rebuilt backend image locally: `sha256:1f753227cca6f55cfa7a40ab788546d636b03448345d2fb6fd92b3e313f6cc5d`
- Confirmed all six backend containers were healthy and running that exact local image with `BACKEND_PULL_POLICY=never`
- `BACKEND_PULL_POLICY=never bash self-hosted/docker/test.sh`
  - Write-scaling: `143/143`
  - Raft failover: `24/24`
  - `ALL SUITES PASSED`
