### PR TITLE
fix(indexes): fence commits behind pending metadata

### DIFF
--- a/crates/database/src/committer.rs
+++ b/crates/database/src/committer.rs
@@ -2586,6 +2586,19 @@ impl<RT: Runtime> Committer<RT> {
                 self.prepared_writes.len(),
             )));
         }
+        if let Some(pending_ts) =
+            self.pending_bootstrap_metadata_write_ts(&transaction.table_mapping)
+        {
+            let metadata = ErrorMetadata::system_occ(
+                Some(u64::from(*transaction.begin_timestamp)),
+                write_source.as_str().map(|source| source.to_string()),
+            );
+            anyhow::bail!(anyhow::anyhow!(metadata).context(format!(
+                "Commit blocked by unresolved _tables/_index metadata write at ts={}; retry after \
+                 the metadata write publishes",
+                u64::from(pending_ts),
+            )));
+        }
 
         // Partition ownership check: verify that all authoritative writes for
         // this operation target tables owned by this node. Deploy metadata
@@ -2685,6 +2698,24 @@ impl<RT: Runtime> Committer<RT> {
             document_writes,
             pending_write,
         })
+    }
+
+    fn pending_bootstrap_metadata_write_ts(
+        &self,
+        table_mapping: &TableMapping,
+    ) -> Option<Timestamp> {
+        let bootstrap_tables = BootstrapTableIds::new(table_mapping);
+        self.pending_writes
+            .iter(Timestamp::MIN, Timestamp::MAX)
+            .find_map(|(ts, writes, _)| {
+                writes
+                    .into_iter()
+                    .any(|(id, _)| {
+                        bootstrap_tables.is_tables_table(id.tablet_id)
+                            || bootstrap_tables.is_index_table(id.tablet_id)
+                    })
+                    .then_some(*ts)
+            })
     }
 
     #[fastrace::trace]

--- a/crates/database/src/tests/write_scaling_tests.rs
+++ b/crates/database/src/tests/write_scaling_tests.rs
@@ -23,6 +23,7 @@ use common::{
     assert_obj,
     bootstrap_model::index::{
         database_index::IndexedFields,
+        IndexMetadata,
         INDEX_TABLE,
     },
     document::{
@@ -2231,6 +2232,87 @@ async fn test_prepare_waits_behind_pending_local_commit(
     tokio::time::timeout(Duration::from_secs(1), local_commit).await???;
     tokio::time::timeout(Duration::from_secs(1), prepare_while_pending).await???;
     node.committer_for_test().rollback_prepared(txn_id).await?;
+
+    Ok(())
+}
+
+#[convex_macro::test_runtime]
+async fn test_pending_index_metadata_blocks_later_document_commit(
+    rt: TestRuntime,
+    pause: PauseController,
+) -> anyhow::Result<()> {
+    let log = Arc::new(InMemoryDistributedLog::new());
+    let node = create_node(&rt, log, None).await?;
+    insert_doc(
+        &node,
+        "messages",
+        assert_obj!("text" => "seed-before-index"),
+    )
+    .await?;
+
+    let hold_guard = pause.hold(AFTER_PENDING_WRITE_SNAPSHOT);
+    let node_for_index = node.clone();
+    let index_commit = tokio::spawn(async move {
+        let mut tx = node_for_index.begin(Identity::system()).await?;
+        let begin_ts = *tx.begin_timestamp();
+        let index_name = IndexName::new(
+            "messages".parse()?,
+            IndexDescriptor::new("by_pending_text")?,
+        )?;
+        IndexModel::new(&mut tx)
+            .add_application_index(
+                TableNamespace::test_user(),
+                IndexMetadata::new_backfilling(
+                    begin_ts,
+                    index_name,
+                    vec!["text".parse()?].try_into()?,
+                ),
+            )
+            .await?;
+        node_for_index.commit(tx).await
+    });
+
+    let pause_guard = hold_guard.wait_for_blocked().await;
+    let err = insert_doc(
+        &node,
+        "messages",
+        assert_obj!("text" => "must-wait-for-index-metadata"),
+    )
+    .await
+    .expect_err("document commit must retry behind unresolved index metadata");
+    assert!(
+        format!("{err:#}").contains("unresolved _tables/_index metadata write"),
+        "unexpected error: {err:#}",
+    );
+
+    if let Some(guard) = pause_guard {
+        guard.unpause();
+    }
+    tokio::time::timeout(Duration::from_secs(1), index_commit).await???;
+
+    insert_doc(
+        &node,
+        "messages",
+        assert_obj!("text" => "after-index-metadata"),
+    )
+    .await?;
+
+    let messages = run_query(
+        node,
+        TableNamespace::test_user(),
+        Query::full_table_scan("messages".parse()?, Order::Asc),
+    )
+    .await?;
+    let texts: Vec<_> = messages
+        .iter()
+        .filter_map(|message| message.value().0.get("text"))
+        .collect();
+    assert!(texts.contains(&&assert_val!("seed-before-index")));
+    assert!(texts.contains(&&assert_val!("after-index-metadata")));
+    assert!(
+        !texts.contains(&&assert_val!("must-wait-for-index-metadata")),
+        "failed commit must not leak while metadata is pending",
+    );
 
     Ok(())
 }


### PR DESCRIPTION
## Summary

Closes #254.

This adds a metadata barrier for pending `_tables` / `_index` writes. If an index/table registry transition is still unresolved in `pending_writes`, later commits now fail closed with retryable OCC metadata instead of validating against speculative registry state and building persistence/Raft index rows that may become stale after rebase.

Normal document writes can still run in parallel when there is no pending bootstrap metadata transition.

## Validation

- `rustfmt --edition 2024 crates/database/src/committer.rs crates/database/src/tests/write_scaling_tests.rs`
- `cargo test --target-dir /tmp/convex-target-issue254 -p database test_pending_index_metadata_blocks_later_document_commit -- --nocapture`
- `cargo test --target-dir /tmp/convex-target-issue254 -p database write_scaling_tests::test_ -- --nocapture` — 77/77 passed
- `cargo check --target-dir /tmp/convex-target-issue254 -p local_backend`
- `git diff --check`
- Rebuilt local backend Docker image: `sha256:1bffa7713d8443738d56a6345d90d608f0c1ee6477b0afadfe118af93ef9cab3`
- Verified all six backend containers healthy on that exact image ID with `BACKEND_PULL_POLICY=never`
- `BACKEND_PULL_POLICY=never bash self-hosted/docker/test.sh`
  - Write scaling suite: 146/146 passed
  - Raft failover suite: 24/24 passed
  - All suites passed
