### PR TITLE
perf(2pc): gate prepare admission behind pending writes

### DIFF
--- a/crates/database/src/committer.rs
+++ b/crates/database/src/committer.rs
@@ -947,7 +947,14 @@ impl<RT: Runtime> Committer<RT> {
         let mut commit_id = 0;
         // Keep track of the commit_id that is currently being traced.
         let mut span_commit_id = None;
+        let mut deferred_prepares = VecDeque::new();
         loop {
+            if self.pending_writes.min_ts().is_none()
+                && let Some(deferred_prepare) = deferred_prepares.pop_front()
+            {
+                self.handle_deferred_prepare(deferred_prepare).await;
+                continue;
+            }
             let bump_fut = if let Some(wait) = &next_bump_wait {
                 Either::Left(
                     self.runtime
@@ -981,6 +988,11 @@ impl<RT: Runtime> Committer<RT> {
                             .saturating_sub(last_raft_nats_outbox_replay.elapsed()),
                     ),
                 )
+            } else {
+                Either::Right(std::future::pending())
+            };
+            let receive_message_fut = if deferred_prepares.is_empty() {
+                Either::Left(rx.recv())
             } else {
                 Either::Right(std::future::pending())
             };
@@ -1492,7 +1504,7 @@ impl<RT: Runtime> Committer<RT> {
                             }
                         }
                 }
-                maybe_message = rx.recv().fuse() => {
+                maybe_message = receive_message_fut.fuse() => {
                     match maybe_message {
                         None => {
                             tracing::info!("All clients have gone away, shutting down committer...");
@@ -1547,8 +1559,19 @@ impl<RT: Runtime> Committer<RT> {
                             }
                         },
                         Some(CommitterMessage::ApplyRaftPreparedRedo { redo, result }) => {
-                            let r = self.handle_raft_prepared_redo(redo);
-                            let _ = result.send(r);
+                            let deferred_prepare = DeferredPrepare::ApplyRaftPreparedRedo {
+                                redo,
+                                result,
+                            };
+                            if let Some(min_pending_ts) = self.pending_writes.min_ts() {
+                                Self::defer_prepare_admission(
+                                    &mut deferred_prepares,
+                                    deferred_prepare,
+                                    min_pending_ts,
+                                );
+                            } else {
+                                self.handle_deferred_prepare(deferred_prepare).await;
+                            }
                         },
                         Some(CommitterMessage::SetRaftState { raft_state, result }) => {
                             tracing::info!(
@@ -1605,10 +1628,21 @@ impl<RT: Runtime> Committer<RT> {
                             write_source,
                             result,
                         }) => {
-                            let r = self
-                                .handle_prepare(transaction_id, transaction, write_source)
-                                .await;
-                            let _ = result.send(r);
+                            let deferred_prepare = DeferredPrepare::Prepare {
+                                transaction_id,
+                                transaction,
+                                write_source,
+                                result,
+                            };
+                            if let Some(min_pending_ts) = self.pending_writes.min_ts() {
+                                Self::defer_prepare_admission(
+                                    &mut deferred_prepares,
+                                    deferred_prepare,
+                                    min_pending_ts,
+                                );
+                            } else {
+                                self.handle_deferred_prepare(deferred_prepare).await;
+                            }
                         },
                         Some(CommitterMessage::PrepareRemote {
                             transaction_id,
@@ -1618,15 +1652,23 @@ impl<RT: Runtime> Committer<RT> {
                             participants,
                             result,
                         }) => {
-                            let r = self.handle_prepare_remote(
+                            let deferred_prepare = DeferredPrepare::PrepareRemote {
                                 transaction_id,
                                 transaction,
                                 write_source,
                                 prepare_ts,
                                 participants,
-                            )
-                            .await;
-                            let _ = result.send(r);
+                                result,
+                            };
+                            if let Some(min_pending_ts) = self.pending_writes.min_ts() {
+                                Self::defer_prepare_admission(
+                                    &mut deferred_prepares,
+                                    deferred_prepare,
+                                    min_pending_ts,
+                                );
+                            } else {
+                                self.handle_deferred_prepare(deferred_prepare).await;
+                            }
                         },
                         Some(CommitterMessage::ValidateRemoteReads {
                             transaction_id,
@@ -4685,6 +4727,60 @@ impl<RT: Runtime> Committer<RT> {
         Ok(result)
     }
 
+    fn defer_prepare_admission(
+        deferred_prepares: &mut VecDeque<DeferredPrepare>,
+        deferred_prepare: DeferredPrepare,
+        min_pending_ts: Timestamp,
+    ) {
+        tracing::debug!(
+            transaction_id = %deferred_prepare.transaction_id(),
+            kind = deferred_prepare.kind(),
+            min_pending_ts = u64::from(min_pending_ts),
+            deferred_prepares = deferred_prepares.len() + 1,
+            "Deferring 2PC prepare admission behind older pending write",
+        );
+        deferred_prepares.push_back(deferred_prepare);
+    }
+
+    async fn handle_deferred_prepare(&mut self, deferred_prepare: DeferredPrepare) {
+        match deferred_prepare {
+            DeferredPrepare::ApplyRaftPreparedRedo { redo, result } => {
+                let r = self.handle_raft_prepared_redo(redo);
+                let _ = result.send(r);
+            },
+            DeferredPrepare::Prepare {
+                transaction_id,
+                transaction,
+                write_source,
+                result,
+            } => {
+                let r = self
+                    .handle_prepare(transaction_id, transaction, write_source)
+                    .await;
+                let _ = result.send(r);
+            },
+            DeferredPrepare::PrepareRemote {
+                transaction_id,
+                transaction,
+                write_source,
+                prepare_ts,
+                participants,
+                result,
+            } => {
+                let r = self
+                    .handle_prepare_remote(
+                        transaction_id,
+                        transaction,
+                        write_source,
+                        prepare_ts,
+                        participants,
+                    )
+                    .await;
+                let _ = result.send(r);
+            },
+        }
+    }
+
     fn handle_validate_remote_reads(
         &mut self,
         transaction_id: crate::two_phase::TwoPhaseTransactionId,
@@ -6208,6 +6304,46 @@ enum CommitterMessage {
         transaction_id: crate::two_phase::TwoPhaseTransactionId,
         result: oneshot::Sender<anyhow::Result<()>>,
     },
+}
+
+enum DeferredPrepare {
+    ApplyRaftPreparedRedo {
+        redo: crate::two_phase::TwoPhaseRedoEntry,
+        result: oneshot::Sender<anyhow::Result<crate::two_phase::PrepareResult>>,
+    },
+    Prepare {
+        transaction_id: crate::two_phase::TwoPhaseTransactionId,
+        transaction: FinalTransaction,
+        write_source: WriteSource,
+        result: oneshot::Sender<anyhow::Result<crate::two_phase::PrepareResult>>,
+    },
+    PrepareRemote {
+        transaction_id: crate::two_phase::TwoPhaseTransactionId,
+        transaction: crate::two_phase::ParticipantTransaction,
+        write_source: WriteSource,
+        prepare_ts: Timestamp,
+        participants: Vec<crate::partition::PartitionId>,
+        result: oneshot::Sender<anyhow::Result<crate::two_phase::PrepareResult>>,
+    },
+}
+
+impl DeferredPrepare {
+    fn transaction_id(&self) -> crate::two_phase::TwoPhaseTransactionId {
+        match self {
+            Self::ApplyRaftPreparedRedo { redo, .. } => redo.transaction_id(),
+            Self::Prepare { transaction_id, .. } | Self::PrepareRemote { transaction_id, .. } => {
+                transaction_id.clone()
+            },
+        }
+    }
+
+    fn kind(&self) -> &'static str {
+        match self {
+            Self::ApplyRaftPreparedRedo { .. } => "raft_prepared_redo",
+            Self::Prepare { .. } => "local_prepare",
+            Self::PrepareRemote { .. } => "remote_prepare",
+        }
+    }
 }
 
 fn is_retryable_system_generated_id_conflict(

--- a/crates/database/src/tests/write_scaling_tests.rs
+++ b/crates/database/src/tests/write_scaling_tests.rs
@@ -2177,71 +2177,58 @@ async fn test_cross_partition_replica_delta_waits_behind_unresolved_prepared_tra
 }
 
 #[convex_macro::test_runtime]
-async fn test_prepare_retries_while_local_commit_is_pending(
+async fn test_prepare_waits_behind_pending_local_commit(
     rt: TestRuntime,
     pause: PauseController,
 ) -> anyhow::Result<()> {
     let log = Arc::new(InMemoryDistributedLog::new());
     let node = create_node(&rt, log, Some(partitioned_map(PartitionId(0)))).await?;
+    insert_doc(&node, "messages", assert_obj!("text" => "seed")).await?;
 
     let hold_guard = pause.hold(AFTER_PENDING_WRITE_SNAPSHOT);
     let node_for_commit = node.clone();
-    let local_commit = async move {
+    let local_commit = tokio::spawn(async move {
         insert_doc(
             &node_for_commit,
             "messages",
             assert_obj!("text" => "pending-local"),
         )
         .await
-    };
+    });
 
     let node_for_prepare = node.clone();
-    let prepare_while_pending = async move {
-        let pause_guard = hold_guard.wait_for_blocked().await;
-
+    let pause_guard = hold_guard.wait_for_blocked().await;
+    let txn_id = TwoPhaseTransactionId::new();
+    let prepare_txn_id = txn_id.clone();
+    let prepare_while_pending = tokio::spawn(async move {
         let mut tx = node_for_prepare.begin(Identity::system()).await?;
         TestFacingModel::new(&mut tx)
             .insert(&"messages".parse()?, assert_obj!("text" => "prepared"))
             .await?;
         let final_tx = tx.finalize()?;
-        let err = node_for_prepare
+        node_for_prepare
             .committer_for_test()
             .prepare(
-                TwoPhaseTransactionId::new(),
+                prepare_txn_id,
                 final_tx,
                 WriteSource::new("prepare_waits_for_pending_commit_test"),
             )
             .await
-            .expect_err("prepare should retry while an older local commit is pending");
-        assert!(
-            format!("{err:#}").contains("blocked by an unresolved pending write"),
-            "unexpected error: {err:#}",
-        );
+    });
 
-        if let Some(guard) = pause_guard {
-            guard.unpause();
-        }
-        anyhow::Ok(())
-    };
+    tokio::time::sleep(Duration::from_millis(50)).await;
+    assert!(
+        !prepare_while_pending.is_finished(),
+        "prepare should wait behind the older pending local commit instead of failing or \
+         bypassing it",
+    );
 
-    futures::try_join!(local_commit, prepare_while_pending)?;
+    if let Some(guard) = pause_guard {
+        guard.unpause();
+    }
 
-    let mut tx = node.begin(Identity::system()).await?;
-    TestFacingModel::new(&mut tx)
-        .insert(
-            &"messages".parse()?,
-            assert_obj!("text" => "prepared-after-publish"),
-        )
-        .await?;
-    let final_tx = tx.finalize()?;
-    let txn_id = TwoPhaseTransactionId::new();
-    node.committer_for_test()
-        .prepare(
-            txn_id.clone(),
-            final_tx,
-            WriteSource::new("prepare_after_pending_commit_test"),
-        )
-        .await?;
+    tokio::time::timeout(Duration::from_secs(1), local_commit).await???;
+    tokio::time::timeout(Duration::from_secs(1), prepare_while_pending).await???;
     node.committer_for_test().rollback_prepared(txn_id).await?;
 
     Ok(())


### PR DESCRIPTION
## Summary
- Add a deferred prepare admission queue so local, remote, and Raft-replayed prepares wait behind older pending writes instead of failing immediately.
- Stop receiving new committer messages while a prepare is waiting behind pending writes, preventing fresh local commits from extending the pending tail forever.
- Update the regression test to prove a prepare waits behind an older pending local commit, then succeeds once that write publishes.

Fixes #246.

## Validation
- `cargo test --target-dir /tmp/convex-target-issue246 -p database test_prepare_waits_behind_pending_local_commit -- --nocapture`
- `cargo test --target-dir /tmp/convex-target-issue246 -p database two_phase -- --nocapture`
- `rustfmt --edition 2024 --check crates/database/src/committer.rs crates/database/src/tests/write_scaling_tests.rs`
- `git diff --check`
- `cargo check --target-dir /tmp/convex-target-issue246 -p local_backend`
- Rebuilt backend image locally: `sha256:6fb1636c46c15ca1a29436d60f77d24b2c62e3bdb8358b10a6915074f8282954`
- Proved all six backend containers used that exact local image with `BACKEND_PULL_POLICY=never`
- `BACKEND_PULL_POLICY=never bash self-hosted/docker/test.sh`: write-scaling 146/146, Raft failover 24/24, all suites passed