### PR TITLE
fix(replication): back off blocked replica redelivery

### DIFF
--- a/crates/database/src/replica.rs
+++ b/crates/database/src/replica.rs
@@ -31,7 +31,7 @@ use crate::{
     committer::CommitterClient,
 };
 
-const RETRYABLE_REPLICA_APPLY_NAK_DELAY: Duration = Duration::from_millis(100);
+const RETRYABLE_REPLICA_APPLY_NAK_DELAY: Duration = Duration::from_millis(250);
 
 pub async fn apply_replication_message(
     committer: &CommitterClient,
@@ -110,44 +110,49 @@ where
     let ts = delta.ts;
     let num_updates = delta.document_updates.len();
 
-    loop {
-        match apply(delta.clone(), transport_id).await {
-            Ok(applied_ts) => {
-                ack.ack().await.with_context(|| {
-                    format!(
-                        "Failed to ack applied replica delta at ts={}",
-                        u64::from(applied_ts),
-                    )
-                })?;
-                return Ok((applied_ts, num_updates));
-            },
-            Err(e) => {
-                if e.downcast_ref::<RetryableReplicaApplyError>().is_some() {
-                    tracing::info!(
-                        "Replica delta at ts={} is temporarily blocked; retrying in place after \
-                         {:?}: {e:#}",
-                        u64::from(ts),
-                        RETRYABLE_REPLICA_APPLY_NAK_DELAY,
-                    );
-                    tokio::time::sleep(RETRYABLE_REPLICA_APPLY_NAK_DELAY).await;
-                    continue;
-                }
-                tracing::error!(
-                    "Failed to apply replica delta at ts={}: {e:#}",
+    match apply(delta, transport_id).await {
+        Ok(applied_ts) => {
+            ack.ack().await.with_context(|| {
+                format!(
+                    "Failed to ack applied replica delta at ts={}",
+                    u64::from(applied_ts),
+                )
+            })?;
+            Ok((applied_ts, num_updates))
+        },
+        Err(e) => {
+            if e.downcast_ref::<RetryableReplicaApplyError>().is_some() {
+                tracing::info!(
+                    "Replica delta at ts={} is temporarily blocked; delayed-NAKing for {:?}: {e:#}",
                     u64::from(ts),
+                    RETRYABLE_REPLICA_APPLY_NAK_DELAY,
                 );
-                if let Err(ack_err) = ack.nak().await {
+                if let Err(ack_err) = ack.nak_with_delay(RETRYABLE_REPLICA_APPLY_NAK_DELAY).await {
                     tracing::warn!(
-                        "Failed to NAK unapplied replica delta at ts={}: {ack_err:#}",
+                        "Failed to delayed-NAK blocked replica delta at ts={}: {ack_err:#}",
                         u64::from(ts),
                     );
                 }
                 anyhow::bail!(
-                    "Failed to apply replica delta at ts={}: {e:#}",
-                    u64::from(ts)
+                    "Retryable failure applying replica delta at ts={}: {e:#}",
+                    u64::from(ts),
                 );
-            },
-        }
+            }
+            tracing::error!(
+                "Failed to apply replica delta at ts={}: {e:#}",
+                u64::from(ts),
+            );
+            if let Err(ack_err) = ack.nak().await {
+                tracing::warn!(
+                    "Failed to NAK unapplied replica delta at ts={}: {ack_err:#}",
+                    u64::from(ts),
+                );
+            }
+            anyhow::bail!(
+                "Failed to apply replica delta at ts={}: {e:#}",
+                u64::from(ts)
+            );
+        },
     }
 }
 
@@ -248,6 +253,7 @@ mod tests {
     use super::{
         apply_replication_message_with,
         consume_replication_stream_with,
+        RETRYABLE_REPLICA_APPLY_NAK_DELAY,
     };
     use crate::{
         commit_delta::{
@@ -265,6 +271,7 @@ mod tests {
         nak: AtomicUsize,
         delayed_nak: AtomicUsize,
         term: AtomicUsize,
+        delayed_nak_delays: parking_lot::Mutex<Vec<Duration>>,
     }
 
     struct RecordingAck {
@@ -283,8 +290,9 @@ mod tests {
             Ok(())
         }
 
-        async fn nak_with_delay(self: Box<Self>, _delay: Duration) -> anyhow::Result<()> {
+        async fn nak_with_delay(self: Box<Self>, delay: Duration) -> anyhow::Result<()> {
             self.counts.delayed_nak.fetch_add(1, Ordering::SeqCst);
+            self.counts.delayed_nak_delays.lock().push(delay);
             Ok(())
         }
 
@@ -354,36 +362,130 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn retryable_apply_failure_retries_in_place() -> anyhow::Result<()> {
+    async fn retryable_apply_failure_delayed_naks_for_redelivery() -> anyhow::Result<()> {
         let counts = Arc::new(AckCounts::default());
         let ts = Timestamp::try_from(42u64)?;
         let attempts = Arc::new(AtomicUsize::new(0));
 
-        let (applied_ts, num_updates) =
-            apply_replication_message_with(test_message(ts, counts.clone()), {
+        let err = apply_replication_message_with(test_message(ts, counts.clone()), {
+            let attempts = attempts.clone();
+            move |_delta, _transport_id| {
                 let attempts = attempts.clone();
-                move |delta, _transport_id| {
-                    let attempts = attempts.clone();
-                    async move {
-                        if attempts.fetch_add(1, Ordering::SeqCst) == 0 {
-                            Err(anyhow::Error::new(RetryableReplicaApplyError::new(
-                                "prepared transaction still unresolved",
-                            )))
-                        } else {
-                            Ok(delta.ts)
-                        }
-                    }
+                async move {
+                    attempts.fetch_add(1, Ordering::SeqCst);
+                    Err(anyhow::Error::new(RetryableReplicaApplyError::new(
+                        "prepared transaction still unresolved",
+                    )))
                 }
-            })
-            .await?;
+            }
+        })
+        .await
+        .expect_err("retryable apply failure should be delayed-NAKed for redelivery");
+
+        let message = format!("{err:#}");
+        assert!(
+            message.contains("Retryable failure applying replica delta"),
+            "{message}",
+        );
+        assert!(message.contains("prepared transaction still unresolved"));
+        assert_eq!(
+            attempts.load(Ordering::SeqCst),
+            1,
+            "retryable failures should not block the consumer by retrying in-process",
+        );
+        assert_eq!(counts.ack.load(Ordering::SeqCst), 0);
+        assert_eq!(counts.nak.load(Ordering::SeqCst), 0);
+        assert_eq!(counts.delayed_nak.load(Ordering::SeqCst), 1);
+        assert_eq!(counts.term.load(Ordering::SeqCst), 0);
+        assert_eq!(
+            counts.delayed_nak_delays.lock().as_slice(),
+            &[RETRYABLE_REPLICA_APPLY_NAK_DELAY],
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn retryable_redelivery_can_ack_after_block_clears() -> anyhow::Result<()> {
+        let counts = Arc::new(AckCounts::default());
+        let ts = Timestamp::try_from(42u64)?;
+
+        let first_attempt = apply_replication_message_with(
+            test_message(ts, counts.clone()),
+            |_delta, _transport_id| async move {
+                Err(anyhow::Error::new(RetryableReplicaApplyError::new(
+                    "prepared transaction still unresolved",
+                )))
+            },
+        )
+        .await;
+        assert!(first_attempt.is_err());
+        assert_eq!(counts.ack.load(Ordering::SeqCst), 0);
+        assert_eq!(counts.nak.load(Ordering::SeqCst), 0);
+        assert_eq!(counts.delayed_nak.load(Ordering::SeqCst), 1);
+
+        let (applied_ts, num_updates) = apply_replication_message_with(
+            test_message(ts, counts.clone()),
+            |delta, _transport_id| async move { Ok(delta.ts) },
+        )
+        .await?;
 
         assert_eq!(applied_ts, ts);
         assert_eq!(num_updates, 0);
-        assert_eq!(attempts.load(Ordering::SeqCst), 2);
         assert_eq!(counts.ack.load(Ordering::SeqCst), 1);
         assert_eq!(counts.nak.load(Ordering::SeqCst), 0);
-        assert_eq!(counts.delayed_nak.load(Ordering::SeqCst), 0);
+        assert_eq!(counts.delayed_nak.load(Ordering::SeqCst), 1);
         assert_eq!(counts.term.load(Ordering::SeqCst), 0);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn consumer_continues_after_retryable_apply_failure() -> anyhow::Result<()> {
+        let counts = Arc::new(AckCounts::default());
+        let first_ts = Timestamp::try_from(42u64)?;
+        let second_ts = Timestamp::try_from(43u64)?;
+        let attempts = Arc::new(AtomicUsize::new(0));
+        let successes = Arc::new(AtomicUsize::new(0));
+        let successes_for_callback = successes.clone();
+        let stream = futures::stream::iter(vec![
+            Ok(test_message(first_ts, counts.clone())),
+            Ok(test_message(second_ts, counts.clone())),
+        ]);
+
+        let err = consume_replication_stream_with(
+            Box::pin(stream),
+            move |message| {
+                let attempts = attempts.clone();
+                async move {
+                    apply_replication_message_with(message, |delta, _transport_id| {
+                        let attempts = attempts.clone();
+                        async move {
+                            if attempts.fetch_add(1, Ordering::SeqCst) == 0 {
+                                Err(anyhow::Error::new(RetryableReplicaApplyError::new(
+                                    "prepared transaction still unresolved",
+                                )))
+                            } else {
+                                Ok(delta.ts)
+                            }
+                        }
+                    })
+                    .await
+                }
+            },
+            move |_ts, _num_updates| {
+                successes_for_callback.fetch_add(1, Ordering::SeqCst);
+            },
+        )
+        .await
+        .expect_err("finite test stream should report stream end");
+
+        assert!(
+            format!("{err:#}").contains("ReplicaDeltaConsumer stream ended"),
+            "unexpected error: {err:#}",
+        );
+        assert_eq!(counts.ack.load(Ordering::SeqCst), 1);
+        assert_eq!(counts.nak.load(Ordering::SeqCst), 0);
+        assert_eq!(counts.delayed_nak.load(Ordering::SeqCst), 1);
+        assert_eq!(successes.load(Ordering::SeqCst), 1);
         Ok(())
     }
 


### PR DESCRIPTION
## Summary

Closes #255.

This changes retryable replica-apply failures from an in-process sleep/retry loop to a JetStream delayed NAK. A blocked delta now asks NATS to redeliver it after a short backoff instead of tying up the replica consumer task, while non-retryable apply failures still fail fast with an immediate NAK.

## Validation

- `rustfmt --edition 2024 crates/database/src/replica.rs`
- `cargo test --target-dir /tmp/convex-target-issue255 -p database replica::tests -- --nocapture` — 7/7 passed
- `cargo test --target-dir /tmp/convex-target-issue255 -p database write_scaling_tests::test_ -- --nocapture` — 76/76 passed
- `cargo check --target-dir /tmp/convex-target-issue255 -p local_backend`
- `git diff --check`
- Rebuilt local backend Docker image: `sha256:162b0883db3118bf55c9e54f6141d7050c3375becdfad6ca1be3c929bc3c4647`
- Verified all six backend containers healthy on that exact image ID with `BACKEND_PULL_POLICY=never`
- `BACKEND_PULL_POLICY=never bash self-hosted/docker/test.sh`
  - Write scaling suite: 146/146 passed
  - Raft failover suite: 24/24 passed
  - All suites passed
