### PR TITLE
fix(routing): fail loud on catalog parse errors

### DIFF
--- a/crates/database/src/committer.rs
+++ b/crates/database/src/committer.rs
@@ -6120,13 +6120,16 @@ impl CommitterClient {
             .placement_state
             .as_ref()
             .map(|placement_state| placement_state.partition_map());
-        let transaction_classification = partition_map.as_ref().map(|partition_map| {
-            crate::two_phase_coordinator::classify_transaction(
-                &transaction,
-                partition_map,
-                &write_source,
-            )
-        });
+        let transaction_classification = partition_map
+            .as_ref()
+            .map(|partition_map| {
+                crate::two_phase_coordinator::classify_transaction(
+                    &transaction,
+                    partition_map,
+                    &write_source,
+                )
+            })
+            .transpose()?;
 
         // Note that we do a best effort validation for memory index sizes. We
         // use the latest snapshot instead of the transaction base snapshot. This

--- a/crates/database/src/tests/write_scaling_tests.rs
+++ b/crates/database/src/tests/write_scaling_tests.rs
@@ -27,6 +27,7 @@ use common::{
         INDEX_TABLE,
     },
     document::{
+        DocumentUpdateWithPrevTs,
         ResolvedDocument,
         ID_FIELD,
     },
@@ -1646,7 +1647,7 @@ async fn test_prepare_participants_include_remote_read_owner(
         &final_tx,
         &partition_map,
         &write_source,
-    );
+    )?;
     assert!(
         matches!(
             classification,
@@ -1660,7 +1661,7 @@ async fn test_prepare_participants_include_remote_read_owner(
         &final_tx,
         &partition_map,
         &write_source,
-    );
+    )?;
     assert_eq!(
         participant_indexes.keys().copied().collect::<Vec<_>>(),
         vec![PartitionId(0), PartitionId(1)],
@@ -1745,7 +1746,7 @@ async fn test_read_owner_validation_rejects_conflicting_owner_write(
         &final_tx,
         &source_map,
         &write_source,
-    );
+    )?;
     let read_owner_tx = ParticipantTransaction::from_final_transaction(
         &final_tx,
         PartitionId(1),
@@ -1822,7 +1823,7 @@ async fn test_read_owner_validate_reads_is_retry_safe(rt: TestRuntime) -> anyhow
         &final_tx,
         &source_map,
         &write_source,
-    );
+    )?;
     let read_owner_tx = ParticipantTransaction::from_final_transaction(
         &final_tx,
         PartitionId(1),
@@ -1902,7 +1903,7 @@ async fn test_read_owner_validation_rejects_timestamp_below_local_floor(
         &final_tx,
         &source_map,
         &write_source,
-    );
+    )?;
     let read_owner_tx = ParticipantTransaction::from_final_transaction(
         &final_tx,
         PartitionId(1),
@@ -4391,7 +4392,7 @@ async fn test_remote_table_catalog_writes_follow_owner_prepare_redo(
         &final_tx,
         &source_map,
         &write_source,
-    );
+    )?;
     let owner_writes = participant_indexes
         .get(&PartitionId(1))
         .expect("projects writes and catalog metadata should route to partition 1");
@@ -4433,6 +4434,58 @@ async fn test_remote_table_catalog_writes_follow_owner_prepare_redo(
     )
     .await?;
     assert_eq!(projects.len(), 1);
+    Ok(())
+}
+
+#[convex_macro::test_runtime]
+async fn test_catalog_write_routing_fails_loud_on_malformed_index_metadata(
+    rt: TestRuntime,
+) -> anyhow::Result<()> {
+    let log = Arc::new(InMemoryDistributedLog::new());
+    let source = create_node(&rt, log, Some(partitioned_map(PartitionId(0)))).await?;
+
+    let mut tx = source.begin(Identity::system()).await?;
+    TestFacingModel::new(&mut tx)
+        .insert(&"projects".parse()?, assert_obj!("name" => "catalog"))
+        .await?;
+    let final_tx = tx.finalize()?;
+    let index_write = final_tx
+        .writes
+        .coalesced_writes()
+        .find(|write| {
+            final_tx
+                .table_mapping
+                .tablet_name(write.id.tablet_id)
+                .is_ok_and(|table| table == *INDEX_TABLE)
+        })
+        .context("project insert should include _index metadata")?;
+    let malformed_document = index_write
+        .new_document
+        .as_ref()
+        .context("_index metadata write should insert a document")?
+        .replace_value(assert_obj!("not" => "index metadata"))?;
+    let malformed_write = DocumentUpdateWithPrevTs {
+        id: index_write.id,
+        old_document: index_write.old_document.clone(),
+        new_document: Some(malformed_document),
+    };
+
+    let err = crate::two_phase_coordinator::routed_partition_for_catalog_write_for_test(
+        &final_tx,
+        &malformed_write,
+        &partitioned_map(PartitionId(0)),
+    )
+    .expect_err("malformed _index metadata must not classify as an unrouted local write");
+    let err = format!("{err:#}");
+    assert!(
+        err.contains("failed to parse _index catalog metadata"),
+        "error should explain the malformed _index metadata routing failure, got {err}",
+    );
+    assert!(
+        err.contains("missing field"),
+        "error should include parser context for the malformed catalog document, got {err}",
+    );
+
     Ok(())
 }
 

--- a/crates/database/src/two_phase_coordinator.rs
+++ b/crates/database/src/two_phase_coordinator.rs
@@ -117,8 +117,8 @@ pub fn classify_transaction(
     transaction: &FinalTransaction,
     partition_map: &PartitionMap,
     write_source: &WriteSource,
-) -> TransactionClassification {
-    let partitions = participant_write_indexes(transaction, partition_map, write_source);
+) -> anyhow::Result<TransactionClassification> {
+    let partitions = participant_write_indexes(transaction, partition_map, write_source)?;
     let mut prepare_participants: BTreeSet<_> = partitions.keys().copied().collect();
     prepare_participants.extend(participant_read_owners(
         transaction,
@@ -126,7 +126,7 @@ pub fn classify_transaction(
         write_source,
     ));
 
-    if partitions.is_empty() {
+    Ok(if partitions.is_empty() {
         TransactionClassification::SinglePartition
     } else if prepare_participants.len() == 1 {
         let owner = *prepare_participants
@@ -140,19 +140,19 @@ pub fn classify_transaction(
         }
     } else {
         TransactionClassification::CrossPartition { partitions }
-    }
+    })
 }
 
 pub(crate) fn participant_write_indexes(
     transaction: &FinalTransaction,
     partition_map: &PartitionMap,
     write_source: &WriteSource,
-) -> BTreeMap<PartitionId, Vec<usize>> {
+) -> anyhow::Result<BTreeMap<PartitionId, Vec<usize>>> {
     let mut participant_indexes: BTreeMap<PartitionId, Vec<usize>> = BTreeMap::new();
 
     for (index, write) in transaction.writes.coalesced_writes().enumerate() {
         let Some(participant) =
-            routed_partition_for_write(transaction, write, partition_map, write_source)
+            routed_partition_for_write(transaction, write, partition_map, write_source)?
         else {
             continue;
         };
@@ -163,22 +163,22 @@ pub(crate) fn participant_write_indexes(
     }
 
     participant_indexes.retain(|_, indexes| !indexes.is_empty());
-    participant_indexes
+    Ok(participant_indexes)
 }
 
 pub(crate) fn participant_prepare_indexes(
     transaction: &FinalTransaction,
     partition_map: &PartitionMap,
     write_source: &WriteSource,
-) -> BTreeMap<PartitionId, Vec<usize>> {
+) -> anyhow::Result<BTreeMap<PartitionId, Vec<usize>>> {
     let mut participant_indexes =
-        participant_write_indexes(transaction, partition_map, write_source);
+        participant_write_indexes(transaction, partition_map, write_source)?;
 
     for participant in participant_read_owners(transaction, partition_map, write_source) {
         participant_indexes.entry(participant).or_default();
     }
 
-    participant_indexes
+    Ok(participant_indexes)
 }
 
 fn participant_read_owners(
@@ -213,13 +213,16 @@ fn routed_partition_for_write(
     write: &DocumentUpdateWithPrevTs,
     partition_map: &PartitionMap,
     write_source: &WriteSource,
-) -> Option<PartitionId> {
-    let table_name = transaction
+) -> anyhow::Result<Option<PartitionId>> {
+    let Some(table_name) = transaction
         .table_mapping
         .tablet_name(write.id.tablet_id)
-        .ok()?;
+        .ok()
+    else {
+        return Ok(None);
+    };
     if let Some(partition) = routed_partition_for_table(&table_name, partition_map, write_source) {
-        return Some(partition);
+        return Ok(Some(partition));
     }
     routed_partition_for_catalog_write(transaction, write, partition_map)
 }
@@ -228,35 +231,69 @@ fn routed_partition_for_catalog_write(
     transaction: &FinalTransaction,
     write: &DocumentUpdateWithPrevTs,
     partition_map: &PartitionMap,
-) -> Option<PartitionId> {
-    let catalog_table = transaction
+) -> anyhow::Result<Option<PartitionId>> {
+    let Some(catalog_table) = transaction
         .table_mapping
         .tablet_name(write.id.tablet_id)
-        .ok()?;
+        .ok()
+    else {
+        return Ok(None);
+    };
     if &catalog_table != &*TABLES_TABLE && &catalog_table != &*INDEX_TABLE {
-        return None;
+        return Ok(None);
     }
-    let document = write
+    let Some(document) = write
         .new_document
         .as_ref()
-        .or_else(|| write.old_document.as_ref().map(|(document, _)| document))?;
+        .or_else(|| write.old_document.as_ref().map(|(document, _)| document))
+    else {
+        return Ok(None);
+    };
     let user_table = if &catalog_table == &*TABLES_TABLE {
-        catalog_write_user_table(document)?
+        catalog_write_user_table(document).with_context(|| {
+            format!(
+                "failed to parse _tables catalog metadata while routing write {:?}",
+                write.id
+            )
+        })?
     } else {
-        let index: common::document::ParsedDocument<TabletIndexMetadata> = document.parse().ok()?;
+        let index: common::document::ParsedDocument<TabletIndexMetadata> =
+            document.parse().with_context(|| {
+                format!(
+                    "failed to parse _index catalog metadata while routing write {:?}",
+                    write.id
+                )
+            })?;
         let index = index.into_value();
         let indexed_tablet = *index.name.table();
-        transaction.table_mapping.tablet_name(indexed_tablet).ok()?
+        transaction
+            .table_mapping
+            .tablet_name(indexed_tablet)
+            .with_context(|| {
+                format!(
+                    "_index catalog metadata for write {:?} references unknown tablet {:?}",
+                    write.id, indexed_tablet
+                )
+            })?
     };
     if user_table.is_system() {
-        return None;
+        return Ok(None);
     }
-    Some(partition_map.partition_for_table(&user_table))
+    Ok(Some(partition_map.partition_for_table(&user_table)))
 }
 
-fn catalog_write_user_table(document: &ResolvedDocument) -> Option<value::TableName> {
-    let metadata: common::document::ParsedDocument<TableMetadata> = document.parse().ok()?;
-    Some(metadata.into_value().name)
+#[cfg(any(test, feature = "testing"))]
+pub(crate) fn routed_partition_for_catalog_write_for_test(
+    transaction: &FinalTransaction,
+    write: &DocumentUpdateWithPrevTs,
+    partition_map: &PartitionMap,
+) -> anyhow::Result<Option<PartitionId>> {
+    routed_partition_for_catalog_write(transaction, write, partition_map)
+}
+
+fn catalog_write_user_table(document: &ResolvedDocument) -> anyhow::Result<value::TableName> {
+    let metadata: common::document::ParsedDocument<TableMetadata> = document.parse()?;
+    Ok(metadata.into_value().name)
 }
 
 async fn prepare_participant(
@@ -925,7 +962,7 @@ pub(crate) async fn coordinate_two_phase_commit_with_mode(
     commit_mode: TwoPhaseCommitMode,
 ) -> anyhow::Result<CommitOutcome> {
     let timer = metrics::two_phase_coordinator_timer();
-    let source_partition = match classify_transaction(&transaction, partition_map, &write_source) {
+    let source_partition = match classify_transaction(&transaction, partition_map, &write_source)? {
         TransactionClassification::SinglePartition => {
             anyhow::bail!("2PC coordinator called for a local single-partition transaction");
         },
@@ -940,7 +977,7 @@ pub(crate) async fn coordinate_two_phase_commit_with_mode(
     };
 
     let participant_indexes =
-        participant_prepare_indexes(&transaction, partition_map, &write_source);
+        participant_prepare_indexes(&transaction, partition_map, &write_source)?;
     let node_addresses = local_committer.node_addresses();
     let participants: Vec<_> = participant_indexes
         .iter()

--- a/docs/issue-journal.md
+++ b/docs/issue-journal.md
@@ -895,6 +895,31 @@ own for distributed changes.
   - `cargo test -p database test_parallel_early_ack_recovers_staging_before_async_cleanup -- --nocapture`
   - `cargo test -p database test_cross_partition_commit_uses_remote_prepare_over_grpc -- --nocapture`
 
+### 2026-07 — Failed loud on malformed catalog metadata during write routing
+
+- **Status:** complete
+- **Related issue:** `#253`
+- **What this fixes:** catalog write routing for `_tables` and `_index`
+  metadata used `Option` fallthroughs while deciding which partition owned a
+  user-table catalog update. A malformed catalog document could therefore be
+  misclassified as an unrouted local/system write instead of surfacing the
+  corruption at the commit boundary.
+- **Behavior:** transaction classification and participant indexing now return
+  `anyhow::Result`. True non-catalog writes can still be unrouted, but catalog
+  metadata parse failures and `_index` references to unknown tablets include
+  explicit routing context and abort the commit path.
+- **Validation:**
+  - `cargo test -p database test_catalog_write_routing_fails_loud_on_malformed_index_metadata -- --nocapture`
+  - `cargo test -p database test_remote_table_catalog_writes_follow_owner_prepare_redo -- --nocapture`
+  - `cargo test -p database test_prepare_participants_include_remote_read_owner -- --nocapture`
+  - `cargo test -p database test_read_owner_validation_rejects_conflicting_owner_write -- --nocapture`
+  - `cargo check -p database`
+  - Built `ghcr.io/martinkalema/convex-horizontal-scaling:backend-latest`
+    and verified all six backend containers ran local image
+    `sha256:35cd189d525742316633558d2c20de3d4d7d6682f1e9796feb840eaf88bb8f22`
+  - `BACKEND_PULL_POLICY=never bash self-hosted/docker/test.sh`
+    passed write-scaling `146/146`, Raft failover `24/24`, `ALL SUITES PASSED`
+
 ## Open Issues
 
 - `#74` is no longer blocked on follower self-sufficiency. The current


### PR DESCRIPTION
## Summary

Closes #253.

This makes catalog-write routing fail loud instead of silently classifying malformed catalog metadata as unrouted:

- changed transaction classification and participant-index collection to return `anyhow::Result`
- propagated catalog routing errors through the committer and 2PC coordinator paths
- replaced `_tables` / `_index` parser fallthroughs with explicit context-bearing errors
- added a regression test that corrupts a real `_index` catalog write and verifies the routing helper fails loudly
- recorded the fix and validation in the issue journal

## Validation

Targeted Rust validation:

- `cargo test --target-dir /tmp/convex-target-issue253 -p database test_catalog_write_routing_fails_loud_on_malformed_index_metadata -- --nocapture`
- `cargo test --target-dir /tmp/convex-target-issue253 -p database test_remote_table_catalog_writes_follow_owner_prepare_redo -- --nocapture`
- `cargo test --target-dir /tmp/convex-target-issue253 -p database test_prepare_participants_include_remote_read_owner -- --nocapture`
- `cargo test --target-dir /tmp/convex-target-issue253 -p database test_read_owner_validation_rejects_conflicting_owner_write -- --nocapture`
- `cargo check --target-dir /tmp/convex-target-issue253 -p database`
- `cargo test --target-dir /tmp/convex-target-issue253 -p database write_scaling_tests -- --nocapture` (`78/78`)
- `git diff --check`

Full local-image cluster validation:

- built `ghcr.io/martinkalema/convex-horizontal-scaling:backend-latest`
- verified all six backend containers ran local image `sha256:35cd189d525742316633558d2c20de3d4d7d6682f1e9796feb840eaf88bb8f22`
- `BACKEND_PULL_POLICY=never bash self-hosted/docker/test.sh`
- result: write-scaling `146/146`, Raft failover `24/24`, `ALL SUITES PASSED`
