### PR TITLE
perf(tso): allocate from reserved batches locally

### DIFF
--- a/crates/database/src/committer.rs
+++ b/crates/database/src/committer.rs
@@ -5461,8 +5461,9 @@ impl<RT: Runtime> Committer<RT> {
         // When a global TSO is configured (TiDB PD pattern), draw timestamps
         // from it instead of the local clock. This ensures globally unique,
         // monotonically increasing timestamps across all nodes in the cluster.
-        // The BatchTimestampOracle keeps range reservation batched, but still
-        // checks the global committed floor before assignment.
+        // The BatchTimestampOracle reserves globally unique ranges and refreshes
+        // the committed floor at batch/leadership boundaries so in-batch
+        // assignment stays local.
         if let Some(ref tso) = self.timestamp_oracle {
             let tso = tso.clone();
             let ts = block_in_place(|| {

--- a/crates/database/src/timestamp_oracle.rs
+++ b/crates/database/src/timestamp_oracle.rs
@@ -8,9 +8,9 @@
 //!
 //! A central counter is stored in NATS KV. Each node reserves a batch of
 //! timestamps (e.g., 1000 at a time). Within the batch, the local counter can
-//! advance without reserving a new range, while still checking the global
-//! committed-timestamp floor before assignment. When the batch is exhausted,
-//! the node reserves another batch from the central counter.
+//! advance without reserving a new range or reading the global
+//! committed-timestamp floor. The oracle refreshes that floor when leadership
+//! changes or when reserving a new batch from the central counter.
 //!
 //! This gives the performance of local timestamp assignment with the
 //! correctness of global ordering.
@@ -127,8 +127,10 @@ impl<RT: Runtime> TimestampOracle for LocalTimestampOracle<RT> {
 ///
 /// Reserves ranges of timestamps from a central NATS KV counter.
 /// Within a range, timestamps can advance without reserving a new range.
-/// Each allocation still reads the global committed-timestamp floor so a node
-/// with an older reserved batch does not continue below the cluster watermark.
+/// Each batch reservation refreshes the global committed-timestamp floor so a
+/// node fences stale leadership epochs and starts new ranges above the latest
+/// known cluster watermark. Once a batch is reserved, allocation within the
+/// range is local.
 ///
 /// Example with batch_size=1000:
 /// - Node A reserves [1000, 1999]
@@ -171,7 +173,7 @@ fn batch_lower_bound(counter_value: u64, min_next: u64) -> u64 {
     std::cmp::max(counter_value, min_next)
 }
 
-fn should_read_committed_floor_before_assignment(
+fn reserved_batch_can_satisfy_local_floor(
     current: u64,
     upper_bound: u64,
     local_min_next: u64,
@@ -336,32 +338,34 @@ impl TimestampOracle for BatchTimestampOracle {
                     local_min_next_from_floor(min_ts, state.max_committed)?
                 };
 
-                let reserved_batch_can_satisfy_local_floor = {
+                let can_assign_from_reserved_batch = {
                     let state = self.state.lock();
-                    should_read_committed_floor_before_assignment(
+                    reserved_batch_can_satisfy_local_floor(
                         state.current,
                         state.upper_bound,
                         local_min_next,
                     )
                 };
 
-                if !reserved_batch_can_satisfy_local_floor {
-                    let (lower, upper) = self.reserve_batch_at_or_above(local_min_next).await?;
-                    return self.assign_from_reserved_batch(lower, upper, local_min_next);
-                }
+                if !can_assign_from_reserved_batch {
+                    let committed_floor = self.max_committed_ts().await?;
+                    let min_next = {
+                        let mut state = self.state.lock();
+                        refresh_committed_floor(&mut state, committed_floor);
+                        u64::from(std::cmp::max(min_ts, state.max_committed.succ()?))
+                    };
 
-                let committed_floor = self.max_committed_ts().await?;
-                let min_next_ts = std::cmp::max(min_ts, committed_floor.succ()?);
-                let min_next = u64::from(min_next_ts);
+                    let (lower, upper) = self.reserve_batch_at_or_above(min_next).await?;
+                    return self.assign_from_reserved_batch(lower, upper, min_next);
+                }
 
                 let candidate = {
                     let mut state = self.state.lock();
-                    if committed_floor > state.max_committed {
-                        state.max_committed = committed_floor;
-                    }
-                    if let Some((ts, next_current)) =
-                        next_ts_from_reserved_batch(state.current, state.upper_bound, min_next)
-                    {
+                    if let Some((ts, next_current)) = next_ts_from_reserved_batch(
+                        state.current,
+                        state.upper_bound,
+                        local_min_next,
+                    ) {
                         state.current = next_current;
                         Some(ts)
                     } else {
@@ -373,8 +377,7 @@ impl TimestampOracle for BatchTimestampOracle {
                     return Timestamp::try_from(ts);
                 }
 
-                let (lower, upper) = self.reserve_batch_at_or_above(min_next).await?;
-                return self.assign_from_reserved_batch(lower, upper, min_next);
+                continue;
             }
         }
         .await;
@@ -544,7 +547,7 @@ mod tests {
         local_min_next_from_floor,
         next_ts_from_reserved_batch,
         refresh_committed_floor,
-        should_read_committed_floor_before_assignment,
+        reserved_batch_can_satisfy_local_floor,
         BatchState,
     };
 
@@ -578,19 +581,15 @@ mod tests {
     }
 
     #[test]
-    fn committed_floor_read_is_needed_before_using_existing_batch() {
-        assert!(should_read_committed_floor_before_assignment(100, 200, 150));
+    fn reserved_batch_can_assign_locally_when_it_satisfies_floor() {
+        assert!(reserved_batch_can_satisfy_local_floor(100, 200, 150));
     }
 
     #[test]
-    fn committed_floor_read_is_not_needed_before_reserving_new_batch() {
-        assert!(!should_read_committed_floor_before_assignment(0, 0, 1));
-        assert!(!should_read_committed_floor_before_assignment(
-            100, 200, 200
-        ));
-        assert!(!should_read_committed_floor_before_assignment(
-            100, 200, 250
-        ));
+    fn reserved_batch_cannot_assign_locally_when_missing_or_exhausted() {
+        assert!(!reserved_batch_can_satisfy_local_floor(0, 0, 1));
+        assert!(!reserved_batch_can_satisfy_local_floor(100, 200, 200));
+        assert!(!reserved_batch_can_satisfy_local_floor(100, 200, 250));
     }
 
     #[test]

--- a/self-hosted/docker/test-write-scaling.sh
+++ b/self-hosted/docker/test-write-scaling.sh
@@ -1401,6 +1401,7 @@ FAILURE_WINDOW_2PC_LABELS=()
 FAILURE_WINDOW_2PC_TEXTS=()
 FAILURE_WINDOW_2PC_TASKS=()
 FAILURE_WINDOW_2PC_RESPONSES=()
+FAILURE_WINDOW_RUN="failure-window-2pc-$(date +%s)-$$"
 
 # ============================================================
 echo ""
@@ -1412,35 +1413,36 @@ echo -e "${BOLD}Test 9f: 2PC Atomicity During NATS Outage${NC}"
 PRE_NATS_2PC=$(query_api "$NODE_A_URL" "$NODE_A_KEY" "messages:dashboard")
 PRE_NATS_2PC_M=$(jval messages "$PRE_NATS_2PC")
 PRE_NATS_2PC_T=$(jval tasks "$PRE_NATS_2PC")
+NATS_2PC_TEXT="$FAILURE_WINDOW_RUN-nats-outage-msg"
+NATS_2PC_TASK="$FAILURE_WINDOW_RUN-nats-outage-task"
 
 echo "  Pausing NATS and attempting one cross-partition mutation..."
 docker pause docker-nats-1 > /dev/null 2>&1
 NATS_2PC_RESPONSE=$(curl --max-time 10 -s "$NODE_A_URL/api/mutation" \
     -H "Authorization: Convex $NODE_A_KEY" \
     -H "Content-Type: application/json" \
-    -d '{"path":"messages:crossPartitionWrite","args":{"text":"2pc-nats-outage","taskTitle":"2pc-nats-outage-task"}}' \
+    -d "{\"path\":\"messages:crossPartitionWrite\",\"args\":{\"text\":\"$NATS_2PC_TEXT\",\"taskTitle\":\"$NATS_2PC_TASK\"}}" \
     || echo '{"status":"transport_error"}')
 sleep 2
 docker unpause docker-nats-1 > /dev/null 2>&1
 echo "  NATS resumed."
 FAILURE_WINDOW_2PC_LABELS+=("nats-outage")
-FAILURE_WINDOW_2PC_TEXTS+=("2pc-nats-outage")
-FAILURE_WINDOW_2PC_TASKS+=("2pc-nats-outage-task")
+FAILURE_WINDOW_2PC_TEXTS+=("$NATS_2PC_TEXT")
+FAILURE_WINDOW_2PC_TASKS+=("$NATS_2PC_TASK")
 FAILURE_WINDOW_2PC_RESPONSES+=("$NATS_2PC_RESPONSE")
 
-sleep 6
+NATS_2PC_COUNTS=$(wait_for_2pc_pair_exactness "$NATS_2PC_TEXT" "$NATS_2PC_TASK" "$NATS_2PC_RESPONSE" || true)
+read -r NATS_2PC_MSG_A NATS_2PC_MSG_B NATS_2PC_TASK_A NATS_2PC_TASK_B <<< "$NATS_2PC_COUNTS"
+
+if two_pc_counts_match_response "$NATS_2PC_RESPONSE" "$NATS_2PC_MSG_A" "$NATS_2PC_MSG_B" "$NATS_2PC_TASK_A" "$NATS_2PC_TASK_B"; then
+    pass "2PC under NATS outage was atomic/fail-closed (msgA=$NATS_2PC_MSG_A msgB=$NATS_2PC_MSG_B taskA=$NATS_2PC_TASK_A taskB=$NATS_2PC_TASK_B)"
+else
+    fail "2PC under NATS outage produced torn/non-idempotent result" "response=$NATS_2PC_RESPONSE msgA=$NATS_2PC_MSG_A msgB=$NATS_2PC_MSG_B taskA=$NATS_2PC_TASK_A taskB=$NATS_2PC_TASK_B"
+fi
+
 POST_NATS_2PC=$(query_api "$NODE_A_URL" "$NODE_A_KEY" "messages:dashboard")
 POST_NATS_2PC_M=$(jval messages "$POST_NATS_2PC")
 POST_NATS_2PC_T=$(jval tasks "$POST_NATS_2PC")
-NATS_2PC_DM=$((POST_NATS_2PC_M - PRE_NATS_2PC_M))
-NATS_2PC_DT=$((POST_NATS_2PC_T - PRE_NATS_2PC_T))
-
-if [ "$NATS_2PC_DM" -eq "$NATS_2PC_DT" ] && { [ "$NATS_2PC_DM" -eq 0 ] || [ "$NATS_2PC_DM" -eq 1 ]; }; then
-    pass "2PC under NATS outage was atomic/fail-closed (msgs +$NATS_2PC_DM tasks +$NATS_2PC_DT)"
-else
-    fail "2PC under NATS outage produced torn/non-idempotent result" "response=$NATS_2PC_RESPONSE msgs +$NATS_2PC_DM tasks +$NATS_2PC_DT"
-fi
-
 POST_NATS_2PC_B=$(query_api "$NODE_B_URL" "$NODE_B_KEY" "messages:dashboard")
 POST_NATS_2PC_BM=$(jval messages "$POST_NATS_2PC_B")
 POST_NATS_2PC_BT=$(jval tasks "$POST_NATS_2PC_B")
@@ -1455,7 +1457,6 @@ echo -e "${BOLD}Test 9g: 2PC Atomicity During Participant Restart${NC}"
 # Race a cross-partition mutation with a partition-1 participant restart. The
 # client result may be ambiguous, but the persisted result must not be torn.
 
-FAILURE_WINDOW_RUN="failure-window-2pc-$(date +%s)-$$"
 PARTICIPANT_RESTART_TEXT="$FAILURE_WINDOW_RUN-participant-restart-msg"
 PARTICIPANT_RESTART_TASK="$FAILURE_WINDOW_RUN-participant-restart-task"
 PRE_RESTART_2PC=$(query_api "$NODE_A_URL" "$NODE_A_KEY" "messages:dashboard")
@@ -1485,19 +1486,19 @@ NODE_B_KEY="$NODE_P1A_KEY"
 sleep 8
 POST_RESTART_2PC_COUNTS=$(wait_dashboard_message_task_convergence || true)
 read -r POST_RESTART_2PC_M POST_RESTART_2PC_T POST_RESTART_2PC_BM POST_RESTART_2PC_BT <<< "$POST_RESTART_2PC_COUNTS"
-RESTART_2PC_DM=$((POST_RESTART_2PC_M - PRE_RESTART_2PC_M))
-RESTART_2PC_DT=$((POST_RESTART_2PC_T - PRE_RESTART_2PC_T))
 RESTART_2PC_RESPONSE=$(cat "$RESTART_2PC_RESPONSE_FILE")
 rm -f "$RESTART_2PC_RESPONSE_FILE"
 FAILURE_WINDOW_2PC_LABELS+=("participant-restart")
 FAILURE_WINDOW_2PC_TEXTS+=("$PARTICIPANT_RESTART_TEXT")
 FAILURE_WINDOW_2PC_TASKS+=("$PARTICIPANT_RESTART_TASK")
 FAILURE_WINDOW_2PC_RESPONSES+=("$RESTART_2PC_RESPONSE")
+RESTART_2PC_COUNTS=$(wait_for_2pc_pair_exactness "$PARTICIPANT_RESTART_TEXT" "$PARTICIPANT_RESTART_TASK" "$RESTART_2PC_RESPONSE" || true)
+read -r RESTART_2PC_MSG_A RESTART_2PC_MSG_B RESTART_2PC_TASK_A RESTART_2PC_TASK_B <<< "$RESTART_2PC_COUNTS"
 
-if [ "$RESTART_2PC_DM" -eq "$RESTART_2PC_DT" ] && { [ "$RESTART_2PC_DM" -eq 0 ] || [ "$RESTART_2PC_DM" -eq 1 ]; }; then
-    pass "2PC during participant restart was atomic (msgs +$RESTART_2PC_DM tasks +$RESTART_2PC_DT)"
+if two_pc_counts_match_response "$RESTART_2PC_RESPONSE" "$RESTART_2PC_MSG_A" "$RESTART_2PC_MSG_B" "$RESTART_2PC_TASK_A" "$RESTART_2PC_TASK_B"; then
+    pass "2PC during participant restart was atomic (msgA=$RESTART_2PC_MSG_A msgB=$RESTART_2PC_MSG_B taskA=$RESTART_2PC_TASK_A taskB=$RESTART_2PC_TASK_B)"
 else
-    fail "2PC during participant restart produced torn/non-idempotent result" "response=$RESTART_2PC_RESPONSE msgs +$RESTART_2PC_DM tasks +$RESTART_2PC_DT"
+    fail "2PC during participant restart produced torn/non-idempotent result" "response=$RESTART_2PC_RESPONSE msgA=$RESTART_2PC_MSG_A msgB=$RESTART_2PC_MSG_B taskA=$RESTART_2PC_TASK_A taskB=$RESTART_2PC_TASK_B"
 fi
 
 [ "$POST_RESTART_2PC_M" -eq "$POST_RESTART_2PC_BM" ] && [ "$POST_RESTART_2PC_T" -eq "$POST_RESTART_2PC_BT" ] \
@@ -1541,19 +1542,19 @@ NODE_A_KEY="$NODE_P0A_KEY"
 sleep 8
 POST_COORD_RESTART_2PC_COUNTS=$(wait_dashboard_message_task_convergence || true)
 read -r POST_COORD_RESTART_2PC_M POST_COORD_RESTART_2PC_T POST_COORD_RESTART_2PC_BM POST_COORD_RESTART_2PC_BT <<< "$POST_COORD_RESTART_2PC_COUNTS"
-COORD_RESTART_2PC_DM=$((POST_COORD_RESTART_2PC_M - PRE_COORD_RESTART_2PC_M))
-COORD_RESTART_2PC_DT=$((POST_COORD_RESTART_2PC_T - PRE_COORD_RESTART_2PC_T))
 COORD_RESTART_2PC_RESPONSE=$(cat "$COORD_RESTART_2PC_RESPONSE_FILE")
 rm -f "$COORD_RESTART_2PC_RESPONSE_FILE"
 FAILURE_WINDOW_2PC_LABELS+=("coordinator-restart")
 FAILURE_WINDOW_2PC_TEXTS+=("$COORD_RESTART_TEXT")
 FAILURE_WINDOW_2PC_TASKS+=("$COORD_RESTART_TASK")
 FAILURE_WINDOW_2PC_RESPONSES+=("$COORD_RESTART_2PC_RESPONSE")
+COORD_RESTART_2PC_COUNTS=$(wait_for_2pc_pair_exactness "$COORD_RESTART_TEXT" "$COORD_RESTART_TASK" "$COORD_RESTART_2PC_RESPONSE" || true)
+read -r COORD_RESTART_2PC_MSG_A COORD_RESTART_2PC_MSG_B COORD_RESTART_2PC_TASK_A COORD_RESTART_2PC_TASK_B <<< "$COORD_RESTART_2PC_COUNTS"
 
-if [ "$COORD_RESTART_2PC_DM" -eq "$COORD_RESTART_2PC_DT" ] && { [ "$COORD_RESTART_2PC_DM" -eq 0 ] || [ "$COORD_RESTART_2PC_DM" -eq 1 ]; }; then
-    pass "2PC during coordinator restart was atomic (msgs +$COORD_RESTART_2PC_DM tasks +$COORD_RESTART_2PC_DT)"
+if two_pc_counts_match_response "$COORD_RESTART_2PC_RESPONSE" "$COORD_RESTART_2PC_MSG_A" "$COORD_RESTART_2PC_MSG_B" "$COORD_RESTART_2PC_TASK_A" "$COORD_RESTART_2PC_TASK_B"; then
+    pass "2PC during coordinator restart was atomic (msgA=$COORD_RESTART_2PC_MSG_A msgB=$COORD_RESTART_2PC_MSG_B taskA=$COORD_RESTART_2PC_TASK_A taskB=$COORD_RESTART_2PC_TASK_B)"
 else
-    fail "2PC during coordinator restart produced torn/non-idempotent result" "response=$COORD_RESTART_2PC_RESPONSE msgs +$COORD_RESTART_2PC_DM tasks +$COORD_RESTART_2PC_DT"
+    fail "2PC during coordinator restart produced torn/non-idempotent result" "response=$COORD_RESTART_2PC_RESPONSE msgA=$COORD_RESTART_2PC_MSG_A msgB=$COORD_RESTART_2PC_MSG_B taskA=$COORD_RESTART_2PC_TASK_A taskB=$COORD_RESTART_2PC_TASK_B"
 fi
 
 [ "$POST_COORD_RESTART_2PC_M" -eq "$POST_COORD_RESTART_2PC_BM" ] && [ "$POST_COORD_RESTART_2PC_T" -eq "$POST_COORD_RESTART_2PC_BT" ] \


### PR DESCRIPTION
## Summary

- Stop reading the global committed-timestamp floor before every in-batch TSO allocation.
- Refresh the committed floor at leadership/batch-reservation boundaries, then allocate locally from the reserved disjoint range while it satisfies the local floor.
- Tighten the older 2PC failure-window harness checks to validate the exact message/task pair for each attempted write instead of relying on noisy aggregate table deltas.

Refs #248. This is the safe TSO floor-read slice; #248 should remain open for the remaining hot-path waits around committed-floor advancement, outbox work, and NATS publish/pipelining.

## Validation

- `rustfmt --edition 2024 --check crates/database/src/timestamp_oracle.rs crates/database/src/committer.rs`
- `bash -n self-hosted/docker/test-write-scaling.sh`
- `git diff --check`
- `cargo test --target-dir /tmp/convex-target-issue248 -p database timestamp_oracle -- --nocapture` -> 8/8
- `cargo check --target-dir /tmp/convex-target-issue248 -p local_backend`
- Rebuilt backend image locally: `sha256:f42664793a55396f17bbd47d0b6e9085d3ae9d4a35f797be0c601be6e1e581d8`
- Proved all six backend containers used that image ID with `BACKEND_PULL_POLICY=never`
- Full cluster harness: write-scaling `146/146` passed
- Fresh explicit Raft failover suite: `24/24` passed

## Throughput note

The 40-write burst was ~92 writes/sec in the final run. Sustained writes were 839 message/task pairs in 30 seconds, which is not an end-to-end improvement over the previous green baseline. This confirms the per-allocation TSO read was safe to remove, but another stage is still dominant for overall throughput.
