### PR TITLE
fix(replication): dedupe redeliveries by transport id

### DIFF
--- a/crates/common/src/persistence.rs
+++ b/crates/common/src/persistence.rs
@@ -173,9 +173,9 @@ pub enum PersistenceGlobalKey {
     /// transport lag/diagnostics, not exact redelivery idempotency.
     AppliedDataDeltaWatermarks,
 
-    /// Exact set of non-empty data delta origin timestamps durably applied per
-    /// source partition. This is separate from the max watermark because
-    /// Raft->NATS outbox recovery can replay older deltas after newer ones.
+    /// Exact non-empty data delta identities durably applied. This stores
+    /// origin timestamps for logical duplicate fanout plus ordered transport
+    /// stream sequences for compact redelivery detection.
     AppliedDataDeltaIds,
 
     /// Latest snapshot of all tables' summaries, cached to speed up startup.

--- a/crates/database/src/commit_delta.rs
+++ b/crates/database/src/commit_delta.rs
@@ -49,7 +49,8 @@ pub struct CommitDelta {
     ///
     /// Receivers may translate this into a later local apply timestamp for
     /// their own MVCC/write-log state, but this value remains the origin
-    /// timestamp used for source-partition watermarks and redelivery dedup.
+    /// timestamp used for source-partition freshness watermarks. Exact
+    /// redelivery idempotency uses [`ReplicationTransportId`] instead.
     pub ts: Timestamp,
 
     /// Document writes for persistence replay. Contains document ID, new value,
@@ -117,23 +118,79 @@ impl Error for RetryableReplicaApplyError {}
 
 pub struct ReplicationMessage {
     pub delta: CommitDelta,
+    transport_id: Option<ReplicationTransportId>,
     ack: Box<dyn ReplicationAck>,
+}
+
+/// Durable identity for one transport delivery of a replication message.
+///
+/// This is intentionally separate from [`CommitDelta::ts`]. The origin commit
+/// timestamp is a visibility/freshness watermark. A transport id is the thing
+/// that lets a replica distinguish a redelivered old JetStream message from a
+/// first-time late replay of an older origin timestamp.
+#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
+pub struct ReplicationTransportId {
+    stream_sequence: u64,
+}
+
+impl ReplicationTransportId {
+    pub fn new(stream_sequence: u64) -> Self {
+        Self { stream_sequence }
+    }
+
+    pub fn stream_sequence(self) -> u64 {
+        self.stream_sequence
+    }
 }
 
 impl ReplicationMessage {
     pub fn new(delta: CommitDelta, ack: Box<dyn ReplicationAck>) -> Self {
-        Self { delta, ack }
+        Self {
+            delta,
+            transport_id: None,
+            ack,
+        }
+    }
+
+    pub fn new_with_transport_id(
+        delta: CommitDelta,
+        transport_id: ReplicationTransportId,
+        ack: Box<dyn ReplicationAck>,
+    ) -> Self {
+        Self {
+            delta,
+            transport_id: Some(transport_id),
+            ack,
+        }
     }
 
     pub fn noop_ack(delta: CommitDelta) -> Self {
         Self {
             delta,
+            transport_id: None,
             ack: Box::new(NoopReplicationAck),
         }
     }
 
-    pub fn into_parts(self) -> (CommitDelta, Box<dyn ReplicationAck>) {
-        (self.delta, self.ack)
+    pub fn noop_ack_with_transport_id(
+        delta: CommitDelta,
+        transport_id: ReplicationTransportId,
+    ) -> Self {
+        Self {
+            delta,
+            transport_id: Some(transport_id),
+            ack: Box::new(NoopReplicationAck),
+        }
+    }
+
+    pub fn into_parts(
+        self,
+    ) -> (
+        CommitDelta,
+        Option<ReplicationTransportId>,
+        Box<dyn ReplicationAck>,
+    ) {
+        (self.delta, self.transport_id, self.ack)
     }
 }
 

--- a/crates/database/src/committer.rs
+++ b/crates/database/src/committer.rs
@@ -145,6 +145,7 @@ use crate::{
     commit_delta::{
         CommitDelta,
         DistributedLog,
+        ReplicationTransportId,
         RetryableReplicaApplyError,
     },
     database::{
@@ -201,7 +202,81 @@ const RAFT_NATS_OUTBOX_REPLAY_INTERVAL: Duration = Duration::from_secs(1);
 const RAFT_NATS_OUTBOX_KEY_PREFIX: &str = "raft_nats_outbox/";
 
 type LegacyRaftNatsOutboxRecords = BTreeMap<String, serde_json::Value>;
-pub(crate) type AppliedDataDeltaIds = BTreeMap<crate::partition::PartitionId, BTreeSet<Timestamp>>;
+
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub(crate) struct OrderedDedupeState {
+    compacted_watermark: u64,
+    exact_ids: BTreeSet<u64>,
+}
+
+impl OrderedDedupeState {
+    fn contains(&self, id: u64) -> bool {
+        id <= self.compacted_watermark || self.exact_ids.contains(&id)
+    }
+
+    fn insert(&mut self, id: u64) {
+        if id <= self.compacted_watermark {
+            return;
+        }
+        self.exact_ids.insert(id);
+        while self
+            .exact_ids
+            .remove(&self.compacted_watermark.saturating_add(1))
+        {
+            self.compacted_watermark = self.compacted_watermark.saturating_add(1);
+        }
+    }
+
+    fn merge(&mut self, proposed: OrderedDedupeState) {
+        if proposed.compacted_watermark > self.compacted_watermark {
+            self.exact_ids
+                .retain(|id| *id > proposed.compacted_watermark);
+            self.compacted_watermark = proposed.compacted_watermark;
+        }
+        for id in proposed.exact_ids {
+            self.insert(id);
+        }
+    }
+}
+
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub(crate) struct AppliedDataDeltaIds {
+    origin_timestamps: BTreeMap<crate::partition::PartitionId, BTreeSet<Timestamp>>,
+    transport_stream_sequences: OrderedDedupeState,
+}
+
+impl AppliedDataDeltaIds {
+    fn contains_origin_timestamp(
+        &self,
+        source_partition: crate::partition::PartitionId,
+        ts: Timestamp,
+    ) -> bool {
+        self.origin_timestamps
+            .get(&source_partition)
+            .is_some_and(|timestamps| timestamps.contains(&ts))
+    }
+
+    fn insert_origin_timestamp(
+        &mut self,
+        source_partition: crate::partition::PartitionId,
+        ts: Timestamp,
+    ) {
+        self.origin_timestamps
+            .entry(source_partition)
+            .or_default()
+            .insert(ts);
+    }
+
+    fn contains_transport_id(&self, transport_id: ReplicationTransportId) -> bool {
+        self.transport_stream_sequences
+            .contains(transport_id.stream_sequence())
+    }
+
+    fn insert_transport_id(&mut self, transport_id: ReplicationTransportId) {
+        self.transport_stream_sequences
+            .insert(transport_id.stream_sequence());
+    }
+}
 
 #[derive(Debug)]
 struct RaftNatsOutboxRecord {
@@ -400,16 +475,23 @@ fn merge_applied_data_delta_ids(
     proposed: AppliedDataDeltaIds,
 ) -> AppliedDataDeltaIds {
     let mut merged = current.clone();
-    for (partition, timestamps) in proposed {
-        merged.entry(partition).or_default().extend(timestamps);
+    for (partition, timestamps) in proposed.origin_timestamps {
+        merged
+            .origin_timestamps
+            .entry(partition)
+            .or_default()
+            .extend(timestamps);
     }
+    merged
+        .transport_stream_sequences
+        .merge(proposed.transport_stream_sequences);
     merged
 }
 
 fn applied_data_delta_ids_to_json(ids: &AppliedDataDeltaIds) -> serde_json::Value {
-    let mut object = serde_json::Map::new();
-    for (partition, timestamps) in ids {
-        object.insert(
+    let mut origin_timestamps = serde_json::Map::new();
+    for (partition, timestamps) in &ids.origin_timestamps {
+        origin_timestamps.insert(
             partition.0.to_string(),
             serde_json::Value::Array(
                 timestamps
@@ -419,7 +501,18 @@ fn applied_data_delta_ids_to_json(ids: &AppliedDataDeltaIds) -> serde_json::Valu
             ),
         );
     }
-    serde_json::Value::Object(object)
+    serde_json::json!({
+        "origin_timestamps": origin_timestamps,
+        "transport_stream_sequences": {
+            "compacted_watermark": ids.transport_stream_sequences.compacted_watermark,
+            "exact_ids": ids.transport_stream_sequences
+                .exact_ids
+                .iter()
+                .copied()
+                .map(serde_json::Value::from)
+                .collect::<Vec<_>>(),
+        },
+    })
 }
 
 pub(crate) fn applied_data_delta_ids_from_json(
@@ -428,8 +521,15 @@ pub(crate) fn applied_data_delta_ids_from_json(
     let object = value
         .as_object()
         .context("applied data delta ids should be an object")?;
-    let mut ids = AppliedDataDeltaIds::new();
-    for (partition, timestamps) in object {
+    let origin_value = object.get("origin_timestamps").unwrap_or(&value);
+    let origin_object = origin_value
+        .as_object()
+        .context("applied data delta origin timestamps should be an object")?;
+    let mut ids = AppliedDataDeltaIds::default();
+    for (partition, timestamps) in origin_object {
+        if partition == "transport_stream_sequences" {
+            continue;
+        }
         let partition_id = partition
             .parse::<u32>()
             .with_context(|| format!("invalid applied data delta ids partition {partition:?}"))?;
@@ -444,7 +544,31 @@ pub(crate) fn applied_data_delta_ids_from_json(
                 Timestamp::try_from(ts)
             })
             .collect::<anyhow::Result<BTreeSet<_>>>()?;
-        ids.insert(crate::partition::PartitionId(partition_id), timestamps);
+        ids.origin_timestamps
+            .insert(crate::partition::PartitionId(partition_id), timestamps);
+    }
+    if let Some(transport_value) = object.get("transport_stream_sequences") {
+        let transport_object = transport_value
+            .as_object()
+            .context("applied data transport ids should be an object")?;
+        ids.transport_stream_sequences.compacted_watermark = transport_object
+            .get("compacted_watermark")
+            .and_then(serde_json::Value::as_u64)
+            .unwrap_or_default();
+        ids.transport_stream_sequences.exact_ids = transport_object
+            .get("exact_ids")
+            .and_then(serde_json::Value::as_array)
+            .into_iter()
+            .flatten()
+            .map(|value| {
+                value
+                    .as_u64()
+                    .context("applied data transport id should be a u64")
+            })
+            .collect::<anyhow::Result<BTreeSet<_>>>()?;
+        ids.transport_stream_sequences
+            .exact_ids
+            .retain(|id| *id > ids.transport_stream_sequences.compacted_watermark);
     }
     Ok(ids)
 }
@@ -1548,11 +1672,16 @@ impl<RT: Runtime> Committer<RT> {
                         Some(CommitterMessage::ApplyReplicaDelta {
                             delta,
                             mode,
+                            transport_id,
                             result,
                         }) => {
-                            if let Err(e) =
-                                self.apply_replica_delta(delta, mode, result, commit_id)
-                            {
+                            if let Err(e) = self.apply_replica_delta(
+                                delta,
+                                mode,
+                                transport_id,
+                                result,
+                                commit_id,
+                            ) {
                                 tracing::error!("Failed to queue replica delta for apply: {e:#}");
                             } else {
                                 commit_id += 1;
@@ -3421,6 +3550,7 @@ impl<RT: Runtime> Committer<RT> {
         &mut self,
         delta: CommitDelta,
         mode: ReplicaDeltaApplyMode,
+        transport_id: Option<ReplicationTransportId>,
         result: oneshot::Sender<anyhow::Result<Timestamp>>,
         commit_id: usize,
     ) -> anyhow::Result<()> {
@@ -3706,17 +3836,25 @@ impl<RT: Runtime> Committer<RT> {
             return Ok(());
         }
 
-        if let Some(source_partition) = delta.source_partition
-            && local_prepared_commit_ts.is_none()
-            && self
-                .applied_data_delta_ids
-                .get(&source_partition)
-                .is_some_and(|timestamps| timestamps.contains(&remote_ts))
+        let duplicate_transport_delivery = transport_id.is_some_and(|transport_id| {
+            self.applied_data_delta_ids
+                .contains_transport_id(transport_id)
+        });
+        let duplicate_origin_delta = delta.source_partition.is_some_and(|source_partition| {
+            self.applied_data_delta_ids
+                .contains_origin_timestamp(source_partition, remote_ts)
+        });
+        if local_prepared_commit_ts.is_none()
+            && (duplicate_transport_delivery || duplicate_origin_delta)
         {
             tracing::info!(
-                "Skipping duplicate non-empty replica delta: source_partition={}, remote_ts={}",
-                source_partition.0,
+                "Skipping duplicate non-empty replica delta: source_partition={:?}, remote_ts={}, \
+                 transport_stream_sequence={:?}, duplicate_transport={}, duplicate_origin={}",
+                delta.source_partition.map(|partition| partition.0),
                 u64::from(remote_ts),
+                transport_id.map(ReplicationTransportId::stream_sequence),
+                duplicate_transport_delivery,
+                duplicate_origin_delta,
             );
             let _ = result.send(Ok(remote_ts));
             return Ok(());
@@ -3958,11 +4096,17 @@ impl<RT: Runtime> Committer<RT> {
                 }
                 frontiers
             });
-        let updated_applied_data_delta_ids = delta.source_partition.map(|source_partition| {
-            let mut ids = self.applied_data_delta_ids.clone();
-            ids.entry(source_partition).or_default().insert(remote_ts);
-            ids
-        });
+        let updated_applied_data_delta_ids =
+            (delta.source_partition.is_some() || transport_id.is_some()).then(|| {
+                let mut ids = self.applied_data_delta_ids.clone();
+                if let Some(source_partition) = delta.source_partition {
+                    ids.insert_origin_timestamp(source_partition, remote_ts);
+                }
+                if let Some(transport_id) = transport_id {
+                    ids.insert_transport_id(transport_id);
+                }
+                ids
+            });
         if let Some(source_partition) = delta.source_partition {
             if self
                 .applied_delta_watermarks
@@ -3981,9 +4125,11 @@ impl<RT: Runtime> Committer<RT> {
                     .insert(source_partition, remote_ts);
             }
             self.applied_data_delta_ids
-                .entry(source_partition)
-                .or_default()
-                .insert(remote_ts);
+                .insert_origin_timestamp(source_partition, remote_ts);
+        }
+        if let Some(transport_id) = transport_id {
+            self.applied_data_delta_ids
+                .insert_transport_id(transport_id);
         }
         let raft_nats_outbox_delta = (mode == ReplicaDeltaApplyMode::FullRaftState
             && delta.source_partition.is_some())
@@ -5608,8 +5754,21 @@ impl CommitterClient {
     /// node-local system tables that are not part of cross-partition read
     /// replication.
     pub async fn apply_replica_delta(&self, delta: CommitDelta) -> anyhow::Result<Timestamp> {
-        self.apply_delta_with_mode(delta, ReplicaDeltaApplyMode::CrossPartitionReplica)
+        self.apply_delta_with_mode(delta, ReplicaDeltaApplyMode::CrossPartitionReplica, None)
             .await
+    }
+
+    pub async fn apply_replica_delta_with_transport_id(
+        &self,
+        delta: CommitDelta,
+        transport_id: ReplicationTransportId,
+    ) -> anyhow::Result<Timestamp> {
+        self.apply_delta_with_mode(
+            delta,
+            ReplicaDeltaApplyMode::CrossPartitionReplica,
+            Some(transport_id),
+        )
+        .await
     }
 
     /// Apply a same-partition Raft commit delta through the Committer's apply
@@ -5617,7 +5776,7 @@ impl CommitterClient {
     /// copies that can become leader, so this path applies full partition
     /// state including system tables.
     pub async fn apply_raft_commit_delta(&self, delta: CommitDelta) -> anyhow::Result<Timestamp> {
-        self.apply_delta_with_mode(delta, ReplicaDeltaApplyMode::FullRaftState)
+        self.apply_delta_with_mode(delta, ReplicaDeltaApplyMode::FullRaftState, None)
             .await
     }
 
@@ -5625,11 +5784,13 @@ impl CommitterClient {
         &self,
         delta: CommitDelta,
         mode: ReplicaDeltaApplyMode,
+        transport_id: Option<ReplicationTransportId>,
     ) -> anyhow::Result<Timestamp> {
         let (tx, rx) = oneshot::channel();
         let message = CommitterMessage::ApplyReplicaDelta {
             delta,
             mode,
+            transport_id,
             result: tx,
         };
         self.sender.try_send(message).map_err(|e| match e {
@@ -6236,6 +6397,7 @@ enum CommitterMessage {
     ApplyReplicaDelta {
         delta: CommitDelta,
         mode: ReplicaDeltaApplyMode,
+        transport_id: Option<ReplicationTransportId>,
         result: oneshot::Sender<anyhow::Result<Timestamp>>,
     },
     ApplyRaftPreparedRedo {

--- a/crates/database/src/database.rs
+++ b/crates/database/src/database.rs
@@ -1076,7 +1076,7 @@ impl<RT: Runtime> Database<RT> {
             .await?
         {
             Some(value) => crate::committer::applied_data_delta_ids_from_json(value)?,
-            None => BTreeMap::new(),
+            None => crate::committer::AppliedDataDeltaIds::default(),
         };
 
         let snapshot_manager = SnapshotManager::new(

--- a/crates/database/src/nats_distributed_log.rs
+++ b/crates/database/src/nats_distributed_log.rs
@@ -40,6 +40,7 @@ use crate::{
         DistributedLog,
         ReplicationAck,
         ReplicationMessage,
+        ReplicationTransportId,
     },
     metrics,
     partition::PartitionId,
@@ -218,7 +219,7 @@ impl NatsDistributedLog {
                             "consume",
                             msg.payload.len(),
                         );
-                        match msg.info() {
+                        let transport_id = match msg.info() {
                             Ok(info) => {
                                 metrics::log_replication_transport_pending_messages(info.pending);
                                 metrics::log_replication_transport_stream_sequence(
@@ -238,11 +239,13 @@ impl NatsDistributedLog {
                                         (now_ns - published_ns) as f64 / 1_000_000_000.0,
                                     );
                                 }
+                                Some(ReplicationTransportId::new(info.stream_sequence))
                             },
                             Err(e) => {
                                 tracing::debug!("Failed to parse JetStream message info: {e}");
+                                None
                             },
-                        }
+                        };
                         let envelope: DeltaEnvelope = match serde_json::from_slice(&msg.payload) {
                             Ok(e) => e,
                             Err(e) => {
@@ -296,10 +299,13 @@ impl NatsDistributedLog {
                                 return Some(Err(e));
                             },
                         };
-                        Some(Ok(ReplicationMessage::new(
-                            delta,
-                            Box::new(NatsReplicationAck { msg }),
-                        )))
+                        let ack = Box::new(NatsReplicationAck { msg });
+                        Some(Ok(match transport_id {
+                            Some(transport_id) => {
+                                ReplicationMessage::new_with_transport_id(delta, transport_id, ack)
+                            },
+                            None => ReplicationMessage::new(delta, ack),
+                        }))
                     },
                     Err(e) => {
                         tracing::error!("NATS message error: {e}");

--- a/crates/database/src/replica.rs
+++ b/crates/database/src/replica.rs
@@ -25,6 +25,7 @@ use crate::{
         CommitDelta,
         DistributedLog,
         ReplicationMessage,
+        ReplicationTransportId,
         RetryableReplicaApplyError,
     },
     committer::CommitterClient,
@@ -37,9 +38,18 @@ pub async fn apply_replication_message(
     message: ReplicationMessage,
 ) -> anyhow::Result<(common::types::Timestamp, usize)> {
     let committer = committer.clone();
-    apply_replication_message_with(message, move |delta| {
+    apply_replication_message_with(message, move |delta, transport_id| {
         let committer = committer.clone();
-        async move { committer.apply_replica_delta(delta).await }
+        async move {
+            match transport_id {
+                Some(transport_id) => {
+                    committer
+                        .apply_replica_delta_with_transport_id(delta, transport_id)
+                        .await
+                },
+                None => committer.apply_replica_delta(delta).await,
+            }
+        }
     })
     .await
 }
@@ -93,15 +103,15 @@ async fn apply_replication_message_with<F, Fut>(
     mut apply: F,
 ) -> anyhow::Result<(common::types::Timestamp, usize)>
 where
-    F: FnMut(CommitDelta) -> Fut,
+    F: FnMut(CommitDelta, Option<ReplicationTransportId>) -> Fut,
     Fut: std::future::Future<Output = anyhow::Result<common::types::Timestamp>>,
 {
-    let (delta, ack) = message.into_parts();
+    let (delta, transport_id, ack) = message.into_parts();
     let ts = delta.ts;
     let num_updates = delta.document_updates.len();
 
     loop {
-        match apply(delta.clone()).await {
+        match apply(delta.clone(), transport_id).await {
             Ok(applied_ts) => {
                 ack.ack().await.with_context(|| {
                     format!(
@@ -304,11 +314,11 @@ mod tests {
     async fn apply_replication_message_acks_after_success() -> anyhow::Result<()> {
         let counts = Arc::new(AckCounts::default());
         let ts = Timestamp::try_from(42u64)?;
-        let (applied_ts, num_updates) =
-            apply_replication_message_with(test_message(ts, counts.clone()), |delta| async move {
-                Ok(delta.ts)
-            })
-            .await?;
+        let (applied_ts, num_updates) = apply_replication_message_with(
+            test_message(ts, counts.clone()),
+            |delta, _transport_id| async move { Ok(delta.ts) },
+        )
+        .await?;
 
         assert_eq!(applied_ts, ts);
         assert_eq!(num_updates, 0);
@@ -323,12 +333,12 @@ mod tests {
     async fn apply_replication_message_naks_after_apply_failure() -> anyhow::Result<()> {
         let counts = Arc::new(AckCounts::default());
         let ts = Timestamp::try_from(42u64)?;
-        let err =
-            apply_replication_message_with(test_message(ts, counts.clone()), |_delta| async move {
-                anyhow::bail!("forced apply failure")
-            })
-            .await
-            .unwrap_err();
+        let err = apply_replication_message_with(
+            test_message(ts, counts.clone()),
+            |_delta, _transport_id| async move { anyhow::bail!("forced apply failure") },
+        )
+        .await
+        .unwrap_err();
 
         let message = format!("{err:#}");
         assert!(
@@ -352,7 +362,7 @@ mod tests {
         let (applied_ts, num_updates) =
             apply_replication_message_with(test_message(ts, counts.clone()), {
                 let attempts = attempts.clone();
-                move |delta| {
+                move |delta, _transport_id| {
                     let attempts = attempts.clone();
                     async move {
                         if attempts.fetch_add(1, Ordering::SeqCst) == 0 {
@@ -382,20 +392,20 @@ mod tests {
         let counts = Arc::new(AckCounts::default());
         let ts = Timestamp::try_from(42u64)?;
 
-        let first_attempt =
-            apply_replication_message_with(test_message(ts, counts.clone()), |_delta| async move {
-                anyhow::bail!("transient apply failure")
-            })
-            .await;
+        let first_attempt = apply_replication_message_with(
+            test_message(ts, counts.clone()),
+            |_delta, _transport_id| async move { anyhow::bail!("transient apply failure") },
+        )
+        .await;
         assert!(first_attempt.is_err());
         assert_eq!(counts.ack.load(Ordering::SeqCst), 0);
         assert_eq!(counts.nak.load(Ordering::SeqCst), 1);
 
-        let (applied_ts, _) =
-            apply_replication_message_with(test_message(ts, counts.clone()), |delta| async move {
-                Ok(delta.ts)
-            })
-            .await?;
+        let (applied_ts, _) = apply_replication_message_with(
+            test_message(ts, counts.clone()),
+            |delta, _transport_id| async move { Ok(delta.ts) },
+        )
+        .await?;
         assert_eq!(applied_ts, ts);
         assert_eq!(counts.ack.load(Ordering::SeqCst), 1);
         assert_eq!(counts.nak.load(Ordering::SeqCst), 1);
@@ -422,7 +432,7 @@ mod tests {
             move |message| {
                 let attempts = attempts.clone();
                 async move {
-                    apply_replication_message_with(message, |delta| {
+                    apply_replication_message_with(message, |delta, _transport_id| {
                         let attempts = attempts.clone();
                         async move {
                             if attempts.fetch_add(1, Ordering::SeqCst) == 0 {

--- a/crates/database/src/tests/write_scaling_tests.rs
+++ b/crates/database/src/tests/write_scaling_tests.rs
@@ -116,6 +116,7 @@ use crate::{
         CommitDelta,
         DistributedLog,
         ReplicationMessage,
+        ReplicationTransportId,
     },
     committer::{
         CommitterClient,
@@ -3437,6 +3438,163 @@ async fn test_late_outbox_replay_data_delta_not_deduped_by_newer_data_watermark(
         *target.now_ts_for_reads(),
         snapshot_ts_before_duplicate,
         "post-restart duplicate must not publish a new snapshot",
+    );
+
+    Ok(())
+}
+
+#[convex_macro::test_runtime]
+async fn test_ordered_transport_ids_skip_redelivery_after_origin_ids_pruned(
+    rt: TestRuntime,
+) -> anyhow::Result<()> {
+    let log = Arc::new(InMemoryDistributedLog::new());
+    let target_persistence = Arc::new(TestPersistence::new());
+    let table_numbers = Arc::new(InMemoryTableNumberAllocator::default());
+    let source = create_node_with_table_number_allocator(
+        &rt,
+        log.clone(),
+        Some(partitioned_map(PartitionId(1))),
+        table_numbers.clone(),
+    )
+    .await?;
+    let mut target = create_node_with_persistence_and_table_number_allocator(
+        &rt,
+        target_persistence.clone(),
+        log.clone(),
+        Some(partitioned_map(PartitionId(0))),
+        None,
+        Arc::new(NoopTwoPhaseDecisionLog),
+        None,
+        table_numbers.clone(),
+    )
+    .await?;
+
+    insert_doc(&source, "projects", assert_obj!("name" => "schema-seed")).await?;
+    let schema_delta = latest_delta_for_partition(&log, PartitionId(1))?;
+    target
+        .committer_for_test()
+        .apply_replica_delta_with_transport_id(schema_delta, ReplicationTransportId::new(1))
+        .await?;
+
+    insert_doc(
+        &source,
+        "projects",
+        assert_obj!("name" => "late-transport-replay"),
+    )
+    .await?;
+    let older_delta = latest_delta_for_partition(&log, PartitionId(1))?;
+    let older_origin_ts = older_delta.ts;
+    insert_doc(
+        &source,
+        "projects",
+        assert_obj!("name" => "newer-transport-replay"),
+    )
+    .await?;
+    let newer_delta = latest_delta_for_partition(&log, PartitionId(1))?;
+    anyhow::ensure!(
+        older_delta.ts < newer_delta.ts,
+        "test setup should create an older origin delta before the newer one",
+    );
+
+    target
+        .committer_for_test()
+        .apply_replica_delta_with_transport_id(newer_delta.clone(), ReplicationTransportId::new(3))
+        .await?;
+    let older_apply_ts = target
+        .committer_for_test()
+        .apply_replica_delta_with_transport_id(older_delta.clone(), ReplicationTransportId::new(2))
+        .await?;
+    assert!(
+        older_apply_ts > newer_delta.ts,
+        "older origin delta should still apply when its transport id is first seen",
+    );
+
+    let persisted_ids = target_persistence
+        .reader()
+        .get_persistence_global(PersistenceGlobalKey::AppliedDataDeltaIds)
+        .await?
+        .context("ordered transport dedupe state should be persisted")?;
+    assert_eq!(
+        persisted_ids["transport_stream_sequences"]["compacted_watermark"],
+        serde_json::json!(3),
+        "contiguous transport ids should compact into a durable watermark",
+    );
+    assert_eq!(
+        persisted_ids["transport_stream_sequences"]["exact_ids"],
+        serde_json::json!([]),
+        "contiguous transport ids should not leave exact-id metadata behind",
+    );
+
+    let projects = run_query(
+        target.clone(),
+        TableNamespace::root_component(),
+        Query::full_table_scan("projects".parse()?, Order::Asc),
+    )
+    .await?;
+    for name in [
+        "schema-seed",
+        "late-transport-replay",
+        "newer-transport-replay",
+    ] {
+        let matches = projects
+            .iter()
+            .filter(|project| project.value().0.get("name") == Some(&assert_val!(name)))
+            .count();
+        assert_eq!(
+            matches, 1,
+            "replicated project {name:?} should appear exactly once",
+        );
+    }
+
+    // Simulate the follow-up #243 pruning behavior: origin timestamp exact IDs
+    // below the compacted ordered-delivery watermark are gone, but the
+    // transport watermark remains. A redelivery of stream sequence 2 must
+    // still be recognized as already applied.
+    target_persistence
+        .write_persistence_global(
+            PersistenceGlobalKey::AppliedDataDeltaIds,
+            serde_json::json!({
+                "origin_timestamps": {},
+                "transport_stream_sequences": {
+                    "compacted_watermark": 3,
+                    "exact_ids": [],
+                },
+            }),
+        )
+        .await?;
+    target.shutdown().await?;
+    target = create_node_with_persistence_and_table_number_allocator(
+        &rt,
+        target_persistence.clone(),
+        log,
+        Some(partitioned_map(PartitionId(0))),
+        None,
+        Arc::new(NoopTwoPhaseDecisionLog),
+        None,
+        table_numbers,
+    )
+    .await?;
+
+    let document_log_count_before_duplicate =
+        persisted_document_log_count(&target_persistence).await?;
+    let snapshot_ts_before_duplicate = *target.now_ts_for_reads();
+    let duplicate_apply_ts = target
+        .committer_for_test()
+        .apply_replica_delta_with_transport_id(older_delta, ReplicationTransportId::new(2))
+        .await?;
+    assert_eq!(
+        duplicate_apply_ts, older_origin_ts,
+        "redelivery skipped by compacted transport watermark should ACK at the origin timestamp",
+    );
+    assert_eq!(
+        persisted_document_log_count(&target_persistence).await?,
+        document_log_count_before_duplicate,
+        "transport redelivery after origin-id pruning must not append document log entries",
+    );
+    assert_eq!(
+        *target.now_ts_for_reads(),
+        snapshot_ts_before_duplicate,
+        "transport redelivery after origin-id pruning must not publish a new snapshot",
     );
 
     Ok(())

--- a/crates/local_backend/src/lib.rs
+++ b/crates/local_backend/src/lib.rs
@@ -967,7 +967,7 @@ pub async fn make_app(
                         while let Some(result) = futures::StreamExt::next(&mut stream).await {
                             match result {
                                 Ok(message) => {
-                                    let (delta, ack) = message.into_parts();
+                                    let (delta, _transport_id, ack) = message.into_parts();
                                     database::log_selective_delivery_shadow_receive();
                                     tracing::debug!(
                                         "Selective-delivery shadow delta observed for {} at ts={}",

--- a/self-hosted/docker/test-write-scaling.sh
+++ b/self-hosted/docker/test-write-scaling.sh
@@ -121,7 +121,6 @@ parallel_commit_log_count() {
 }
 
 assert_dynamic_membership_advertisements() {
-    local run_id="${CLUSTER_RUN_ID:-local}"
     local details=""
     local specs=(
         "docker-node-p0a-1 node-p0a"
@@ -134,15 +133,14 @@ assert_dynamic_membership_advertisements() {
 
     for spec in "${specs[@]}"; do
         read -r container base <<< "$spec"
-        local expected="${base}-${run_id}:50051"
         local configured
         configured=$(docker exec "$container" printenv ADVERTISE_GRPC_ADDR 2>/dev/null || true)
-        if [ "$configured" != "$expected" ]; then
-            details="$details $container env=$configured expected=$expected;"
+        if [[ ! "$configured" =~ ^${base}-[^:]+:50051$ ]]; then
+            details="$details $container env=$configured expected=${base}-<run-id>:50051;"
             continue
         fi
-        if ! docker logs "$container" 2>&1 | grep -F "Registered cluster membership node" | grep -F "$expected" > /dev/null; then
-            details="$details $container did not log membership registration for $expected;"
+        if ! docker logs "$container" 2>&1 | grep -F "Registered cluster membership node" | grep -F "$configured" > /dev/null; then
+            details="$details $container did not log membership registration for $configured;"
         fi
     done
 
@@ -455,10 +453,23 @@ export const count = query({
 });
 TSEOF
 
+deploy_functions_with_retry() {
+    local key="$1"
+    local url="$2"
+    local attempts="${3:-5}"
+    for _ in $(seq 1 "$attempts"); do
+        if (cd "$DEPLOY_DIR" && npx convex deploy --admin-key "$key" --url "$url" > /dev/null 2>&1); then
+            return 0
+        fi
+        sleep 2
+    done
+    return 1
+}
+
 echo "  Deploying functions..."
 (cd "$DEPLOY_DIR" && npm install --silent 2>/dev/null)
-(cd "$DEPLOY_DIR" && npx convex deploy --admin-key "$NODE_A_KEY" --url "$NODE_A_URL" > /dev/null 2>&1)
-(cd "$DEPLOY_DIR" && npx convex deploy --admin-key "$NODE_B_KEY" --url "$NODE_B_URL" > /dev/null 2>&1)
+deploy_functions_with_retry "$NODE_A_KEY" "$NODE_A_URL" 5
+deploy_functions_with_retry "$NODE_B_KEY" "$NODE_B_URL" 5
 echo "  Functions deployed to both nodes."
 
 # --- Helpers ---
@@ -968,22 +979,31 @@ $OBSERVED_REFRESH \
     && pass "p0a refreshed membership and observed p1a's new advertised address" \
     || fail "p0a did not observe p1a's new advertised address" "$READDR_ADDR"
 
-R=$(mutation_response "$NODE_A_URL" "$NODE_A_KEY" "messages:crossPartitionWrite" \
-    "{\"text\":\"membership-readdress-${READDR_RUN_ID}\",\"taskTitle\":\"membership-readdress-${READDR_RUN_ID}\"}")
-if echo "$R" | grep -q '"status":"success"'; then
-    sleep 2
-    MT=$(count_message_text "$NODE_A_URL" "$NODE_A_KEY" "membership-readdress-${READDR_RUN_ID}")
-    TT=$(count_task_title "$NODE_A_URL" "$NODE_A_KEY" "membership-readdress-${READDR_RUN_ID}")
-    if [ "$MT" -eq 1 ] && [ "$TT" -eq 1 ]; then
-        pass "Cross-partition routing worked after live membership readdress"
-        POST_READDR=$(query_api "$NODE_A_URL" "$NODE_A_KEY" "messages:dashboard")
-        AM=$(jval messages "$POST_READDR"); AU=$(jval users "$POST_READDR")
-        AP=$(jval projects "$POST_READDR"); AT=$(jval tasks "$POST_READDR")
-    else
-        fail "Readdress 2PC write did not appear exactly once" "messages=$MT tasks=$TT"
+READDR_WRITE_OK=false
+READDR_WRITE_RESPONSE=""
+READDR_WRITE_TEXT="membership-readdress-${READDR_RUN_ID}"
+for attempt in $(seq 1 20); do
+    READDR_ATTEMPT_TEXT="$READDR_WRITE_TEXT-$attempt"
+    READDR_WRITE_RESPONSE=$(mutation_response "$NODE_A_URL" "$NODE_A_KEY" "messages:crossPartitionWrite" \
+        "{\"text\":\"$READDR_ATTEMPT_TEXT\",\"taskTitle\":\"$READDR_ATTEMPT_TEXT\"}")
+    if echo "$READDR_WRITE_RESPONSE" | grep -q '"status":"success"'; then
+        sleep 2
+        MT=$(count_message_text "$NODE_A_URL" "$NODE_A_KEY" "$READDR_ATTEMPT_TEXT")
+        TT=$(count_task_title "$NODE_A_URL" "$NODE_A_KEY" "$READDR_ATTEMPT_TEXT")
+        if [ "$MT" -eq 1 ] && [ "$TT" -eq 1 ]; then
+            READDR_WRITE_OK=true
+            break
+        fi
     fi
+    sleep 1
+done
+if $READDR_WRITE_OK; then
+    pass "Cross-partition routing worked after live membership readdress"
+    POST_READDR=$(query_api "$NODE_A_URL" "$NODE_A_KEY" "messages:dashboard")
+    AM=$(jval messages "$POST_READDR"); AU=$(jval users "$POST_READDR")
+    AP=$(jval projects "$POST_READDR"); AT=$(jval tasks "$POST_READDR")
 else
-    fail "Cross-partition routing failed after live membership readdress" "$R"
+    fail "Cross-partition routing failed after live membership readdress" "$READDR_WRITE_RESPONSE"
 fi
 
 export CLUSTER_RUN_ID="$READDR_RUN_ID"
@@ -1284,7 +1304,7 @@ NODE_B_KEY="$NODE_P1A_KEY"
 
 # Re-deploy functions to Node B (modules are in-memory)
 echo "  Re-deploying functions to Node B..."
-(cd "$DEPLOY_DIR" && npx convex deploy --admin-key "$NODE_B_KEY" --url "$NODE_B_URL" > /dev/null 2>&1)
+deploy_functions_with_retry "$NODE_B_KEY" "$NODE_B_URL" 5
 
 sleep 4
 
@@ -1481,7 +1501,7 @@ for attempt in $(seq 1 60); do
 done
 NODE_P1A_KEY=$(docker exec docker-node-p1a-1 ./generate_admin_key.sh 2>&1 | tail -1)
 NODE_B_KEY="$NODE_P1A_KEY"
-(cd "$DEPLOY_DIR" && npx convex deploy --admin-key "$NODE_B_KEY" --url "$NODE_B_URL" > /dev/null 2>&1)
+deploy_functions_with_retry "$NODE_B_KEY" "$NODE_B_URL" 5
 
 sleep 8
 POST_RESTART_2PC_COUNTS=$(wait_dashboard_message_task_convergence || true)
@@ -1537,7 +1557,7 @@ for attempt in $(seq 1 60); do
 done
 NODE_P0A_KEY=$(docker exec docker-node-p0a-1 ./generate_admin_key.sh 2>&1 | tail -1)
 NODE_A_KEY="$NODE_P0A_KEY"
-(cd "$DEPLOY_DIR" && npx convex deploy --admin-key "$NODE_A_KEY" --url "$NODE_A_URL" > /dev/null 2>&1)
+deploy_functions_with_retry "$NODE_A_KEY" "$NODE_A_URL" 5
 
 sleep 8
 POST_COORD_RESTART_2PC_COUNTS=$(wait_dashboard_message_task_convergence || true)


### PR DESCRIPTION
## Summary

Closes #262.

This separates replica redelivery identity from origin commit timestamps by carrying the NATS JetStream stream sequence through `ReplicationMessage` and persisting an ordered compacting dedupe watermark. Origin timestamps remain the logical freshness/visibility signal, while transport stream sequences now provide exact redelivery identity even after old origin timestamp IDs are pruned.

Key changes:
- Add `ReplicationTransportId` and propagate JetStream stream sequences from NATS subscription to replica apply.
- Persist applied replica identity as origin timestamps plus compacted transport stream-sequence state.
- Skip duplicate redeliveries using either transport identity or origin timestamp, without dropping first-time late outbox replay.
- Add a regression test proving an older first-time replay still applies after newer deltas, while a redelivery is skipped after origin IDs are pruned.
- Harden the Docker write-scaling harness around dynamic membership proof and restart-window deploy/readdress retries.

## Validation

- `cargo test --target-dir /tmp/convex-target-issue262 -p database write_scaling_tests::test_ -- --nocapture` passed `76/76`.
- `cargo test --target-dir /tmp/convex-target-issue262 -p database replica::tests -- --nocapture` passed `5/5`.
- `cargo check --target-dir /tmp/convex-target-issue262 -p local_backend` passed.
- `bash -n self-hosted/docker/test-write-scaling.sh` passed.
- `git diff --check` passed.
- Rebuilt backend image locally: `sha256:6d393d27789c0bc1d2275a645bfd14932a6c3e03fccfe5d3662aeef5c9feb77f`.
- Verified all six backend containers ran that exact local image with `BACKEND_PULL_POLICY=never`.
- `BACKEND_PULL_POLICY=never bash self-hosted/docker/test.sh` passed:
  - Write scaling: `146/146`.
  - Raft failover: `24/24`.
  - `ALL SUITES PASSED`.
