### PR TITLE
perf(2pc): garbage collect resolved decisions

### DIFF
--- a/crates/database/src/tests/write_scaling_tests.rs
+++ b/crates/database/src/tests/write_scaling_tests.rs
@@ -6915,6 +6915,57 @@ async fn test_watcher_rolls_back_abandoned_prepare_without_decision(
     Ok(())
 }
 
+#[test]
+fn test_watcher_gc_deletes_only_fully_resolved_decisions_after_grace() -> anyhow::Result<()> {
+    let td = TestDriver::new_with_io();
+    td.run_until(async move {
+        let decision_log = Arc::new(InMemoryTwoPhaseDecisionLog::new());
+        let partial_txn = TwoPhaseTransactionId("partial-gc-test".to_string());
+        let full_txn = TwoPhaseTransactionId("full-gc-test".to_string());
+
+        let mut partial = TwoPhaseDecision::committed(100, vec![0, 1]);
+        partial.mark_participant_resolved(PartitionId(0));
+        decision_log.write_decision(&partial_txn, &partial).await?;
+
+        let mut full = TwoPhaseDecision::committed(200, vec![0, 1]);
+        full.mark_participant_resolved(PartitionId(0));
+        full.mark_participant_resolved(PartitionId(1));
+        assert!(full.ready_for_gc(Duration::ZERO));
+        decision_log.write_decision(&full_txn, &full).await?;
+
+        assert!(
+            !crate::two_phase_watcher::garbage_collect_resolved_decision(
+                decision_log.as_ref(),
+                &partial_txn,
+                &partial,
+                Duration::ZERO,
+            )
+            .await?,
+            "partial decisions must remain recoverable",
+        );
+        assert!(
+            crate::two_phase_watcher::garbage_collect_resolved_decision(
+                decision_log.as_ref(),
+                &full_txn,
+                &full,
+                Duration::ZERO,
+            )
+            .await?,
+            "fully resolved decisions should be removed after the grace period",
+        );
+
+        assert!(
+            decision_log.get_decision(&partial_txn).await?.is_some(),
+            "unresolved decisions must stay in the decision log",
+        );
+        assert!(
+            decision_log.get_decision(&full_txn).await?.is_none(),
+            "fully resolved decisions should be deleted",
+        );
+        Ok(())
+    })
+}
+
 #[convex_macro::test_runtime]
 async fn test_watcher_commits_prepared_redo_when_final_decision_was_already_resolved(
     rt: TestRuntime,

--- a/crates/database/src/two_phase.rs
+++ b/crates/database/src/two_phase.rs
@@ -146,6 +146,8 @@ pub enum TwoPhaseDecision {
         staged_at_unix_millis: Option<u64>,
         #[serde(default)]
         resolved_participants: Vec<u32>,
+        #[serde(default)]
+        fully_resolved_at_unix_millis: Option<u64>,
     },
     /// All participants prepared successfully. Commit.
     Committed {
@@ -153,6 +155,8 @@ pub enum TwoPhaseDecision {
         participants: Vec<u32>,
         #[serde(default)]
         resolved_participants: Vec<u32>,
+        #[serde(default)]
+        fully_resolved_at_unix_millis: Option<u64>,
     },
     /// A participant failed to prepare, or coordinator timed out. Rollback.
     RolledBack {
@@ -160,6 +164,8 @@ pub enum TwoPhaseDecision {
         participants: Vec<u32>,
         #[serde(default)]
         resolved_participants: Vec<u32>,
+        #[serde(default)]
+        fully_resolved_at_unix_millis: Option<u64>,
     },
 }
 
@@ -228,6 +234,7 @@ impl TwoPhaseDecision {
             transaction_digest,
             staged_at_unix_millis: Some(now_unix_millis()),
             resolved_participants: Vec::new(),
+            fully_resolved_at_unix_millis: None,
         }
     }
 
@@ -236,6 +243,7 @@ impl TwoPhaseDecision {
             commit_ts,
             participants,
             resolved_participants: Vec::new(),
+            fully_resolved_at_unix_millis: None,
         }
     }
 
@@ -244,6 +252,7 @@ impl TwoPhaseDecision {
             reason,
             participants,
             resolved_participants: Vec::new(),
+            fully_resolved_at_unix_millis: None,
         }
     }
 
@@ -272,6 +281,23 @@ impl TwoPhaseDecision {
         }
     }
 
+    pub fn fully_resolved_at_unix_millis(&self) -> Option<u64> {
+        match self {
+            Self::Staging {
+                fully_resolved_at_unix_millis,
+                ..
+            }
+            | Self::Committed {
+                fully_resolved_at_unix_millis,
+                ..
+            }
+            | Self::RolledBack {
+                fully_resolved_at_unix_millis,
+                ..
+            } => *fully_resolved_at_unix_millis,
+        }
+    }
+
     pub fn is_staging(&self) -> bool {
         matches!(self, Self::Staging { .. })
     }
@@ -296,24 +322,41 @@ impl TwoPhaseDecision {
     }
 
     pub fn mark_participant_resolved(&mut self, participant: PartitionId) {
-        let resolved = match self {
+        let (participants, resolved, fully_resolved_at_unix_millis) = match self {
             Self::Staging {
+                participants,
                 resolved_participants,
+                fully_resolved_at_unix_millis,
                 ..
             }
             | Self::Committed {
+                participants,
                 resolved_participants,
+                fully_resolved_at_unix_millis,
                 ..
             }
             | Self::RolledBack {
+                participants,
                 resolved_participants,
+                fully_resolved_at_unix_millis,
                 ..
-            } => resolved_participants,
+            } => (
+                participants,
+                resolved_participants,
+                fully_resolved_at_unix_millis,
+            ),
         };
         if !resolved.contains(&participant.0) {
             resolved.push(participant.0);
             resolved.sort_unstable();
             resolved.dedup();
+        }
+        if fully_resolved_at_unix_millis.is_none()
+            && participants
+                .iter()
+                .all(|participant| resolved.contains(participant))
+        {
+            *fully_resolved_at_unix_millis = Some(now_unix_millis());
         }
     }
 
@@ -323,11 +366,13 @@ impl TwoPhaseDecision {
                 commit_ts,
                 participants,
                 resolved_participants,
+                fully_resolved_at_unix_millis,
                 ..
             } if self.all_participants_staged() => Some(Self::Committed {
                 commit_ts: *commit_ts,
                 participants: participants.clone(),
                 resolved_participants: resolved_participants.clone(),
+                fully_resolved_at_unix_millis: *fully_resolved_at_unix_millis,
             }),
             _ => None,
         }
@@ -401,6 +446,17 @@ impl TwoPhaseDecision {
         self.participants()
             .iter()
             .all(|participant| self.resolved_participants().contains(participant))
+    }
+
+    pub fn fully_resolved_age(&self) -> Option<Duration> {
+        let resolved_at = self.fully_resolved_at_unix_millis()?;
+        let now = now_unix_millis();
+        Some(Duration::from_millis(now.saturating_sub(resolved_at)))
+    }
+
+    pub fn ready_for_gc(&self, grace: Duration) -> bool {
+        self.all_participants_resolved()
+            && self.fully_resolved_age().is_some_and(|age| age >= grace)
     }
 
     pub fn staged_read_policy(&self) -> StagedTransactionReadPolicy {
@@ -1784,10 +1840,12 @@ mod tests {
                 commit_ts,
                 participants,
                 resolved_participants,
+                fully_resolved_at_unix_millis,
             } => {
                 assert_eq!(commit_ts, 12345);
                 assert_eq!(participants, vec![0, 1]);
                 assert_eq!(resolved_participants, vec![0]);
+                assert_eq!(fully_resolved_at_unix_millis, None);
             },
             _ => panic!("Wrong variant"),
         }
@@ -1825,6 +1883,7 @@ mod tests {
                 transaction_digest,
                 staged_at_unix_millis,
                 resolved_participants,
+                fully_resolved_at_unix_millis,
             } => {
                 assert_eq!(commit_ts, 12345);
                 assert_eq!(participants, vec![0, 1]);
@@ -1838,6 +1897,7 @@ mod tests {
                 assert_eq!(Some(&transaction_digest), decision.transaction_digest(),);
                 assert!(staged_at_unix_millis.is_some());
                 assert!(resolved_participants.is_empty());
+                assert_eq!(fully_resolved_at_unix_millis, None);
             },
             _ => panic!("Wrong variant"),
         }
@@ -1941,6 +2001,26 @@ mod tests {
         assert!(!decision.all_participants_resolved());
         decision.mark_participant_resolved(PartitionId(1));
         assert!(decision.all_participants_resolved());
+    }
+
+    #[test]
+    fn test_decision_records_fully_resolved_time_for_gc() {
+        let mut decision = TwoPhaseDecision::committed(12345, vec![0, 1]);
+
+        assert!(!decision.all_participants_resolved());
+        assert_eq!(decision.fully_resolved_at_unix_millis(), None);
+        assert!(!decision.ready_for_gc(Duration::ZERO));
+
+        decision.mark_participant_resolved(PartitionId(0));
+        assert!(!decision.all_participants_resolved());
+        assert_eq!(decision.fully_resolved_at_unix_millis(), None);
+        assert!(!decision.ready_for_gc(Duration::ZERO));
+
+        decision.mark_participant_resolved(PartitionId(1));
+        assert!(decision.all_participants_resolved());
+        assert!(decision.fully_resolved_at_unix_millis().is_some());
+        assert!(decision.ready_for_gc(Duration::ZERO));
+        assert!(!decision.ready_for_gc(Duration::from_secs(60)));
     }
 
     #[test]
@@ -2182,6 +2262,7 @@ mod tests {
                 commit_ts,
                 participants,
                 resolved_participants,
+                ..
             }) = result
             else {
                 panic!("expected committed recovery");

--- a/crates/database/src/two_phase_watcher.rs
+++ b/crates/database/src/two_phase_watcher.rs
@@ -22,12 +22,15 @@ use crate::{
     two_phase::{
         StagingRecoveryResult,
         TwoPhaseDecision,
+        TwoPhaseDecisionLog,
         TwoPhaseTransactionId,
         PREPARE_TIMEOUT_SECS,
         TWO_PHASE_KV_BUCKET,
         TWO_PHASE_KV_PREFIX,
     },
 };
+
+const RESOLVED_DECISION_GC_GRACE: Duration = Duration::from_secs(60);
 
 async fn apply_final_decision_for_local_partition(
     committer: &CommitterClient,
@@ -100,6 +103,24 @@ async fn apply_final_decision_for_local_partition(
     }
 }
 
+pub async fn garbage_collect_resolved_decision(
+    decision_log: &dyn TwoPhaseDecisionLog,
+    txn_id: &TwoPhaseTransactionId,
+    decision: &TwoPhaseDecision,
+    grace: Duration,
+) -> anyhow::Result<bool> {
+    if !decision.ready_for_gc(grace) {
+        return Ok(false);
+    }
+    decision_log.delete_decision(txn_id).await?;
+    tracing::info!(
+        "2PC Watcher: deleted fully resolved decision for txn={} after {:?} grace",
+        txn_id,
+        grace,
+    );
+    Ok(true)
+}
+
 /// Apply an existing durable 2PC decision to this local participant.
 pub async fn resolve_decision_for_local_partition(
     committer: &CommitterClient,
@@ -166,10 +187,20 @@ pub async fn resolve_decision_for_local_partition(
             .await?
             && updated.all_participants_resolved()
         {
-            tracing::info!(
-                "2PC Watcher: fully resolved decision for txn={} retained for follower recovery",
-                txn_id,
-            );
+            if !garbage_collect_resolved_decision(
+                decision_log.as_ref(),
+                &txn_id,
+                &updated,
+                RESOLVED_DECISION_GC_GRACE,
+            )
+            .await?
+            {
+                tracing::info!(
+                    "2PC Watcher: fully resolved decision for txn={} retained for follower \
+                     recovery grace",
+                    txn_id,
+                );
+            }
         }
     }
     Ok(resolved)


### PR DESCRIPTION
## Summary
- record when 2PC decisions become fully resolved across all participants
- garbage-collect fully resolved decision records after a follower-recovery grace period
- keep partially resolved decisions recoverable until every participant has observed the final outcome

Fixes #244

## Validation
- `rustfmt --edition 2024 --check crates/database/src/two_phase.rs crates/database/src/two_phase_watcher.rs crates/database/src/tests/write_scaling_tests.rs`
- `git diff --check`
- `export PATH="$HOME/.nvm/versions/node/v20.19.5/bin:$PATH"; env PROTOC=/Users/martin/Desktop/convex-horizontal-scaling/crates/pb_build/protoc/protoc-macos-universal cargo check --target-dir /tmp/convex-target-issue244 -p local_backend`
- `export PATH="$HOME/.nvm/versions/node/v20.19.5/bin:$PATH"; env PROTOC=/Users/martin/Desktop/convex-horizontal-scaling/crates/pb_build/protoc/protoc-macos-universal cargo test --target-dir /tmp/convex-target-issue244 -p database two_phase -- --nocapture` (`37/37`)
- rebuilt `ghcr.io/martinkalema/convex-horizontal-scaling:backend-latest` locally
- proved all six backend containers used local image `sha256:555b7ea5a00064c8a184d4359ac243736ee0eb5a88fd941982af776023df904b`
- `BACKEND_PULL_POLICY=never bash self-hosted/docker/test.sh`
  - write scaling: `146/146`
  - Raft failover: `24/24`
  - all suites passed
