### PR TITLE
fix(cluster): establish canonical Raft genesis

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2852,6 +2852,7 @@ dependencies = [
  "async-recursion",
  "async-trait",
  "async_lru",
+ "base64 0.13.1",
  "bytes",
  "cmd_util",
  "common",

--- a/crates/application/src/lib.rs
+++ b/crates/application/src/lib.rs
@@ -709,23 +709,11 @@ pub async fn create_storage<RT: Runtime>(
 }
 
 impl<RT: Runtime> Application<RT> {
-    pub async fn initialize_storage(
+    async fn storage_from_type(
         runtime: RT,
         database: &Database<RT>,
-        storage_tag_initializer: StorageTagInitializer,
-        instance_name: String,
+        storage_type: model::database_globals::types::StorageType,
     ) -> anyhow::Result<ApplicationStorage> {
-        let storage_type = {
-            let mut tx = database.begin_system().await?;
-            let storage_type = DatabaseGlobalsModel::new(&mut tx)
-                .initialize_storage_tag(storage_tag_initializer, instance_name)
-                .await?;
-            database
-                .commit_with_write_source(tx, "init_storage")
-                .await?;
-            storage_type
-        };
-
         let files_storage =
             create_storage(runtime.clone(), &storage_type, StorageUseCase::Files).await?;
         let modules_storage =
@@ -738,16 +726,11 @@ impl<RT: Runtime> Application<RT> {
         .await?;
         let exports_storage =
             create_storage(runtime.clone(), &storage_type, StorageUseCase::Exports).await?;
-        let snapshot_imports_storage = create_storage(
-            runtime.clone(),
-            &storage_type,
-            StorageUseCase::SnapshotImports,
-        )
-        .await?;
+        let snapshot_imports_storage =
+            create_storage(runtime, &storage_type, StorageUseCase::SnapshotImports).await?;
 
-        // Search storage needs to be set for Database to be fully initialized
         database.set_search_storage(search_storage.clone());
-        tracing::info!("{:?} storage is configured.", storage_type);
+        tracing::info!(?storage_type, "Storage is configured");
 
         Ok(ApplicationStorage {
             files_storage,
@@ -756,6 +739,53 @@ impl<RT: Runtime> Application<RT> {
             exports_storage,
             snapshot_imports_storage,
         })
+    }
+
+    pub async fn initialize_storage(
+        runtime: RT,
+        database: &Database<RT>,
+        storage_tag_initializer: StorageTagInitializer,
+        instance_name: String,
+    ) -> anyhow::Result<ApplicationStorage> {
+        let storage_type =
+            Self::initialize_storage_config(database, storage_tag_initializer, instance_name)
+                .await?;
+
+        Self::storage_from_type(runtime, database, storage_type).await
+    }
+
+    /// Persist the deployment's storage configuration without constructing the
+    /// runtime storage handles. Cluster bootstrap uses this to include the
+    /// configuration in canonical genesis before configuring search storage.
+    pub async fn initialize_storage_config(
+        database: &Database<RT>,
+        storage_tag_initializer: StorageTagInitializer,
+        instance_name: String,
+    ) -> anyhow::Result<model::database_globals::types::StorageType> {
+        let mut tx = database.begin_system().await?;
+        let storage_type = DatabaseGlobalsModel::new(&mut tx)
+            .initialize_storage_tag(storage_tag_initializer, instance_name)
+            .await?;
+        database
+            .commit_with_write_source(tx, "init_storage")
+            .await?;
+        Ok(storage_type)
+    }
+
+    pub async fn load_storage(
+        runtime: RT,
+        database: &Database<RT>,
+    ) -> anyhow::Result<ApplicationStorage> {
+        let storage_type = {
+            let mut tx = database.begin_system().await?;
+            DatabaseGlobalsModel::new(&mut tx)
+                .database_globals()
+                .await?
+                .storage_type
+                .clone()
+                .context("Database storage has not been initialized")?
+        };
+        Self::storage_from_type(runtime, database, storage_type).await
     }
 
     pub async fn new(

--- a/crates/common/src/persistence.rs
+++ b/crates/common/src/persistence.rs
@@ -190,6 +190,18 @@ pub enum PersistenceGlobalKey {
     /// copied into checkpoints.
     RaftNatsOutbox,
 
+    /// Identity of the canonical cluster genesis installed through every
+    /// partition's Raft state machine. This is cluster-global and must be
+    /// copied into checkpoints so fresh and snapshot-restored voters retain
+    /// the same genesis authority.
+    ClusterGenesis,
+
+    /// Node-local evidence that this persistence applied cluster genesis from
+    /// its partition's Raft log. Unlike `ClusterGenesis`, this must not be
+    /// copied into checkpoints because each voter proves Raft application
+    /// independently.
+    ClusterGenesisRaftApplied,
+
     /// Internal id of _tables.by_id index, for bootstrapping.
     TablesByIdIndex,
     /// Internal id of _tables table, for bootstrapping.
@@ -225,6 +237,10 @@ impl From<PersistenceGlobalKey> for String {
             PersistenceGlobalKey::TableSummary => "table_summary".to_string(),
             PersistenceGlobalKey::TwoPhaseRedoRecords => "two_phase_redo_records".to_string(),
             PersistenceGlobalKey::RaftNatsOutbox => "raft_nats_outbox".to_string(),
+            PersistenceGlobalKey::ClusterGenesis => "cluster_genesis".to_string(),
+            PersistenceGlobalKey::ClusterGenesisRaftApplied => {
+                "cluster_genesis_raft_applied".to_string()
+            },
             PersistenceGlobalKey::TablesByIdIndex => "tables_by_id".to_string(),
             PersistenceGlobalKey::IndexByIdIndex => "index_by_id".to_string(),
             // NB: For compatibility, these are referred to as "table_id"s, not "tablet_id"s.
@@ -250,6 +266,8 @@ impl FromStr for PersistenceGlobalKey {
             "table_summary" => Ok(Self::TableSummary),
             "two_phase_redo_records" => Ok(Self::TwoPhaseRedoRecords),
             "raft_nats_outbox" => Ok(Self::RaftNatsOutbox),
+            "cluster_genesis" => Ok(Self::ClusterGenesis),
+            "cluster_genesis_raft_applied" => Ok(Self::ClusterGenesisRaftApplied),
             "tables_by_id" => Ok(Self::TablesByIdIndex),
             "tables_table_id" => Ok(Self::TablesTabletId),
             "index_by_id" => Ok(Self::IndexByIdIndex),
@@ -267,7 +285,14 @@ impl PersistenceGlobalKey {
     pub fn checkpoint_keys() -> Vec<Self> {
         Self::all_keys()
             .into_iter()
-            .filter(|key| !matches!(key, Self::TwoPhaseRedoRecords | Self::RaftNatsOutbox))
+            .filter(|key| {
+                !matches!(
+                    key,
+                    Self::TwoPhaseRedoRecords
+                        | Self::RaftNatsOutbox
+                        | Self::ClusterGenesisRaftApplied
+                )
+            })
             .collect()
     }
 }

--- a/crates/database/Cargo.toml
+++ b/crates/database/Cargo.toml
@@ -38,6 +38,7 @@ async-broadcast = { workspace = true }
 async-nats = { workspace = true }
 async-recursion = { workspace = true }
 async-trait = { workspace = true }
+base64 = { workspace = true }
 bytes = { workspace = true }
 async_lru = { workspace = true }
 cmd_util = { workspace = true }

--- a/crates/database/src/checkpoint.rs
+++ b/crates/database/src/checkpoint.rs
@@ -41,6 +41,7 @@ use common::{
     types::{
         IndexId,
         PersistenceVersion,
+        RepeatableTimestamp,
         Timestamp,
     },
 };
@@ -65,6 +66,44 @@ pub struct CheckpointData {
     pub globals: BTreeMap<String, JsonValue>,
 }
 
+/// A checkpoint scans the physical document log from its beginning, but the
+/// logical snapshot it must protect is `checkpoint_ts`. Persistence backends
+/// validate the lower bound of `load_documents`, which would otherwise reject
+/// every checkpoint once retention advances beyond `Timestamp::MIN`.
+struct CheckpointRetentionValidator {
+    inner: Arc<dyn RetentionValidator>,
+    checkpoint_ts: Timestamp,
+}
+
+#[async_trait]
+impl RetentionValidator for CheckpointRetentionValidator {
+    fn optimistic_validate_snapshot(&self, _ts: Timestamp) -> anyhow::Result<()> {
+        self.inner.optimistic_validate_snapshot(self.checkpoint_ts)
+    }
+
+    async fn validate_snapshot(&self, _ts: Timestamp) -> anyhow::Result<()> {
+        self.inner.validate_snapshot(self.checkpoint_ts).await
+    }
+
+    async fn validate_document_snapshot(&self, _ts: Timestamp) -> anyhow::Result<()> {
+        self.inner
+            .validate_document_snapshot(self.checkpoint_ts)
+            .await
+    }
+
+    async fn min_snapshot_ts(&self) -> anyhow::Result<RepeatableTimestamp> {
+        self.inner.min_snapshot_ts().await
+    }
+
+    async fn min_document_snapshot_ts(&self) -> anyhow::Result<RepeatableTimestamp> {
+        self.inner.min_document_snapshot_ts().await
+    }
+
+    fn fail_if_falling_behind(&self) -> anyhow::Result<()> {
+        self.inner.fail_if_falling_behind()
+    }
+}
+
 /// Creates a checkpoint from an existing persistence layer.
 /// Called periodically on the Primary to produce checkpoint files.
 pub async fn create_checkpoint(
@@ -72,12 +111,16 @@ pub async fn create_checkpoint(
     timestamp: Timestamp,
     retention_validator: Arc<dyn RetentionValidator>,
 ) -> anyhow::Result<CheckpointData> {
+    let checkpoint_retention_validator = Arc::new(CheckpointRetentionValidator {
+        inner: retention_validator,
+        checkpoint_ts: timestamp,
+    });
     let documents: Vec<DocumentLogEntry> = persistence
         .load_documents(
             TimestampRange::new((Bound::Unbounded, Bound::Included(timestamp))),
             Order::Asc,
             10_000,
-            retention_validator,
+            checkpoint_retention_validator,
         )
         .try_collect()
         .await
@@ -346,5 +389,36 @@ impl PersistenceReader for CheckpointPersistence {
 
     fn version(&self) -> PersistenceVersion {
         self.version
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use common::{
+        persistence::{
+            fake_retention_validator::FakeRetentionValidator,
+            RetentionValidator,
+        },
+        types::Timestamp,
+    };
+
+    use super::CheckpointRetentionValidator;
+
+    #[convex_macro::test_runtime]
+    async fn checkpoint_retention_validates_checkpoint_ts_instead_of_scan_start(
+        _rt: common::runtime::testing::TestRuntime,
+    ) -> anyhow::Result<()> {
+        let retention_min = Timestamp::try_from(100u64)?;
+        let checkpoint_ts = Timestamp::try_from(200u64)?;
+        let validator = CheckpointRetentionValidator {
+            inner: Arc::new(FakeRetentionValidator::new(retention_min, retention_min)),
+            checkpoint_ts,
+        };
+
+        validator.validate_document_snapshot(Timestamp::MIN).await?;
+        validator.validate_snapshot(Timestamp::MIN).await?;
+        Ok(())
     }
 }

--- a/crates/database/src/cluster_genesis.rs
+++ b/crates/database/src/cluster_genesis.rs
@@ -1,0 +1,431 @@
+//! Canonical clustered database genesis.
+//!
+//! Fresh Convex persistences contain random bootstrap IDs and deployment-global
+//! values. A cluster therefore cannot treat independent local initialization as
+//! equivalent state. Partition 0 creates one checkpoint candidate, commits it
+//! through Raft, and publishes the committed payload for the other partition
+//! leaders to commit through their own Raft groups. NATS transports the
+//! payload; the per-partition Raft logs remain the installation authority.
+
+use anyhow::Context;
+use async_nats::jetstream::object_store::GetErrorKind;
+use common::{
+    persistence::PersistenceGlobalKey,
+    sha256::Sha256,
+};
+use serde::{
+    Deserialize,
+    Serialize,
+};
+use tokio::io::AsyncReadExt;
+
+use crate::{
+    checkpoint::CheckpointData,
+    partition::PartitionId,
+    snapshot_checkpointer::{
+        checkpoint_from_bytes,
+        checkpoint_to_bytes,
+    },
+};
+
+const GENESIS_FORMAT_VERSION: u32 = 1;
+const GENESIS_KV_BUCKET: &str = "convex_cluster_genesis";
+const GENESIS_OBJECT_BUCKET: &str = "convex_cluster_genesis_payloads";
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct ClusterGenesisMarker {
+    pub format_version: u32,
+    pub genesis_id: String,
+}
+
+impl ClusterGenesisMarker {
+    pub fn parse(value: serde_json::Value) -> anyhow::Result<Self> {
+        let marker: Self =
+            serde_json::from_value(value).context("Cluster genesis marker is malformed")?;
+        anyhow::ensure!(
+            marker.format_version == GENESIS_FORMAT_VERSION,
+            "Unsupported cluster genesis format version {}",
+            marker.format_version,
+        );
+        anyhow::ensure!(
+            !marker.genesis_id.is_empty(),
+            "Cluster genesis ID must not be empty",
+        );
+        Ok(marker)
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct ClusterGenesisManifest {
+    pub format_version: u32,
+    pub genesis_id: String,
+    pub payload_sha256: String,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct CanonicalGenesisPayload {
+    pub manifest: ClusterGenesisManifest,
+    pub checkpoint_bytes: Vec<u8>,
+}
+
+pub fn validate_manifest(manifest: &ClusterGenesisManifest) -> anyhow::Result<()> {
+    anyhow::ensure!(
+        manifest.format_version == GENESIS_FORMAT_VERSION,
+        "Unsupported cluster genesis manifest version {}",
+        manifest.format_version,
+    );
+    anyhow::ensure!(
+        !manifest.genesis_id.is_empty(),
+        "Cluster genesis manifest ID must not be empty",
+    );
+    anyhow::ensure!(
+        !manifest.payload_sha256.is_empty(),
+        "Cluster genesis payload digest must not be empty",
+    );
+    Ok(())
+}
+
+fn digest(bytes: &[u8]) -> String {
+    hex::encode(Sha256::hash(bytes))
+}
+
+fn node_local_checkpoint_keys() -> impl Iterator<Item = PersistenceGlobalKey> {
+    [
+        PersistenceGlobalKey::ReplicationFrontiers,
+        PersistenceGlobalKey::AppliedDeltaWatermarks,
+        PersistenceGlobalKey::AppliedDataDeltaWatermarks,
+        PersistenceGlobalKey::AppliedDataDeltaIds,
+        PersistenceGlobalKey::ClusterGenesisRaftApplied,
+    ]
+    .into_iter()
+}
+
+pub fn canonicalize_checkpoint(
+    mut checkpoint: CheckpointData,
+) -> anyhow::Result<CanonicalGenesisPayload> {
+    for key in node_local_checkpoint_keys() {
+        checkpoint.globals.remove(&String::from(key));
+    }
+    checkpoint
+        .globals
+        .remove(&String::from(PersistenceGlobalKey::ClusterGenesis));
+
+    let genesis_id = digest(&checkpoint_to_bytes(&checkpoint)?);
+    let marker = ClusterGenesisMarker {
+        format_version: GENESIS_FORMAT_VERSION,
+        genesis_id: genesis_id.clone(),
+    };
+    checkpoint.globals.insert(
+        String::from(PersistenceGlobalKey::ClusterGenesis),
+        serde_json::to_value(marker)?,
+    );
+    let checkpoint_bytes = checkpoint_to_bytes(&checkpoint)?;
+    let manifest = ClusterGenesisManifest {
+        format_version: GENESIS_FORMAT_VERSION,
+        genesis_id,
+        payload_sha256: digest(&checkpoint_bytes),
+    };
+    Ok(CanonicalGenesisPayload {
+        manifest,
+        checkpoint_bytes,
+    })
+}
+
+pub fn validate_payload(
+    manifest: &ClusterGenesisManifest,
+    checkpoint_bytes: &[u8],
+) -> anyhow::Result<CheckpointData> {
+    validate_manifest(manifest)?;
+    anyhow::ensure!(
+        digest(checkpoint_bytes) == manifest.payload_sha256,
+        "Cluster genesis payload digest does not match manifest",
+    );
+    let checkpoint = checkpoint_from_bytes(checkpoint_bytes)
+        .context("Failed to decode cluster genesis checkpoint")?;
+    let marker_value = checkpoint
+        .globals
+        .get(&String::from(PersistenceGlobalKey::ClusterGenesis))
+        .context("Cluster genesis checkpoint is missing its durable marker")?
+        .clone();
+    let marker = ClusterGenesisMarker::parse(marker_value)?;
+    anyhow::ensure!(
+        marker.genesis_id == manifest.genesis_id,
+        "Cluster genesis checkpoint ID {} does not match manifest {}",
+        marker.genesis_id,
+        manifest.genesis_id,
+    );
+    Ok(checkpoint)
+}
+
+fn encode<T: Serialize>(value: &T, context: &str) -> anyhow::Result<Vec<u8>> {
+    serde_json::to_vec(value).with_context(|| format!("Failed to encode {context}"))
+}
+
+fn decode<'a, T: Deserialize<'a>>(bytes: &'a [u8], context: &str) -> anyhow::Result<T> {
+    serde_json::from_slice(bytes).with_context(|| format!("Failed to decode {context}"))
+}
+
+#[derive(Clone)]
+pub struct NatsClusterGenesisStore {
+    kv: async_nats::jetstream::kv::Store,
+    objects: async_nats::jetstream::object_store::ObjectStore,
+    namespace: String,
+}
+
+impl NatsClusterGenesisStore {
+    pub async fn connect(nats_url: &str, cluster_secret: &[u8]) -> anyhow::Result<Self> {
+        let _ = rustls::crypto::ring::default_provider().install_default();
+        let client = async_nats::connect(nats_url)
+            .await
+            .with_context(|| format!("Cluster genesis: failed to connect to NATS at {nats_url}"))?;
+        let jetstream = async_nats::jetstream::new(client);
+        let kv = jetstream
+            .create_key_value(async_nats::jetstream::kv::Config {
+                bucket: GENESIS_KV_BUCKET.to_string(),
+                history: 4,
+                ..Default::default()
+            })
+            .await
+            .context("Cluster genesis: failed to create metadata bucket")?;
+        let objects = match jetstream.get_object_store(GENESIS_OBJECT_BUCKET).await {
+            Ok(objects) => objects,
+            Err(_) => match jetstream
+                .create_object_store(async_nats::jetstream::object_store::Config {
+                    bucket: GENESIS_OBJECT_BUCKET.to_string(),
+                    description: Some("Canonical Convex cluster genesis checkpoints".to_string()),
+                    ..Default::default()
+                })
+                .await
+            {
+                Ok(objects) => objects,
+                Err(_) => jetstream
+                    .get_object_store(GENESIS_OBJECT_BUCKET)
+                    .await
+                    .context("Cluster genesis: failed to create or open payload bucket")?,
+            },
+        };
+        Ok(Self {
+            kv,
+            objects,
+            namespace: digest(cluster_secret),
+        })
+    }
+
+    fn manifest_key(&self) -> &str {
+        &self.namespace
+    }
+
+    fn payload_key(&self, genesis_id: &str) -> String {
+        format!("{}-{genesis_id}", self.namespace)
+    }
+
+    fn partition_ready_key(&self, partition: PartitionId) -> String {
+        format!("{}.partition.{}", self.namespace, partition.0)
+    }
+
+    pub async fn load_manifest(&self) -> anyhow::Result<Option<ClusterGenesisManifest>> {
+        let Some(entry) = self
+            .kv
+            .entry(self.manifest_key())
+            .await
+            .context("Cluster genesis: failed to read canonical manifest")?
+        else {
+            return Ok(None);
+        };
+        Ok(Some(decode(&entry.value, "cluster genesis manifest")?))
+    }
+
+    pub async fn put_payload(&self, payload: &CanonicalGenesisPayload) -> anyhow::Result<()> {
+        let key = self.payload_key(&payload.manifest.genesis_id);
+        if let Some(existing) = self.load_payload(&payload.manifest).await? {
+            anyhow::ensure!(
+                existing == payload.checkpoint_bytes,
+                "Cluster genesis object {key} already contains different bytes",
+            );
+            return Ok(());
+        }
+        self.objects
+            .put(key.as_str(), &mut payload.checkpoint_bytes.as_slice())
+            .await
+            .context("Cluster genesis: failed to upload checkpoint payload")?;
+        Ok(())
+    }
+
+    pub async fn load_payload(
+        &self,
+        manifest: &ClusterGenesisManifest,
+    ) -> anyhow::Result<Option<Vec<u8>>> {
+        let Some(bytes) = self
+            .load_payload_by_genesis_id(&manifest.genesis_id)
+            .await?
+        else {
+            return Ok(None);
+        };
+        validate_payload(manifest, &bytes)?;
+        Ok(Some(bytes))
+    }
+
+    pub async fn load_payload_by_genesis_id(
+        &self,
+        genesis_id: &str,
+    ) -> anyhow::Result<Option<Vec<u8>>> {
+        let key = self.payload_key(genesis_id);
+        let mut object = match self.objects.get(&key).await {
+            Ok(object) => object,
+            Err(error) if error.kind() == GetErrorKind::NotFound => return Ok(None),
+            Err(error) => {
+                return Err(error).context("Cluster genesis: failed to read checkpoint payload");
+            },
+        };
+        let mut bytes = Vec::new();
+        object
+            .read_to_end(&mut bytes)
+            .await
+            .context("Cluster genesis: failed to download checkpoint payload")?;
+        Ok(Some(bytes))
+    }
+
+    pub async fn publish_manifest(&self, manifest: &ClusterGenesisManifest) -> anyhow::Result<()> {
+        if let Some(existing) = self.load_manifest().await? {
+            anyhow::ensure!(
+                existing == *manifest,
+                "Cluster already has genesis {}, refusing conflicting genesis {}",
+                existing.genesis_id,
+                manifest.genesis_id,
+            );
+            return Ok(());
+        }
+        let bytes = encode(manifest, "cluster genesis manifest")?;
+        if self
+            .kv
+            .create(self.manifest_key(), bytes.into())
+            .await
+            .is_err()
+        {
+            let existing = self
+                .load_manifest()
+                .await?
+                .context("Cluster genesis manifest disappeared after create race")?;
+            anyhow::ensure!(
+                existing == *manifest,
+                "Concurrent cluster genesis {} conflicts with {}",
+                existing.genesis_id,
+                manifest.genesis_id,
+            );
+        }
+        Ok(())
+    }
+
+    pub async fn mark_partition_ready(
+        &self,
+        partition: PartitionId,
+        manifest: &ClusterGenesisManifest,
+    ) -> anyhow::Result<()> {
+        let key = self.partition_ready_key(partition);
+        let value = encode(manifest, "partition genesis readiness")?;
+        match self.kv.entry(&key).await? {
+            Some(entry) => {
+                let existing: ClusterGenesisManifest =
+                    decode(&entry.value, "partition genesis readiness")?;
+                anyhow::ensure!(
+                    existing == *manifest,
+                    "Partition {} reports conflicting cluster genesis {}",
+                    partition,
+                    existing.genesis_id,
+                );
+            },
+            None => {
+                if self.kv.create(&key, value.into()).await.is_err() {
+                    let entry = self
+                        .kv
+                        .entry(&key)
+                        .await?
+                        .context("Partition genesis readiness disappeared after create race")?;
+                    let existing: ClusterGenesisManifest =
+                        decode(&entry.value, "partition genesis readiness")?;
+                    anyhow::ensure!(existing == *manifest, "Partition genesis race conflicted");
+                }
+            },
+        }
+        Ok(())
+    }
+
+    pub async fn all_partitions_ready(
+        &self,
+        num_partitions: u32,
+        manifest: &ClusterGenesisManifest,
+    ) -> anyhow::Result<bool> {
+        for partition in 0..num_partitions {
+            let Some(entry) = self
+                .kv
+                .entry(self.partition_ready_key(PartitionId(partition)))
+                .await?
+            else {
+                return Ok(false);
+            };
+            let ready: ClusterGenesisManifest =
+                decode(&entry.value, "partition genesis readiness")?;
+            anyhow::ensure!(
+                ready == *manifest,
+                "Partition {partition} is ready on conflicting genesis {}",
+                ready.genesis_id,
+            );
+        }
+        Ok(true)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+
+    use common::types::Timestamp;
+
+    use super::*;
+
+    fn checkpoint() -> CheckpointData {
+        CheckpointData {
+            timestamp: Timestamp::must(7),
+            documents: Vec::new(),
+            globals: BTreeMap::from([
+                (
+                    String::from(PersistenceGlobalKey::TablesTabletId),
+                    serde_json::json!("tables"),
+                ),
+                (
+                    String::from(PersistenceGlobalKey::ReplicationFrontiers),
+                    serde_json::json!({"0": 9}),
+                ),
+            ]),
+        }
+    }
+
+    #[test]
+    fn canonical_payload_is_stable_and_strips_node_local_progress() -> anyhow::Result<()> {
+        let first = canonicalize_checkpoint(checkpoint())?;
+        let second = canonicalize_checkpoint(checkpoint())?;
+        assert_eq!(first, second);
+
+        let decoded = validate_payload(&first.manifest, &first.checkpoint_bytes)?;
+        assert!(!decoded
+            .globals
+            .contains_key(&String::from(PersistenceGlobalKey::ReplicationFrontiers)));
+        let marker = ClusterGenesisMarker::parse(
+            decoded.globals[&String::from(PersistenceGlobalKey::ClusterGenesis)].clone(),
+        )?;
+        assert_eq!(marker.genesis_id, first.manifest.genesis_id);
+        Ok(())
+    }
+
+    #[test]
+    fn payload_corruption_fails_closed() -> anyhow::Result<()> {
+        let mut payload = canonicalize_checkpoint(checkpoint())?;
+        payload.checkpoint_bytes.push(0);
+        let error = match validate_payload(&payload.manifest, &payload.checkpoint_bytes) {
+            Ok(_) => panic!("corrupt payload unexpectedly validated"),
+            Err(error) => error,
+        };
+        assert!(format!("{error:#}").contains("digest does not match"));
+        Ok(())
+    }
+}

--- a/crates/database/src/commit_delta.rs
+++ b/crates/database/src/commit_delta.rs
@@ -12,7 +12,13 @@ use std::{
     },
     error::Error,
     fmt,
-    sync::Arc,
+    sync::{
+        atomic::{
+            AtomicBool,
+            Ordering,
+        },
+        Arc,
+    },
     time::Duration,
 };
 
@@ -267,6 +273,47 @@ impl DistributedLog for NoopDistributedLog {
     }
 }
 
+/// Suppresses bootstrap-candidate deltas until canonical cluster genesis has
+/// been confirmed. Candidate state is intentionally local and must never enter
+/// the shared replication stream.
+pub struct ClusterGenesisGatedDistributedLog {
+    inner: Arc<dyn DistributedLog>,
+    ready: Arc<AtomicBool>,
+}
+
+impl ClusterGenesisGatedDistributedLog {
+    pub fn new(inner: Arc<dyn DistributedLog>, ready: Arc<AtomicBool>) -> Self {
+        Self { inner, ready }
+    }
+}
+
+#[async_trait]
+impl DistributedLog for ClusterGenesisGatedDistributedLog {
+    async fn publish(&self, delta: CommitDelta) -> anyhow::Result<()> {
+        if !self.ready.load(Ordering::SeqCst) {
+            return Ok(());
+        }
+        self.inner.publish(delta).await
+    }
+
+    async fn subscribe(
+        &self,
+        from_ts: Timestamp,
+    ) -> anyhow::Result<BoxStream<'static, anyhow::Result<ReplicationMessage>>> {
+        self.inner.subscribe(from_ts).await
+    }
+
+    async fn subscribe_filtered(
+        &self,
+        from_ts: Timestamp,
+        source_partitions: Option<Vec<PartitionId>>,
+    ) -> anyhow::Result<BoxStream<'static, anyhow::Result<ReplicationMessage>>> {
+        self.inner
+            .subscribe_filtered(from_ts, source_partitions)
+            .await
+    }
+}
+
 impl CommitDelta {
     pub fn touched_table_names(&self) -> BTreeSet<TableName> {
         self.tablet_id_to_table_name.values().cloned().collect()
@@ -361,16 +408,54 @@ pub mod testing {
 mod tests {
     use std::{
         collections::BTreeMap,
-        sync::Arc,
+        sync::{
+            atomic::{
+                AtomicBool,
+                Ordering,
+            },
+            Arc,
+        },
     };
 
     use common::types::Timestamp;
     use value::TableName;
 
     use crate::{
-        commit_delta::CommitDelta,
+        commit_delta::{
+            testing::InMemoryDistributedLog,
+            ClusterGenesisGatedDistributedLog,
+            CommitDelta,
+            DistributedLog,
+        },
         write_log::WriteSource,
     };
+
+    fn test_delta() -> CommitDelta {
+        CommitDelta {
+            ts: Timestamp::MIN,
+            document_writes: Arc::new(Vec::new()),
+            document_updates: Vec::new(),
+            index_writes: Arc::new(Vec::new()),
+            write_source: WriteSource::unknown(),
+            write_bytes: 0,
+            tablet_id_to_table_name: BTreeMap::new(),
+            source_partition: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn cluster_genesis_gate_suppresses_candidate_deltas() {
+        let inner = Arc::new(InMemoryDistributedLog::new());
+        let ready = Arc::new(AtomicBool::new(false));
+        let gated = ClusterGenesisGatedDistributedLog::new(inner.clone(), ready.clone());
+
+        gated.publish(test_delta()).await.unwrap();
+        assert!(inner.deltas().is_empty());
+
+        ready.store(true, Ordering::SeqCst);
+        gated.publish(test_delta()).await.unwrap();
+        assert_eq!(inner.deltas().len(), 1);
+    }
 
     #[test]
     fn touched_table_names_collects_unique_tables() {

--- a/crates/database/src/committer.rs
+++ b/crates/database/src/committer.rs
@@ -1843,10 +1843,10 @@ impl<RT: Runtime> Committer<RT> {
                             );
                             let _ = result.send(r);
                         },
-                        Some(CommitterMessage::AllocateCommitTs { result }) => {
+                        Some(CommitterMessage::AllocateCommitTs { min_ts, result }) => {
                             let r = self
                                 .ensure_leader_for_writes()
-                                .and_then(|_| self.next_commit_ts());
+                                .and_then(|_| self.next_commit_ts_at_or_after(min_ts));
                             let _ = result.send(r);
                         },
                         Some(CommitterMessage::CommitPrepared {
@@ -2215,7 +2215,7 @@ impl<RT: Runtime> Committer<RT> {
         if self
             .raft_state
             .as_ref()
-            .is_some_and(|raft_state| !raft_state.is_leader())
+            .is_none_or(|raft_state| !raft_state.can_serve_as_leader())
         {
             return;
         }
@@ -2252,7 +2252,7 @@ impl<RT: Runtime> Committer<RT> {
         if self
             .raft_state
             .as_ref()
-            .is_some_and(|raft_state| !raft_state.is_leader())
+            .is_none_or(|raft_state| !raft_state.can_serve_as_leader())
         {
             return Ok(None);
         }
@@ -2262,6 +2262,11 @@ impl<RT: Runtime> Committer<RT> {
 
     fn ensure_leader_for_writes(&self) -> anyhow::Result<()> {
         if let Some(ref raft) = self.raft_state {
+            anyhow::ensure!(
+                raft.is_cluster_genesis_ready(),
+                "Cluster genesis is not ready for partition {}; retry after bootstrap completes",
+                raft.partition_id(),
+            );
             if !raft.is_leader() {
                 let leader = raft.leader_id();
                 metrics::log_write_rejected_not_leader(raft.partition_id());
@@ -2452,11 +2457,11 @@ impl<RT: Runtime> Committer<RT> {
                 );
                 local_commit_floor
             } else {
-                anyhow::bail!(
-                    "2PC Prepare assigned ts={} but this participant requires ts>={}",
-                    commit_ts,
-                    local_commit_floor,
-                );
+                return Err(crate::two_phase::PrepareTimestampTooLow {
+                    proposed_ts: commit_ts,
+                    required_ts: local_commit_floor,
+                }
+                .into());
             };
             (commit_ts, local_commit_ts)
         } else {
@@ -3149,7 +3154,7 @@ impl<RT: Runtime> Committer<RT> {
         }
         self.raft_state
             .as_ref()
-            .is_none_or(|raft_state| raft_state.is_leader())
+            .is_some_and(|raft_state| raft_state.can_serve_as_leader())
     }
 
     fn propose_commit_to_raft_state(
@@ -3159,6 +3164,11 @@ impl<RT: Runtime> Committer<RT> {
         let Some(raft) = raft_state else {
             return Ok(None);
         };
+        anyhow::ensure!(
+            raft.is_cluster_genesis_ready(),
+            "Cluster genesis is not ready for partition {}",
+            raft.partition_id(),
+        );
         if !raft.is_leader() {
             anyhow::bail!(
                 "Raft leadership lost before proposing commit at ts={} for partition {}",
@@ -3202,6 +3212,11 @@ impl<RT: Runtime> Committer<RT> {
         let Some(raft) = self.raft_state.as_ref() else {
             return Ok(None);
         };
+        anyhow::ensure!(
+            raft.is_cluster_genesis_ready(),
+            "Cluster genesis is not ready for partition {}",
+            raft.partition_id(),
+        );
         if !raft.is_leader() {
             anyhow::bail!(
                 "Raft leadership lost before proposing 2PC prepare for txn={} on partition {}",
@@ -4457,11 +4472,11 @@ impl<RT: Runtime> Committer<RT> {
             metrics::log_two_phase_resolver_validation(local_partition, "timestamp_floor");
             metrics::log_two_phase_resolver_timestamp_floor_rejection(local_partition);
             timer.finish_with("timestamp_floor");
-            anyhow::bail!(
-                "2PC Prepare assigned ts={} but this participant requires ts>={}",
-                validate_ts,
-                local_commit_floor,
-            );
+            return Err(crate::two_phase::PrepareTimestampTooLow {
+                proposed_ts: validate_ts,
+                required_ts: local_commit_floor,
+            }
+            .into());
         }
 
         let stale_timer = metrics::commit_is_stale_timer();
@@ -5661,8 +5676,15 @@ impl<RT: Runtime> Committer<RT> {
     }
 
     fn next_commit_ts(&mut self) -> anyhow::Result<Timestamp> {
+        self.next_commit_ts_at_or_after(Timestamp::MIN)
+    }
+
+    fn next_commit_ts_at_or_after(
+        &mut self,
+        requested_floor: Timestamp,
+    ) -> anyhow::Result<Timestamp> {
         let _timer = next_commit_ts_seconds();
-        let local_floor = self.local_commit_floor()?;
+        let local_floor = cmp::max(self.local_commit_floor()?, requested_floor);
         let timestamp_stage_path = if self.timestamp_oracle.is_some() {
             "tso"
         } else {
@@ -6239,8 +6261,15 @@ impl CommitterClient {
     }
 
     pub async fn allocate_commit_ts(&self) -> anyhow::Result<Timestamp> {
+        self.allocate_commit_ts_at_or_after(Timestamp::MIN).await
+    }
+
+    pub async fn allocate_commit_ts_at_or_after(
+        &self,
+        min_ts: Timestamp,
+    ) -> anyhow::Result<Timestamp> {
         let (tx, rx) = oneshot::channel();
-        let message = CommitterMessage::AllocateCommitTs { result: tx };
+        let message = CommitterMessage::AllocateCommitTs { min_ts, result: tx };
         self.sender.try_send(message).map_err(|e| match e {
             TrySendError::Full(..) => metrics::committer_full_error().into(),
             TrySendError::Closed(..) => metrics::shutdown_error(),
@@ -6523,6 +6552,7 @@ enum CommitterMessage {
         result: oneshot::Sender<anyhow::Result<()>>,
     },
     AllocateCommitTs {
+        min_ts: Timestamp,
         result: oneshot::Sender<anyhow::Result<Timestamp>>,
     },
     /// 2PC CommitPrepared: finalize a previously prepared transaction.

--- a/crates/database/src/lib.rs
+++ b/crates/database/src/lib.rs
@@ -12,6 +12,7 @@
 
 mod bootstrap_model;
 pub mod checkpoint;
+pub mod cluster_genesis;
 pub mod commit_client;
 pub mod commit_delta;
 mod committer;

--- a/crates/database/src/raft_partition.rs
+++ b/crates/database/src/raft_partition.rs
@@ -79,6 +79,8 @@ pub struct RaftPartitionState {
     node_id: u64,
     /// Local serving lease for coordinator-owned reads/subscriptions.
     leader_serving_lease_valid_until: Arc<Mutex<Option<Instant>>>,
+    /// Cluster-wide genesis has been installed by every configured partition.
+    cluster_genesis_ready: Arc<AtomicBool>,
 }
 
 impl RaftPartitionState {
@@ -94,6 +96,18 @@ impl RaftPartitionState {
         self.leader_serving_lease_valid_until
             .lock()
             .is_some_and(|valid_until| valid_until > Instant::now())
+    }
+
+    pub fn is_cluster_genesis_ready(&self) -> bool {
+        self.cluster_genesis_ready.load(Ordering::SeqCst)
+    }
+
+    pub fn mark_cluster_genesis_ready(&self) {
+        self.cluster_genesis_ready.store(true, Ordering::SeqCst);
+    }
+
+    pub fn can_serve_as_leader(&self) -> bool {
+        self.is_cluster_genesis_ready() && self.is_leader() && self.has_leader_serving_lease()
     }
 
     /// Get the current leader's node ID.
@@ -151,12 +165,18 @@ impl RaftPartitionState {
             } else {
                 None
             })),
+            cluster_genesis_ready: Arc::new(AtomicBool::new(true)),
         }
     }
 
     #[cfg(any(test, feature = "testing"))]
     pub fn expire_leader_serving_lease_for_test(&self) {
         *self.leader_serving_lease_valid_until.lock() = Some(Instant::now());
+    }
+
+    #[cfg(any(test, feature = "testing"))]
+    pub fn mark_cluster_genesis_unready_for_test(&self) {
+        self.cluster_genesis_ready.store(false, Ordering::SeqCst);
     }
 }
 
@@ -181,6 +201,24 @@ impl RaftPartitionManager {
         peer_senders: HashMap<u64, mpsc::UnboundedSender<Message>>,
         snapshot_provider: Option<Arc<dyn crate::raft_storage::RaftSnapshotProvider>>,
         timestamp_oracle: Option<Arc<dyn TimestampOracle>>,
+    ) -> anyhow::Result<Self> {
+        Self::new_with_cluster_genesis_gate(
+            config,
+            engine,
+            peer_senders,
+            snapshot_provider,
+            timestamp_oracle,
+            Arc::new(AtomicBool::new(true)),
+        )
+    }
+
+    pub fn new_with_cluster_genesis_gate(
+        config: RaftNodeConfig,
+        engine: Arc<raft_engine::Engine>,
+        peer_senders: HashMap<u64, mpsc::UnboundedSender<Message>>,
+        snapshot_provider: Option<Arc<dyn crate::raft_storage::RaftSnapshotProvider>>,
+        timestamp_oracle: Option<Arc<dyn TimestampOracle>>,
+        cluster_genesis_ready: Arc<AtomicBool>,
     ) -> anyhow::Result<Self> {
         let (mailbox_tx, mailbox_rx) = mpsc::unbounded_channel();
 
@@ -265,6 +303,7 @@ impl RaftPartitionManager {
             partition_id: config.partition_id,
             node_id: config.node_id,
             leader_serving_lease_valid_until,
+            cluster_genesis_ready,
         };
         metrics::log_raft_is_leader(config.partition_id, false);
         metrics::log_raft_leader_id(config.partition_id, 0);

--- a/crates/database/src/raft_state_machine.rs
+++ b/crates/database/src/raft_state_machine.rs
@@ -11,6 +11,10 @@ use serde::{
 };
 
 use crate::{
+    cluster_genesis::{
+        CanonicalGenesisPayload,
+        ClusterGenesisManifest,
+    },
     commit_delta::CommitDelta,
     nats_distributed_log::DeltaEnvelope,
     two_phase::TwoPhaseRedoEntry,
@@ -20,8 +24,16 @@ use crate::{
 #[derive(Serialize, Deserialize)]
 #[serde(tag = "type", content = "payload", rename_all = "snake_case")]
 pub enum RaftStateMachineEntry {
-    CommitDelta { envelope: DeltaEnvelope },
-    TwoPhasePrepare { redo: TwoPhaseRedoEntry },
+    CommitDelta {
+        envelope: DeltaEnvelope,
+    },
+    TwoPhasePrepare {
+        redo: TwoPhaseRedoEntry,
+    },
+    ClusterGenesis {
+        manifest: ClusterGenesisManifest,
+        checkpoint_base64: String,
+    },
 }
 
 impl RaftStateMachineEntry {
@@ -33,6 +45,13 @@ impl RaftStateMachineEntry {
 
     pub fn two_phase_prepare(redo: TwoPhaseRedoEntry) -> Self {
         Self::TwoPhasePrepare { redo }
+    }
+
+    pub fn cluster_genesis(payload: &CanonicalGenesisPayload) -> Self {
+        Self::ClusterGenesis {
+            manifest: payload.manifest.clone(),
+            checkpoint_base64: base64::encode(&payload.checkpoint_bytes),
+        }
     }
 
     pub fn to_bytes(&self) -> anyhow::Result<Vec<u8>> {
@@ -86,6 +105,9 @@ mod tests {
             RaftStateMachineEntry::TwoPhasePrepare { .. } => {
                 panic!("expected commit delta entry")
             },
+            RaftStateMachineEntry::ClusterGenesis { .. } => {
+                panic!("expected commit delta entry")
+            },
         }
         Ok(())
     }
@@ -112,6 +134,31 @@ mod tests {
             RaftStateMachineEntry::TwoPhasePrepare { .. } => {
                 panic!("expected commit delta entry")
             },
+            RaftStateMachineEntry::ClusterGenesis { .. } => {
+                panic!("expected commit delta entry")
+            },
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn cluster_genesis_entry_roundtrips() -> anyhow::Result<()> {
+        let payload =
+            crate::cluster_genesis::canonicalize_checkpoint(crate::checkpoint::CheckpointData {
+                timestamp: Timestamp::must(9),
+                documents: Vec::new(),
+                globals: Default::default(),
+            })?;
+        let bytes = RaftStateMachineEntry::cluster_genesis(&payload).to_bytes()?;
+        match RaftStateMachineEntry::from_bytes(&bytes)? {
+            RaftStateMachineEntry::ClusterGenesis {
+                manifest,
+                checkpoint_base64,
+            } => {
+                assert_eq!(manifest, payload.manifest);
+                assert_eq!(base64::decode(checkpoint_base64)?, payload.checkpoint_bytes);
+            },
+            _ => panic!("expected cluster genesis entry"),
         }
         Ok(())
     }

--- a/crates/database/src/tests/write_scaling_tests.rs
+++ b/crates/database/src/tests/write_scaling_tests.rs
@@ -150,6 +150,7 @@ use crate::{
         TimestampOracle,
     },
     two_phase::{
+        prepare_timestamp_too_low,
         testing::InMemoryTwoPhaseDecisionLog,
         NodeAddresses,
         NoopTwoPhaseDecisionLog,
@@ -475,6 +476,7 @@ struct TestTwoPhaseCommitGrpcService {
     committer: CommitterClient,
     prepare_calls: Arc<AtomicUsize>,
     validate_reads_calls: Arc<AtomicUsize>,
+    forced_prepare_floor: Mutex<Option<Timestamp>>,
 }
 
 impl TestTwoPhaseCommitGrpcService {
@@ -495,6 +497,20 @@ impl TestTwoPhaseCommitGrpcService {
             committer,
             prepare_calls,
             validate_reads_calls,
+            forced_prepare_floor: Mutex::new(None),
+        }
+    }
+
+    fn rejecting_first_prepare_below(
+        committer: CommitterClient,
+        prepare_calls: Arc<AtomicUsize>,
+        forced_prepare_floor: Timestamp,
+    ) -> Self {
+        Self {
+            committer,
+            prepare_calls,
+            validate_reads_calls: Arc::new(AtomicUsize::new(0)),
+            forced_prepare_floor: Mutex::new(Some(forced_prepare_floor)),
         }
     }
 }
@@ -517,6 +533,14 @@ impl TwoPhaseCommitService for TestTwoPhaseCommitGrpcService {
             .prepare_ts
             .try_into()
             .map_err(|e| Status::invalid_argument(format!("Invalid prepare timestamp: {e:#}")))?;
+        if let Some(required_ts) = self.forced_prepare_floor.lock().take() {
+            if prepare_ts < required_ts {
+                return Ok(Response::new(TwoPcPrepareResponse {
+                    prepare_ts: u64::from(prepare_ts),
+                    required_prepare_ts: Some(u64::from(required_ts)),
+                }));
+            }
+        }
         self.committer
             .ensure_placement_version(PlacementVersion::from(req.placement_version))
             .map_err(|e| Status::failed_precondition(format!("Prepare rejected: {e:#}")))?;
@@ -530,11 +554,24 @@ impl TwoPhaseCommitService for TestTwoPhaseCommitGrpcService {
                 prepare_ts,
                 req.participants.iter().copied().map(PartitionId).collect(),
             )
-            .await
-            .map_err(|e| Status::internal(format!("Prepare failed: {e:#}")))?;
+            .await;
+
+        let result = match result {
+            Ok(result) => result,
+            Err(err) => {
+                if let Some(retry) = prepare_timestamp_too_low(&err) {
+                    return Ok(Response::new(TwoPcPrepareResponse {
+                        prepare_ts: u64::from(retry.proposed_ts),
+                        required_prepare_ts: Some(u64::from(retry.required_ts)),
+                    }));
+                }
+                return Err(Status::internal(format!("Prepare failed: {err:#}")));
+            },
+        };
 
         Ok(Response::new(TwoPcPrepareResponse {
             prepare_ts: u64::from(result.prepare_ts),
+            required_prepare_ts: None,
         }))
     }
 
@@ -558,12 +595,23 @@ impl TwoPhaseCommitService for TestTwoPhaseCommitGrpcService {
             .ensure_placement_version(PlacementVersion::from(req.placement_version))
             .map_err(|e| Status::failed_precondition(format!("ValidateReads rejected: {e:#}")))?;
 
-        self.committer
+        let result = self
+            .committer
             .validate_remote_reads(txn_id, transaction, req.write_source.into(), validate_ts)
-            .await
-            .map_err(|e| Status::internal(format!("ValidateReads failed: {e:#}")))?;
+            .await;
 
-        Ok(Response::new(TwoPcValidateReadsResponse {}))
+        if let Err(err) = result {
+            if let Some(retry) = prepare_timestamp_too_low(&err) {
+                return Ok(Response::new(TwoPcValidateReadsResponse {
+                    required_prepare_ts: Some(u64::from(retry.required_ts)),
+                }));
+            }
+            return Err(Status::internal(format!("ValidateReads failed: {err:#}")));
+        }
+
+        Ok(Response::new(TwoPcValidateReadsResponse {
+            required_prepare_ts: None,
+        }))
     }
 
     async fn commit_prepared(
@@ -881,6 +929,7 @@ impl TwoPhaseCommitService for FailingCommitAfterLocalPrepareGrpcService {
             .map_err(|e| Status::internal(format!("Prepare failed: {e:#}")))?;
         Ok(Response::new(TwoPcPrepareResponse {
             prepare_ts: u64::from(result.prepare_ts),
+            required_prepare_ts: None,
         }))
     }
 
@@ -983,6 +1032,7 @@ impl TwoPhaseCommitService for FailingRollbackAfterPrepareGrpcService {
             .map_err(|e| Status::internal(format!("Prepare failed: {e:#}")))?;
         Ok(Response::new(TwoPcPrepareResponse {
             prepare_ts: u64::from(result.prepare_ts),
+            required_prepare_ts: None,
         }))
     }
 
@@ -6292,6 +6342,104 @@ fn test_cross_partition_commit_uses_remote_prepare_over_grpc() -> anyhow::Result
             assert_obj!("name" => "follow-up-remote"),
         )
         .await?;
+
+        server.shutdown().await?;
+        Ok(())
+    })
+}
+
+#[test]
+fn test_cross_partition_prepare_retry_jumps_to_participant_timestamp_floor() -> anyhow::Result<()> {
+    let td = TestDriver::new_with_io();
+    let rt = td.rt();
+    td.run_until(async move {
+        let log = Arc::new(InMemoryDistributedLog::new());
+        let node_b = create_node_with_options(
+            &rt,
+            log.clone(),
+            Some(partitioned_map(PartitionId(1))),
+            None,
+            Some(Arc::new(InMemoryTimestampOracle::new())),
+        )
+        .await?;
+
+        insert_doc(&node_b, "projects", assert_obj!("name" => "seed")).await?;
+        let remote_seed_delta = log
+            .deltas()
+            .into_iter()
+            .last()
+            .expect("seed project should publish a delta");
+        let forced_prepare_floor = Timestamp::try_from(
+            u64::from(remote_seed_delta.ts)
+                .checked_add(1_000_000_000_000)
+                .context("forced prepare floor overflow")?,
+        )?;
+        let prepare_calls = Arc::new(AtomicUsize::new(0));
+        let server = start_two_pc_server(
+            TestTwoPhaseCommitGrpcService::rejecting_first_prepare_below(
+                node_b.committer_for_test(),
+                prepare_calls.clone(),
+                forced_prepare_floor,
+            ),
+        )
+        .await?;
+
+        let coordinator_tso = Arc::new(RecordingTimestampOracle::new());
+        let node_a = create_node_with_options(
+            &rt,
+            log.clone(),
+            Some(partitioned_map(PartitionId(0))),
+            Some(NodeAddresses::from_config(&format!("1={}", server.addr()))),
+            Some(coordinator_tso.clone()),
+        )
+        .await?;
+        node_a
+            .committer_for_test()
+            .apply_replica_delta(remote_seed_delta)
+            .await?;
+        insert_doc(&node_a, "messages", assert_obj!("text" => "seed")).await?;
+
+        let initial_delta_count = log.deltas().len();
+        let mut tx = node_a.begin(Identity::system()).await?;
+        let mut model = TestFacingModel::new(&mut tx);
+        model
+            .insert(
+                &"messages".parse()?,
+                assert_obj!("text" => "local-after-floor-retry"),
+            )
+            .await?;
+        model
+            .insert(
+                &"projects".parse()?,
+                assert_obj!("name" => "remote-after-floor-retry"),
+            )
+            .await?;
+        let commit_ts = node_a.commit(tx).await?;
+
+        assert!(
+            commit_ts >= forced_prepare_floor,
+            "2PC commit ts {commit_ts} must jump to participant floor {forced_prepare_floor}",
+        );
+        assert_eq!(
+            prepare_calls.load(Ordering::SeqCst),
+            2,
+            "the participant should reject once and accept the floor-aware retry",
+        );
+        assert!(
+            coordinator_tso
+                .requested_floors()
+                .iter()
+                .any(|floor| *floor >= forced_prepare_floor),
+            "coordinator TSO was never asked to reserve at the participant floor",
+        );
+        let committed_halves = log.deltas()[initial_delta_count..]
+            .iter()
+            .filter(|delta| delta.ts == commit_ts)
+            .count();
+        assert_eq!(
+            committed_halves, 2,
+            "the retried 2PC transaction should publish both halves exactly once",
+        );
 
         server.shutdown().await?;
         Ok(())

--- a/crates/database/src/two_phase.rs
+++ b/crates/database/src/two_phase.rs
@@ -544,6 +544,34 @@ pub struct PrepareResult {
     pub prepare_ts: Timestamp,
 }
 
+/// A participant has advanced beyond the coordinator's proposed timestamp.
+///
+/// This is a normal 2PC retry signal, not an RPC failure. Keeping the required
+/// floor structured lets the coordinator jump across disjoint TSO batches in
+/// one retry instead of guessing from an error string.
+#[derive(Debug)]
+pub struct PrepareTimestampTooLow {
+    pub proposed_ts: Timestamp,
+    pub required_ts: Timestamp,
+}
+
+impl std::fmt::Display for PrepareTimestampTooLow {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "2PC Prepare assigned ts={} but this participant requires ts>={}",
+            self.proposed_ts, self.required_ts,
+        )
+    }
+}
+
+impl std::error::Error for PrepareTimestampTooLow {}
+
+pub fn prepare_timestamp_too_low(err: &anyhow::Error) -> Option<&PrepareTimestampTooLow> {
+    err.chain()
+        .find_map(|cause| cause.downcast_ref::<PrepareTimestampTooLow>())
+}
+
 /// Redo log entry persisted during Prepare for crash recovery.
 /// If a node crashes after Prepare but before CommitPrepared/RollbackPrepared,
 /// the transaction watcher reads the redo log and resolves the transaction
@@ -1699,7 +1727,17 @@ impl TwoPhaseCommitGrpcClient {
             .prepare(self.request(request))
             .await
             .context("gRPC Prepare failed")?;
-        let TwoPcPrepareResponse { prepare_ts } = response.into_inner();
+        let TwoPcPrepareResponse {
+            prepare_ts,
+            required_prepare_ts,
+        } = response.into_inner();
+        if let Some(required_prepare_ts) = required_prepare_ts {
+            return Err(PrepareTimestampTooLow {
+                proposed_ts: prepare_ts.try_into()?,
+                required_ts: required_prepare_ts.try_into()?,
+            }
+            .into());
+        }
         Ok(PrepareResult {
             prepare_ts: prepare_ts.try_into()?,
         })
@@ -1720,11 +1758,19 @@ impl TwoPhaseCommitGrpcClient {
             validate_ts: u64::from(validate_ts),
             placement_version: u64::from(placement_version),
         };
-        self.client
+        let response = self
+            .client
             .clone()
             .validate_reads(self.request(request))
             .await
             .context("gRPC ValidateReads failed")?;
+        if let Some(required_prepare_ts) = response.into_inner().required_prepare_ts {
+            return Err(PrepareTimestampTooLow {
+                proposed_ts: validate_ts,
+                required_ts: required_prepare_ts.try_into()?,
+            }
+            .into());
+        }
         Ok(())
     }
 

--- a/crates/database/src/two_phase_coordinator.rs
+++ b/crates/database/src/two_phase_coordinator.rs
@@ -57,6 +57,7 @@ use crate::{
     },
     transaction::FinalTransaction,
     two_phase::{
+        prepare_timestamp_too_low,
         NodeAddresses,
         ParticipantTransaction,
         StagingRecoveryResult,
@@ -283,7 +284,7 @@ fn routed_partition_for_catalog_write(
 }
 
 #[cfg(any(test, feature = "testing"))]
-pub(crate) fn routed_partition_for_catalog_write_for_test(
+pub fn routed_partition_for_catalog_write_for_test(
     transaction: &FinalTransaction,
     write: &DocumentUpdateWithPrevTs,
     partition_map: &PartitionMap,
@@ -861,9 +862,12 @@ async fn mark_participant_resolved(
     Ok(())
 }
 
+fn required_prepare_ts(err: &anyhow::Error) -> Option<Timestamp> {
+    prepare_timestamp_too_low(err).map(|retry| retry.required_ts)
+}
+
 fn is_retryable_prepare_ts_error(err: &anyhow::Error) -> bool {
-    err.chain()
-        .any(|cause| cause.to_string().contains("2PC Prepare assigned ts="))
+    required_prepare_ts(err).is_some()
 }
 
 fn is_ambiguous_prepare_error(err: &anyhow::Error) -> bool {
@@ -1009,10 +1013,13 @@ pub(crate) async fn coordinate_two_phase_commit_with_mode(
 
     let mut last_retryable_error = None;
     let mut prepare_attempts = 0usize;
+    let mut min_prepare_ts = Timestamp::MIN;
     for attempt in 0..MAX_PREPARE_TS_RETRIES {
         let txn_id = TwoPhaseTransactionId::new();
         prepare_attempts = attempt + 1;
-        let prepare_ts = local_committer.allocate_commit_ts().await?;
+        let prepare_ts = local_committer
+            .allocate_commit_ts_at_or_after(min_prepare_ts)
+            .await?;
         tracing::info!(
             "2PC Coordinator: starting txn={}, participants={:?}, prepare_ts={}, attempt={}",
             txn_id,
@@ -1057,6 +1064,10 @@ pub(crate) async fn coordinate_two_phase_commit_with_mode(
             let all_failures_retryable = failures
                 .iter()
                 .all(|failure| is_retryable_prepare_ts_error(&failure.err));
+            let required_retry_floor = failures
+                .iter()
+                .filter_map(|failure| required_prepare_ts(&failure.err))
+                .max();
             let selected_failure_index = failures
                 .iter()
                 .position(|failure| !is_retryable_prepare_ts_error(&failure.err))
@@ -1088,11 +1099,14 @@ pub(crate) async fn coordinate_two_phase_commit_with_mode(
                 && attempt + 1 < MAX_PREPARE_TS_RETRIES
                 && all_failures_retryable;
             if retryable_prepare_ts_error {
+                min_prepare_ts = required_retry_floor
+                    .expect("all retryable timestamp failures must include a required floor");
                 metrics::log_two_phase_prepare_retry();
                 tracing::info!(
-                    "2PC Coordinator: retrying txn={} with a newer prepare timestamp after \
-                     participant {} rejected ts on attempt {}",
+                    "2PC Coordinator: retrying txn={} at or above ts={} after participant {} \
+                     rejected ts on attempt {}",
                     txn_id,
+                    u64::from(min_prepare_ts),
                     selected_failure.participant,
                     attempt + 1,
                 );
@@ -1232,6 +1246,7 @@ mod tests {
         reads::ReadSet,
         two_phase::{
             ParticipantTransaction,
+            PrepareTimestampTooLow,
             TwoPhaseDecision,
             TwoPhaseParticipantIntent,
             TwoPhaseRedoEntry,
@@ -1250,17 +1265,27 @@ mod tests {
     }
 
     #[test]
-    fn retryable_prepare_ts_error_detects_wrapped_grpc_status() {
-        let err = anyhow::anyhow!(
-            "Prepare failed: 2PC Prepare assigned ts=10 but this participant requires ts>=20"
-        )
+    fn retryable_prepare_ts_error_detects_wrapped_structured_floor() -> anyhow::Result<()> {
+        let err = anyhow::Error::new(PrepareTimestampTooLow {
+            proposed_ts: Timestamp::try_from(10u64)?,
+            required_ts: Timestamp::try_from(20u64)?,
+        })
         .context("gRPC Prepare failed");
         assert!(is_retryable_prepare_ts_error(&err));
+        assert_eq!(super::required_prepare_ts(&err), Some(20u64.try_into()?));
+        Ok(())
     }
 
     #[test]
     fn retryable_prepare_ts_error_rejects_unrelated_errors() {
         let err = anyhow::anyhow!("gRPC Prepare failed");
+        assert!(!is_retryable_prepare_ts_error(&err));
+    }
+
+    #[test]
+    fn retryable_prepare_ts_error_rejects_matching_text_without_structured_floor() {
+        let err =
+            anyhow::anyhow!("2PC Prepare assigned ts=10 but this participant requires ts>=20");
         assert!(!is_retryable_prepare_ts_error(&err));
     }
 

--- a/crates/local_backend/src/deploy_config.rs
+++ b/crates/local_backend/src/deploy_config.rs
@@ -161,6 +161,10 @@ async fn raft_leader_origin(st: &DeployRouterState) -> anyhow::Result<Option<Str
     let Some(raft_state) = st.raft_state.as_ref() else {
         return Ok(None);
     };
+    anyhow::ensure!(
+        raft_state.is_cluster_genesis_ready(),
+        "Canonical cluster genesis is not Raft-confirmed by every partition"
+    );
     if raft_state.is_leader() {
         return Ok(None);
     }

--- a/crates/local_backend/src/lib.rs
+++ b/crates/local_backend/src/lib.rs
@@ -7,7 +7,13 @@
 use std::{
     self,
     collections::BTreeMap,
-    sync::Arc,
+    sync::{
+        atomic::{
+            AtomicBool,
+            Ordering,
+        },
+        Arc,
+    },
     time::Duration,
 };
 
@@ -453,8 +459,7 @@ fn should_run_cluster_singleton_workers(
     if partition_id != route_authority::CLUSTER_COORDINATOR_PARTITION {
         return false;
     }
-    raft_state
-        .is_none_or(|raft_state| raft_state.is_leader() && raft_state.has_leader_serving_lease())
+    raft_state.is_none_or(database::raft_partition::RaftPartitionState::can_serve_as_leader)
 }
 
 fn start_cluster_singleton_worker_supervisor(
@@ -499,6 +504,261 @@ fn application_worker_startup_policy(
     }
 }
 
+async fn load_cluster_genesis_marker(
+    persistence: &Arc<dyn Persistence>,
+) -> anyhow::Result<Option<database::cluster_genesis::ClusterGenesisMarker>> {
+    persistence
+        .reader()
+        .get_persistence_global(common::persistence::PersistenceGlobalKey::ClusterGenesis)
+        .await?
+        .map(database::cluster_genesis::ClusterGenesisMarker::parse)
+        .transpose()
+}
+
+async fn load_raft_applied_genesis(
+    persistence: &Arc<dyn Persistence>,
+) -> anyhow::Result<Option<database::cluster_genesis::ClusterGenesisMarker>> {
+    persistence
+        .reader()
+        .get_persistence_global(
+            common::persistence::PersistenceGlobalKey::ClusterGenesisRaftApplied,
+        )
+        .await?
+        .map(database::cluster_genesis::ClusterGenesisMarker::parse)
+        .transpose()
+}
+
+async fn record_raft_applied_genesis_marker(
+    persistence: &Arc<dyn Persistence>,
+    marker: &database::cluster_genesis::ClusterGenesisMarker,
+) -> anyhow::Result<()> {
+    if let Some(existing) = load_raft_applied_genesis(persistence).await? {
+        anyhow::ensure!(
+            existing == *marker,
+            "Local Raft applied genesis {} conflicts with canonical genesis {}",
+            existing.genesis_id,
+            marker.genesis_id,
+        );
+        return Ok(());
+    }
+    persistence
+        .write_persistence_global(
+            common::persistence::PersistenceGlobalKey::ClusterGenesisRaftApplied,
+            serde_json::to_value(marker)?,
+        )
+        .await
+}
+
+async fn record_raft_applied_genesis(
+    persistence: &Arc<dyn Persistence>,
+    manifest: &database::cluster_genesis::ClusterGenesisManifest,
+) -> anyhow::Result<()> {
+    record_raft_applied_genesis_marker(
+        persistence,
+        &database::cluster_genesis::ClusterGenesisMarker {
+            format_version: manifest.format_version,
+            genesis_id: manifest.genesis_id.clone(),
+        },
+    )
+    .await
+}
+
+async fn prepare_cluster_genesis(
+    runtime: &ProdRuntime,
+    database: &Database<ProdRuntime>,
+    persistence: &Arc<dyn Persistence>,
+    store: &database::cluster_genesis::NatsClusterGenesisStore,
+    partition_id: database::partition::PartitionId,
+    persistence_was_fresh: bool,
+) -> anyhow::Result<database::cluster_genesis::CanonicalGenesisPayload> {
+    let local_marker = load_cluster_genesis_marker(persistence).await?;
+    if local_marker.is_none() {
+        anyhow::ensure!(
+            persistence_was_fresh,
+            "Existing partition {} persistence has no canonical cluster genesis marker; refusing \
+             to guess cluster identity",
+            partition_id,
+        );
+        if partition_id == route_authority::CLUSTER_COORDINATOR_PARTITION
+            && store.load_manifest().await?.is_none()
+        {
+            let candidate = database::cluster_genesis::canonicalize_checkpoint(
+                database.build_raft_snapshot_checkpoint().await?,
+            )?;
+            store.put_payload(&candidate).await?;
+            store.publish_manifest(&candidate.manifest).await?;
+        }
+    }
+
+    let mut waits = 0u64;
+    let manifest = loop {
+        if let Some(manifest) = store.load_manifest().await? {
+            break manifest;
+        }
+        anyhow::ensure!(
+            local_marker.is_none(),
+            "Local persistence has cluster genesis {}, but the canonical NATS manifest is \
+             missing; refusing to create a new identity",
+            local_marker.as_ref().expect("checked above").genesis_id,
+        );
+        if waits % 20 == 0 {
+            tracing::info!(
+                %partition_id,
+                "Waiting for coordinator partition to publish canonical cluster genesis"
+            );
+        }
+        waits += 1;
+        runtime.wait(Duration::from_millis(250)).await;
+    };
+    database::cluster_genesis::validate_manifest(&manifest)?;
+
+    if let Some(marker) = local_marker.as_ref() {
+        anyhow::ensure!(
+            marker.genesis_id == manifest.genesis_id,
+            "Local cluster genesis {} conflicts with canonical genesis {}",
+            marker.genesis_id,
+            manifest.genesis_id,
+        );
+    }
+    let checkpoint_bytes = store.load_payload(&manifest).await?.ok_or_else(|| {
+        anyhow::anyhow!(
+            "Canonical cluster genesis payload {} is missing",
+            manifest.genesis_id
+        )
+    })?;
+    let payload = database::cluster_genesis::CanonicalGenesisPayload {
+        manifest,
+        checkpoint_bytes,
+    };
+    if local_marker.is_none() {
+        let checkpoint = database::cluster_genesis::validate_payload(
+            &payload.manifest,
+            &payload.checkpoint_bytes,
+        )?;
+        database
+            .committer_client()
+            .install_snapshot(checkpoint)
+            .await?;
+        tracing::info!(
+            %partition_id,
+            genesis_id = %payload.manifest.genesis_id,
+            "Installed canonical cluster genesis before application startup"
+        );
+    }
+    Ok(payload)
+}
+
+async fn propose_cluster_genesis(
+    database: &Database<ProdRuntime>,
+    persistence: &Arc<dyn Persistence>,
+    raft_state: &database::raft_partition::RaftPartitionState,
+    payload: &database::cluster_genesis::CanonicalGenesisPayload,
+) -> anyhow::Result<bool> {
+    if !raft_state.is_leader() {
+        return Ok(false);
+    }
+    let data =
+        database::raft_state_machine::RaftStateMachineEntry::cluster_genesis(payload).to_bytes()?;
+    let (result_tx, result_rx) = tokio::sync::oneshot::channel();
+    raft_state.send(database::raft_node::RaftMessage::Propose(
+        database::raft_node::RaftProposal { data, result_tx },
+    ))?;
+    match result_rx.await? {
+        database::raft_node::RaftProposalResult::Committed { index } => {
+            install_raft_confirmed_cluster_genesis(
+                &database.committer_client(),
+                persistence,
+                &payload.manifest,
+                &payload.checkpoint_bytes,
+            )
+            .await?;
+            raft_state.mark_applied(index).await?;
+            Ok(true)
+        },
+        database::raft_node::RaftProposalResult::Rejected => Ok(false),
+    }
+}
+
+async fn install_raft_confirmed_cluster_genesis(
+    committer: &database::CommitterClient,
+    persistence: &Arc<dyn Persistence>,
+    manifest: &database::cluster_genesis::ClusterGenesisManifest,
+    checkpoint_bytes: &[u8],
+) -> anyhow::Result<()> {
+    if let Some(marker) = load_cluster_genesis_marker(persistence).await? {
+        anyhow::ensure!(
+            marker.genesis_id == manifest.genesis_id,
+            "Raft committed cluster genesis {} conflicts with local genesis {}",
+            manifest.genesis_id,
+            marker.genesis_id,
+        );
+    }
+    let checkpoint = database::cluster_genesis::validate_payload(manifest, checkpoint_bytes)?;
+    committer.install_snapshot(checkpoint).await?;
+    record_raft_applied_genesis(persistence, manifest).await
+}
+
+fn start_cluster_genesis_coordinator(
+    runtime: ProdRuntime,
+    database: Database<ProdRuntime>,
+    persistence: Arc<dyn Persistence>,
+    store: database::cluster_genesis::NatsClusterGenesisStore,
+    payload: database::cluster_genesis::CanonicalGenesisPayload,
+    raft_state: database::raft_partition::RaftPartitionState,
+    num_partitions: u32,
+) {
+    let coordinator_runtime = runtime.clone();
+    runtime.spawn_background("cluster_genesis_coordinator", async move {
+        loop {
+            let result: anyhow::Result<bool> = async {
+                match load_raft_applied_genesis(&persistence).await? {
+                    Some(applied) => {
+                        anyhow::ensure!(
+                            applied.genesis_id == payload.manifest.genesis_id,
+                            "Raft applied genesis {} conflicts with canonical genesis {}",
+                            applied.genesis_id,
+                            payload.manifest.genesis_id,
+                        );
+                    },
+                    None => {
+                        if !propose_cluster_genesis(&database, &persistence, &raft_state, &payload)
+                            .await?
+                        {
+                            return Ok(false);
+                        }
+                    },
+                }
+                store
+                    .mark_partition_ready(raft_state.partition_id(), &payload.manifest)
+                    .await?;
+                if !store
+                    .all_partitions_ready(num_partitions, &payload.manifest)
+                    .await?
+                {
+                    return Ok(false);
+                }
+                raft_state.mark_cluster_genesis_ready();
+                tracing::info!(
+                    partition = %raft_state.partition_id(),
+                    genesis_id = %payload.manifest.genesis_id,
+                    "Cluster genesis is Raft-confirmed by every partition; serving enabled"
+                );
+                Ok(true)
+            }
+            .await;
+            match result {
+                Ok(true) => return,
+                Ok(false) => {},
+                Err(error) => tracing::error!(
+                    partition = %raft_state.partition_id(),
+                    "Cluster genesis remains fail-closed: {error:#}"
+                ),
+            }
+            coordinator_runtime.wait(Duration::from_millis(250)).await;
+        }
+    });
+}
+
 pub async fn make_app(
     runtime: ProdRuntime,
     config: LocalConfig,
@@ -508,6 +768,8 @@ pub async fn make_app(
 ) -> anyhow::Result<BackendAppState> {
     let key_broker = config.key_broker()?;
     let persistence_was_fresh = persistence.is_fresh();
+    let raft_cluster_enabled = config.partition_id.is_some() && config.raft_node_id.is_some();
+    let cluster_genesis_ready = Arc::new(AtomicBool::new(!raft_cluster_enabled));
     let in_process_searcher = Arc::new(InProcessSearcher::new(runtime.clone())?);
     let searcher: Arc<dyn Searcher> = in_process_searcher.clone();
     // TODO(CX-6572) Separate `SegmentMetadataFetcher` from `SearcherImpl`
@@ -526,6 +788,16 @@ pub async fn make_app(
         Arc::new(database::nats_distributed_log::NatsDistributedLog::connect(nats_config).await?)
     } else {
         Arc::new(database::commit_delta::NoopDistributedLog)
+    };
+    let distributed_log: Arc<dyn database::commit_delta::DistributedLog> = if raft_cluster_enabled {
+        Arc::new(
+            database::commit_delta::ClusterGenesisGatedDistributedLog::new(
+                distributed_log,
+                cluster_genesis_ready.clone(),
+            ),
+        )
+    } else {
+        distributed_log
     };
 
     // Set up the global Timestamp Oracle (TSO) for multi-node deployments.
@@ -609,34 +881,147 @@ pub async fn make_app(
         )
     });
 
-    let database = Database::load(
-        persistence.clone(),
-        runtime.clone(),
-        searcher.clone(),
-        preempt_tx.clone(),
-        virtual_system_mapping().clone(),
-        Some(SharedIndexCache),
-        Arc::new(new_rate_limiter(
+    let load_database = || {
+        Database::load(
+            persistence.clone(),
             runtime.clone(),
-            Quota::per_second(*DOCUMENT_RETENTION_RATE_LIMIT),
-        )),
-        deleted_tablet_sender,
-        distributed_log.clone(),
-        config.replication_mode == "replica",
-        config.partition_id.map(|id| {
-            static_placement_metadata
-                .as_ref()
-                .expect("partitioned startup should have placement metadata")
-                .into_partition_map(database::partition::PartitionId(id))
-        }),
-        static_node_addresses.clone(),
-        two_phase_decision_log,
-        Some(cluster_grpc_auth.clone()),
-        timestamp_oracle.clone(),
-        table_number_allocator,
-        None, // raft_state: set after Raft node starts, not during Database::load
-    )
-    .await?;
+            searcher.clone(),
+            preempt_tx.clone(),
+            virtual_system_mapping().clone(),
+            Some(SharedIndexCache),
+            Arc::new(new_rate_limiter(
+                runtime.clone(),
+                Quota::per_second(*DOCUMENT_RETENTION_RATE_LIMIT),
+            )),
+            deleted_tablet_sender.clone(),
+            distributed_log.clone(),
+            config.replication_mode == "replica",
+            config.partition_id.map(|id| {
+                static_placement_metadata
+                    .as_ref()
+                    .expect("partitioned startup should have placement metadata")
+                    .into_partition_map(database::partition::PartitionId(id))
+            }),
+            static_node_addresses.clone(),
+            two_phase_decision_log.clone(),
+            Some(cluster_grpc_auth.clone()),
+            timestamp_oracle.clone(),
+            table_number_allocator.clone(),
+            None, // raft_state: set after Raft node starts, not during Database::load
+        )
+    };
+    let mut database = load_database().await?;
+
+    if config.replication_mode == "replica" && persistence_was_fresh {
+        let checkpoint_path = config.checkpoint_storage_path.as_ref().ok_or_else(|| {
+            anyhow::anyhow!(
+                "CHECKPOINT_STORAGE_PATH is required to bootstrap a fresh replica from checkpoint"
+            )
+        })?;
+        let checkpoint_storage: Arc<dyn Storage> = Arc::new(LocalDirStorage::for_use_case(
+            runtime.clone(),
+            checkpoint_path,
+            StorageUseCase::Checkpoints,
+        )?);
+        let checkpoint = match database::snapshot_checkpointer::load_latest_checkpoint(
+            &checkpoint_storage,
+        )
+        .await
+        {
+            Ok(Some(checkpoint)) => checkpoint,
+            Ok(None) => {
+                metrics::log_replica_bootstrap_result(false);
+                anyhow::bail!(
+                    "Fresh replica startup requires a checkpoint, but none was found at {}",
+                    checkpoint_path
+                );
+            },
+            Err(e) => {
+                metrics::log_replica_bootstrap_result(false);
+                return Err(e);
+            },
+        };
+        let checkpoint_ts = checkpoint.timestamp;
+        if let Err(e) = database
+            .committer_client()
+            .install_snapshot(checkpoint)
+            .await
+        {
+            metrics::log_replica_bootstrap_result(false);
+            return Err(e);
+        }
+        metrics::log_replica_bootstrap_result(true);
+        tracing::info!("Bootstrapped fresh replica from checkpoint at ts={checkpoint_ts}");
+    }
+
+    initialize_application_system_tables(&database).await?;
+    if raft_cluster_enabled && config.replication_mode != "replica" {
+        Application::initialize_storage_config(
+            &database,
+            config.storage_tag_initializer(),
+            config.name(),
+        )
+        .await?;
+    }
+
+    let (cluster_genesis_store, cluster_genesis_payload) = if raft_cluster_enabled {
+        let nats_url = config.nats_url.as_deref().ok_or_else(|| {
+            anyhow::anyhow!("Raft cluster genesis requires NATS_URL for payload transport")
+        })?;
+        let partition_id = database::partition::PartitionId(
+            config
+                .partition_id
+                .expect("raft cluster requires partition ID"),
+        );
+        let store = database::cluster_genesis::NatsClusterGenesisStore::connect(
+            nats_url,
+            instance_secret.as_bytes(),
+        )
+        .await?;
+        let payload = prepare_cluster_genesis(
+            &runtime,
+            &database,
+            &persistence,
+            &store,
+            partition_id,
+            persistence_was_fresh,
+        )
+        .await?;
+        (Some(store), Some(payload))
+    } else {
+        (None, None)
+    };
+
+    if raft_cluster_enabled && persistence_was_fresh {
+        database.shutdown().await?;
+        database = load_database().await?;
+        tracing::info!(
+            partition_id = ?config.partition_id,
+            "Reloaded serving database from canonical cluster genesis"
+        );
+    }
+
+    let application_storage = if config.replication_mode == "replica" {
+        // Replica uses local storage — doesn't write storage config to DB.
+        let replica_path = config
+            .replica_storage_path
+            .as_ref()
+            .ok_or_else(|| anyhow::anyhow!("REPLICA_STORAGE_PATH is required in replica mode"))?;
+        let (storage, search_storage) =
+            application::ApplicationStorage::new_local(runtime.clone(), replica_path)?;
+        database.set_search_storage(search_storage);
+        storage
+    } else if raft_cluster_enabled {
+        Application::load_storage(runtime.clone(), &database).await?
+    } else {
+        Application::initialize_storage(
+            runtime.clone(),
+            &database,
+            config.storage_tag_initializer(),
+            config.name(),
+        )
+        .await?
+    };
 
     let placement_metadata_store: Option<Arc<dyn database::partition::PlacementMetadataStore>> =
         if let (Some(bootstrap_metadata), Some(nats_url)) = (
@@ -706,69 +1091,6 @@ pub async fn make_app(
             None
         };
 
-    if config.replication_mode == "replica" && persistence_was_fresh {
-        let checkpoint_path = config.checkpoint_storage_path.as_ref().ok_or_else(|| {
-            anyhow::anyhow!(
-                "CHECKPOINT_STORAGE_PATH is required to bootstrap a fresh replica from checkpoint"
-            )
-        })?;
-        let checkpoint_storage: Arc<dyn Storage> = Arc::new(LocalDirStorage::for_use_case(
-            runtime.clone(),
-            checkpoint_path,
-            StorageUseCase::Checkpoints,
-        )?);
-        let checkpoint = match database::snapshot_checkpointer::load_latest_checkpoint(
-            &checkpoint_storage,
-        )
-        .await
-        {
-            Ok(Some(checkpoint)) => checkpoint,
-            Ok(None) => {
-                metrics::log_replica_bootstrap_result(false);
-                anyhow::bail!(
-                    "Fresh replica startup requires a checkpoint, but none was found at {}",
-                    checkpoint_path
-                );
-            },
-            Err(e) => {
-                metrics::log_replica_bootstrap_result(false);
-                return Err(e);
-            },
-        };
-        let checkpoint_ts = checkpoint.timestamp;
-        if let Err(e) = database
-            .committer_client()
-            .install_snapshot(checkpoint)
-            .await
-        {
-            metrics::log_replica_bootstrap_result(false);
-            return Err(e);
-        }
-        metrics::log_replica_bootstrap_result(true);
-        tracing::info!("Bootstrapped fresh replica from checkpoint at ts={checkpoint_ts}");
-    }
-
-    initialize_application_system_tables(&database).await?;
-    let application_storage = if config.replication_mode == "replica" {
-        // Replica uses local storage — doesn't write storage config to DB.
-        let replica_path = config
-            .replica_storage_path
-            .as_ref()
-            .ok_or_else(|| anyhow::anyhow!("REPLICA_STORAGE_PATH is required in replica mode"))?;
-        let (storage, search_storage) =
-            application::ApplicationStorage::new_local(runtime.clone(), replica_path)?;
-        database.set_search_storage(search_storage);
-        storage
-    } else {
-        Application::initialize_storage(
-            runtime.clone(),
-            &database,
-            config.storage_tag_initializer(),
-            config.name(),
-        )
-        .await?
-    };
-
     let file_storage = FileStorage {
         transactional_file_storage: TransactionalFileStorage::new(
             runtime.clone(),
@@ -778,7 +1100,7 @@ pub async fn make_app(
         database: database.clone(),
     };
 
-    // Start the SnapshotCheckpointer on the Primary when NATS is configured.
+    // Start checkpoint publication only after canonical genesis is Raft-confirmed.
     if config.replication_mode == "primary" && config.nats_url.is_some() {
         let checkpoint_path = config.checkpoint_storage_path.as_ref().ok_or_else(|| {
             anyhow::anyhow!("CHECKPOINT_STORAGE_PATH is required in primary mode with NATS_URL")
@@ -788,13 +1110,23 @@ pub async fn make_app(
             checkpoint_path,
             StorageUseCase::Checkpoints,
         )?);
-        let _checkpointer = database::snapshot_checkpointer::SnapshotCheckpointer::start(
-            runtime.clone(),
-            persistence.reader(),
-            database.retention_validator(),
-            checkpoint_storage,
-        );
-        tracing::info!("Started SnapshotCheckpointer for replication");
+        let checkpointer_runtime = runtime.clone();
+        let checkpointer_database = database.clone();
+        let checkpointer_persistence = persistence.clone();
+        let checkpointer_genesis_ready = cluster_genesis_ready.clone();
+        runtime.spawn_background("snapshot_checkpointer_gate", async move {
+            while !checkpointer_genesis_ready.load(Ordering::SeqCst) {
+                checkpointer_runtime.wait(Duration::from_millis(100)).await;
+            }
+            let _checkpointer = database::snapshot_checkpointer::SnapshotCheckpointer::start(
+                checkpointer_runtime,
+                checkpointer_persistence.reader(),
+                checkpointer_database.retention_validator(),
+                checkpoint_storage,
+            );
+            tracing::info!("Started SnapshotCheckpointer for replication");
+            std::future::pending::<()>().await;
+        });
     }
 
     let node_process_timeout = *ACTION_USER_TIMEOUT + Duration::from_secs(5);
@@ -855,7 +1187,7 @@ pub async fn make_app(
         config.convex_site_url()?,
         searcher.clone(),
         segment_metadata_fetcher,
-        persistence,
+        persistence.clone(),
         actions,
         Arc::new(RedactLogsToClient::new(config.redact_logs_to_client)),
         Arc::new(ApplicationAuth::new(
@@ -1055,7 +1387,11 @@ pub async fn make_app(
                 replica_delta_consumer_start_ts(*database.now_ts_for_reads(), config.partition_id);
             let consumer_name = config.name();
             let consumer_runtime = runtime.clone();
+            let consumer_genesis_ready = cluster_genesis_ready.clone();
             runtime.spawn_background("replica_delta_consumer_setup", async move {
+                while !consumer_genesis_ready.load(Ordering::SeqCst) {
+                    consumer_runtime.wait(Duration::from_millis(100)).await;
+                }
                 let mut backoff = Duration::from_millis(250);
                 loop {
                     tracing::info!(
@@ -1150,13 +1486,22 @@ pub async fn make_app(
     // Start the 2PC Transaction Watcher for crash recovery.
     if let Some(partition_id) = config.partition_id {
         if let Some(nats_url) = &config.nats_url {
-            database::two_phase_watcher::start(
-                runtime.clone(),
-                database.committer_client(),
-                nats_url.clone(),
-                database::partition::PartitionId(partition_id),
-            );
-            tracing::info!("Started 2PC Transaction Watcher");
+            let watcher_runtime = runtime.clone();
+            let watcher_committer = database.committer_client();
+            let watcher_nats_url = nats_url.clone();
+            let watcher_genesis_ready = cluster_genesis_ready.clone();
+            runtime.spawn_background("two_phase_watcher_gate", async move {
+                while !watcher_genesis_ready.load(Ordering::SeqCst) {
+                    watcher_runtime.wait(Duration::from_millis(100)).await;
+                }
+                database::two_phase_watcher::start(
+                    watcher_runtime,
+                    watcher_committer,
+                    watcher_nats_url,
+                    database::partition::PartitionId(partition_id),
+                );
+                tracing::info!("Started 2PC Transaction Watcher");
+            });
         }
     }
 
@@ -1237,12 +1582,13 @@ pub async fn make_app(
                 })
             }) as Arc<dyn database::raft_storage::RaftSnapshotProvider>
         };
-        let mut manager = RaftPartitionManager::new(
+        let mut manager = RaftPartitionManager::new_with_cluster_genesis_gate(
             raft_config,
             raft_engine,
             peer_senders,
             Some(snapshot_provider),
             timestamp_oracle.clone(),
+            cluster_genesis_ready.clone(),
         )?;
         let raft_state = manager.state();
         raft_state_for_app = Some(raft_state.clone());
@@ -1261,10 +1607,13 @@ pub async fn make_app(
         if let Some(mut node) = manager.take_node() {
             let committer = database.committer_client();
             let raft_state_for_apply = raft_state.clone();
+            let persistence_for_apply = persistence.clone();
             runtime.spawn_background("raft_node", async move {
                 let committer_for_entries = committer.clone();
                 let raft_state_for_entries = raft_state_for_apply.clone();
+                let persistence_for_entries = persistence_for_apply.clone();
                 let committer_for_snapshots = committer.clone();
+                let persistence_for_snapshots = persistence_for_apply.clone();
                 if let Err(e) = node
                     .run(
                         move |data| {
@@ -1312,6 +1661,24 @@ pub async fn make_app(
                                         )
                                     })?;
                                 },
+                                RaftStateMachineEntry::ClusterGenesis {
+                                    manifest,
+                                    checkpoint_base64,
+                                } => {
+                                    let checkpoint_bytes = base64::decode(checkpoint_base64)?;
+                                    let committer = committer_for_entries.clone();
+                                    let persistence = persistence_for_entries.clone();
+                                    let rt = tokio::runtime::Handle::current();
+                                    rt.block_on(async {
+                                        install_raft_confirmed_cluster_genesis(
+                                            &committer,
+                                            &persistence,
+                                            &manifest,
+                                            &checkpoint_bytes,
+                                        )
+                                        .await
+                                    })?;
+                                },
                             }
 
                             Ok(())
@@ -1321,10 +1688,23 @@ pub async fn make_app(
                                 database::snapshot_checkpointer::checkpoint_from_bytes(
                                     snapshot_bytes,
                                 )?;
+                            let genesis_marker = checkpoint
+                                .globals
+                                .get(&String::from(
+                                    common::persistence::PersistenceGlobalKey::ClusterGenesis,
+                                ))
+                                .cloned()
+                                .map(database::cluster_genesis::ClusterGenesisMarker::parse)
+                                .transpose()?;
                             let committer = committer_for_snapshots.clone();
+                            let persistence = persistence_for_snapshots.clone();
                             let rt = tokio::runtime::Handle::current();
                             rt.block_on(async {
                                 committer.install_snapshot(checkpoint).await?;
+                                if let Some(marker) = genesis_marker {
+                                    record_raft_applied_genesis_marker(&persistence, &marker)
+                                        .await?;
+                                }
                                 Ok::<_, anyhow::Error>(())
                             })
                         },
@@ -1342,6 +1722,25 @@ pub async fn make_app(
         // Committer so normal writes propose through Raft and followers reject
         // non-leader writes.
         database.attach_raft_state(raft_state.clone()).await?;
+
+        let genesis_store = cluster_genesis_store.clone().ok_or_else(|| {
+            anyhow::anyhow!("Raft cluster started without a canonical genesis store")
+        })?;
+        let genesis_payload = cluster_genesis_payload.clone().ok_or_else(|| {
+            anyhow::anyhow!("Raft cluster started without a canonical genesis payload")
+        })?;
+        let num_partitions = config
+            .num_partitions
+            .ok_or_else(|| anyhow::anyhow!("Raft cluster genesis requires NUM_PARTITIONS"))?;
+        start_cluster_genesis_coordinator(
+            runtime.clone(),
+            database.clone(),
+            persistence.clone(),
+            genesis_store,
+            genesis_payload,
+            raft_state.clone(),
+            num_partitions,
+        );
 
         // Start transport clients for each peer.
         for client in transport_clients {
@@ -1489,6 +1888,13 @@ mod tests {
             Some(database::partition::PartitionId(0)),
             Some(&raft_state),
         ));
+        raft_state.mark_cluster_genesis_unready_for_test();
+        assert!(!super::should_run_cluster_singleton_workers(
+            false,
+            Some(database::partition::PartitionId(0)),
+            Some(&raft_state),
+        ));
+        raft_state.mark_cluster_genesis_ready();
         raft_state.expire_leader_serving_lease_for_test();
         assert!(!super::should_run_cluster_singleton_workers(
             false,
@@ -1623,6 +2029,114 @@ mod tests {
 
                 primary.shutdown().await?;
                 st.shutdown().await?;
+                Ok(())
+            },
+        )
+    }
+
+    #[test]
+    fn canonical_genesis_replaces_independent_random_bootstrap() -> anyhow::Result<()> {
+        let tokio = ProdRuntime::init_tokio()?;
+        let runtime = ProdRuntime::new(&tokio);
+        let test_runtime = runtime.clone();
+        runtime.block_on(
+            "canonical_genesis_replaces_independent_random_bootstrap",
+            async move {
+                let source_persistence = Arc::new(TestPersistence::new());
+                let target_persistence = Arc::new(TestPersistence::new());
+                let (_source_shutdown_tx, source_shutdown_rx) = async_broadcast::broadcast(1);
+                let (_target_shutdown_tx, target_shutdown_rx) = async_broadcast::broadcast(1);
+                let source = make_app(
+                    test_runtime.clone(),
+                    LocalConfig::new_for_test()?,
+                    source_persistence,
+                    source_shutdown_rx,
+                    ShutdownSignal::no_op(),
+                )
+                .await?;
+                let target = make_app(
+                    test_runtime,
+                    LocalConfig::new_for_test()?,
+                    target_persistence.clone(),
+                    target_shutdown_rx,
+                    ShutdownSignal::no_op(),
+                )
+                .await?;
+
+                let source_checkpoint = source
+                    .application
+                    .database()
+                    .build_raft_snapshot_checkpoint()
+                    .await?;
+                let target_checkpoint = target
+                    .application
+                    .database()
+                    .build_raft_snapshot_checkpoint()
+                    .await?;
+                let canonical =
+                    database::cluster_genesis::canonicalize_checkpoint(source_checkpoint)?;
+                let independent =
+                    database::cluster_genesis::canonicalize_checkpoint(target_checkpoint)?;
+                assert_ne!(
+                    canonical.manifest.genesis_id,
+                    independent.manifest.genesis_id
+                );
+
+                let checkpoint = database::cluster_genesis::validate_payload(
+                    &canonical.manifest,
+                    &canonical.checkpoint_bytes,
+                )?;
+                let genesis_ts = checkpoint.timestamp;
+                let expected_documents = checkpoint
+                    .documents
+                    .iter()
+                    .filter(|entry| entry.ts <= genesis_ts)
+                    .map(|entry| (entry.id, entry.value.clone()))
+                    .collect::<BTreeMap<_, _>>();
+                let expected_globals = checkpoint.globals.clone();
+                target
+                    .application
+                    .database()
+                    .committer_client()
+                    .install_snapshot(checkpoint)
+                    .await?;
+
+                let installed_documents = target_persistence
+                    .load_documents(
+                        TimestampRange::all(),
+                        Order::Asc,
+                        10_000,
+                        Arc::new(NoopRetentionValidator),
+                    )
+                    .try_filter(|entry| futures::future::ready(entry.ts <= genesis_ts))
+                    .map_ok(|entry| (entry.id, entry.value))
+                    .try_collect::<BTreeMap<_, _>>()
+                    .await?;
+                assert_eq!(installed_documents, expected_documents);
+                for key in [
+                    common::persistence::PersistenceGlobalKey::TablesByIdIndex,
+                    common::persistence::PersistenceGlobalKey::IndexByIdIndex,
+                    common::persistence::PersistenceGlobalKey::TablesTabletId,
+                    common::persistence::PersistenceGlobalKey::IndexTabletId,
+                    common::persistence::PersistenceGlobalKey::ClusterGenesis,
+                ] {
+                    assert_eq!(
+                        target_persistence.get_persistence_global(key).await?,
+                        expected_globals.get(&String::from(key)).cloned(),
+                        "canonical persistence global {key:?} diverged",
+                    );
+                }
+                let marker = target_persistence
+                    .get_persistence_global(
+                        common::persistence::PersistenceGlobalKey::ClusterGenesis,
+                    )
+                    .await?
+                    .expect("installed checkpoint must retain canonical genesis marker");
+                let marker = database::cluster_genesis::ClusterGenesisMarker::parse(marker)?;
+                assert_eq!(marker.genesis_id, canonical.manifest.genesis_id);
+
+                source.shutdown().await?;
+                target.shutdown().await?;
                 Ok(())
             },
         )

--- a/crates/local_backend/src/query_forwarding_api.rs
+++ b/crates/local_backend/src/query_forwarding_api.rs
@@ -111,6 +111,10 @@ impl SelectiveQueryForwardingApi {
         let Some(raft_state) = self.raft_state.as_ref() else {
             return Ok(None);
         };
+        anyhow::ensure!(
+            raft_state.is_cluster_genesis_ready(),
+            "Canonical cluster genesis is not ready"
+        );
         if raft_state.is_leader() {
             if raft_state.has_leader_serving_lease() {
                 return Ok(None);
@@ -178,6 +182,14 @@ impl SelectiveQueryForwardingApi {
         let Some(partition_id) = self.partition_id else {
             return Ok(());
         };
+        if let Some(raft_state) = self.raft_state.as_ref()
+            && !raft_state.is_cluster_genesis_ready()
+        {
+            return Err(self.unsupported_cluster_surface_error(
+                surface,
+                "canonical cluster genesis is not Raft-confirmed by every partition".to_string(),
+            ));
+        }
         if partition_id != SELECTIVE_QUERY_AUTHORITY_PARTITION {
             return Err(self.unsupported_cluster_surface_error(
                 surface,

--- a/crates/local_backend/src/route_authority.rs
+++ b/crates/local_backend/src/route_authority.rs
@@ -481,6 +481,20 @@ pub(crate) fn ensure_local_backend_api_authority(
     } else {
         (path, RouteAuthorityClass::FailClosed)
     };
+    let static_schema = matches!(
+        normalize_local_backend_api_path(path),
+        "/dashboard_openapi.json" | "/v1/openapi.json"
+    );
+    if !static_schema
+        && let Some(raft_state) = st.raft_state()
+        && !raft_state.is_cluster_genesis_ready()
+    {
+        return Err(unsupported_local_backend_cluster_surface_error(
+            surface,
+            class,
+            "canonical cluster genesis is not Raft-confirmed by every partition".to_string(),
+        ));
+    }
     match class {
         RouteAuthorityClass::AnyNodeSafe | RouteAuthorityClass::ExplicitForwarding => Ok(()),
         RouteAuthorityClass::CoordinatorOwner => {
@@ -613,5 +627,22 @@ mod tests {
             format!("{err:#}").contains("fresh Raft serving lease"),
             "unexpected error: {err:#}",
         );
+    }
+
+    #[test]
+    fn test_stateful_routes_fail_closed_before_cluster_genesis() {
+        let raft_state = RaftPartitionState::new_for_test(true, 1, PartitionId(0), 1);
+        raft_state.mark_cluster_genesis_unready_for_test();
+        let st = TestAuthorityContext {
+            replica_mode: false,
+            partition_id: Some(PartitionId(0)),
+            raft_state: Some(raft_state),
+        };
+
+        let error = ensure_local_backend_api_authority(&st, "/api/sync")
+            .expect_err("stateful route must remain closed before canonical genesis");
+        assert!(format!("{error:#}").contains("canonical cluster genesis"));
+        ensure_local_backend_api_authority(&st, "/api/dashboard_openapi.json")
+            .expect("static schema remains safe during bootstrap");
     }
 }

--- a/crates/local_backend/src/subs/mod.rs
+++ b/crates/local_backend/src/subs/mod.rs
@@ -267,6 +267,11 @@ async fn run_sync_socket(
                 }
             }
             if let Some(raft_state) = st.raft_state.as_ref() {
+                if !raft_state.is_cluster_genesis_ready() {
+                    anyhow::bail!(
+                        "Sync socket authority lost: canonical cluster genesis is not ready"
+                    );
+                }
                 if !raft_state.is_leader() {
                     anyhow::bail!(
                         "Sync socket authority lost: coordinator partition is a Raft follower"

--- a/crates/local_backend/src/two_phase_service.rs
+++ b/crates/local_backend/src/two_phase_service.rs
@@ -20,7 +20,9 @@ use database::{
     },
     raft_partition::RaftPartitionState,
     two_phase::{
+        prepare_timestamp_too_low,
         ParticipantTransaction,
+        PrepareResult,
         TwoPhaseCommitGrpcClient,
         TwoPhaseCommitGrpcClientPool,
         TwoPhaseTransactionId,
@@ -81,10 +83,55 @@ impl TwoPhaseCommitGrpcService {
         TonicTwoPcServer::new(self)
     }
 
+    fn prepare_response(
+        result: anyhow::Result<PrepareResult>,
+        error_context: &str,
+    ) -> Result<Response<TwoPcPrepareResponse>, Status> {
+        match result {
+            Ok(result) => Ok(Response::new(TwoPcPrepareResponse {
+                prepare_ts: u64::from(result.prepare_ts),
+                required_prepare_ts: None,
+            })),
+            Err(err) => {
+                if let Some(retry) = prepare_timestamp_too_low(&err) {
+                    return Ok(Response::new(TwoPcPrepareResponse {
+                        prepare_ts: u64::from(retry.proposed_ts),
+                        required_prepare_ts: Some(u64::from(retry.required_ts)),
+                    }));
+                }
+                Err(Status::internal(format!("{error_context}: {err:#}")))
+            },
+        }
+    }
+
+    fn validate_reads_response(
+        result: anyhow::Result<()>,
+        error_context: &str,
+    ) -> Result<Response<TwoPcValidateReadsResponse>, Status> {
+        match result {
+            Ok(()) => Ok(Response::new(TwoPcValidateReadsResponse {
+                required_prepare_ts: None,
+            })),
+            Err(err) => {
+                if let Some(retry) = prepare_timestamp_too_low(&err) {
+                    return Ok(Response::new(TwoPcValidateReadsResponse {
+                        required_prepare_ts: Some(u64::from(retry.required_ts)),
+                    }));
+                }
+                Err(Status::internal(format!("{error_context}: {err:#}")))
+            },
+        }
+    }
+
     async fn leader_client(&self) -> Result<Option<Arc<TwoPhaseCommitGrpcClient>>, Status> {
         let Some(raft_state) = self.raft_state.as_ref() else {
             return Ok(None);
         };
+        if !raft_state.is_cluster_genesis_ready() {
+            return Err(Status::unavailable(
+                "Canonical cluster genesis is not Raft-confirmed by every partition",
+            ));
+        }
         if raft_state.is_leader() {
             return Ok(None);
         }
@@ -199,11 +246,8 @@ impl TwoPhaseCommitService for TwoPhaseCommitGrpcService {
                     placement_version,
                     &participants,
                 )
-                .await
-                .map_err(|e| Status::internal(format!("Leader Prepare failed: {e:#}")))?;
-            return Ok(Response::new(TwoPcPrepareResponse {
-                prepare_ts: u64::from(result.prepare_ts),
-            }));
+                .await;
+            return Self::prepare_response(result, "Leader Prepare failed");
         }
 
         let result = self
@@ -215,12 +259,9 @@ impl TwoPhaseCommitService for TwoPhaseCommitGrpcService {
                 prepare_ts,
                 participants,
             )
-            .await
-            .map_err(|e| Status::internal(format!("Prepare failed: {e:#}")))?;
+            .await;
 
-        Ok(Response::new(TwoPcPrepareResponse {
-            prepare_ts: u64::from(result.prepare_ts),
-        }))
+        Self::prepare_response(result, "Prepare failed")
     }
 
     async fn validate_reads(
@@ -243,7 +284,7 @@ impl TwoPhaseCommitService for TwoPhaseCommitGrpcService {
         self.ensure_placement_version(placement_version).await?;
 
         if let Some(client) = self.leader_client().await? {
-            client
+            let result = client
                 .validate_reads(
                     &txn_id,
                     transaction,
@@ -251,17 +292,16 @@ impl TwoPhaseCommitService for TwoPhaseCommitGrpcService {
                     validate_ts,
                     placement_version,
                 )
-                .await
-                .map_err(|e| Status::internal(format!("Leader ValidateReads failed: {e:#}")))?;
-            return Ok(Response::new(TwoPcValidateReadsResponse {}));
+                .await;
+            return Self::validate_reads_response(result, "Leader ValidateReads failed");
         }
 
-        self.committer
+        let result = self
+            .committer
             .validate_remote_reads(txn_id, transaction, req.write_source.into(), validate_ts)
-            .await
-            .map_err(|e| Status::internal(format!("ValidateReads failed: {e:#}")))?;
+            .await;
 
-        Ok(Response::new(TwoPcValidateReadsResponse {}))
+        Self::validate_reads_response(result, "ValidateReads failed")
     }
 
     async fn commit_prepared(

--- a/crates/pb/protos/replication.proto
+++ b/crates/pb/protos/replication.proto
@@ -171,8 +171,13 @@ message TwoPcPrepareRequest {
 }
 
 message TwoPcPrepareResponse {
-  // The prepare timestamp assigned by the participant's TSO.
+  // The coordinator timestamp accepted by the participant.
   uint64 prepare_ts = 1;
+
+  // Set when the participant cannot accept prepare_ts because its committed
+  // state has already advanced. The coordinator must allocate a new global
+  // timestamp at or above this floor and retry the whole prepare attempt.
+  optional uint64 required_prepare_ts = 2;
 }
 
 message TwoPcValidateReadsRequest {
@@ -196,6 +201,10 @@ message TwoPcValidateReadsRequest {
 }
 
 message TwoPcValidateReadsResponse {
+  // Set when validate_ts is behind the read owner's committed state. The
+  // coordinator must allocate a new global timestamp at or above this floor
+  // and retry the whole prepare attempt.
+  optional uint64 required_prepare_ts = 1;
 }
 
 message TwoPcParticipantTransaction {

--- a/npm-packages/@convex-dev/platform/public-deployment-openapi.json
+++ b/npm-packages/@convex-dev/platform/public-deployment-openapi.json
@@ -326,6 +326,50 @@
           }
         }
       },
+      "ReadAfterWriteFenceToken": {
+        "type": "object",
+        "required": [
+          "ts"
+        ],
+        "properties": {
+          "sourcePartition": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "int32",
+            "minimum": 0
+          },
+          "ts": {
+            "$ref": "#/components/schemas/SerializedTs"
+          }
+        }
+      },
+      "ReadAfterWriteToken": {
+        "type": "object",
+        "required": [
+          "ts"
+        ],
+        "properties": {
+          "participantFences": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ReadAfterWriteFenceToken"
+            }
+          },
+          "sourcePartition": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "int32",
+            "minimum": 0
+          },
+          "ts": {
+            "$ref": "#/components/schemas/SerializedTs"
+          }
+        }
+      },
       "SerializedTs": {
         "type": "string"
       },
@@ -358,6 +402,16 @@
           },
           "path": {
             "type": "string"
+          },
+          "readAfterWrite": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/ReadAfterWriteToken"
+              }
+            ]
           }
         }
       },
@@ -426,6 +480,16 @@
           "path": {
             "type": "string"
           },
+          "readAfterWrite": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/ReadAfterWriteToken"
+              }
+            ]
+          },
           "ts": {
             "$ref": "#/components/schemas/SerializedTs"
           }
@@ -445,6 +509,16 @@
                 "items": {
                   "type": "string"
                 }
+              },
+              "readAfterWrite": {
+                "oneOf": [
+                  {
+                    "type": "null"
+                  },
+                  {
+                    "$ref": "#/components/schemas/ReadAfterWriteToken"
+                  }
+                ]
               },
               "status": {
                 "type": "string",

--- a/self-hosted/docker/test-write-scaling.sh
+++ b/self-hosted/docker/test-write-scaling.sh
@@ -98,6 +98,7 @@ BACKEND_CONTAINERS=(
     docker-node-p1b-1
     docker-node-p1c-1
 )
+CANONICAL_GENESIS_ID=""
 
 pass() {
     PASSED=$((PASSED + 1))
@@ -151,6 +152,76 @@ assert_dynamic_membership_advertisements() {
     fi
 }
 
+read_persistence_global() {
+    local database_name="$1"
+    local key="$2"
+    docker exec docker-postgres-1 psql -U postgres -d "$database_name" -Atc \
+        "SELECT convert_from(json_value, 'UTF8') FROM persistence_globals WHERE key = '$key'" \
+        2>/dev/null || true
+}
+
+genesis_id_from_json() {
+    python3 -c 'import json,sys; print(json.load(sys.stdin)["genesis_id"])'
+}
+
+wait_for_persistence_global() {
+    local database_name="$1"
+    local key="$2"
+    local value=""
+    for _ in $(seq 1 90); do
+        value=$(read_persistence_global "$database_name" "$key")
+        if [ -n "$value" ]; then
+            printf '%s' "$value"
+            return 0
+        fi
+        sleep 1
+    done
+    return 1
+}
+
+assert_canonical_cluster_genesis() {
+    local details=""
+    local expected=""
+    local specs=(
+        "convex_node_p0a docker-node-p0a-1"
+        "convex_node_p0b docker-node-p0b-1"
+        "convex_node_p0c docker-node-p0c-1"
+        "convex_node_p1a docker-node-p1a-1"
+        "convex_node_p1b docker-node-p1b-1"
+        "convex_node_p1c docker-node-p1c-1"
+    )
+
+    for spec in "${specs[@]}"; do
+        read -r database_name container <<< "$spec"
+        local marker
+        local applied
+        marker=$(wait_for_persistence_global "$database_name" cluster_genesis || true)
+        applied=$(wait_for_persistence_global "$database_name" cluster_genesis_raft_applied || true)
+        if [ -z "$marker" ] || [ -z "$applied" ]; then
+            details="$details $container marker=${marker:-missing} raft_applied=${applied:-missing};"
+            continue
+        fi
+        local marker_id
+        local applied_id
+        marker_id=$(genesis_id_from_json <<< "$marker" 2>/dev/null || true)
+        applied_id=$(genesis_id_from_json <<< "$applied" 2>/dev/null || true)
+        if [ -z "$expected" ]; then
+            expected="$marker_id"
+        fi
+        if [ -z "$marker_id" ] || [ "$marker_id" != "$expected" ] || [ "$applied_id" != "$expected" ]; then
+            details="$details $container marker=$marker_id raft_applied=$applied_id expected=$expected;"
+        fi
+    done
+
+    if [ -z "$details" ] && [ -n "$expected" ]; then
+        CANONICAL_GENESIS_ID="$expected"
+        pass "All six nodes installed one canonical Convex genesis"
+        pass "Every node applied canonical genesis through its partition Raft log"
+    else
+        fail "Cluster genesis state diverged" "$details"
+    fi
+}
+
 # --- Preflight ---
 
 echo ""
@@ -166,6 +237,7 @@ done
 echo "  Containers running."
 
 assert_dynamic_membership_advertisements
+assert_canonical_cluster_genesis
 
 if [ "${EXPECT_PARALLEL_2PC_EARLY_ACK:-false}" = "true" ]; then
     EARLY_ACK_ENV_OK=true
@@ -1301,6 +1373,19 @@ done
 # Re-generate Node B key (may have changed on restart)
 NODE_P1A_KEY=$(docker exec docker-node-p1a-1 ./generate_admin_key.sh 2>&1 | tail -1)
 NODE_B_KEY="$NODE_P1A_KEY"
+
+RESTART_GENESIS=$(wait_for_persistence_global convex_node_p1a cluster_genesis || true)
+RESTART_RAFT_GENESIS=$(wait_for_persistence_global convex_node_p1a cluster_genesis_raft_applied || true)
+RESTART_GENESIS_ID=$(genesis_id_from_json <<< "$RESTART_GENESIS" 2>/dev/null || true)
+RESTART_RAFT_GENESIS_ID=$(genesis_id_from_json <<< "$RESTART_RAFT_GENESIS" 2>/dev/null || true)
+if [ -n "$CANONICAL_GENESIS_ID" ] \
+    && [ "$RESTART_GENESIS_ID" = "$CANONICAL_GENESIS_ID" ] \
+    && [ "$RESTART_RAFT_GENESIS_ID" = "$CANONICAL_GENESIS_ID" ]; then
+    pass "Restarted node retained canonical Raft-applied genesis identity"
+else
+    fail "Restarted node lost canonical genesis identity" \
+        "canonical=$CANONICAL_GENESIS_ID marker=$RESTART_GENESIS_ID raft_applied=$RESTART_RAFT_GENESIS_ID"
+fi
 
 # Re-deploy functions to Node B (modules are in-memory)
 echo "  Re-deploying functions to Node B..."


### PR DESCRIPTION
## Summary

- create one canonical Convex genesis checkpoint on partition 0, publish it through an authenticated NATS store, and require every partition to install it through its own Raft log
- persist separate cluster-global genesis identity and node-local Raft-application evidence; gate stateful routes, writes, subscriptions, workers, replication, and checkpoint publication until genesis is confirmed
- reload fresh clustered databases from canonical persistence before starting serving workers so cached table/index metadata cannot retain candidate bootstrap state
- suppress pre-genesis candidate deltas from cross-node replication
- integrate the canonical-genesis gate with the current-term applied-leader readiness barrier and crash-consistent Raft snapshot installation from #274 and #276
- make 2PC timestamp-floor retries structured and floor-aware across write and read-only participants
- validate checkpoint scans at the protected checkpoint timestamp instead of the physical scan lower bound
- add Rust and six-node regressions for canonical identity, restart durability, TSO batch gaps, and checkpoint retention

## Correctness invariants

- all voters start from the same system-table IDs and deployment-global values
- no node serves clustered state or publishes candidate bootstrap deltas before Raft confirms canonical genesis
- every write/proposal path requires canonical genesis plus an applied current-term Raft leader
- coordinator reads, subscriptions, frontier advertisements, and singleton workers additionally require a valid Raft serving lease
- each persistence independently records that its own partition Raft log applied genesis
- Raft snapshot recovery preserves canonical-genesis application evidence without bypassing crash-consistent snapshot staging
- a participant timestamp-floor rejection causes one global TSO reservation at or above the maximum required floor
- checkpoint creation remains valid after document retention advances

## Validation

- `cargo check -p local_backend`: passed
- focused canonical-genesis, route-authority, checkpoint-retention, and structured 2PC timestamp-floor regressions: passed
- `cargo test -p database --lib`: 595 passed, 2 ignored
- `cargo test -p local_backend --lib`: 103 passed
- exact local image: `sha256:99e4cbf3440461e40c64aaf253a2bf16be4e1a2a0db3b291e544d622a8a299d0`
- embedded revision: `6bf63e593a5d352319e15d27f8b15f1744294059`
- clean cluster created with volumes removed and `BACKEND_PULL_POLICY=never`
- all six backend containers verified healthy on that exact image ID and revision
- canonical-genesis preflight: all six nodes shared one genesis ID and independently recorded Raft application
- write-scaling cluster suite: 152/152 passed
- Raft failover cluster suite: 24/24 passed
- all suites passed

Closes #277
