### PR TITLE
fix(raft): make state machine replay idempotent

### DIFF
--- a/crates/common/src/persistence.rs
+++ b/crates/common/src/persistence.rs
@@ -131,6 +131,23 @@ pub enum ConflictStrategy {
     Overwrite,
 }
 
+/// An unversioned persistence-global value written atomically with a batch of
+/// document and index revisions.
+#[derive(Clone, Debug, PartialEq)]
+pub struct PersistenceGlobalWrite {
+    pub key: String,
+    pub value: JsonValue,
+}
+
+impl PersistenceGlobalWrite {
+    pub fn new(key: impl Into<String>, value: JsonValue) -> Self {
+        Self {
+            key: key.into(),
+            value,
+        }
+    }
+}
+
 // When adding a new persistence global, make sure it's copied
 // or computed in migrate_db_cluster/text_index_worker.
 #[cfg_attr(test, derive(proptest_derive::Arbitrary))]
@@ -285,6 +302,23 @@ pub trait Persistence: Sync + Send + 'static {
         documents: &'a [DocumentLogEntry],
         indexes: &'a [PersistenceIndexEntry],
         conflict_strategy: ConflictStrategy,
+    ) -> anyhow::Result<()> {
+        self.write_with_persistence_globals(documents, indexes, conflict_strategy, &[])
+            .await
+    }
+
+    /// Atomically writes versioned document/index revisions and unversioned
+    /// persistence-global values in one storage transaction.
+    ///
+    /// Raft state-machine apply uses this to bind a stable apply identity to
+    /// the exact Convex revisions it installs. Implementations must not expose
+    /// either side without the other after a crash.
+    async fn write_with_persistence_globals<'a>(
+        &self,
+        documents: &'a [DocumentLogEntry],
+        indexes: &'a [PersistenceIndexEntry],
+        conflict_strategy: ConflictStrategy,
+        persistence_globals: &'a [PersistenceGlobalWrite],
     ) -> anyhow::Result<()>;
 
     /// Writes global key-value data for the whole persistence.

--- a/crates/common/src/testing/persistence_test_suite.rs
+++ b/crates/common/src/testing/persistence_test_suite.rs
@@ -63,6 +63,7 @@ use crate::{
         NoopRetentionValidator,
         Persistence,
         PersistenceGlobalKey,
+        PersistenceGlobalWrite,
         PersistenceIndexEntry,
         PersistenceReader,
         TimestampRange,
@@ -205,6 +206,13 @@ macro_rules! run_persistence_test_suite {
             let $db = $create_db;
             let p = $create_persistence;
             persistence_test_suite::persistence_global(::std::sync::Arc::new(p)).await
+        }
+
+        #[tokio::test]
+        async fn test_persistence_atomic_write_with_global() -> anyhow::Result<()> {
+            let $db = $create_db;
+            let p = $create_persistence;
+            persistence_test_suite::atomic_write_with_global(::std::sync::Arc::new(p)).await
         }
 
         #[tokio::test]
@@ -1540,6 +1548,71 @@ pub async fn persistence_global<P: Persistence>(p: Arc<P>) -> anyhow::Result<()>
     let value = very_nested_json(257);
     p.write_persistence_global(key, value.clone()).await?;
     assert_eq!(p.reader().get_persistence_global(key).await?, Some(value));
+    Ok(())
+}
+
+pub async fn atomic_write_with_global<P: Persistence>(p: Arc<P>) -> anyhow::Result<()> {
+    let mut id_generator = TestIdGenerator::new();
+    let table: TableName = "atomic_write".parse()?;
+    let document = doc(id_generator.user_generate(&table), 17, Some(42), None)?;
+    let marker = PersistenceGlobalWrite::new("test_atomic_marker", json!({"committed": 17}));
+    p.write_with_persistence_globals(
+        std::slice::from_ref(&document),
+        &[],
+        ConflictStrategy::Error,
+        std::slice::from_ref(&marker),
+    )
+    .await?;
+
+    let loaded = p
+        .reader()
+        .load_documents(
+            TimestampRange::at(Timestamp::must(17)),
+            Order::Asc,
+            16,
+            Arc::new(NoopRetentionValidator),
+        )
+        .try_collect::<Vec<_>>()
+        .await?;
+    assert_eq!(loaded, vec![document.clone()]);
+    assert_eq!(
+        p.reader()
+            .get_persistence_global_raw("test_atomic_marker")
+            .await?,
+        Some(marker.value),
+    );
+
+    let rejected_marker =
+        PersistenceGlobalWrite::new("test_rejected_atomic_marker", json!({"committed": false}));
+    let earlier_valid_document = doc(id_generator.user_generate(&table), 18, Some(43), None)?;
+    p.write_with_persistence_globals(
+        &[earlier_valid_document.clone(), document],
+        &[],
+        ConflictStrategy::Error,
+        std::slice::from_ref(&rejected_marker),
+    )
+    .await
+    .expect_err("duplicate document revision should reject the atomic batch");
+    assert_eq!(
+        p.reader()
+            .get_persistence_global_raw("test_rejected_atomic_marker")
+            .await?,
+        None,
+        "a failed document write must roll back its persistence-global marker",
+    );
+    assert!(
+        p.reader()
+            .load_documents(
+                TimestampRange::at(Timestamp::must(18)),
+                Order::Asc,
+                16,
+                Arc::new(NoopRetentionValidator),
+            )
+            .try_collect::<Vec<_>>()
+            .await?
+            .is_empty(),
+        "a conflict later in the batch must roll back earlier document rows",
+    );
     Ok(())
 }
 

--- a/crates/common/src/testing/test_persistence.rs
+++ b/crates/common/src/testing/test_persistence.rs
@@ -44,6 +44,7 @@ use crate::{
         LatestDocument,
         Persistence,
         PersistenceGlobalKey,
+        PersistenceGlobalWrite,
         PersistenceIndexEntry,
         PersistenceReader,
         RetentionValidator,
@@ -99,22 +100,44 @@ impl Persistence for TestPersistence {
         Arc::new(self.clone()) as Arc<_>
     }
 
-    async fn write<'a>(
+    async fn write_with_persistence_globals<'a>(
         &self,
         documents: &'a [DocumentLogEntry],
         indexes: &'a [PersistenceIndexEntry],
         conflict_strategy: ConflictStrategy,
+        persistence_globals: &'a [PersistenceGlobalWrite],
     ) -> anyhow::Result<()> {
         let mut inner = self.inner.lock();
+        if conflict_strategy == ConflictStrategy::Error {
+            let mut document_keys = BTreeSet::new();
+            for update in documents {
+                anyhow::ensure!(
+                    document_keys.insert((update.ts, update.id))
+                        && !inner.log.contains_key(&(update.ts, update.id)),
+                    "Unique constraint not satisfied. Failed to write document at ts {} with id \
+                     {}: (document, ts) pair already exists",
+                    update.ts,
+                    update.id
+                );
+            }
+            let mut index_keys = BTreeSet::new();
+            for update in indexes {
+                let key = (update.index_id, update.key.clone(), update.ts);
+                anyhow::ensure!(
+                    index_keys.insert(key)
+                        && !inner
+                            .index
+                            .get(&update.index_id)
+                            .is_some_and(|idx| idx.contains_key(&(update.key.clone(), update.ts))),
+                    "Unique constraint not satisfied. Failed to write to index {} at ts {} with \
+                     key {:?}: (key, ts) pair already exists",
+                    update.index_id,
+                    update.ts,
+                    update.key,
+                );
+            }
+        }
         for update in documents {
-            anyhow::ensure!(
-                conflict_strategy == ConflictStrategy::Overwrite
-                    || !inner.log.contains_key(&(update.ts, update.id)),
-                "Unique constraint not satisfied. Failed to write document at ts {} with id {}: \
-                 (document, ts) pair already exists",
-                update.ts,
-                update.id
-            );
             inner.log.insert(
                 (update.ts, update.id),
                 (update.value.clone(), update.prev_ts),
@@ -123,24 +146,16 @@ impl Persistence for TestPersistence {
         inner.is_fresh = false;
         for update in indexes {
             let index_key_bytes = update.key.clone();
-            anyhow::ensure!(
-                conflict_strategy == ConflictStrategy::Overwrite
-                    || !inner
-                        .index
-                        .get(&update.index_id)
-                        .map(|idx| idx.contains_key(&(index_key_bytes.clone(), update.ts)))
-                        .unwrap_or(false),
-                "Unique constraint not satisfied. Failed to write to index {} at ts {} with key \
-                 {:?}: (key, ts) pair already exists",
-                update.index_id,
-                update.ts,
-                index_key_bytes
-            );
             inner
                 .index
                 .entry(update.index_id)
                 .or_default()
                 .insert((index_key_bytes, update.ts), update.value);
+        }
+        for write in persistence_globals {
+            inner
+                .persistence_globals
+                .insert(write.key.clone(), write.value.clone());
         }
         Ok(())
     }

--- a/crates/database/src/checkpoint.rs
+++ b/crates/database/src/checkpoint.rs
@@ -32,6 +32,7 @@ use common::{
         LatestDocument,
         Persistence,
         PersistenceGlobalKey,
+        PersistenceGlobalWrite,
         PersistenceIndexEntry,
         PersistenceReader,
         RetentionValidator,
@@ -138,11 +139,12 @@ impl Persistence for CheckpointPersistence {
         Arc::new(self.clone()) as Arc<_>
     }
 
-    async fn write<'a>(
+    async fn write_with_persistence_globals<'a>(
         &self,
         _documents: &'a [DocumentLogEntry],
         _indexes: &'a [PersistenceIndexEntry],
         _conflict_strategy: ConflictStrategy,
+        _persistence_globals: &'a [PersistenceGlobalWrite],
     ) -> anyhow::Result<()> {
         anyhow::bail!("CheckpointPersistence is read-only")
     }

--- a/crates/database/src/committer.rs
+++ b/crates/database/src/committer.rs
@@ -63,6 +63,7 @@ use common::{
         NoopRetentionValidator,
         Persistence,
         PersistenceGlobalKey,
+        PersistenceGlobalWrite,
         PersistenceIndexEntry,
         PersistenceReader,
         RepeatablePersistence,
@@ -116,6 +117,10 @@ use rand::Rng;
 use search::{
     query::tokenize,
     TextIndexWriteSize,
+};
+use serde::{
+    Deserialize,
+    Serialize,
 };
 use tokio::sync::{
     mpsc::{
@@ -199,10 +204,99 @@ use crate::{
 const INITIAL_PERSISTENCE_WRITES_BACKOFF: Duration = Duration::from_secs(1);
 const MAX_PERSISTENCE_WRITES_BACKOFF: Duration = Duration::from_secs(60);
 const RAFT_NATS_OUTBOX_REPLAY_INTERVAL: Duration = Duration::from_secs(1);
-const RAFT_NATS_OUTBOX_KEY_PREFIX: &str = "raft_nats_outbox/";
+pub(crate) const RAFT_NATS_OUTBOX_KEY_PREFIX: &str = "raft_nats_outbox/";
+pub(crate) const RAFT_APPLY_MARKER_KEY_PREFIX: &str = "raft_apply_marker/";
 const MAX_APPLIED_DATA_ORIGIN_TIMESTAMPS_PER_PARTITION: usize = 1024;
 
 type LegacyRaftNatsOutboxRecords = BTreeMap<String, serde_json::Value>;
+
+/// Stable identity journaled in the same persistence transaction as a
+/// Raft-applied Convex write. The raw marker bridges the crash window until
+/// the identity is consolidated into `AppliedDataDeltaIds`.
+#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
+pub(crate) struct RaftApplyMarker {
+    source_partition: crate::partition::PartitionId,
+    origin_ts: Timestamp,
+}
+
+#[derive(Deserialize, Serialize)]
+struct RaftApplyMarkerValue {
+    source_partition: u32,
+    origin_ts: u64,
+}
+
+impl RaftApplyMarker {
+    fn from_delta(delta: &CommitDelta) -> anyhow::Result<Self> {
+        let source_partition = delta.source_partition.with_context(|| {
+            format!(
+                "Raft apply delta at ts={} did not include a source partition",
+                u64::from(delta.ts),
+            )
+        })?;
+        Ok(Self {
+            source_partition,
+            origin_ts: delta.ts,
+        })
+    }
+
+    fn key(self) -> String {
+        format!(
+            "{RAFT_APPLY_MARKER_KEY_PREFIX}{:020}/{:020}",
+            self.source_partition.0,
+            u64::from(self.origin_ts),
+        )
+    }
+
+    fn persistence_write(self) -> anyhow::Result<PersistenceGlobalWrite> {
+        Ok(PersistenceGlobalWrite::new(
+            self.key(),
+            serde_json::to_value(RaftApplyMarkerValue {
+                source_partition: self.source_partition.0,
+                origin_ts: u64::from(self.origin_ts),
+            })?,
+        ))
+    }
+
+    fn from_record(key: &str, value: serde_json::Value) -> anyhow::Result<Self> {
+        let suffix = key
+            .strip_prefix(RAFT_APPLY_MARKER_KEY_PREFIX)
+            .with_context(|| format!("Invalid Raft apply marker key {key:?}"))?;
+        let (partition, origin_ts) = suffix
+            .split_once('/')
+            .with_context(|| format!("Invalid Raft apply marker key {key:?}"))?;
+        let marker = Self {
+            source_partition: crate::partition::PartitionId(
+                partition
+                    .parse::<u32>()
+                    .with_context(|| format!("Invalid Raft apply marker partition in {key:?}"))?,
+            ),
+            origin_ts: Timestamp::try_from(
+                origin_ts
+                    .parse::<u64>()
+                    .with_context(|| format!("Invalid Raft apply marker timestamp in {key:?}"))?,
+            )?,
+        };
+        let persisted: RaftApplyMarkerValue = serde_json::from_value(value)
+            .with_context(|| format!("Invalid Raft apply marker value for {key:?}"))?;
+        anyhow::ensure!(
+            persisted.source_partition == marker.source_partition.0
+                && persisted.origin_ts == u64::from(marker.origin_ts),
+            "Raft apply marker key/value identity mismatch for {key:?}",
+        );
+        Ok(marker)
+    }
+}
+
+pub(crate) async fn load_raft_apply_markers(
+    reader: Arc<dyn PersistenceReader>,
+) -> anyhow::Result<BTreeSet<RaftApplyMarker>> {
+    reader
+        .list_persistence_globals_with_prefix(RAFT_APPLY_MARKER_KEY_PREFIX)
+        .await?
+        .into_iter()
+        .map(|(key, value)| RaftApplyMarker::from_record(&key, value))
+        .collect()
+}
 
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
 pub(crate) struct OrderedDedupeState {
@@ -340,6 +434,7 @@ enum PersistenceWrite {
         commit_id: usize,
         delta: CommitDelta,
         raft_applied_index: Option<u64>,
+        raft_apply_marker: Option<RaftApplyMarker>,
     },
     RejectedBeforePersistence {
         pending_write: PendingWriteHandle,
@@ -353,6 +448,7 @@ enum PersistenceWrite {
         commit_id: usize,
         delta: CommitDelta,
         raft_applied_index: Option<u64>,
+        raft_apply_marker: Option<RaftApplyMarker>,
     },
     PreparedRejectedBeforePersistence {
         transaction_id: crate::two_phase::TwoPhaseTransactionId,
@@ -380,7 +476,17 @@ enum PersistenceWrite {
         applied_delta_watermarks: Option<BTreeMap<crate::partition::PartitionId, Timestamp>>,
         applied_data_delta_watermarks: Option<BTreeMap<crate::partition::PartitionId, Timestamp>>,
         applied_data_delta_ids: Option<AppliedDataDeltaIds>,
+        raft_apply_marker: Option<RaftApplyMarker>,
         raft_nats_outbox_delta: Option<CommitDelta>,
+        result: oneshot::Sender<anyhow::Result<Timestamp>>,
+        commit_id: usize,
+    },
+    /// A crash left an atomic Raft apply marker next to already-installed
+    /// Convex revisions. Consolidate the identity and ACK replay without
+    /// publishing another logical write.
+    RaftReplayRecovery {
+        marker: RaftApplyMarker,
+        delta: CommitDelta,
         result: oneshot::Sender<anyhow::Result<Timestamp>>,
         commit_id: usize,
     },
@@ -412,6 +518,7 @@ impl PersistenceWrite {
             Self::PreparedRejectedBeforePersistence { commit_id, .. } => *commit_id,
             Self::MaxRepeatableTimestamp { commit_id, .. } => *commit_id,
             Self::ReplicaDelta { commit_id, .. } => *commit_id,
+            Self::RaftReplayRecovery { commit_id, .. } => *commit_id,
             Self::RemoteReadFrontierHeartbeat { commit_id, .. } => *commit_id,
             Self::InstallSnapshot { commit_id, .. } => *commit_id,
         }
@@ -419,6 +526,9 @@ impl PersistenceWrite {
 }
 
 pub const AFTER_PENDING_WRITE_SNAPSHOT: &str = "after_pending_write_snapshot";
+pub const AFTER_RAFT_CONVEX_PERSISTENCE: &str = "after_raft_convex_persistence";
+pub const AFTER_RAFT_SNAPSHOT_PUBLICATION: &str = "after_raft_snapshot_publication";
+pub const AFTER_RAFT_APPLIED_INDEX_PERSISTENCE: &str = "after_raft_applied_index_persistence";
 
 fn remote_read_partitions(
     reads: &ReadSet,
@@ -925,6 +1035,11 @@ pub struct Committer<RT: Runtime> {
     // source partition and origin commit timestamp.
     applied_data_delta_ids: AppliedDataDeltaIds,
 
+    // Raft data writes that reached Convex persistence atomically but had not
+    // yet been consolidated into `applied_data_delta_ids` when the process
+    // stopped. Replay must repair bookkeeping without installing them again.
+    raft_apply_markers: BTreeSet<RaftApplyMarker>,
+
     // Sender for requeueing internal work that must wait for earlier state
     // machine timestamps to become visible without blocking the committer loop.
     sender: mpsc::Sender<CommitterMessage>,
@@ -1004,6 +1119,7 @@ impl<RT: Runtime> Committer<RT> {
         applied_delta_watermarks: BTreeMap<crate::partition::PartitionId, Timestamp>,
         applied_data_delta_watermarks: BTreeMap<crate::partition::PartitionId, Timestamp>,
         applied_data_delta_ids: AppliedDataDeltaIds,
+        raft_apply_markers: BTreeSet<RaftApplyMarker>,
     ) -> CommitterClient {
         let mut applied_data_delta_ids = applied_data_delta_ids;
         applied_data_delta_ids
@@ -1037,6 +1153,7 @@ impl<RT: Runtime> Committer<RT> {
             applied_delta_watermarks,
             applied_data_delta_watermarks,
             applied_data_delta_ids,
+            raft_apply_markers,
             sender: tx.clone(),
         };
         let handle = runtime.spawn("committer", async move {
@@ -1195,12 +1312,23 @@ impl<RT: Runtime> Committer<RT> {
                             parent_trace,
                             delta,
                             raft_applied_index,
+                            raft_apply_marker,
                             ..
                         } => {
+                            let commit_ts = pending_write.must_commit_ts();
+                            if let Some(marker) = raft_apply_marker
+                                && let Err(err) = self.consolidate_raft_apply_marker(marker).await
+                            {
+                                return Self::fail_committed_write(
+                                    result,
+                                    commit_ts,
+                                    "consolidate atomic Raft apply marker",
+                                    err,
+                                );
+                            }
                             let parent_span = initialize_root_from_parent("Committer::publish_commit", parent_trace);
                             let publish_commit_span = committer_span.as_ref().map(|root| Span::enter_with_parents("publish_commit", [root, &parent_span])).unwrap_or_else(|| parent_span);
                             let _guard = publish_commit_span.set_local_parent();
-                            let commit_ts = pending_write.must_commit_ts();
                             self.dequeue_snapshot(pending_commit_id);
                             let published_commit = match self.publish_commit(
                                 pending_write, delta,
@@ -1216,6 +1344,12 @@ impl<RT: Runtime> Committer<RT> {
                                 },
                             };
                             drop(_guard);
+                            if raft_applied_index.is_some() {
+                                self.runtime
+                                    .pause_client()
+                                    .wait(AFTER_RAFT_SNAPSHOT_PUBLICATION)
+                                    .await;
+                            }
                             if let Some(raft_applied_index) = raft_applied_index {
                                 let raft_mark_timer =
                                     metrics::commit_hot_path_stage_timer("local", "raft_mark_applied");
@@ -1241,6 +1375,10 @@ impl<RT: Runtime> Committer<RT> {
                                     );
                                 }
                                 raft_mark_timer.finish();
+                                self.runtime
+                                    .pause_client()
+                                    .wait(AFTER_RAFT_APPLIED_INDEX_PERSISTENCE)
+                                    .await;
                             }
                             let use_raft_nats_outbox =
                                 Self::should_record_raft_nats_outbox_delta(&published_commit.delta);
@@ -1316,9 +1454,20 @@ impl<RT: Runtime> Committer<RT> {
                             transaction_id,
                             delta,
                             raft_applied_index,
+                            raft_apply_marker,
                             ..
                         } => {
                             let commit_ts = delta.ts;
+                            if let Some(marker) = raft_apply_marker
+                                && let Err(err) = self.consolidate_raft_apply_marker(marker).await
+                            {
+                                return self.fail_prepared_committed_write(
+                                    &transaction_id,
+                                    commit_ts,
+                                    "consolidate atomic Raft apply marker",
+                                    err,
+                                );
+                            }
                             let published_commit = match self.publish_prepared_commit(
                                 transaction_id.clone(),
                                 delta,
@@ -1334,6 +1483,12 @@ impl<RT: Runtime> Committer<RT> {
                                     );
                                 },
                             };
+                            if published_commit.raft_applied_index.is_some() {
+                                self.runtime
+                                    .pause_client()
+                                    .wait(AFTER_RAFT_SNAPSHOT_PUBLICATION)
+                                    .await;
+                            }
                             if let Some(raft_applied_index) = published_commit.raft_applied_index {
                                 let raft_mark_timer = metrics::commit_hot_path_stage_timer(
                                     "2pc_participant",
@@ -1363,6 +1518,10 @@ impl<RT: Runtime> Committer<RT> {
                                     );
                                 }
                                 raft_mark_timer.finish();
+                                self.runtime
+                                    .pause_client()
+                                    .wait(AFTER_RAFT_APPLIED_INDEX_PERSISTENCE)
+                                    .await;
                             }
                             let use_raft_nats_outbox =
                                 Self::should_record_raft_nats_outbox_delta(&published_commit.delta);
@@ -1468,6 +1627,7 @@ impl<RT: Runtime> Committer<RT> {
                             applied_delta_watermarks,
                             applied_data_delta_watermarks,
                             applied_data_delta_ids,
+                            raft_apply_marker,
                             raft_nats_outbox_delta,
                             result,
                             ..
@@ -1525,6 +1685,20 @@ impl<RT: Runtime> Committer<RT> {
                                         applied_data_delta_ids_json,
                                     )
                                     .await?;
+                            }
+                            if let Some(marker) = raft_apply_marker {
+                                anyhow::ensure!(
+                                    self.applied_data_delta_ids.contains_origin_timestamp(
+                                        marker.source_partition,
+                                        marker.origin_ts,
+                                    ),
+                                    "Raft apply marker {} was not consolidated before cleanup",
+                                    marker.key(),
+                                );
+                                self.persistence
+                                    .delete_persistence_global_raw(&marker.key())
+                                    .await?;
+                                self.raft_apply_markers.remove(&marker);
                             }
                             if let Some(delta) = raft_nats_outbox_delta.as_ref() {
                                 Self::add_raft_nats_outbox_delta(
@@ -1587,7 +1761,46 @@ impl<RT: Runtime> Committer<RT> {
                                     );
                                 }
                             }
+                            if raft_apply_marker.is_some() {
+                                self.runtime
+                                    .pause_client()
+                                    .wait(AFTER_RAFT_SNAPSHOT_PUBLICATION)
+                                    .await;
+                            }
                             let _ = result.send(Ok(commit_ts));
+                        },
+                        PersistenceWrite::RaftReplayRecovery {
+                            marker,
+                            delta,
+                            result,
+                            ..
+                        } => {
+                            let recovery_result = async {
+                                if self.raft_apply_markers.contains(&marker) {
+                                    self.consolidate_raft_apply_marker(marker).await?;
+                                }
+                                if Self::should_record_raft_nats_outbox_delta(&delta) {
+                                    Self::add_raft_nats_outbox_delta(
+                                        self.persistence.clone(),
+                                        &delta,
+                                    )
+                                    .await?;
+                                }
+                                if delta.source_partition
+                                    == Some(self.local_partition_for_two_phase())
+                                    && let Some(transaction_id) = self
+                                        .remove_prepared_transaction_at_origin_ts(delta.ts)?
+                                {
+                                    Self::delete_two_phase_redo(
+                                        self.persistence.clone(),
+                                        &transaction_id,
+                                    )
+                                    .await?;
+                                }
+                                anyhow::Ok(marker.origin_ts)
+                            }
+                            .await;
+                            let _ = result.send(recovery_result);
                         },
                         PersistenceWrite::RemoteReadFrontierHeartbeat {
                             commit_ts,
@@ -2789,13 +3002,20 @@ impl<RT: Runtime> Committer<RT> {
         index_writes: Arc<Vec<PersistenceIndexEntry>>,
         document_writes: Arc<Vec<DocumentLogEntry>>,
         write_source: WriteSource,
+        raft_apply_marker: Option<RaftApplyMarker>,
+        raft_nats_outbox_delta: Option<CommitDelta>,
     ) -> anyhow::Result<()> {
         let timer = metrics::commit_persistence_write_timer();
+        let raft_apply_writes = Self::raft_apply_persistence_writes(
+            raft_apply_marker,
+            raft_nats_outbox_delta.as_ref(),
+        )?;
         persistence
-            .write(
+            .write_with_persistence_globals(
                 document_writes.as_slice(),
                 &index_writes,
                 ConflictStrategy::Error,
+                &raft_apply_writes,
             )
             .await
             .with_context(|| format!("Commit ({write_source:?}) failed to write to persistence"))?;
@@ -2935,6 +3155,69 @@ impl<RT: Runtime> Committer<RT> {
         result
     }
 
+    async fn consolidate_raft_apply_marker(
+        &mut self,
+        marker: RaftApplyMarker,
+    ) -> anyhow::Result<()> {
+        let mut data_watermarks = self.applied_data_delta_watermarks.clone();
+        if data_watermarks
+            .get(&marker.source_partition)
+            .is_none_or(|current| *current < marker.origin_ts)
+        {
+            data_watermarks.insert(marker.source_partition, marker.origin_ts);
+        }
+
+        let mut applied_ids = self.applied_data_delta_ids.clone();
+        applied_ids.insert_origin_timestamp(marker.source_partition, marker.origin_ts);
+        applied_ids.prune_origin_timestamps_below_watermarks(&data_watermarks);
+
+        // The raw marker remains the crash-safe source of truth until both
+        // compact durable summaries have been written. Deleting it last makes
+        // every interruption point recoverable.
+        self.persistence
+            .write_persistence_global(
+                PersistenceGlobalKey::AppliedDataDeltaWatermarks,
+                partition_timestamp_map_to_json(&data_watermarks),
+            )
+            .await?;
+        self.persistence
+            .write_persistence_global(
+                PersistenceGlobalKey::AppliedDataDeltaIds,
+                applied_data_delta_ids_to_json(&applied_ids),
+            )
+            .await?;
+        self.persistence
+            .delete_persistence_global_raw(&marker.key())
+            .await?;
+
+        self.applied_data_delta_watermarks = data_watermarks;
+        self.applied_data_delta_ids = applied_ids;
+        self.raft_apply_markers.remove(&marker);
+        Ok(())
+    }
+
+    fn raft_apply_persistence_writes(
+        marker: Option<RaftApplyMarker>,
+        delta: Option<&CommitDelta>,
+    ) -> anyhow::Result<Vec<PersistenceGlobalWrite>> {
+        let Some(marker) = marker else {
+            anyhow::ensure!(
+                delta.is_none(),
+                "Raft outbox delta supplied without an atomic apply marker",
+            );
+            return Ok(Vec::new());
+        };
+        let delta = delta.context("Raft apply marker supplied without its committed delta")?;
+        anyhow::ensure!(
+            marker == RaftApplyMarker::from_delta(delta)?,
+            "Raft apply marker did not match its committed delta",
+        );
+        Ok(vec![
+            marker.persistence_write()?,
+            Self::raft_nats_outbox_persistence_write(delta)?,
+        ])
+    }
+
     fn raft_nats_outbox_key(ts: Timestamp) -> String {
         u64::from(ts).to_string()
     }
@@ -3014,15 +3297,21 @@ impl<RT: Runtime> Committer<RT> {
         persistence: Arc<dyn Persistence>,
         delta: &CommitDelta,
     ) -> anyhow::Result<()> {
+        let PersistenceGlobalWrite { key, value } =
+            Self::raft_nats_outbox_persistence_write(delta)?;
+        persistence.write_persistence_global_raw(&key, value).await
+    }
+
+    fn raft_nats_outbox_persistence_write(
+        delta: &CommitDelta,
+    ) -> anyhow::Result<PersistenceGlobalWrite> {
         let envelope = DeltaEnvelope::from_delta(delta, "", None)
             .context("Failed to encode Raft->NATS outbox delta")?;
-        persistence
-            .write_persistence_global_raw(
-                &Self::raft_nats_outbox_entry_key(delta)?,
-                serde_json::to_value(envelope)
-                    .context("Failed to serialize Raft->NATS outbox delta")?,
-            )
-            .await
+        Ok(PersistenceGlobalWrite::new(
+            Self::raft_nats_outbox_entry_key(delta)?,
+            serde_json::to_value(envelope)
+                .context("Failed to serialize Raft->NATS outbox delta")?,
+        ))
     }
 
     async fn record_raft_nats_outbox_delta(
@@ -3626,6 +3915,33 @@ impl<RT: Runtime> Committer<RT> {
         };
         use value::ResolvedDocumentId;
 
+        let raft_apply_marker = (mode == ReplicaDeltaApplyMode::FullRaftState
+            && !delta.document_updates.is_empty())
+        .then(|| RaftApplyMarker::from_delta(&delta))
+        .transpose()?;
+        if let Some(marker) = raft_apply_marker
+            && self.raft_apply_markers.contains(&marker)
+        {
+            tracing::info!(
+                "Recovering already-installed Raft delta without reapplying: partition={}, \
+                 origin_ts={}",
+                marker.source_partition.0,
+                u64::from(marker.origin_ts),
+            );
+            self.persistence_writes.push_back(
+                async move {
+                    Ok(PersistenceWrite::RaftReplayRecovery {
+                        marker,
+                        delta,
+                        result,
+                        commit_id,
+                    })
+                }
+                .boxed(),
+            );
+            return Ok(());
+        }
+
         // Apply replica deltas in the same timestamp domain as the leader's
         // commit. Followers should never "forget" a higher remote commit
         // timestamp and then hand out a lower local one for a future 2PC
@@ -3904,6 +4220,31 @@ impl<RT: Runtime> Committer<RT> {
             self.applied_data_delta_ids
                 .contains_origin_timestamp(source_partition, remote_ts)
         });
+        if mode == ReplicaDeltaApplyMode::FullRaftState
+            && (duplicate_transport_delivery || duplicate_origin_delta)
+        {
+            let marker = raft_apply_marker.context(
+                "non-empty full-state Raft replay should have a stable apply marker identity",
+            )?;
+            tracing::info!(
+                "Repairing side effects for durably deduplicated Raft replay: partition={}, \
+                 origin_ts={}",
+                marker.source_partition.0,
+                u64::from(marker.origin_ts),
+            );
+            self.persistence_writes.push_back(
+                async move {
+                    Ok(PersistenceWrite::RaftReplayRecovery {
+                        marker,
+                        delta,
+                        result,
+                        commit_id,
+                    })
+                }
+                .boxed(),
+            );
+            return Ok(());
+        }
         if local_prepared_commit_ts.is_none()
             && (duplicate_transport_delivery || duplicate_origin_delta)
         {
@@ -4203,6 +4544,11 @@ impl<RT: Runtime> Committer<RT> {
         .then(|| delta.clone());
 
         let persistence = self.persistence.clone();
+        let pause_client = self.runtime.pause_client();
+        let raft_apply_writes = Self::raft_apply_persistence_writes(
+            raft_apply_marker,
+            raft_nats_outbox_delta.as_ref(),
+        )?;
         self.enqueue_snapshot(commit_id, commit_ts, snapshot.clone());
 
         self.persistence_writes.push_back({
@@ -4216,8 +4562,16 @@ impl<RT: Runtime> Committer<RT> {
             async move {
                 // Write to persistence (so function runner can load modules).
                 persistence
-                    .write(&doc_writes, &idx_writes, ConflictStrategy::Overwrite)
+                    .write_with_persistence_globals(
+                        &doc_writes,
+                        &idx_writes,
+                        ConflictStrategy::Overwrite,
+                        &raft_apply_writes,
+                    )
                     .await?;
+                if raft_apply_marker.is_some() {
+                    pause_client.wait(AFTER_RAFT_CONVEX_PERSISTENCE).await;
+                }
 
                 // Advance max_repeatable_ts in persistence.
                 persistence
@@ -4247,6 +4601,7 @@ impl<RT: Runtime> Committer<RT> {
                     applied_delta_watermarks,
                     applied_data_delta_watermarks,
                     applied_data_delta_ids,
+                    raft_apply_marker,
                     raft_nats_outbox_delta,
                     result,
                     commit_id,
@@ -5154,6 +5509,9 @@ impl<RT: Runtime> Committer<RT> {
                         });
                     },
                 };
+                let raft_apply_marker = raft_applied_index
+                    .map(|_| RaftApplyMarker::from_delta(&delta))
+                    .transpose()?;
                 let persistence_stage_timer =
                     metrics::commit_hot_path_stage_timer("2pc_participant", "persistence_write");
                 let mut backoff = Backoff::new(
@@ -5169,6 +5527,8 @@ impl<RT: Runtime> Committer<RT> {
                             delta.index_writes.clone(),
                             delta.document_writes.clone(),
                             delta.write_source.clone(),
+                            raft_apply_marker,
+                            raft_apply_marker.map(|_| delta.clone()),
                         )
                         .in_span(Span::enter_with_local_parent(name)),
                     ));
@@ -5184,6 +5544,9 @@ impl<RT: Runtime> Committer<RT> {
                             return Err(e);
                         }
                     } else {
+                        if raft_apply_marker.is_some() {
+                            pause_client.wait(AFTER_RAFT_CONVEX_PERSISTENCE).await;
+                        }
                         pause_client.wait(AFTER_PENDING_WRITE_SNAPSHOT).await;
                         persistence_stage_timer.finish();
                         return Ok(PersistenceWrite::PreparedCommit {
@@ -5191,6 +5554,7 @@ impl<RT: Runtime> Committer<RT> {
                             commit_id,
                             delta,
                             raft_applied_index,
+                            raft_apply_marker,
                         });
                     }
                 }
@@ -5504,6 +5868,9 @@ impl<RT: Runtime> Committer<RT> {
                         });
                     },
                 };
+                let raft_apply_marker = raft_applied_index
+                    .map(|_| RaftApplyMarker::from_delta(&delta))
+                    .transpose()?;
                 let persistence_stage_timer =
                     metrics::commit_hot_path_stage_timer("local", "persistence_write");
                 let mut backoff = Backoff::new(
@@ -5520,6 +5887,8 @@ impl<RT: Runtime> Committer<RT> {
                             delta.index_writes.clone(),
                             delta.document_writes.clone(),
                             delta.write_source.clone(),
+                            raft_apply_marker,
+                            raft_apply_marker.map(|_| delta.clone()),
                         )
                         .in_span(Span::enter_with_local_parent(name)),
                     ));
@@ -5535,6 +5904,9 @@ impl<RT: Runtime> Committer<RT> {
                             return Err(e);
                         }
                     } else {
+                        if raft_apply_marker.is_some() {
+                            pause_client.wait(AFTER_RAFT_CONVEX_PERSISTENCE).await;
+                        }
                         pause_client.wait(AFTER_PENDING_WRITE_SNAPSHOT).await;
                         persistence_stage_timer.finish();
                         return Ok(PersistenceWrite::Commit {
@@ -5545,6 +5917,7 @@ impl<RT: Runtime> Committer<RT> {
                             commit_id,
                             delta,
                             raft_applied_index,
+                            raft_apply_marker,
                         });
                     }
                 }

--- a/crates/database/src/database.rs
+++ b/crates/database/src/database.rs
@@ -1078,6 +1078,7 @@ impl<RT: Runtime> Database<RT> {
             Some(value) => crate::committer::applied_data_delta_ids_from_json(value)?,
             None => crate::committer::AppliedDataDeltaIds::default(),
         };
+        let raft_apply_markers = crate::committer::load_raft_apply_markers(reader.clone()).await?;
 
         let snapshot_manager = SnapshotManager::new(
             *ts,
@@ -1143,6 +1144,7 @@ impl<RT: Runtime> Database<RT> {
             applied_delta_watermarks,
             applied_data_delta_watermarks,
             applied_data_delta_ids,
+            raft_apply_markers,
         );
         let table_mapping_snapshot_cache =
             AsyncLru::new(runtime.clone(), 20, 2, "table_mapping_snapshot");

--- a/crates/database/src/raft_partition.rs
+++ b/crates/database/src/raft_partition.rs
@@ -155,6 +155,31 @@ impl RaftPartitionState {
     }
 
     #[cfg(any(test, feature = "testing"))]
+    pub fn new_with_mailbox_for_test(
+        is_leader: bool,
+        leader_id: u64,
+        partition_id: PartitionId,
+        node_id: u64,
+    ) -> (Self, mpsc::UnboundedReceiver<RaftMessage>) {
+        let (proposal_tx, proposal_rx) = mpsc::unbounded_channel();
+        (
+            Self {
+                is_leader: Arc::new(AtomicBool::new(is_leader)),
+                leader_id: Arc::new(AtomicU64::new(leader_id)),
+                proposal_tx,
+                partition_id,
+                node_id,
+                leader_serving_lease_valid_until: Arc::new(Mutex::new(if is_leader {
+                    Some(Instant::now() + std::time::Duration::from_secs(60))
+                } else {
+                    None
+                })),
+            },
+            proposal_rx,
+        )
+    }
+
+    #[cfg(any(test, feature = "testing"))]
     pub fn expire_leader_serving_lease_for_test(&self) {
         *self.leader_serving_lease_valid_until.lock() = Some(Instant::now());
     }

--- a/crates/database/src/tests/write_scaling_tests.rs
+++ b/crates/database/src/tests/write_scaling_tests.rs
@@ -123,6 +123,11 @@ use crate::{
     committer::{
         CommitterClient,
         AFTER_PENDING_WRITE_SNAPSHOT,
+        AFTER_RAFT_APPLIED_INDEX_PERSISTENCE,
+        AFTER_RAFT_CONVEX_PERSISTENCE,
+        AFTER_RAFT_SNAPSHOT_PUBLICATION,
+        RAFT_APPLY_MARKER_KEY_PREFIX,
+        RAFT_NATS_OUTBOX_KEY_PREFIX,
     },
     membership::{
         ClusterNodeId,
@@ -130,6 +135,7 @@ use crate::{
         MembershipVersion,
         NodeMembership,
     },
+    nats_distributed_log::DeltaEnvelope,
     partition::{
         PartitionId,
         PartitionMap,
@@ -138,7 +144,12 @@ use crate::{
         StaticPlacementConfig,
     },
     query::ResolvedQuery,
+    raft_node::{
+        RaftMessage,
+        RaftProposalResult,
+    },
     raft_partition::RaftPartitionState,
+    raft_state_machine::RaftStateMachineEntry,
     snapshot_manager::partition_timestamp_map_from_json,
     table_number_allocator::{
         testing::InMemoryTableNumberAllocator,
@@ -452,6 +463,54 @@ async fn persisted_document_log_count(tp: &Arc<TestPersistence>) -> anyhow::Resu
         .try_collect::<Vec<_>>()
         .await?
         .len())
+}
+
+async fn commit_next_raft_delta_for_test(
+    raft_rx: &mut tokio::sync::mpsc::UnboundedReceiver<RaftMessage>,
+    index: u64,
+) -> anyhow::Result<CommitDelta> {
+    let message = tokio::time::timeout(Duration::from_secs(1), raft_rx.recv())
+        .await?
+        .context("test Raft mailbox closed before receiving a proposal")?;
+    let RaftMessage::Propose(proposal) = message else {
+        anyhow::bail!("expected a Raft proposal in the test mailbox")
+    };
+    let delta = match RaftStateMachineEntry::from_bytes(&proposal.data)? {
+        RaftStateMachineEntry::CommitDelta { envelope } => envelope.to_delta()?,
+        RaftStateMachineEntry::TwoPhasePrepare { .. } => {
+            anyhow::bail!("expected a commit delta Raft entry")
+        },
+    };
+    proposal
+        .result_tx
+        .send(RaftProposalResult::Committed { index })
+        .map_err(|_| anyhow::anyhow!("commit waiter dropped before test Raft decision"))?;
+    Ok(delta)
+}
+
+async fn acknowledge_next_raft_applied_for_test(
+    mut raft_rx: tokio::sync::mpsc::UnboundedReceiver<RaftMessage>,
+    expected_index: u64,
+) -> anyhow::Result<bool> {
+    while let Some(message) = raft_rx.recv().await {
+        match message {
+            RaftMessage::MarkApplied { index, result_tx } => {
+                anyhow::ensure!(
+                    index == expected_index,
+                    "expected applied index {expected_index}, got {index}",
+                );
+                result_tx
+                    .send(Ok(()))
+                    .map_err(|_| anyhow::anyhow!("committer dropped Raft applied-index waiter"))?;
+                return Ok(true);
+            },
+            RaftMessage::Propose(_) => {
+                anyhow::bail!("received an unexpected second Raft proposal")
+            },
+            RaftMessage::Raft(_) | RaftMessage::Shutdown => {},
+        }
+    }
+    Ok(false)
 }
 
 async fn global_table_scan_or_empty(
@@ -1266,6 +1325,347 @@ async fn test_failed_raft_proposal_does_not_publish_or_persist(
         "failed Raft proposal must not be resurrected from persistence",
     );
 
+    Ok(())
+}
+
+async fn assert_raft_replay_is_idempotent_across_crash_window(
+    rt: &TestRuntime,
+    pause: PauseController,
+    pause_label: &'static str,
+    expect_raw_marker_at_crash: bool,
+) -> anyhow::Result<()> {
+    let log = Arc::new(SwitchableDistributedLog::default());
+    let persistence = Arc::new(TestPersistence::new());
+    let node = create_node_with_custom_distributed_log(
+        rt,
+        persistence.clone(),
+        log.clone(),
+        Some(partitioned_map(PartitionId(0))),
+        Arc::new(crate::LocalTableNumberAllocator),
+    )
+    .await?;
+    insert_doc(&node, "messages", assert_obj!("text" => "seed")).await?;
+    log.fail_publishes.store(true, Ordering::SeqCst);
+
+    let (raft_state, mut raft_rx) =
+        RaftPartitionState::new_with_mailbox_for_test(true, 1, PartitionId(0), 1);
+    node.attach_raft_state(raft_state).await?;
+
+    let hold = pause.hold(pause_label);
+    let node_for_commit = node.clone();
+    let commit_task = tokio::spawn(async move {
+        insert_doc(
+            &node_for_commit,
+            "messages",
+            assert_obj!("text" => "raft-committed"),
+        )
+        .await
+    });
+    let delta = commit_next_raft_delta_for_test(&mut raft_rx, 7).await?;
+    let mark_applied_task = tokio::spawn(acknowledge_next_raft_applied_for_test(raft_rx, 7));
+    let pause_guard = hold
+        .wait_for_blocked()
+        .await
+        .context("Raft commit did not reach the injected crash boundary")?;
+
+    let raw_markers = persistence
+        .reader()
+        .list_persistence_globals_with_prefix(RAFT_APPLY_MARKER_KEY_PREFIX)
+        .await?;
+    assert_eq!(
+        !raw_markers.is_empty(),
+        expect_raw_marker_at_crash,
+        "raw apply marker presence should identify which crash bridge is durable",
+    );
+    let outbox_at_crash = persistence
+        .reader()
+        .list_persistence_globals_with_prefix(RAFT_NATS_OUTBOX_KEY_PREFIX)
+        .await?;
+    assert_eq!(
+        outbox_at_crash.len(),
+        1,
+        "the cross-partition outbox record must be atomic with Raft state-machine persistence",
+    );
+    let installed_document_count = persisted_document_log_count(&persistence).await?;
+
+    // Abort the committer at the selected boundary. The test replays the entry
+    // even at the post-applied-index boundary to prove duplicate delivery is
+    // harmless in addition to exercising the real pre-index recovery window.
+    node.shutdown().await?;
+    pause_guard.unpause();
+    let interrupted = tokio::time::timeout(Duration::from_secs(1), commit_task).await??;
+    assert!(
+        interrupted.is_err(),
+        "the client commit must not complete after the injected process stop",
+    );
+    drop(node);
+    let applied_index_was_persisted = mark_applied_task.await??;
+    assert_eq!(
+        applied_index_was_persisted,
+        pause_label == AFTER_RAFT_APPLIED_INDEX_PERSISTENCE,
+        "the injected boundary must precisely bracket applied-index persistence",
+    );
+
+    let restarted = create_node_with_custom_distributed_log(
+        rt,
+        persistence.clone(),
+        log,
+        Some(partitioned_map(PartitionId(0))),
+        Arc::new(crate::LocalTableNumberAllocator),
+    )
+    .await?;
+    restarted
+        .attach_raft_state(RaftPartitionState::new_for_test(
+            false,
+            1,
+            PartitionId(0),
+            2,
+        ))
+        .await?;
+    let snapshot_before_replay = *restarted.now_ts_for_reads();
+    let replay_ts = restarted
+        .committer_for_test()
+        .apply_raft_commit_delta(delta.clone())
+        .await?;
+    assert_eq!(
+        replay_ts, delta.ts,
+        "already-installed Raft replay should ACK at its stable origin timestamp",
+    );
+    assert_eq!(
+        persisted_document_log_count(&persistence).await?,
+        installed_document_count,
+        "Raft replay must not append a second document-log version",
+    );
+    assert_eq!(
+        *restarted.now_ts_for_reads(),
+        snapshot_before_replay,
+        "Raft replay must not publish a second snapshot or invalidation",
+    );
+    assert!(
+        persistence
+            .reader()
+            .list_persistence_globals_with_prefix(RAFT_APPLY_MARKER_KEY_PREFIX)
+            .await?
+            .is_empty(),
+        "successful replay recovery should consolidate and clear the raw marker",
+    );
+    let outbox_records = persistence
+        .reader()
+        .list_persistence_globals_with_prefix(RAFT_NATS_OUTBOX_KEY_PREFIX)
+        .await?;
+    assert_eq!(
+        outbox_records.len(),
+        1,
+        "Raft replay recovery must restore exactly one cross-partition outbox record",
+    );
+    let recovered_envelope: DeltaEnvelope = serde_json::from_value(outbox_records[0].1.clone())?;
+    let recovered_delta = recovered_envelope.to_delta()?;
+    assert_eq!(
+        recovered_delta.ts, delta.ts,
+        "the recovered outbox record must contain the original committed delta",
+    );
+
+    let messages = run_query(
+        restarted,
+        TableNamespace::root_component(),
+        Query::full_table_scan("messages".parse()?, Order::Asc),
+    )
+    .await?;
+    assert_eq!(
+        messages.len(),
+        2,
+        "the committed write must remain visible once"
+    );
+    Ok(())
+}
+
+#[convex_macro::test_runtime]
+async fn test_raft_replay_after_crash_post_persistence_is_idempotent(
+    rt: TestRuntime,
+    pause: PauseController,
+) -> anyhow::Result<()> {
+    assert_raft_replay_is_idempotent_across_crash_window(
+        &rt,
+        pause,
+        AFTER_RAFT_CONVEX_PERSISTENCE,
+        true,
+    )
+    .await
+}
+
+#[convex_macro::test_runtime]
+async fn test_raft_replay_after_crash_post_snapshot_is_idempotent(
+    rt: TestRuntime,
+    pause: PauseController,
+) -> anyhow::Result<()> {
+    assert_raft_replay_is_idempotent_across_crash_window(
+        &rt,
+        pause,
+        AFTER_RAFT_SNAPSHOT_PUBLICATION,
+        false,
+    )
+    .await
+}
+
+#[convex_macro::test_runtime]
+async fn test_raft_replay_after_crash_post_applied_index_is_idempotent(
+    rt: TestRuntime,
+    pause: PauseController,
+) -> anyhow::Result<()> {
+    assert_raft_replay_is_idempotent_across_crash_window(
+        &rt,
+        pause,
+        AFTER_RAFT_APPLIED_INDEX_PERSISTENCE,
+        false,
+    )
+    .await
+}
+
+#[convex_macro::test_runtime]
+async fn test_raft_prepared_commit_replay_after_crash_is_idempotent(
+    rt: TestRuntime,
+    pause: PauseController,
+) -> anyhow::Result<()> {
+    let log = Arc::new(SwitchableDistributedLog::default());
+    let persistence = Arc::new(TestPersistence::new());
+    let node = create_node_with_custom_distributed_log(
+        &rt,
+        persistence.clone(),
+        log.clone(),
+        Some(partitioned_map(PartitionId(1))),
+        Arc::new(crate::LocalTableNumberAllocator),
+    )
+    .await?;
+    insert_doc(&node, "projects", assert_obj!("name" => "seed")).await?;
+
+    let mut tx = node.begin(Identity::system()).await?;
+    TestFacingModel::new(&mut tx)
+        .insert(
+            &"projects".parse()?,
+            assert_obj!("name" => "raft-prepared-committed"),
+        )
+        .await?;
+    let final_tx = tx.finalize()?;
+    let write_indexes: Vec<_> = final_tx
+        .writes
+        .coalesced_writes()
+        .enumerate()
+        .map(|(index, _)| index)
+        .collect();
+    let write_source = WriteSource::new("raft_prepared_commit_crash_replay_test");
+    let participant_tx = ParticipantTransaction::from_final_transaction(
+        &final_tx,
+        PartitionId(1),
+        &write_indexes,
+        &partitioned_map(PartitionId(1)),
+        &write_source,
+    )?;
+    let txn_id = TwoPhaseTransactionId::new();
+    let prepare_ts = node.committer_for_test().allocate_commit_ts().await?;
+    node.committer_for_test()
+        .prepare_remote(
+            txn_id.clone(),
+            participant_tx,
+            write_source,
+            prepare_ts,
+            vec![PartitionId(1)],
+        )
+        .await?;
+
+    log.fail_publishes.store(true, Ordering::SeqCst);
+    let (raft_state, mut raft_rx) =
+        RaftPartitionState::new_with_mailbox_for_test(true, 1, PartitionId(1), 1);
+    node.attach_raft_state(raft_state).await?;
+    let hold = pause.hold(AFTER_RAFT_CONVEX_PERSISTENCE);
+    let committer = node.committer_for_test();
+    let txn_id_for_commit = txn_id.clone();
+    let commit_task =
+        tokio::spawn(async move { committer.commit_prepared(txn_id_for_commit).await });
+    let delta = commit_next_raft_delta_for_test(&mut raft_rx, 11).await?;
+    let mark_applied_task = tokio::spawn(acknowledge_next_raft_applied_for_test(raft_rx, 11));
+    let pause_guard = hold
+        .wait_for_blocked()
+        .await
+        .context("prepared commit did not reach atomic Raft persistence")?;
+
+    assert_eq!(delta.ts, prepare_ts);
+    assert_eq!(
+        persistence
+            .reader()
+            .list_persistence_globals_with_prefix(RAFT_APPLY_MARKER_KEY_PREFIX)
+            .await?
+            .len(),
+        1,
+    );
+    assert_eq!(
+        persistence
+            .reader()
+            .list_persistence_globals_with_prefix(RAFT_NATS_OUTBOX_KEY_PREFIX)
+            .await?
+            .len(),
+        1,
+    );
+    let installed_document_count = persisted_document_log_count(&persistence).await?;
+
+    node.shutdown().await?;
+    pause_guard.unpause();
+    let interrupted = tokio::time::timeout(Duration::from_secs(1), commit_task).await??;
+    assert!(interrupted.is_err());
+    drop(node);
+    assert!(!mark_applied_task.await??);
+
+    let restarted = create_node_with_custom_distributed_log(
+        &rt,
+        persistence.clone(),
+        log,
+        Some(partitioned_map(PartitionId(1))),
+        Arc::new(crate::LocalTableNumberAllocator),
+    )
+    .await?;
+    restarted
+        .attach_raft_state(RaftPartitionState::new_for_test(
+            false,
+            1,
+            PartitionId(1),
+            2,
+        ))
+        .await?;
+    let snapshot_before_replay = *restarted.now_ts_for_reads();
+    let replay_ts = restarted
+        .committer_for_test()
+        .apply_raft_commit_delta(delta)
+        .await?;
+    assert_eq!(replay_ts, prepare_ts);
+    assert_eq!(
+        persisted_document_log_count(&persistence).await?,
+        installed_document_count,
+        "prepared Raft replay must not append another document version",
+    );
+    assert_eq!(
+        *restarted.now_ts_for_reads(),
+        snapshot_before_replay,
+        "prepared Raft replay must not publish another snapshot",
+    );
+    assert!(persistence
+        .reader()
+        .list_persistence_globals_with_prefix(RAFT_APPLY_MARKER_KEY_PREFIX)
+        .await?
+        .is_empty(),);
+    assert_eq!(
+        persistence
+            .reader()
+            .get_persistence_global(PersistenceGlobalKey::TwoPhaseRedoRecords)
+            .await?,
+        Some(serde_json::json!({})),
+        "replayed prepared commit must clear its durable redo record",
+    );
+    let projects = run_query(
+        restarted,
+        TableNamespace::root_component(),
+        Query::full_table_scan("projects".parse()?, Order::Asc),
+    )
+    .await?;
+    assert_eq!(projects.len(), 2);
     Ok(())
 }
 

--- a/crates/database/src/two_phase_coordinator.rs
+++ b/crates/database/src/two_phase_coordinator.rs
@@ -283,7 +283,7 @@ fn routed_partition_for_catalog_write(
 }
 
 #[cfg(any(test, feature = "testing"))]
-pub(crate) fn routed_partition_for_catalog_write_for_test(
+pub fn routed_partition_for_catalog_write_for_test(
     transaction: &FinalTransaction,
     write: &DocumentUpdateWithPrevTs,
     partition_map: &PartitionMap,

--- a/crates/mysql/src/lib.rs
+++ b/crates/mysql/src/lib.rs
@@ -73,6 +73,7 @@ use common::{
         LatestDocument,
         Persistence,
         PersistenceGlobalKey,
+        PersistenceGlobalWrite,
         PersistenceIndexEntry,
         PersistenceReader,
         PersistenceTableSize,
@@ -381,11 +382,12 @@ impl<RT: Runtime> Persistence for MySqlPersistence<RT> {
     }
 
     #[fastrace::trace]
-    async fn write<'a>(
+    async fn write_with_persistence_globals<'a>(
         &self,
         documents: &'a [DocumentLogEntry],
         indexes: &'a [PersistenceIndexEntry],
         conflict_strategy: ConflictStrategy,
+        persistence_globals: &'a [PersistenceGlobalWrite],
     ) -> anyhow::Result<()> {
         anyhow::ensure!(documents.len() <= sql::MAX_INSERT_SIZE);
         let mut write_size = 0;
@@ -505,6 +507,16 @@ impl<RT: Runtime> Persistence for MySqlPersistence<RT> {
                                 ]
                             }),
                         )
+                        .await?;
+                }
+                for write in persistence_globals {
+                    let mut params = if multitenant {
+                        vec![instance_name.clone()]
+                    } else {
+                        vec![]
+                    };
+                    params.extend([write.key.clone().into(), write.value.clone().into()]);
+                    tx.exec_drop(sql::write_persistence_global(multitenant), params)
                         .await?;
                 }
                 Ok(())

--- a/crates/postgres/src/lib.rs
+++ b/crates/postgres/src/lib.rs
@@ -69,6 +69,7 @@ use common::{
         LatestDocument,
         Persistence,
         PersistenceGlobalKey,
+        PersistenceGlobalWrite,
         PersistenceIndexEntry,
         PersistenceReader,
         PersistenceTableSize,
@@ -485,11 +486,12 @@ impl Persistence for PostgresPersistence {
     }
 
     #[fastrace::trace]
-    async fn write<'a>(
+    async fn write_with_persistence_globals<'a>(
         &self,
         documents: &'a [DocumentLogEntry],
         indexes: &'a [PersistenceIndexEntry],
         conflict_strategy: ConflictStrategy,
+        persistence_globals: &'a [PersistenceGlobalWrite],
     ) -> anyhow::Result<()> {
         anyhow::ensure!(documents.len() <= MAX_INSERT_SIZE);
         let mut write_size = 0;
@@ -584,6 +586,22 @@ impl Persistence for PostgresPersistence {
 
                 let timer = metrics::insert_timer();
                 try_join!(insert_docs, insert_idxs)?;
+                if !persistence_globals.is_empty() {
+                    let write_global = tx
+                        .prepare_cached(sql::write_persistence_global(multitenant))
+                        .await?;
+                    for write in persistence_globals {
+                        let mut params = [
+                            Param::Text(write.key.clone()),
+                            Param::JsonValue(write.value.to_string()),
+                        ]
+                        .to_vec();
+                        if multitenant {
+                            params.push(Param::Text(instance_name.to_string()));
+                        }
+                        tx.execute_raw(&write_global, params).await?;
+                    }
+                }
                 timer.finish();
 
                 Ok(())

--- a/crates/sqlite/src/lib.rs
+++ b/crates/sqlite/src/lib.rs
@@ -37,6 +37,7 @@ use common::{
         LatestDocument,
         Persistence,
         PersistenceGlobalKey,
+        PersistenceGlobalWrite,
         PersistenceIndexEntry,
         PersistenceReader,
         RetentionValidator,
@@ -253,11 +254,12 @@ impl Persistence for SqlitePersistence {
         })
     }
 
-    async fn write<'a>(
+    async fn write_with_persistence_globals<'a>(
         &self,
         documents: &'a [DocumentLogEntry],
         indexes: &'a [PersistenceIndexEntry],
         conflict_strategy: ConflictStrategy,
+        persistence_globals: &'a [PersistenceGlobalWrite],
     ) -> anyhow::Result<()> {
         let mut inner = self.inner.lock();
         let tx = inner.connection.transaction()?;
@@ -317,6 +319,13 @@ impl Persistence for SqlitePersistence {
             };
         }
         drop(insert_index_query);
+
+        let mut write_global_query = tx.prepare_cached(WRITE_PERSISTENCE_GLOBAL)?;
+        for write in persistence_globals {
+            let json_value = serde_json::to_string(&write.value)?;
+            write_global_query.execute(params![&write.key, &json_value])?;
+        }
+        drop(write_global_query);
 
         tx.commit()?;
         Ok(())


### PR DESCRIPTION
## Summary

- add an atomic persistence operation that writes document/index revisions together with Raft apply metadata
- journal each committed Raft entry by stable `(source partition, origin timestamp)` identity and persist its Raft-to-NATS outbox record in the same transaction
- recover committed-entry replay without reinstalling document versions, republishing snapshots, or emitting duplicate invalidations
- repair durable dedupe summaries, outbox state, and prepared-2PC redo state during replay recovery
- add deterministic crash-boundary tests after Convex persistence, snapshot publication, and applied-index persistence

## Root cause

Convex state persistence and the Raft applied index are separate durable operations. A process crash after installing a committed entry but before persisting the applied index causes Raft to replay that entry after restart. Without a durable apply identity attached atomically to the installed revisions, replay could install the logical write again and repeat snapshot/invalidation side effects. A crash after the applied index advanced but before NATS publication could also strand cross-partition delivery.

This change makes the state-machine write, apply marker, and Raft-to-NATS outbox record one atomic storage transaction. Replay detects either the raw crash-window marker or its consolidated durable identity and repairs side effects without applying the logical write twice.

## Validation

- `cargo fmt -p common -p database -p sqlite -p postgres -p mysql -- --check`
- full `database` suite: 565 passed, 0 failed, 2 ignored
- applicable `local_backend` suite: 99 passed, 0 failed, 1 unrelated OpenAPI-spec test filtered
- focused Raft replay tests for all three crash boundaries and prepared 2PC replay passed
- shared atomic-persistence test and SQLite implementation test passed
- MySQL/Postgres/SQLite/database compile checks passed
- exact local Docker image `sha256:a2da13997cfd37d42c7d1fdafff5b823d3ec5d01db008912ca888878da5b0612` used by all six healthy backend containers
- full cluster harness: 146/146 write-scaling tests and 24/24 Raft failover tests passed

The standalone Postgres persistence test binary compiled, but its local runtime setup could not connect because this machine has no PostgreSQL role named `martin`; the containerized full-cluster validation remained green.

Fixes #275
