### PR TITLE
perf(outbox): store raft nats outbox as per-entry records

### DIFF
--- a/crates/common/src/persistence.rs
+++ b/crates/common/src/persistence.rs
@@ -296,6 +296,15 @@ pub trait Persistence: Sync + Send + 'static {
         value: JsonValue,
     ) -> anyhow::Result<()>;
 
+    /// Writes global key-value data under an arbitrary persistence-global key.
+    /// This is for internally namespaced records where one logical feature owns
+    /// a bounded key prefix instead of one fixed enum key.
+    async fn write_persistence_global_raw(&self, key: &str, value: JsonValue)
+        -> anyhow::Result<()>;
+
+    /// Deletes global key-value data under an arbitrary persistence-global key.
+    async fn delete_persistence_global_raw(&self, key: &str) -> anyhow::Result<()>;
+
     async fn load_index_chunk(
         &self,
         cursor: Option<IndexEntry>,
@@ -569,6 +578,16 @@ pub trait PersistenceReader: Send + Sync + 'static {
         &self,
         key: PersistenceGlobalKey,
     ) -> anyhow::Result<Option<JsonValue>>;
+
+    /// Reads global key-value data under an arbitrary persistence-global key.
+    async fn get_persistence_global_raw(&self, key: &str) -> anyhow::Result<Option<JsonValue>>;
+
+    /// Lists global key-value data whose key starts with `prefix`, ordered by
+    /// key. Callers should reserve feature-specific prefixes.
+    async fn list_persistence_globals_with_prefix(
+        &self,
+        prefix: &str,
+    ) -> anyhow::Result<Vec<(String, JsonValue)>>;
 
     /// Performs a single point get using an index.
     async fn index_get(

--- a/crates/common/src/testing/test_persistence.rs
+++ b/crates/common/src/testing/test_persistence.rs
@@ -150,7 +150,27 @@ impl Persistence for TestPersistence {
         key: PersistenceGlobalKey,
         value: JsonValue,
     ) -> anyhow::Result<()> {
-        self.inner.lock().persistence_globals.insert(key, value);
+        self.inner
+            .lock()
+            .persistence_globals
+            .insert(String::from(key), value);
+        Ok(())
+    }
+
+    async fn write_persistence_global_raw(
+        &self,
+        key: &str,
+        value: JsonValue,
+    ) -> anyhow::Result<()> {
+        self.inner
+            .lock()
+            .persistence_globals
+            .insert(key.to_string(), value);
+        Ok(())
+    }
+
+    async fn delete_persistence_global_raw(&self, key: &str) -> anyhow::Result<()> {
+        self.inner.lock().persistence_globals.remove(key);
         Ok(())
     }
 
@@ -434,7 +454,25 @@ impl PersistenceReader for TestPersistence {
         &self,
         key: PersistenceGlobalKey,
     ) -> anyhow::Result<Option<JsonValue>> {
-        Ok(self.inner.lock().persistence_globals.get(&key).cloned())
+        self.get_persistence_global_raw(&String::from(key)).await
+    }
+
+    async fn get_persistence_global_raw(&self, key: &str) -> anyhow::Result<Option<JsonValue>> {
+        Ok(self.inner.lock().persistence_globals.get(key).cloned())
+    }
+
+    async fn list_persistence_globals_with_prefix(
+        &self,
+        prefix: &str,
+    ) -> anyhow::Result<Vec<(String, JsonValue)>> {
+        Ok(self
+            .inner
+            .lock()
+            .persistence_globals
+            .iter()
+            .filter(|(key, _)| key.starts_with(prefix))
+            .map(|(key, value)| (key.clone(), value.clone()))
+            .collect())
     }
 
     fn version(&self) -> PersistenceVersion {
@@ -446,7 +484,7 @@ struct Inner {
     is_fresh: bool,
     log: BTreeMap<(Timestamp, InternalDocumentId), (Option<ResolvedDocument>, Option<Timestamp>)>,
     index: BTreeMap<IndexId, BTreeMap<(IndexKeyBytes, Timestamp), Option<InternalDocumentId>>>,
-    persistence_globals: BTreeMap<PersistenceGlobalKey, JsonValue>,
+    persistence_globals: BTreeMap<String, JsonValue>,
 }
 
 impl Inner {

--- a/crates/database/src/checkpoint.rs
+++ b/crates/database/src/checkpoint.rs
@@ -155,6 +155,18 @@ impl Persistence for CheckpointPersistence {
         anyhow::bail!("CheckpointPersistence is read-only")
     }
 
+    async fn write_persistence_global_raw(
+        &self,
+        _key: &str,
+        _value: JsonValue,
+    ) -> anyhow::Result<()> {
+        anyhow::bail!("CheckpointPersistence is read-only")
+    }
+
+    async fn delete_persistence_global_raw(&self, _key: &str) -> anyhow::Result<()> {
+        anyhow::bail!("CheckpointPersistence is read-only")
+    }
+
     async fn load_index_chunk(
         &self,
         _cursor: Option<common::index::IndexEntry>,
@@ -311,8 +323,25 @@ impl PersistenceReader for CheckpointPersistence {
         &self,
         key: PersistenceGlobalKey,
     ) -> anyhow::Result<Option<JsonValue>> {
+        self.get_persistence_global_raw(&String::from(key)).await
+    }
+
+    async fn get_persistence_global_raw(&self, key: &str) -> anyhow::Result<Option<JsonValue>> {
         let inner = self.inner.lock();
-        Ok(inner.globals.get(&String::from(key)).cloned())
+        Ok(inner.globals.get(key).cloned())
+    }
+
+    async fn list_persistence_globals_with_prefix(
+        &self,
+        prefix: &str,
+    ) -> anyhow::Result<Vec<(String, JsonValue)>> {
+        let inner = self.inner.lock();
+        Ok(inner
+            .globals
+            .iter()
+            .filter(|(key, _)| key.starts_with(prefix))
+            .map(|(key, value)| (key.clone(), value.clone()))
+            .collect())
     }
 
     fn version(&self) -> PersistenceVersion {

--- a/crates/database/src/committer.rs
+++ b/crates/database/src/committer.rs
@@ -198,9 +198,24 @@ use crate::{
 const INITIAL_PERSISTENCE_WRITES_BACKOFF: Duration = Duration::from_secs(1);
 const MAX_PERSISTENCE_WRITES_BACKOFF: Duration = Duration::from_secs(60);
 const RAFT_NATS_OUTBOX_REPLAY_INTERVAL: Duration = Duration::from_secs(1);
+const RAFT_NATS_OUTBOX_KEY_PREFIX: &str = "raft_nats_outbox/";
 
-type RaftNatsOutboxRecords = BTreeMap<String, serde_json::Value>;
+type LegacyRaftNatsOutboxRecords = BTreeMap<String, serde_json::Value>;
 pub(crate) type AppliedDataDeltaIds = BTreeMap<crate::partition::PartitionId, BTreeSet<Timestamp>>;
+
+#[derive(Debug)]
+struct RaftNatsOutboxRecord {
+    key: String,
+    ts: Timestamp,
+    value: serde_json::Value,
+    storage: RaftNatsOutboxRecordStorage,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum RaftNatsOutboxRecordStorage {
+    LegacyBlob,
+    PerEntry,
+}
 
 /// State held for a 2PC-prepared transaction awaiting commit/rollback.
 struct PreparedTransaction {
@@ -2693,45 +2708,90 @@ impl<RT: Runtime> Committer<RT> {
         u64::from(ts).to_string()
     }
 
+    fn raft_nats_outbox_entry_key(delta: &CommitDelta) -> anyhow::Result<String> {
+        let source_partition = delta.source_partition.with_context(|| {
+            format!(
+                "Raft->NATS outbox delta at ts={} did not include a source partition",
+                u64::from(delta.ts)
+            )
+        })?;
+        Ok(format!(
+            "{RAFT_NATS_OUTBOX_KEY_PREFIX}{:020}/{:020}",
+            source_partition.0,
+            u64::from(delta.ts)
+        ))
+    }
+
+    fn parse_raft_nats_outbox_entry_key(key: &str) -> anyhow::Result<Timestamp> {
+        let (_, ts) = key
+            .strip_prefix(RAFT_NATS_OUTBOX_KEY_PREFIX)
+            .and_then(|suffix| suffix.rsplit_once('/'))
+            .with_context(|| format!("Failed to parse Raft->NATS outbox key {key:?}"))?;
+        ts.parse::<u64>()
+            .with_context(|| format!("Failed to parse Raft->NATS outbox timestamp in {key:?}"))
+            .and_then(Timestamp::try_from)
+    }
+
     async fn load_raft_nats_outbox_records(
         persistence: Arc<dyn Persistence>,
-    ) -> anyhow::Result<RaftNatsOutboxRecords> {
+    ) -> anyhow::Result<Vec<RaftNatsOutboxRecord>> {
+        let mut records = Vec::new();
+        for (key, value) in persistence
+            .reader()
+            .list_persistence_globals_with_prefix(RAFT_NATS_OUTBOX_KEY_PREFIX)
+            .await?
+        {
+            let ts = Self::parse_raft_nats_outbox_entry_key(&key)?;
+            records.push(RaftNatsOutboxRecord {
+                key,
+                ts,
+                value,
+                storage: RaftNatsOutboxRecordStorage::PerEntry,
+            });
+        }
+
         let Some(value) = persistence
             .reader()
             .get_persistence_global(PersistenceGlobalKey::RaftNatsOutbox)
             .await?
         else {
-            return Ok(BTreeMap::new());
+            records.sort_by_key(|record| record.ts);
+            return Ok(records);
         };
-        serde_json::from_value(value).context("Failed to parse Raft->NATS outbox records")
-    }
-
-    async fn write_raft_nats_outbox_records(
-        persistence: Arc<dyn Persistence>,
-        records: &RaftNatsOutboxRecords,
-    ) -> anyhow::Result<()> {
-        persistence
-            .write_persistence_global(
-                PersistenceGlobalKey::RaftNatsOutbox,
-                serde_json::to_value(records)
-                    .context("Failed to serialize Raft->NATS outbox records")?,
-            )
-            .await
+        let legacy_records: LegacyRaftNatsOutboxRecords =
+            serde_json::from_value(value).context("Failed to parse Raft->NATS outbox records")?;
+        for (key, value) in legacy_records {
+            let ts = key
+                .parse::<u64>()
+                .with_context(|| format!("Failed to parse Raft->NATS outbox key {key:?}"))
+                .and_then(Timestamp::try_from)?;
+            if records.iter().any(|record| record.ts == ts) {
+                continue;
+            }
+            records.push(RaftNatsOutboxRecord {
+                key,
+                ts,
+                value,
+                storage: RaftNatsOutboxRecordStorage::LegacyBlob,
+            });
+        }
+        records.sort_by_key(|record| record.ts);
+        Ok(records)
     }
 
     async fn add_raft_nats_outbox_delta(
         persistence: Arc<dyn Persistence>,
         delta: &CommitDelta,
     ) -> anyhow::Result<()> {
-        let mut records = Self::load_raft_nats_outbox_records(persistence.clone()).await?;
         let envelope = DeltaEnvelope::from_delta(delta, "", None)
             .context("Failed to encode Raft->NATS outbox delta")?;
-        records.insert(
-            Self::raft_nats_outbox_key(delta.ts),
-            serde_json::to_value(envelope)
-                .context("Failed to serialize Raft->NATS outbox delta")?,
-        );
-        Self::write_raft_nats_outbox_records(persistence, &records).await
+        persistence
+            .write_persistence_global_raw(
+                &Self::raft_nats_outbox_entry_key(delta)?,
+                serde_json::to_value(envelope)
+                    .context("Failed to serialize Raft->NATS outbox delta")?,
+            )
+            .await
     }
 
     async fn record_raft_nats_outbox_delta(
@@ -2747,43 +2807,52 @@ impl<RT: Runtime> Committer<RT> {
         result
     }
 
-    async fn delete_raft_nats_outbox_delta(
+    async fn delete_legacy_raft_nats_outbox_delta(
         persistence: Arc<dyn Persistence>,
         ts: Timestamp,
     ) -> anyhow::Result<()> {
-        let mut records = Self::load_raft_nats_outbox_records(persistence.clone()).await?;
+        let Some(value) = persistence
+            .reader()
+            .get_persistence_global(PersistenceGlobalKey::RaftNatsOutbox)
+            .await?
+        else {
+            return Ok(());
+        };
+        let mut records: LegacyRaftNatsOutboxRecords =
+            serde_json::from_value(value).context("Failed to parse Raft->NATS outbox records")?;
         records.remove(&Self::raft_nats_outbox_key(ts));
-        Self::write_raft_nats_outbox_records(persistence, &records).await
+        if records.is_empty() {
+            return persistence
+                .delete_persistence_global_raw(&String::from(PersistenceGlobalKey::RaftNatsOutbox))
+                .await;
+        }
+        persistence
+            .write_persistence_global(
+                PersistenceGlobalKey::RaftNatsOutbox,
+                serde_json::to_value(records)
+                    .context("Failed to serialize Raft->NATS outbox records")?,
+            )
+            .await
     }
 
-    async fn clear_raft_nats_outbox_delta(
+    async fn clear_raft_nats_outbox_record(
         persistence: Arc<dyn Persistence>,
-        ts: Timestamp,
+        record: &RaftNatsOutboxRecord,
         path: &'static str,
     ) -> anyhow::Result<()> {
         let timer = metrics::commit_hot_path_stage_timer(path, "raft_nats_outbox_clear");
-        let result = Self::delete_raft_nats_outbox_delta(persistence, ts).await;
+        let result = match record.storage {
+            RaftNatsOutboxRecordStorage::LegacyBlob => {
+                Self::delete_legacy_raft_nats_outbox_delta(persistence, record.ts).await
+            },
+            RaftNatsOutboxRecordStorage::PerEntry => {
+                persistence.delete_persistence_global_raw(&record.key).await
+            },
+        };
         if result.is_ok() {
             timer.finish();
         }
         result
-    }
-
-    fn sorted_raft_nats_outbox_records(
-        records: RaftNatsOutboxRecords,
-    ) -> anyhow::Result<Vec<(Timestamp, serde_json::Value)>> {
-        let mut sorted = records
-            .into_iter()
-            .map(|(key, value)| {
-                let ts = key
-                    .parse::<u64>()
-                    .with_context(|| format!("Failed to parse Raft->NATS outbox key {key:?}"))
-                    .and_then(Timestamp::try_from)?;
-                Ok((ts, value))
-            })
-            .collect::<anyhow::Result<Vec<_>>>()?;
-        sorted.sort_by_key(|(ts, _)| *ts);
-        Ok(sorted)
     }
 
     async fn replay_raft_nats_outbox_once(
@@ -2792,23 +2861,25 @@ impl<RT: Runtime> Committer<RT> {
     ) -> anyhow::Result<usize> {
         let records = Self::load_raft_nats_outbox_records(persistence.clone()).await?;
         let mut replayed = 0usize;
-        for (delta_ts, value) in Self::sorted_raft_nats_outbox_records(records)? {
-            let envelope: DeltaEnvelope = serde_json::from_value(value)
-                .with_context(|| format!("Failed to parse Raft->NATS outbox delta {delta_ts}"))?;
-            let delta = envelope
-                .to_delta()
-                .with_context(|| format!("Failed to decode Raft->NATS outbox delta {delta_ts}"))?;
+        for record in records {
+            let envelope: DeltaEnvelope = serde_json::from_value(record.value.clone())
+                .with_context(|| {
+                    format!("Failed to parse Raft->NATS outbox delta {}", record.ts)
+                })?;
+            let delta = envelope.to_delta().with_context(|| {
+                format!("Failed to decode Raft->NATS outbox delta {}", record.ts)
+            })?;
             anyhow::ensure!(
-                delta.ts == delta_ts,
+                delta.ts == record.ts,
                 "Raft->NATS outbox key {} did not match encoded delta ts {}",
-                u64::from(delta_ts),
+                u64::from(record.ts),
                 u64::from(delta.ts),
             );
             Self::publish_commit_delta(distributed_log.clone(), delta, "raft_nats_outbox_replay")
                 .await?;
-            Self::clear_raft_nats_outbox_delta(
+            Self::clear_raft_nats_outbox_record(
                 persistence.clone(),
-                delta_ts,
+                &record,
                 "raft_nats_outbox_replay",
             )
             .await?;
@@ -6172,7 +6243,10 @@ mod tests {
             DocumentUpdate,
             ResolvedDocument,
         },
-        persistence::Persistence,
+        persistence::{
+            Persistence,
+            PersistenceGlobalKey,
+        },
         testing::TestPersistence,
         types::{
             GenericIndexName,
@@ -6197,6 +6271,8 @@ mod tests {
         remap_index_metadata_update,
         replica_delta_timestamps,
         Committer,
+        RaftNatsOutboxRecordStorage,
+        RAFT_NATS_OUTBOX_KEY_PREFIX,
     };
     use crate::{
         commit_delta::{
@@ -6204,6 +6280,7 @@ mod tests {
             DistributedLog,
             ReplicationMessage,
         },
+        nats_distributed_log::DeltaEnvelope,
         partition::PartitionId,
         raft_node::RaftProposalResult,
         write_log::WriteSource,
@@ -6526,6 +6603,133 @@ mod tests {
             Committer::<TestRuntime>::load_raft_nats_outbox_records(persistence)
                 .await?
                 .is_empty()
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn raft_nats_outbox_records_use_per_entry_globals() -> anyhow::Result<()> {
+        let persistence: Arc<dyn Persistence> = Arc::new(TestPersistence::new());
+        let ts_2 = Timestamp::must(2);
+        let ts_10 = Timestamp::must(10);
+
+        Committer::<TestRuntime>::add_raft_nats_outbox_delta(
+            persistence.clone(),
+            &test_outbox_delta(ts_10),
+        )
+        .await?;
+        Committer::<TestRuntime>::add_raft_nats_outbox_delta(
+            persistence.clone(),
+            &test_outbox_delta(ts_2),
+        )
+        .await?;
+
+        assert!(
+            persistence
+                .reader()
+                .get_persistence_global(PersistenceGlobalKey::RaftNatsOutbox)
+                .await?
+                .is_none(),
+            "new outbox records should not rewrite the legacy aggregate blob",
+        );
+        let records = Committer::<TestRuntime>::load_raft_nats_outbox_records(persistence).await?;
+        assert_eq!(records.len(), 2);
+        assert_eq!(records[0].ts, ts_2);
+        assert_eq!(records[1].ts, ts_10);
+        assert!(records.iter().all(|record| {
+            record.storage == RaftNatsOutboxRecordStorage::PerEntry
+                && record.key.starts_with(RAFT_NATS_OUTBOX_KEY_PREFIX)
+        }));
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn raft_nats_outbox_backlog_stays_per_entry() -> anyhow::Result<()> {
+        let persistence: Arc<dyn Persistence> = Arc::new(TestPersistence::new());
+        let backlog_len = 256;
+
+        for ts in 1..=backlog_len {
+            Committer::<TestRuntime>::add_raft_nats_outbox_delta(
+                persistence.clone(),
+                &test_outbox_delta(Timestamp::must(ts)),
+            )
+            .await?;
+        }
+
+        let raw_records = persistence
+            .reader()
+            .list_persistence_globals_with_prefix(RAFT_NATS_OUTBOX_KEY_PREFIX)
+            .await?;
+        assert_eq!(raw_records.len(), backlog_len as usize);
+        assert!(
+            persistence
+                .reader()
+                .get_persistence_global(PersistenceGlobalKey::RaftNatsOutbox)
+                .await?
+                .is_none(),
+            "a large backlog should not recreate the legacy aggregate blob",
+        );
+
+        let records =
+            Committer::<TestRuntime>::load_raft_nats_outbox_records(persistence.clone()).await?;
+        assert_eq!(records.len(), backlog_len as usize);
+        assert_eq!(records.first().unwrap().ts, Timestamp::must(1));
+        assert_eq!(records.last().unwrap().ts, Timestamp::must(backlog_len));
+
+        let key_to_clear = records[127].key.clone();
+        Committer::<TestRuntime>::clear_raft_nats_outbox_record(
+            persistence.clone(),
+            &records[127],
+            "test",
+        )
+        .await?;
+
+        let raw_records_after_clear = persistence
+            .reader()
+            .list_persistence_globals_with_prefix(RAFT_NATS_OUTBOX_KEY_PREFIX)
+            .await?;
+        assert_eq!(raw_records_after_clear.len(), backlog_len as usize - 1);
+        assert!(
+            raw_records_after_clear
+                .iter()
+                .all(|(key, _)| key != &key_to_clear),
+            "clearing one outbox entry should delete only that per-entry row",
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn raft_nats_outbox_replays_and_clears_legacy_blob() -> anyhow::Result<()> {
+        let persistence: Arc<dyn Persistence> = Arc::new(TestPersistence::new());
+        let log = Arc::new(RecordingDistributedLog::default());
+        let ts = Timestamp::must(12);
+        let envelope = DeltaEnvelope::from_delta(&test_outbox_delta(ts), "", None)?;
+        let legacy_records = BTreeMap::from([(
+            Committer::<TestRuntime>::raft_nats_outbox_key(ts),
+            serde_json::to_value(envelope)?,
+        )]);
+        persistence
+            .write_persistence_global(
+                PersistenceGlobalKey::RaftNatsOutbox,
+                serde_json::to_value(legacy_records)?,
+            )
+            .await?;
+
+        let replayed = Committer::<TestRuntime>::replay_raft_nats_outbox_once(
+            persistence.clone(),
+            log.clone(),
+        )
+        .await?;
+
+        assert_eq!(replayed, 1);
+        assert_eq!(log.published(), vec![ts]);
+        assert!(
+            persistence
+                .reader()
+                .get_persistence_global(PersistenceGlobalKey::RaftNatsOutbox)
+                .await?
+                .is_none(),
+            "legacy aggregate blob should be deleted after its final record replays",
         );
         Ok(())
     }

--- a/crates/database/src/tests/write_scaling_tests.rs
+++ b/crates/database/src/tests/write_scaling_tests.rs
@@ -3132,19 +3132,21 @@ async fn test_raft_apply_records_nats_outbox_when_publish_unavailable(
         .apply_raft_commit_delta(delta)
         .await?;
 
-    let outbox = follower_persistence
+    let records = follower_persistence
         .reader()
-        .get_persistence_global(PersistenceGlobalKey::RaftNatsOutbox)
-        .await?
-        .context("Raft follower apply should record the delta before NATS publish")?;
-    let records: std::collections::BTreeMap<String, serde_json::Value> =
-        serde_json::from_value(outbox)?;
+        .list_persistence_globals_with_prefix("raft_nats_outbox/")
+        .await?;
     assert_eq!(
         records.len(),
         1,
         "failed NATS publish should leave the Raft-applied delta in the outbox",
     );
-    assert!(records.contains_key(&u64::from(delta_ts).to_string()));
+    assert!(
+        records
+            .iter()
+            .any(|(key, _)| key.ends_with(&format!("/{:020}", u64::from(delta_ts)))),
+        "outbox should include one per-entry record for the failed delta timestamp",
+    );
     assert!(
         replay_log.published().is_empty(),
         "the failing log must not observe a successful publish before recovery",
@@ -3175,19 +3177,21 @@ async fn test_partitioned_commit_records_nats_outbox_when_publish_unavailable(
     )
     .await?;
 
-    let outbox = persistence
+    let records = persistence
         .reader()
-        .get_persistence_global(PersistenceGlobalKey::RaftNatsOutbox)
-        .await?
-        .context("partitioned local commit should record a Raft->NATS outbox entry")?;
-    let records: std::collections::BTreeMap<String, serde_json::Value> =
-        serde_json::from_value(outbox)?;
+        .list_persistence_globals_with_prefix("raft_nats_outbox/")
+        .await?;
     assert_eq!(
         records.len(),
         1,
         "failed NATS publish should leave the accepted local commit in the outbox",
     );
-    assert!(records.contains_key(&u64::from(commit_ts).to_string()));
+    assert!(
+        records
+            .iter()
+            .any(|(key, _)| key.ends_with(&format!("/{:020}", u64::from(commit_ts)))),
+        "outbox should include one per-entry record for the failed commit timestamp",
+    );
     assert!(
         replay_log.published().is_empty(),
         "the failing log must not observe a successful publish",

--- a/crates/mysql/src/lib.rs
+++ b/crates/mysql/src/lib.rs
@@ -518,8 +518,23 @@ impl<RT: Runtime> Persistence for MySqlPersistence<RT> {
         value: JsonValue,
     ) -> anyhow::Result<()> {
         let timer = write_persistence_global_timer(self.read_pool.cluster_name(), key);
+        let result = self
+            .write_persistence_global_raw(&String::from(key), value)
+            .await;
+        if result.is_ok() {
+            timer.finish();
+        }
+        result
+    }
+
+    async fn write_persistence_global_raw(
+        &self,
+        key: &str,
+        value: JsonValue,
+    ) -> anyhow::Result<()> {
         let multitenant = self.multitenant;
         let instance_name = mysql_async::Value::from(&self.instance_name.raw);
+        let key = key.to_string();
         self.lease
             .transact(async move |tx| {
                 let stmt = sql::write_persistence_global(multitenant);
@@ -528,13 +543,29 @@ impl<RT: Runtime> Persistence for MySqlPersistence<RT> {
                 } else {
                     vec![]
                 };
-                params.extend([String::from(key).into(), value.into()]);
+                params.extend([key.into(), value.into()]);
                 tx.exec_drop(stmt, params).await?;
                 Ok(())
             })
             .await?;
-        timer.finish();
         Ok(())
+    }
+
+    async fn delete_persistence_global_raw(&self, key: &str) -> anyhow::Result<()> {
+        let multitenant = self.multitenant;
+        let instance_name = mysql_async::Value::from(&self.instance_name.raw);
+        let key = key.to_string();
+        self.lease
+            .transact(async move |tx| {
+                let mut params = vec![key.into()];
+                if multitenant {
+                    params.push(instance_name);
+                }
+                tx.exec_drop(sql::delete_persistence_global(multitenant), params)
+                    .await?;
+                Ok(())
+            })
+            .await
     }
 
     async fn load_index_chunk(
@@ -1546,14 +1577,19 @@ impl<RT: Runtime> PersistenceReader for MySqlReader<RT> {
         &self,
         key: PersistenceGlobalKey,
     ) -> anyhow::Result<Option<JsonValue>> {
+        self.get_persistence_global_raw(&String::from(key)).await
+    }
+
+    async fn get_persistence_global_raw(&self, key: &str) -> anyhow::Result<Option<JsonValue>> {
         let mut client = self
             .read_pool
             .acquire("get_persistence_global", &self.db_name)
             .await?;
-        let mut params = vec![String::from(key).into()];
+        let mut params = vec![key.into()];
         if self.multitenant {
             params.push(self.instance_name.to_string().into());
         }
+        let key = key.to_string();
         let rows = client
             .query_collect(sql::get_persistence_global(self.multitenant), params, 1, Ok)
             .await?;
@@ -1569,6 +1605,41 @@ impl<RT: Runtime> PersistenceReader for MySqlReader<RT> {
             Ok(json_value)
         });
         value.transpose()
+    }
+
+    async fn list_persistence_globals_with_prefix(
+        &self,
+        prefix: &str,
+    ) -> anyhow::Result<Vec<(String, JsonValue)>> {
+        let mut client = self
+            .read_pool
+            .acquire("list_persistence_globals_with_prefix", &self.db_name)
+            .await?;
+        let mut params = vec![format!("{prefix}%").into()];
+        if self.multitenant {
+            params.push(self.instance_name.to_string().into());
+        }
+        let rows = client
+            .query_collect(
+                sql::list_persistence_globals_with_prefix(self.multitenant),
+                params,
+                usize::MAX,
+                Ok,
+            )
+            .await?;
+        rows.into_iter()
+            .map(|r| {
+                let key = String::from_utf8(bytes_col(&r, 0)?.to_vec())
+                    .context("Persistence global key was not UTF-8")?;
+                let binary_value = bytes_col(&r, 1)?;
+                let mut json_deserializer = serde_json::Deserializer::from_slice(binary_value);
+                json_deserializer.disable_recursion_limit();
+                let json_value = JsonValue::deserialize(&mut json_deserializer)
+                    .with_context(|| format!("Invalid JSON at persistence key {key:?}"))?;
+                json_deserializer.end()?;
+                Ok((key, json_value))
+            })
+            .collect()
     }
 
     fn version(&self) -> PersistenceVersion {

--- a/crates/mysql/src/sql.rs
+++ b/crates/mysql/src/sql.rs
@@ -596,6 +596,34 @@ pub const fn get_persistence_global(multitenant: bool) -> &'static str {
     )
 }
 
+pub const fn list_persistence_globals_with_prefix(multitenant: bool) -> &'static str {
+    tableify!(
+        multitenant,
+        formatcp!(
+            r#"SELECT `key`, json_value FROM @db_name.persistence_globals FORCE INDEX (PRIMARY) WHERE `key` LIKE ? {instance_clause} ORDER BY `key` ASC"#,
+            instance_clause = if multitenant {
+                "AND instance_name = ?"
+            } else {
+                ""
+            }
+        )
+    )
+}
+
+pub const fn delete_persistence_global(multitenant: bool) -> &'static str {
+    tableify!(
+        multitenant,
+        formatcp!(
+            r#"DELETE FROM @db_name.persistence_globals WHERE `key` = ? {instance_clause}"#,
+            instance_clause = if multitenant {
+                "AND instance_name = ?"
+            } else {
+                ""
+            }
+        )
+    )
+}
+
 // Maximum number of writes within a single transaction. This is the sum of
 // TRANSACTION_MAX_SYSTEM_NUM_WRITES and TRANSACTION_MAX_NUM_USER_WRITES.
 pub const MAX_INSERT_SIZE: usize = 56000;

--- a/crates/postgres/src/lib.rs
+++ b/crates/postgres/src/lib.rs
@@ -596,18 +596,44 @@ impl Persistence for PostgresPersistence {
         key: PersistenceGlobalKey,
         value: JsonValue,
     ) -> anyhow::Result<()> {
+        self.write_persistence_global_raw(&String::from(key), value)
+            .await
+    }
+
+    async fn write_persistence_global_raw(
+        &self,
+        key: &str,
+        value: JsonValue,
+    ) -> anyhow::Result<()> {
         let multitenant = self.multitenant;
         let instance_name = self.instance_name.clone();
+        let key = key.to_string();
         self.lease
             .transact(async move |tx| {
                 let stmt = tx
                     .prepare_cached(sql::write_persistence_global(multitenant))
                     .await?;
-                let mut params = [
-                    Param::PersistenceGlobalKey(key),
-                    Param::JsonValue(value.to_string()),
-                ]
-                .to_vec();
+                let mut params = [Param::Text(key), Param::JsonValue(value.to_string())].to_vec();
+                if multitenant {
+                    params.push(Param::Text(instance_name.to_string()));
+                }
+                tx.execute_raw(&stmt, params).await?;
+                Ok(())
+            })
+            .await?;
+        Ok(())
+    }
+
+    async fn delete_persistence_global_raw(&self, key: &str) -> anyhow::Result<()> {
+        let multitenant = self.multitenant;
+        let instance_name = self.instance_name.clone();
+        let key = key.to_string();
+        self.lease
+            .transact(async move |tx| {
+                let stmt = tx
+                    .prepare_cached(sql::delete_persistence_global(multitenant))
+                    .await?;
+                let mut params = vec![Param::Text(key)];
                 if multitenant {
                     params.push(Param::Text(instance_name.to_string()));
                 }
@@ -1676,15 +1702,20 @@ impl PersistenceReader for PostgresReader {
         &self,
         key: PersistenceGlobalKey,
     ) -> anyhow::Result<Option<JsonValue>> {
+        self.get_persistence_global_raw(&String::from(key)).await
+    }
+
+    async fn get_persistence_global_raw(&self, key: &str) -> anyhow::Result<Option<JsonValue>> {
         let mut client = self
             .read_pool
             .get_connection("get_persistence_global", &self.schema, &self.instance_name)
             .await?;
-        let mut params = vec![Param::PersistenceGlobalKey(key)];
+        let mut params = vec![Param::Text(key.to_string())];
         if self.multitenant {
             params.push(Param::Text(self.instance_name.to_string()));
         }
         let multitenant = self.multitenant;
+        let key = key.to_string();
         let row_stream = client
             .with_retry(async move |client| {
                 let stmt = client
@@ -1707,6 +1738,47 @@ impl PersistenceReader for PostgresReader {
             Ok(json_value)
         });
         value.transpose()
+    }
+
+    async fn list_persistence_globals_with_prefix(
+        &self,
+        prefix: &str,
+    ) -> anyhow::Result<Vec<(String, JsonValue)>> {
+        let mut client = self
+            .read_pool
+            .get_connection(
+                "list_persistence_globals_with_prefix",
+                &self.schema,
+                &self.instance_name,
+            )
+            .await?;
+        let mut params = vec![Param::Text(format!("{prefix}%"))];
+        if self.multitenant {
+            params.push(Param::Text(self.instance_name.to_string()));
+        }
+        let multitenant = self.multitenant;
+        let row_stream = client
+            .with_retry(async move |client| {
+                let stmt = client
+                    .prepare_cached(sql::list_persistence_globals_with_prefix(multitenant))
+                    .await?;
+                client.query_raw(&stmt, &params).await
+            })
+            .await?;
+        futures::pin_mut!(row_stream);
+
+        let mut results = Vec::new();
+        while let Some(row) = row_stream.try_next().await? {
+            let key: String = row.get(0);
+            let binary_value: Vec<u8> = row.get(1);
+            let mut json_deserializer = serde_json::Deserializer::from_slice(&binary_value);
+            json_deserializer.disable_recursion_limit();
+            let json_value = JsonValue::deserialize(&mut json_deserializer)
+                .with_context(|| format!("Invalid JSON at persistence key {key:?}"))?;
+            json_deserializer.end()?;
+            results.push((key, json_value));
+        }
+        Ok(results)
     }
 
     fn version(&self) -> PersistenceVersion {
@@ -1959,7 +2031,6 @@ enum Param {
     JsonValue(String),
     Deleted(bool),
     Bytes(Vec<u8>),
-    PersistenceGlobalKey(PersistenceGlobalKey),
     Text(String),
 }
 
@@ -1979,7 +2050,6 @@ impl ToSql for Param {
             Param::Deleted(d) => d.to_sql(ty, out),
             Param::Bytes(v) => v.to_sql(ty, out),
             Param::Limit(v) => v.to_sql(ty, out),
-            Param::PersistenceGlobalKey(key) => String::from(*key).to_sql(ty, out),
             Param::Text(v) => v.to_sql(ty, out),
         }
     }

--- a/crates/postgres/src/sql.rs
+++ b/crates/postgres/src/sql.rs
@@ -679,6 +679,35 @@ pub const fn get_persistence_global(multitenant: bool) -> &'static str {
     )
 }
 
+pub const fn list_persistence_globals_with_prefix(multitenant: bool) -> &'static str {
+    tableify!(
+        multitenant,
+        formatcp!(
+            "SELECT key, json_value FROM @db_name.persistence_globals WHERE key LIKE \
+             $1{instance_clause} ORDER BY key ASC",
+            instance_clause = if multitenant {
+                " AND instance_name = $2"
+            } else {
+                ""
+            }
+        )
+    )
+}
+
+pub const fn delete_persistence_global(multitenant: bool) -> &'static str {
+    tableify!(
+        multitenant,
+        formatcp!(
+            "DELETE FROM @db_name.persistence_globals WHERE key = $1{instance_clause}",
+            instance_clause = if multitenant {
+                " AND instance_name = $2"
+            } else {
+                ""
+            }
+        )
+    )
+}
+
 // Gross: after initialization, the first thing database does is insert metadata
 // documents.
 pub const fn check_newly_created(multitenant: bool) -> &'static str {

--- a/crates/sqlite/src/lib.rs
+++ b/crates/sqlite/src/lib.rs
@@ -217,13 +217,9 @@ ORDER BY B.key {order}
         Ok(triples)
     }
 
-    fn _get_persistence_global(
-        &self,
-        key: PersistenceGlobalKey,
-    ) -> anyhow::Result<Option<JsonValue>> {
+    fn _get_persistence_global_raw(&self, key: &str) -> anyhow::Result<Option<JsonValue>> {
         let connection = &self.inner.lock().connection;
         let mut stmt = connection.prepare(GET_PERSISTENCE_GLOBAL)?;
-        let key = String::from(key);
         let params: Vec<&dyn ToSql> = vec![&key];
         let mut row_iter = stmt.query_map(&params[..], |row| {
             let json_value_str: String = row.get(0)?;
@@ -331,12 +327,29 @@ impl Persistence for SqlitePersistence {
         key: PersistenceGlobalKey,
         value: JsonValue,
     ) -> anyhow::Result<()> {
+        self.write_persistence_global_raw(&String::from(key), value)
+            .await
+    }
+
+    async fn write_persistence_global_raw(
+        &self,
+        key: &str,
+        value: JsonValue,
+    ) -> anyhow::Result<()> {
         let mut inner = self.inner.lock();
         let tx = inner.connection.transaction()?;
         let mut write_query = tx.prepare_cached(WRITE_PERSISTENCE_GLOBAL)?;
         let json_value = serde_json::to_string(&value)?;
-        write_query.execute(params![&String::from(key), &json_value])?;
+        write_query.execute(params![key, &json_value])?;
         drop(write_query);
+        tx.commit()?;
+        Ok(())
+    }
+
+    async fn delete_persistence_global_raw(&self, key: &str) -> anyhow::Result<()> {
+        let mut inner = self.inner.lock();
+        let tx = inner.connection.transaction()?;
+        tx.execute(DELETE_PERSISTENCE_GLOBAL, params![key])?;
         tx.commit()?;
         Ok(())
     }
@@ -579,7 +592,35 @@ impl PersistenceReader for SqlitePersistence {
         &self,
         key: PersistenceGlobalKey,
     ) -> anyhow::Result<Option<JsonValue>> {
-        self._get_persistence_global(key)
+        self.get_persistence_global_raw(&String::from(key)).await
+    }
+
+    async fn get_persistence_global_raw(&self, key: &str) -> anyhow::Result<Option<JsonValue>> {
+        self._get_persistence_global_raw(key)
+    }
+
+    async fn list_persistence_globals_with_prefix(
+        &self,
+        prefix: &str,
+    ) -> anyhow::Result<Vec<(String, JsonValue)>> {
+        let connection = &self.inner.lock().connection;
+        let like_prefix = format!("{prefix}%");
+        let mut stmt = connection.prepare(LIST_PERSISTENCE_GLOBALS_WITH_PREFIX)?;
+        let rows = stmt.query_map(params![like_prefix], |row| {
+            let key: String = row.get(0)?;
+            let json_value_str: String = row.get(1)?;
+            Ok((key, json_value_str))
+        })?;
+        rows.map(|row| {
+            let (key, json_value_str) = row?;
+            let mut json_deserializer = serde_json::Deserializer::from_str(&json_value_str);
+            json_deserializer.disable_recursion_limit();
+            let json_value = JsonValue::deserialize(&mut json_deserializer)
+                .with_context(|| format!("Invalid JSON at persistence key {key:?}"))?;
+            json_deserializer.end()?;
+            Ok((key, json_value))
+        })
+        .collect()
     }
 
     fn version(&self) -> PersistenceVersion {
@@ -686,6 +727,9 @@ fn load_document_row(
 }
 
 const GET_PERSISTENCE_GLOBAL: &str = "SELECT json_value FROM persistence_globals WHERE key = ?";
+const LIST_PERSISTENCE_GLOBALS_WITH_PREFIX: &str =
+    "SELECT key, json_value FROM persistence_globals WHERE key LIKE ? ORDER BY key ASC";
+const DELETE_PERSISTENCE_GLOBAL: &str = "DELETE FROM persistence_globals WHERE key = ?";
 
 const INSERT_DOCUMENT: &str = "INSERT INTO documents (id, ts, table_id, json_value, deleted, \
                                prev_ts) VALUES (?, ?, ?, ?, ?, ?)";


### PR DESCRIPTION
## Summary
- Replace the single Raft-to-NATS outbox JSON blob with ordered per-entry persistence-global records.
- Keep legacy blob replay/cleanup support so existing outbox entries can drain safely.
- Extend persistence backends with raw namespaced global reads/writes/deletes/prefix scans.
- Update NATS-outage tests and add backlog-shape coverage proving large backlogs stay per-entry instead of recreating the aggregate blob.

Fixes #245

## Validation
- `rustfmt --edition 2024 --check crates/common/src/persistence.rs crates/common/src/testing/test_persistence.rs crates/database/src/checkpoint.rs crates/database/src/committer.rs crates/database/src/tests/write_scaling_tests.rs crates/mysql/src/lib.rs crates/mysql/src/sql.rs crates/postgres/src/lib.rs crates/postgres/src/sql.rs crates/sqlite/src/lib.rs`
- `git diff --check`
- `cargo test --target-dir /tmp/convex-target-issue245 -p database raft_nats_outbox -- --nocapture` (7/7)
- `cargo test --target-dir /tmp/convex-target-issue245 -p database records_nats_outbox_when_publish_unavailable -- --nocapture` (2/2)
- `cargo check --target-dir /tmp/convex-target-issue245 -p local_backend`
- Rebuilt backend image: `sha256:aa6521d1c3e83225355dae485c3e4879c0dfd6de829bd6571fa26bc857178a30`
- Proved all six backend containers used that exact local image ID with `BACKEND_PULL_POLICY=never`
- `BACKEND_PULL_POLICY=never bash self-hosted/docker/test.sh`: write-scaling 146/146, Raft failover 24/24, all suites passed
