### PR TITLE
fix(raft): make snapshot installation crash-consistent

### DIFF
--- a/crates/database/src/committer.rs
+++ b/crates/database/src/committer.rs
@@ -144,6 +144,7 @@ use vector::VectorIndexWriteSize;
 use crate::{
     bootstrap_model::defaults::BootstrapTableIds,
     checkpoint::{
+        create_checkpoint,
         CheckpointData,
         CheckpointPersistence,
     },
@@ -167,6 +168,13 @@ use crate::{
     },
     nats_distributed_log::DeltaEnvelope,
     raft_node::RaftProposalResult,
+    raft_snapshot::{
+        encode_snapshot as encode_raft_snapshot,
+        load_state_machine_index,
+        state_machine_index_persistence_write,
+        RaftSnapshotTemporarilyUnavailable,
+        RAFT_STATE_MACHINE_INDEX_KEY,
+    },
     raft_state_machine::RaftStateMachineEntry,
     reads::ReadSet,
     search_index_bootstrap::{
@@ -478,6 +486,7 @@ enum PersistenceWrite {
         applied_data_delta_ids: Option<AppliedDataDeltaIds>,
         raft_apply_marker: Option<RaftApplyMarker>,
         raft_nats_outbox_delta: Option<CommitDelta>,
+        raft_state_machine_index: Option<u64>,
         result: oneshot::Sender<anyhow::Result<Timestamp>>,
         commit_id: usize,
     },
@@ -487,6 +496,7 @@ enum PersistenceWrite {
     RaftReplayRecovery {
         marker: RaftApplyMarker,
         delta: CommitDelta,
+        raft_state_machine_index: u64,
         result: oneshot::Sender<anyhow::Result<Timestamp>>,
         commit_id: usize,
     },
@@ -498,6 +508,7 @@ enum PersistenceWrite {
         commit_id: usize,
     },
     InstallSnapshot {
+        source: SnapshotInstallSource,
         snapshot_ts: Timestamp,
         snapshot: Snapshot,
         replication_frontiers: BTreeMap<crate::partition::PartitionId, Timestamp>,
@@ -507,6 +518,301 @@ enum PersistenceWrite {
         result: oneshot::Sender<anyhow::Result<Timestamp>>,
         commit_id: usize,
     },
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum SnapshotInstallSource {
+    Bootstrap,
+    Raft,
+}
+
+struct RaftSnapshotRequest {
+    raft_index: u64,
+    raft_term: u64,
+    result: oneshot::Sender<anyhow::Result<Vec<u8>>>,
+}
+
+struct SnapshotInstallRequest {
+    checkpoint: CheckpointData,
+    source: SnapshotInstallSource,
+    result: oneshot::Sender<anyhow::Result<Timestamp>>,
+}
+
+struct PreparedCheckpointInstall {
+    snapshot_ts: Timestamp,
+    compacted_documents: Vec<DocumentLogEntry>,
+    index_entries: Vec<PersistenceIndexEntry>,
+    snapshot: Snapshot,
+    replication_frontiers: BTreeMap<crate::partition::PartitionId, Timestamp>,
+    applied_delta_watermarks: BTreeMap<crate::partition::PartitionId, Timestamp>,
+    applied_data_delta_watermarks: BTreeMap<crate::partition::PartitionId, Timestamp>,
+    applied_data_delta_ids: AppliedDataDeltaIds,
+}
+
+async fn prepare_checkpoint_install<RT: Runtime>(
+    runtime: RT,
+    persistence: Arc<dyn Persistence>,
+    virtual_system_mapping: VirtualSystemMapping,
+    partition_map: Option<crate::partition::PartitionMap>,
+    checkpoint: &CheckpointData,
+) -> anyhow::Result<PreparedCheckpointInstall> {
+    let snapshot_ts = checkpoint.timestamp;
+    let compacted_documents = compact_checkpoint_documents(checkpoint);
+    let checkpoint_persistence = Arc::new(CheckpointPersistence::from_checkpoint(
+        CheckpointData {
+            timestamp: checkpoint.timestamp,
+            documents: compacted_documents.clone(),
+            globals: checkpoint.globals.clone(),
+        },
+        persistence.reader().version(),
+    ));
+    let repeatable_ts =
+        RepeatableTimestamp::new_validated(snapshot_ts, RepeatableReason::SnapshotManagerLatest);
+    let mut db_snapshot = DatabaseSnapshot::load(
+        runtime,
+        checkpoint_persistence,
+        repeatable_ts,
+        Arc::new(NoopRetentionValidator),
+        virtual_system_mapping,
+    )
+    .await?;
+
+    if let Some(value) = checkpoint
+        .globals
+        .get(&String::from(PersistenceGlobalKey::TableSummary))
+    {
+        let summary_snapshot = TableSummarySnapshot::try_from(value.clone())?;
+        let table_summaries = TableSummaries::new(
+            summary_snapshot,
+            db_snapshot.table_registry().table_mapping(),
+            &db_snapshot.snapshot.virtual_system_mapping,
+        )?;
+        db_snapshot.snapshot.table_summaries = Some(table_summaries);
+    }
+
+    let index_entries = checkpoint_index_entries(&db_snapshot.snapshot, &compacted_documents);
+    let replication_frontiers = checkpoint
+        .globals
+        .get(&String::from(PersistenceGlobalKey::ReplicationFrontiers))
+        .map(|value| crate::snapshot_manager::replication_frontiers_from_json(value.clone()))
+        .transpose()?
+        .unwrap_or_else(|| {
+            partition_map
+                .as_ref()
+                .map(|map| {
+                    map.all_partitions()
+                        .into_iter()
+                        .filter(|partition| *partition != map.local_partition())
+                        .map(|partition| (partition, Timestamp::MIN))
+                        .collect()
+                })
+                .unwrap_or_default()
+        });
+    let applied_delta_watermarks = checkpoint
+        .globals
+        .get(&String::from(PersistenceGlobalKey::AppliedDeltaWatermarks))
+        .map(|value| partition_timestamp_map_from_json(value.clone(), "applied delta watermarks"))
+        .transpose()?
+        .unwrap_or_default();
+    let applied_data_delta_watermarks = checkpoint
+        .globals
+        .get(&String::from(
+            PersistenceGlobalKey::AppliedDataDeltaWatermarks,
+        ))
+        .map(|value| {
+            partition_timestamp_map_from_json(value.clone(), "applied data delta watermarks")
+        })
+        .transpose()?
+        .unwrap_or_default();
+    let applied_data_delta_ids = checkpoint
+        .globals
+        .get(&String::from(PersistenceGlobalKey::AppliedDataDeltaIds))
+        .map(|value| applied_data_delta_ids_from_json(value.clone()))
+        .transpose()?
+        .unwrap_or_default();
+
+    Ok(PreparedCheckpointInstall {
+        snapshot_ts,
+        compacted_documents,
+        index_entries,
+        snapshot: db_snapshot.snapshot,
+        replication_frontiers,
+        applied_delta_watermarks,
+        applied_data_delta_watermarks,
+        applied_data_delta_ids,
+    })
+}
+
+async fn persist_checkpoint_install(
+    persistence: Arc<dyn Persistence>,
+    checkpoint: &CheckpointData,
+    prepared: &PreparedCheckpointInstall,
+    source: SnapshotInstallSource,
+) -> anyhow::Result<()> {
+    let reader = persistence.reader();
+    let mut existing_documents = Vec::new();
+    let mut document_stream = reader.load_documents(
+        TimestampRange::all(),
+        Order::Asc,
+        1024,
+        Arc::new(NoopRetentionValidator),
+    );
+    while let Some(entry) = document_stream.try_next().await? {
+        existing_documents.push((entry.ts, entry.id));
+    }
+    if !existing_documents.is_empty() {
+        persistence.delete(existing_documents).await?;
+    }
+
+    let mut cursor = None;
+    loop {
+        let chunk = persistence.load_index_chunk(cursor.clone(), 1024).await?;
+        if chunk.is_empty() {
+            break;
+        }
+        cursor = chunk.last().cloned();
+        persistence.delete_index_entries(chunk).await?;
+    }
+
+    for chunk in prepared.compacted_documents.chunks(1024) {
+        persistence
+            .write(chunk, &[], ConflictStrategy::Overwrite)
+            .await?;
+    }
+    for chunk in prepared.index_entries.chunks(1024) {
+        persistence
+            .write(&[], chunk, ConflictStrategy::Overwrite)
+            .await?;
+    }
+
+    for prefix in [RAFT_NATS_OUTBOX_KEY_PREFIX, RAFT_APPLY_MARKER_KEY_PREFIX] {
+        for (key, _) in reader.list_persistence_globals_with_prefix(prefix).await? {
+            persistence.delete_persistence_global_raw(&key).await?;
+        }
+    }
+
+    let mut copied_keys = PersistenceGlobalKey::checkpoint_keys();
+    if source == SnapshotInstallSource::Raft {
+        copied_keys.extend([
+            PersistenceGlobalKey::TwoPhaseRedoRecords,
+            PersistenceGlobalKey::RaftNatsOutbox,
+        ]);
+    }
+    for key in copied_keys {
+        let raw_key = String::from(key);
+        if let Some(value) = checkpoint.globals.get(&raw_key) {
+            persistence
+                .write_persistence_global(key, value.clone())
+                .await?;
+        } else {
+            persistence.delete_persistence_global_raw(&raw_key).await?;
+        }
+    }
+
+    if source == SnapshotInstallSource::Raft {
+        if !checkpoint
+            .globals
+            .contains_key(&String::from(PersistenceGlobalKey::TwoPhaseRedoRecords))
+        {
+            persistence
+                .write_persistence_global(
+                    PersistenceGlobalKey::TwoPhaseRedoRecords,
+                    serde_json::json!({}),
+                )
+                .await?;
+        }
+        for (key, value) in checkpoint.globals.iter().filter(|(key, _)| {
+            key.starts_with(RAFT_NATS_OUTBOX_KEY_PREFIX)
+                || key.as_str() == RAFT_STATE_MACHINE_INDEX_KEY
+        }) {
+            persistence
+                .write_persistence_global_raw(key, value.clone())
+                .await?;
+        }
+    } else {
+        persistence
+            .write_persistence_global(
+                PersistenceGlobalKey::TwoPhaseRedoRecords,
+                serde_json::json!({}),
+            )
+            .await?;
+        persistence
+            .delete_persistence_global_raw(RAFT_STATE_MACHINE_INDEX_KEY)
+            .await?;
+    }
+
+    if !checkpoint.globals.contains_key(&String::from(
+        PersistenceGlobalKey::AppliedDataDeltaWatermarks,
+    )) {
+        persistence
+            .write_persistence_global(
+                PersistenceGlobalKey::AppliedDataDeltaWatermarks,
+                serde_json::json!({}),
+            )
+            .await?;
+    }
+    if !checkpoint
+        .globals
+        .contains_key(&String::from(PersistenceGlobalKey::AppliedDataDeltaIds))
+    {
+        persistence
+            .write_persistence_global(
+                PersistenceGlobalKey::AppliedDataDeltaIds,
+                serde_json::json!({}),
+            )
+            .await?;
+    }
+    Ok(())
+}
+
+pub async fn recover_staged_raft_snapshot_install<RT: Runtime>(
+    engine: Arc<raft_engine::Engine>,
+    partition_id: crate::partition::PartitionId,
+    persistence: Arc<dyn Persistence>,
+    runtime: RT,
+    virtual_system_mapping: VirtualSystemMapping,
+    partition_map: Option<crate::partition::PartitionMap>,
+) -> anyhow::Result<bool> {
+    let Some(pending) =
+        crate::raft_storage::ConvexRaftStorage::pending_snapshot_install_for_engine(
+            &engine,
+            partition_id,
+        )?
+    else {
+        return Ok(false);
+    };
+    let metadata = pending.snapshot.get_metadata();
+    let decoded = crate::raft_snapshot::decode_snapshot(
+        pending.snapshot.get_data(),
+        metadata.index,
+        metadata.term,
+    )?;
+    let prepared = prepare_checkpoint_install(
+        runtime,
+        persistence.clone(),
+        virtual_system_mapping,
+        partition_map,
+        &decoded.checkpoint,
+    )
+    .await?;
+    persist_checkpoint_install(
+        persistence,
+        &decoded.checkpoint,
+        &prepared,
+        SnapshotInstallSource::Raft,
+    )
+    .await?;
+    crate::raft_storage::ConvexRaftStorage::commit_pending_snapshot_install_for_engine(
+        &engine,
+        partition_id,
+    )?;
+    tracing::info!(
+        "Recovered staged Raft snapshot install for partition {} at index {} and ts={}",
+        partition_id.0,
+        decoded.raft_index,
+        u64::from(decoded.checkpoint.timestamp),
+    );
+    Ok(true)
 }
 
 impl PersistenceWrite {
@@ -1214,14 +1520,45 @@ impl<RT: Runtime> Committer<RT> {
         // Keep track of the commit_id that is currently being traced.
         let mut span_commit_id = None;
         let mut deferred_prepares = VecDeque::new();
+        let mut pending_raft_snapshot: Option<RaftSnapshotRequest> = None;
+        let mut pending_snapshot_install: Option<SnapshotInstallRequest> = None;
+        let mut snapshot_install_in_progress = false;
         loop {
-            if self.pending_writes.min_ts().is_none()
+            if let Some(request) = pending_snapshot_install.take() {
+                if self.persistence_writes.is_empty() {
+                    self.install_snapshot(
+                        request.checkpoint,
+                        request.source,
+                        request.result,
+                        commit_id,
+                    )?;
+                    commit_id += 1;
+                    snapshot_install_in_progress = true;
+                    continue;
+                }
+                pending_snapshot_install = Some(request);
+            }
+            if let Some(request) = pending_raft_snapshot.take() {
+                if self.persistence_writes.is_empty() {
+                    let result = self
+                        .build_raft_snapshot_bytes(request.raft_index, request.raft_term)
+                        .await;
+                    let _ = request.result.send(result);
+                    continue;
+                }
+                pending_raft_snapshot = Some(request);
+            }
+            let snapshot_barrier_active = pending_raft_snapshot.is_some()
+                || pending_snapshot_install.is_some()
+                || snapshot_install_in_progress;
+            if !snapshot_barrier_active
+                && self.pending_writes.min_ts().is_none()
                 && let Some(deferred_prepare) = deferred_prepares.pop_front()
             {
                 self.handle_deferred_prepare(deferred_prepare).await;
                 continue;
             }
-            let bump_fut = if let Some(wait) = &next_bump_wait {
+            let bump_fut = if !snapshot_barrier_active && let Some(wait) = &next_bump_wait {
                 Either::Left(
                     self.runtime
                         .wait(wait.saturating_sub(last_bumped_repeatable_ts.elapsed())),
@@ -1229,10 +1566,11 @@ impl<RT: Runtime> Committer<RT> {
             } else {
                 Either::Right(std::future::pending())
             };
-            let remote_read_frontier_heartbeat_fut = if self
-                .placement_state
-                .as_ref()
-                .is_some_and(|placement_state| placement_state.num_partitions() > 1)
+            let remote_read_frontier_heartbeat_fut = if !snapshot_barrier_active
+                && self
+                    .placement_state
+                    .as_ref()
+                    .is_some_and(|placement_state| placement_state.num_partitions() > 1)
             {
                 Either::Left(
                     self.runtime.wait(
@@ -1243,10 +1581,11 @@ impl<RT: Runtime> Committer<RT> {
             } else {
                 Either::Right(std::future::pending())
             };
-            let raft_nats_outbox_replay_fut = if self
-                .placement_state
-                .as_ref()
-                .is_some_and(|placement_state| placement_state.num_partitions() > 1)
+            let raft_nats_outbox_replay_fut = if !snapshot_barrier_active
+                && self
+                    .placement_state
+                    .as_ref()
+                    .is_some_and(|placement_state| placement_state.num_partitions() > 1)
             {
                 Either::Left(
                     self.runtime.wait(
@@ -1257,7 +1596,7 @@ impl<RT: Runtime> Committer<RT> {
             } else {
                 Either::Right(std::future::pending())
             };
-            let receive_message_fut = if deferred_prepares.is_empty() {
+            let receive_message_fut = if deferred_prepares.is_empty() && !snapshot_barrier_active {
                 Either::Left(rx.recv())
             } else {
                 Either::Right(std::future::pending())
@@ -1629,6 +1968,7 @@ impl<RT: Runtime> Committer<RT> {
                             applied_data_delta_ids,
                             raft_apply_marker,
                             raft_nats_outbox_delta,
+                            raft_state_machine_index,
                             result,
                             ..
                         } => {
@@ -1699,6 +2039,19 @@ impl<RT: Runtime> Committer<RT> {
                                     .delete_persistence_global_raw(&marker.key())
                                     .await?;
                                 self.raft_apply_markers.remove(&marker);
+                            }
+                            if let Some(raft_state_machine_index) = raft_state_machine_index {
+                                let durable_index = load_state_machine_index(
+                                    self.persistence.reader().as_ref(),
+                                )
+                                .await?;
+                                anyhow::ensure!(
+                                    durable_index >= raft_state_machine_index,
+                                    "Raft apply at index {} persisted without its state-machine \
+                                     binding (durable index {})",
+                                    raft_state_machine_index,
+                                    durable_index,
+                                );
                             }
                             if let Some(delta) = raft_nats_outbox_delta.as_ref() {
                                 Self::add_raft_nats_outbox_delta(
@@ -1772,10 +2125,22 @@ impl<RT: Runtime> Committer<RT> {
                         PersistenceWrite::RaftReplayRecovery {
                             marker,
                             delta,
+                            raft_state_machine_index,
                             result,
                             ..
                         } => {
                             let recovery_result = async {
+                                let durable_index = load_state_machine_index(
+                                    self.persistence.reader().as_ref(),
+                                )
+                                .await?;
+                                anyhow::ensure!(
+                                    durable_index >= raft_state_machine_index,
+                                    "Raft replay at index {} found state without its durable \
+                                     state-machine binding (durable index {})",
+                                    raft_state_machine_index,
+                                    durable_index,
+                                );
                                 if self.raft_apply_markers.contains(&marker) {
                                     self.consolidate_raft_apply_marker(marker).await?;
                                 }
@@ -1832,6 +2197,7 @@ impl<RT: Runtime> Committer<RT> {
                             let _ = result.send(Ok(commit_ts));
                         },
                         PersistenceWrite::InstallSnapshot {
+                            source,
                             snapshot_ts,
                             snapshot,
                             replication_frontiers,
@@ -1856,6 +2222,11 @@ impl<RT: Runtime> Committer<RT> {
                                 replication_frontiers,
                                 applied_delta_watermarks,
                             );
+                            self.raft_apply_markers.clear();
+                            if source == SnapshotInstallSource::Raft {
+                                self.recover_two_phase_redo_records().await?;
+                            }
+                            snapshot_install_in_progress = false;
                             let _ = result.send(Ok(snapshot_ts));
                         },
                     }
@@ -1914,12 +2285,14 @@ impl<RT: Runtime> Committer<RT> {
                         Some(CommitterMessage::ApplyReplicaDelta {
                             delta,
                             mode,
+                            raft_state_machine_index,
                             transport_id,
                             result,
                         }) => {
                             if let Err(e) = self.apply_replica_delta(
                                 delta,
                                 mode,
+                                raft_state_machine_index,
                                 transport_id,
                                 result,
                                 commit_id,
@@ -1929,8 +2302,13 @@ impl<RT: Runtime> Committer<RT> {
                                 commit_id += 1;
                             }
                         },
-                        Some(CommitterMessage::ApplyRaftPreparedRedo { redo, result }) => {
+                        Some(CommitterMessage::ApplyRaftPreparedRedo {
+                            raft_state_machine_index,
+                            redo,
+                            result,
+                        }) => {
                             let deferred_prepare = DeferredPrepare::ApplyRaftPreparedRedo {
+                                raft_state_machine_index,
                                 redo,
                                 result,
                             };
@@ -1955,8 +2333,47 @@ impl<RT: Runtime> Committer<RT> {
                             let _ = result.send(());
                         },
                         Some(CommitterMessage::InstallSnapshot { checkpoint, result }) => {
-                            self.install_snapshot(checkpoint, result, commit_id)?;
-                            commit_id += 1;
+                            anyhow::ensure!(
+                                pending_snapshot_install.is_none(),
+                                "multiple snapshot installs were admitted concurrently",
+                            );
+                            pending_snapshot_install = Some(SnapshotInstallRequest {
+                                checkpoint,
+                                source: SnapshotInstallSource::Bootstrap,
+                                result,
+                            });
+                        },
+                        Some(CommitterMessage::InstallRaftSnapshot { checkpoint, result }) => {
+                            anyhow::ensure!(
+                                pending_snapshot_install.is_none(),
+                                "multiple snapshot installs were admitted concurrently",
+                            );
+                            pending_snapshot_install = Some(SnapshotInstallRequest {
+                                checkpoint,
+                                source: SnapshotInstallSource::Raft,
+                                result,
+                            });
+                        },
+                        Some(CommitterMessage::BuildRaftSnapshot {
+                            raft_index,
+                            raft_term,
+                            result,
+                        }) => {
+                            anyhow::ensure!(
+                                pending_raft_snapshot.is_none(),
+                                "multiple Raft snapshot barriers were admitted concurrently",
+                            );
+                            if self.persistence_writes.is_empty() {
+                                pending_raft_snapshot = Some(RaftSnapshotRequest {
+                                    raft_index,
+                                    raft_term,
+                                    result,
+                                });
+                            } else {
+                                let _ = result.send(Err(
+                                    RaftSnapshotTemporarilyUnavailable.into(),
+                                ));
+                            }
                         },
                         #[cfg(any(test, feature = "testing"))]
                         Some(CommitterMessage::BumpMaxRepeatableTs { result }) => {
@@ -3004,11 +3421,13 @@ impl<RT: Runtime> Committer<RT> {
         write_source: WriteSource,
         raft_apply_marker: Option<RaftApplyMarker>,
         raft_nats_outbox_delta: Option<CommitDelta>,
+        raft_state_machine_index: Option<u64>,
     ) -> anyhow::Result<()> {
         let timer = metrics::commit_persistence_write_timer();
         let raft_apply_writes = Self::raft_apply_persistence_writes(
             raft_apply_marker,
             raft_nats_outbox_delta.as_ref(),
+            raft_state_machine_index,
         )?;
         persistence
             .write_with_persistence_globals(
@@ -3199,11 +3618,12 @@ impl<RT: Runtime> Committer<RT> {
     fn raft_apply_persistence_writes(
         marker: Option<RaftApplyMarker>,
         delta: Option<&CommitDelta>,
+        raft_state_machine_index: Option<u64>,
     ) -> anyhow::Result<Vec<PersistenceGlobalWrite>> {
         let Some(marker) = marker else {
             anyhow::ensure!(
-                delta.is_none(),
-                "Raft outbox delta supplied without an atomic apply marker",
+                delta.is_none() && raft_state_machine_index.is_none(),
+                "Raft apply metadata supplied without an atomic apply marker",
             );
             return Ok(Vec::new());
         };
@@ -3212,9 +3632,12 @@ impl<RT: Runtime> Committer<RT> {
             marker == RaftApplyMarker::from_delta(delta)?,
             "Raft apply marker did not match its committed delta",
         );
+        let raft_state_machine_index = raft_state_machine_index
+            .context("Raft apply marker supplied without a state-machine index")?;
         Ok(vec![
             marker.persistence_write()?,
             Self::raft_nats_outbox_persistence_write(delta)?,
+            state_machine_index_persistence_write(raft_state_machine_index),
         ])
     }
 
@@ -3692,9 +4115,100 @@ impl<RT: Runtime> Committer<RT> {
         })
     }
 
+    /// Capture one stable Convex generation for the exact Raft prefix the
+    /// storage layer is snapshotting. The committer loop admits no later work
+    /// while this method runs, and all earlier persistence futures have
+    /// already drained.
+    fn build_raft_snapshot_bytes(
+        &self,
+        raft_index: u64,
+        raft_term: u64,
+    ) -> BoxFuture<'static, anyhow::Result<Vec<u8>>> {
+        let (checkpoint_ts, replication_frontiers, table_summary_snapshot) = {
+            let snapshot_manager = self.snapshot_manager.read();
+            let (ts, snapshot) = snapshot_manager.latest();
+            let table_summary_snapshot =
+                snapshot
+                    .table_summaries
+                    .as_ref()
+                    .map(|summaries| TableSummarySnapshot {
+                        tables: summaries
+                            .tables
+                            .iter()
+                            .map(|(key, value)| (*key, value.clone()))
+                            .collect(),
+                        ts: *ts,
+                    });
+            (
+                *ts,
+                snapshot_manager.replication_frontiers(),
+                table_summary_snapshot,
+            )
+        };
+        let persistence = self.persistence.clone();
+        let retention_validator = self.retention_validator.clone();
+        async move {
+            let reader = persistence.reader();
+            let state_machine_index = load_state_machine_index(reader.as_ref()).await?;
+            anyhow::ensure!(
+                state_machine_index <= raft_index,
+                "Convex state includes Raft index {state_machine_index}, beyond requested \
+                 snapshot index {raft_index}",
+            );
+            anyhow::ensure!(
+                reader
+                    .list_persistence_globals_with_prefix(RAFT_APPLY_MARKER_KEY_PREFIX)
+                    .await?
+                    .is_empty(),
+                "Cannot generate a Raft snapshot while an apply marker is unresolved",
+            );
+
+            let mut checkpoint =
+                create_checkpoint(reader.as_ref(), checkpoint_ts, retention_validator).await?;
+
+            let mut globals = BTreeMap::new();
+            for key in PersistenceGlobalKey::checkpoint_keys().into_iter().chain([
+                PersistenceGlobalKey::TwoPhaseRedoRecords,
+                PersistenceGlobalKey::RaftNatsOutbox,
+            ]) {
+                if let Some(value) = reader.get_persistence_global(key).await? {
+                    globals.insert(String::from(key), value);
+                }
+            }
+            for (key, value) in reader
+                .list_persistence_globals_with_prefix(RAFT_NATS_OUTBOX_KEY_PREFIX)
+                .await?
+            {
+                globals.insert(key, value);
+            }
+            globals.insert(
+                RAFT_STATE_MACHINE_INDEX_KEY.to_string(),
+                state_machine_index.into(),
+            );
+            globals.insert(
+                String::from(PersistenceGlobalKey::MaxRepeatableTimestamp),
+                serde_json::Value::from(u64::from(checkpoint_ts)),
+            );
+            globals.insert(
+                String::from(PersistenceGlobalKey::ReplicationFrontiers),
+                replication_frontiers_to_json(&replication_frontiers),
+            );
+            if let Some(table_summary_snapshot) = table_summary_snapshot {
+                globals.insert(
+                    String::from(PersistenceGlobalKey::TableSummary),
+                    serde_json::Value::from(&table_summary_snapshot),
+                );
+            }
+            checkpoint.globals = globals;
+            encode_raft_snapshot(raft_index, raft_term, state_machine_index, &checkpoint)
+        }
+        .boxed()
+    }
+
     fn install_snapshot(
         &mut self,
         checkpoint: CheckpointData,
+        source: SnapshotInstallSource,
         result: oneshot::Sender<anyhow::Result<Timestamp>>,
         commit_id: usize,
     ) -> anyhow::Result<()> {
@@ -3705,174 +4219,27 @@ impl<RT: Runtime> Committer<RT> {
             .placement_state
             .as_ref()
             .map(|placement_state| placement_state.partition_map());
-        let persistence_version = persistence.reader().version();
 
         self.persistence_writes.push_back(
             async move {
-                let checkpoint_ts = checkpoint.timestamp;
-                let compacted_documents = compact_checkpoint_documents(&checkpoint);
-                let checkpoint_persistence = Arc::new(CheckpointPersistence::from_checkpoint(
-                    CheckpointData {
-                        timestamp: checkpoint.timestamp,
-                        documents: compacted_documents.clone(),
-                        globals: checkpoint.globals.clone(),
-                    },
-                    persistence_version,
-                ));
-                let repeatable_ts = RepeatableTimestamp::new_validated(
-                    checkpoint_ts,
-                    RepeatableReason::SnapshotManagerLatest,
-                );
-                let retention_validator = Arc::new(NoopRetentionValidator);
-                let mut db_snapshot = DatabaseSnapshot::load(
+                let prepared = prepare_checkpoint_install(
                     runtime,
-                    checkpoint_persistence,
-                    repeatable_ts,
-                    retention_validator,
+                    persistence.clone(),
                     virtual_system_mapping,
+                    partition_map,
+                    &checkpoint,
                 )
                 .await?;
-
-                if let Some(value) = checkpoint
-                    .globals
-                    .get(&String::from(PersistenceGlobalKey::TableSummary))
-                {
-                    let summary_snapshot = TableSummarySnapshot::try_from(value.clone())?;
-                    let table_summaries = TableSummaries::new(
-                        summary_snapshot,
-                        db_snapshot.table_registry().table_mapping(),
-                        &db_snapshot.snapshot.virtual_system_mapping,
-                    )?;
-                    db_snapshot.snapshot.table_summaries = Some(table_summaries);
-                }
-
-                let index_entries =
-                    checkpoint_index_entries(&db_snapshot.snapshot, &compacted_documents);
-
-                let mut existing_documents = Vec::new();
-                let persistence_reader = persistence.reader();
-                let mut document_stream = persistence_reader.load_documents(
-                    TimestampRange::all(),
-                    Order::Asc,
-                    1024,
-                    Arc::new(NoopRetentionValidator),
-                );
-                while let Some(entry) = document_stream.try_next().await? {
-                    existing_documents.push((entry.ts, entry.id));
-                }
-                if !existing_documents.is_empty() {
-                    persistence.delete(existing_documents).await?;
-                }
-
-                let mut cursor = None;
-                loop {
-                    let chunk = persistence.load_index_chunk(cursor.clone(), 1024).await?;
-                    if chunk.is_empty() {
-                        break;
-                    }
-                    cursor = chunk.last().cloned();
-                    persistence.delete_index_entries(chunk).await?;
-                }
-
-                for chunk in compacted_documents.chunks(1024) {
-                    persistence
-                        .write(chunk, &[], ConflictStrategy::Overwrite)
-                        .await?;
-                }
-                for chunk in index_entries.chunks(1024) {
-                    persistence
-                        .write(&[], chunk, ConflictStrategy::Overwrite)
-                        .await?;
-                }
-                for key in PersistenceGlobalKey::checkpoint_keys() {
-                    if let Some(value) = checkpoint.globals.get(&String::from(key)) {
-                        persistence
-                            .write_persistence_global(key, value.clone())
-                            .await?;
-                    }
-                }
-                persistence
-                    .write_persistence_global(
-                        PersistenceGlobalKey::TwoPhaseRedoRecords,
-                        serde_json::json!({}),
-                    )
-                    .await?;
-                if !checkpoint.globals.contains_key(&String::from(
-                    PersistenceGlobalKey::AppliedDataDeltaWatermarks,
-                )) {
-                    persistence
-                        .write_persistence_global(
-                            PersistenceGlobalKey::AppliedDataDeltaWatermarks,
-                            serde_json::json!({}),
-                        )
-                        .await?;
-                }
-                if !checkpoint
-                    .globals
-                    .contains_key(&String::from(PersistenceGlobalKey::AppliedDataDeltaIds))
-                {
-                    persistence
-                        .write_persistence_global(
-                            PersistenceGlobalKey::AppliedDataDeltaIds,
-                            serde_json::json!({}),
-                        )
-                        .await?;
-                }
-
-                let replication_frontiers = checkpoint
-                    .globals
-                    .get(&String::from(PersistenceGlobalKey::ReplicationFrontiers))
-                    .map(|value| {
-                        crate::snapshot_manager::replication_frontiers_from_json(value.clone())
-                    })
-                    .transpose()?
-                    .unwrap_or_else(|| {
-                        partition_map
-                            .as_ref()
-                            .map(|map| {
-                                map.all_partitions()
-                                    .into_iter()
-                                    .filter(|partition| *partition != map.local_partition())
-                                    .map(|partition| (partition, Timestamp::MIN))
-                                    .collect()
-                            })
-                            .unwrap_or_default()
-                    });
-                let applied_delta_watermarks = checkpoint
-                    .globals
-                    .get(&String::from(PersistenceGlobalKey::AppliedDeltaWatermarks))
-                    .map(|value| {
-                        partition_timestamp_map_from_json(value.clone(), "applied delta watermarks")
-                    })
-                    .transpose()?
-                    .unwrap_or_default();
-                let applied_data_delta_watermarks = checkpoint
-                    .globals
-                    .get(&String::from(
-                        PersistenceGlobalKey::AppliedDataDeltaWatermarks,
-                    ))
-                    .map(|value| {
-                        partition_timestamp_map_from_json(
-                            value.clone(),
-                            "applied data delta watermarks",
-                        )
-                    })
-                    .transpose()?
-                    .unwrap_or_default();
-                let applied_data_delta_ids = checkpoint
-                    .globals
-                    .get(&String::from(PersistenceGlobalKey::AppliedDataDeltaIds))
-                    .map(|value| applied_data_delta_ids_from_json(value.clone()))
-                    .transpose()?
-                    .unwrap_or_default();
+                persist_checkpoint_install(persistence, &checkpoint, &prepared, source).await?;
 
                 Ok(PersistenceWrite::InstallSnapshot {
-                    snapshot_ts: checkpoint_ts,
-                    snapshot: db_snapshot.snapshot,
-                    replication_frontiers,
-                    applied_delta_watermarks,
-                    applied_data_delta_watermarks,
-                    applied_data_delta_ids,
+                    source,
+                    snapshot_ts: prepared.snapshot_ts,
+                    snapshot: prepared.snapshot,
+                    replication_frontiers: prepared.replication_frontiers,
+                    applied_delta_watermarks: prepared.applied_delta_watermarks,
+                    applied_data_delta_watermarks: prepared.applied_data_delta_watermarks,
+                    applied_data_delta_ids: prepared.applied_data_delta_ids,
                     result,
                     commit_id,
                 })
@@ -3899,6 +4266,7 @@ impl<RT: Runtime> Committer<RT> {
         &mut self,
         delta: CommitDelta,
         mode: ReplicaDeltaApplyMode,
+        raft_state_machine_index: Option<u64>,
         transport_id: Option<ReplicationTransportId>,
         result: oneshot::Sender<anyhow::Result<Timestamp>>,
         commit_id: usize,
@@ -3922,6 +4290,8 @@ impl<RT: Runtime> Committer<RT> {
         if let Some(marker) = raft_apply_marker
             && self.raft_apply_markers.contains(&marker)
         {
+            let raft_state_machine_index = raft_state_machine_index
+                .context("full-state Raft replay did not include its committed log index")?;
             tracing::info!(
                 "Recovering already-installed Raft delta without reapplying: partition={}, \
                  origin_ts={}",
@@ -3933,6 +4303,7 @@ impl<RT: Runtime> Committer<RT> {
                     Ok(PersistenceWrite::RaftReplayRecovery {
                         marker,
                         delta,
+                        raft_state_machine_index,
                         result,
                         commit_id,
                     })
@@ -4226,6 +4597,8 @@ impl<RT: Runtime> Committer<RT> {
             let marker = raft_apply_marker.context(
                 "non-empty full-state Raft replay should have a stable apply marker identity",
             )?;
+            let raft_state_machine_index = raft_state_machine_index
+                .context("full-state Raft replay did not include its committed log index")?;
             tracing::info!(
                 "Repairing side effects for durably deduplicated Raft replay: partition={}, \
                  origin_ts={}",
@@ -4237,6 +4610,7 @@ impl<RT: Runtime> Committer<RT> {
                     Ok(PersistenceWrite::RaftReplayRecovery {
                         marker,
                         delta,
+                        raft_state_machine_index,
                         result,
                         commit_id,
                     })
@@ -4548,6 +4922,7 @@ impl<RT: Runtime> Committer<RT> {
         let raft_apply_writes = Self::raft_apply_persistence_writes(
             raft_apply_marker,
             raft_nats_outbox_delta.as_ref(),
+            raft_state_machine_index,
         )?;
         self.enqueue_snapshot(commit_id, commit_ts, snapshot.clone());
 
@@ -4603,6 +4978,7 @@ impl<RT: Runtime> Committer<RT> {
                     applied_data_delta_ids,
                     raft_apply_marker,
                     raft_nats_outbox_delta,
+                    raft_state_machine_index,
                     result,
                     commit_id,
                 })
@@ -4657,6 +5033,32 @@ impl<RT: Runtime> Committer<RT> {
         let mut records = Self::load_two_phase_redo_records(persistence.clone()).await?;
         records.insert(entry.transaction_id.clone(), entry);
         Self::write_two_phase_redo_records(persistence, &records).await
+    }
+
+    async fn persist_two_phase_redo_with_state_machine_index(
+        persistence: Arc<dyn Persistence>,
+        entry: crate::two_phase::TwoPhaseRedoEntry,
+        raft_state_machine_index: u64,
+    ) -> anyhow::Result<()> {
+        let mut records = Self::load_two_phase_redo_records(persistence.clone()).await?;
+        records.insert(entry.transaction_id.clone(), entry);
+        let redo_value = serde_json::to_value(records)
+            .context("2PC: Failed to serialize Raft-applied redo records")?;
+        persistence
+            .write_with_persistence_globals(
+                &[],
+                &[],
+                ConflictStrategy::Overwrite,
+                &[
+                    PersistenceGlobalWrite::new(
+                        String::from(PersistenceGlobalKey::TwoPhaseRedoRecords),
+                        redo_value,
+                    ),
+                    state_machine_index_persistence_write(raft_state_machine_index),
+                ],
+            )
+            .await
+            .context("2PC: Failed to atomically persist redo and Raft state-machine index")
     }
 
     async fn delete_two_phase_redo(
@@ -5178,6 +5580,12 @@ impl<RT: Runtime> Committer<RT> {
             },
         };
         if let Some(raft_applied_index) = raft_applied_index {
+            Self::persist_two_phase_redo_with_state_machine_index(
+                self.persistence.clone(),
+                redo,
+                raft_applied_index,
+            )
+            .await?;
             let Some(raft_state) = self.raft_state.as_ref() else {
                 anyhow::bail!(
                     "2PC Prepare txn={} returned Raft applied index {} without Raft state",
@@ -5283,6 +5691,12 @@ impl<RT: Runtime> Committer<RT> {
             },
         };
         if let Some(raft_applied_index) = raft_applied_index {
+            Self::persist_two_phase_redo_with_state_machine_index(
+                self.persistence.clone(),
+                redo,
+                raft_applied_index,
+            )
+            .await?;
             let Some(raft_state) = self.raft_state.as_ref() else {
                 anyhow::bail!(
                     "2PC Prepare txn={} returned Raft applied index {} without Raft state",
@@ -5312,8 +5726,12 @@ impl<RT: Runtime> Committer<RT> {
 
     async fn handle_deferred_prepare(&mut self, deferred_prepare: DeferredPrepare) {
         match deferred_prepare {
-            DeferredPrepare::ApplyRaftPreparedRedo { redo, result } => {
-                let r = self.handle_raft_prepared_redo(redo);
+            DeferredPrepare::ApplyRaftPreparedRedo {
+                raft_state_machine_index,
+                redo,
+                result,
+            } => {
+                let r = self.handle_raft_prepared_redo(raft_state_machine_index, redo);
                 let _ = result.send(r);
             },
             DeferredPrepare::Prepare {
@@ -5529,6 +5947,7 @@ impl<RT: Runtime> Committer<RT> {
                             delta.write_source.clone(),
                             raft_apply_marker,
                             raft_apply_marker.map(|_| delta.clone()),
+                            raft_applied_index,
                         )
                         .in_span(Span::enter_with_local_parent(name)),
                     ));
@@ -5680,6 +6099,7 @@ impl<RT: Runtime> Committer<RT> {
 
     fn handle_raft_prepared_redo(
         &mut self,
+        raft_state_machine_index: u64,
         redo: crate::two_phase::TwoPhaseRedoEntry,
     ) -> anyhow::Result<crate::two_phase::PrepareResult> {
         let transaction_id = redo.transaction_id();
@@ -5695,10 +6115,13 @@ impl<RT: Runtime> Committer<RT> {
             .with_context(|| {
                 format!("2PC Raft Prepare Apply: failed to stage txn={transaction_id}")
             })?;
-        if let Err(err) = Self::block_on_current_runtime(Self::persist_two_phase_redo(
-            self.persistence.clone(),
-            redo,
-        )) {
+        if let Err(err) =
+            Self::block_on_current_runtime(Self::persist_two_phase_redo_with_state_machine_index(
+                self.persistence.clone(),
+                redo,
+                raft_state_machine_index,
+            ))
+        {
             if let Err(rollback_err) = self.handle_rollback_prepared(transaction_id.clone()) {
                 tracing::error!(
                     "2PC Raft Prepare Apply: failed to rollback in-memory txn={} after redo \
@@ -5889,6 +6312,7 @@ impl<RT: Runtime> Committer<RT> {
                             delta.write_source.clone(),
                             raft_apply_marker,
                             raft_apply_marker.map(|_| delta.clone()),
+                            raft_applied_index,
                         )
                         .in_span(Span::enter_with_local_parent(name)),
                     ));
@@ -6194,8 +6618,13 @@ impl CommitterClient {
     /// node-local system tables that are not part of cross-partition read
     /// replication.
     pub async fn apply_replica_delta(&self, delta: CommitDelta) -> anyhow::Result<Timestamp> {
-        self.apply_delta_with_mode(delta, ReplicaDeltaApplyMode::CrossPartitionReplica, None)
-            .await
+        self.apply_delta_with_mode(
+            delta,
+            ReplicaDeltaApplyMode::CrossPartitionReplica,
+            None,
+            None,
+        )
+        .await
     }
 
     pub async fn apply_replica_delta_with_transport_id(
@@ -6206,6 +6635,7 @@ impl CommitterClient {
         self.apply_delta_with_mode(
             delta,
             ReplicaDeltaApplyMode::CrossPartitionReplica,
+            None,
             Some(transport_id),
         )
         .await
@@ -6215,21 +6645,32 @@ impl CommitterClient {
     /// loop. Unlike cross-partition NATS replication, Raft followers are HA
     /// copies that can become leader, so this path applies full partition
     /// state including system tables.
-    pub async fn apply_raft_commit_delta(&self, delta: CommitDelta) -> anyhow::Result<Timestamp> {
-        self.apply_delta_with_mode(delta, ReplicaDeltaApplyMode::FullRaftState, None)
-            .await
+    pub async fn apply_raft_commit_delta(
+        &self,
+        raft_state_machine_index: u64,
+        delta: CommitDelta,
+    ) -> anyhow::Result<Timestamp> {
+        self.apply_delta_with_mode(
+            delta,
+            ReplicaDeltaApplyMode::FullRaftState,
+            Some(raft_state_machine_index),
+            None,
+        )
+        .await
     }
 
     async fn apply_delta_with_mode(
         &self,
         delta: CommitDelta,
         mode: ReplicaDeltaApplyMode,
+        raft_state_machine_index: Option<u64>,
         transport_id: Option<ReplicationTransportId>,
     ) -> anyhow::Result<Timestamp> {
         let (tx, rx) = oneshot::channel();
         let message = CommitterMessage::ApplyReplicaDelta {
             delta,
             mode,
+            raft_state_machine_index,
             transport_id,
             result: tx,
         };
@@ -6246,10 +6687,15 @@ impl CommitterClient {
     /// safely finish or roll back the transaction.
     pub async fn apply_raft_prepared_redo(
         &self,
+        raft_state_machine_index: u64,
         redo: crate::two_phase::TwoPhaseRedoEntry,
     ) -> anyhow::Result<crate::two_phase::PrepareResult> {
         let (tx, rx) = oneshot::channel();
-        let message = CommitterMessage::ApplyRaftPreparedRedo { redo, result: tx };
+        let message = CommitterMessage::ApplyRaftPreparedRedo {
+            raft_state_machine_index,
+            redo,
+            result: tx,
+        };
         self.sender.try_send(message).map_err(|e| match e {
             TrySendError::Full(..) => metrics::committer_full_error().into(),
             TrySendError::Closed(..) => metrics::shutdown_error(),
@@ -6736,6 +7182,40 @@ impl CommitterClient {
         result
     }
 
+    pub async fn install_raft_snapshot(
+        &self,
+        checkpoint: CheckpointData,
+    ) -> anyhow::Result<Timestamp> {
+        let (tx, rx) = oneshot::channel();
+        let message = CommitterMessage::InstallRaftSnapshot {
+            checkpoint,
+            result: tx,
+        };
+        self.sender.try_send(message).map_err(|e| match e {
+            TrySendError::Full(..) => metrics::committer_full_error().into(),
+            TrySendError::Closed(..) => metrics::shutdown_error(),
+        })?;
+        rx.await.map_err(|_| metrics::shutdown_error())?
+    }
+
+    pub async fn build_raft_snapshot(
+        &self,
+        raft_index: u64,
+        raft_term: u64,
+    ) -> anyhow::Result<Vec<u8>> {
+        let (tx, rx) = oneshot::channel();
+        let message = CommitterMessage::BuildRaftSnapshot {
+            raft_index,
+            raft_term,
+            result: tx,
+        };
+        self.sender.try_send(message).map_err(|e| match e {
+            TrySendError::Full(..) => metrics::committer_full_error().into(),
+            TrySendError::Closed(..) => metrics::shutdown_error(),
+        })?;
+        rx.await.map_err(|_| metrics::shutdown_error())?
+    }
+
     #[cfg(any(test, feature = "testing"))]
     pub async fn bump_max_repeatable_ts(&self) -> anyhow::Result<Timestamp> {
         let (tx, rx) = oneshot::channel();
@@ -6840,10 +7320,12 @@ enum CommitterMessage {
     ApplyReplicaDelta {
         delta: CommitDelta,
         mode: ReplicaDeltaApplyMode,
+        raft_state_machine_index: Option<u64>,
         transport_id: Option<ReplicationTransportId>,
         result: oneshot::Sender<anyhow::Result<Timestamp>>,
     },
     ApplyRaftPreparedRedo {
+        raft_state_machine_index: u64,
         redo: crate::two_phase::TwoPhaseRedoEntry,
         result: oneshot::Sender<anyhow::Result<crate::two_phase::PrepareResult>>,
     },
@@ -6854,6 +7336,15 @@ enum CommitterMessage {
     InstallSnapshot {
         checkpoint: CheckpointData,
         result: oneshot::Sender<anyhow::Result<Timestamp>>,
+    },
+    InstallRaftSnapshot {
+        checkpoint: CheckpointData,
+        result: oneshot::Sender<anyhow::Result<Timestamp>>,
+    },
+    BuildRaftSnapshot {
+        raft_index: u64,
+        raft_term: u64,
+        result: oneshot::Sender<anyhow::Result<Vec<u8>>>,
     },
     #[cfg(any(test, feature = "testing"))]
     BumpMaxRepeatableTs { result: oneshot::Sender<Timestamp> },
@@ -6914,6 +7405,7 @@ enum CommitterMessage {
 
 enum DeferredPrepare {
     ApplyRaftPreparedRedo {
+        raft_state_machine_index: u64,
         redo: crate::two_phase::TwoPhaseRedoEntry,
         result: oneshot::Sender<anyhow::Result<crate::two_phase::PrepareResult>>,
     },

--- a/crates/database/src/database.rs
+++ b/crates/database/src/database.rs
@@ -194,7 +194,6 @@ use crate::{
     },
     schema_registry::SchemaRegistry,
     search_index_bootstrap::SearchIndexBootstrapWorker,
-    snapshot_checkpointer::checkpoint_to_bytes,
     snapshot_manager::{
         partition_timestamp_map_from_json,
         replication_frontiers_from_json,
@@ -2130,11 +2129,6 @@ impl<RT: Runtime> Database<RT> {
 
         checkpoint.globals = globals;
         Ok(checkpoint)
-    }
-
-    pub async fn build_raft_snapshot_bytes(&self) -> anyhow::Result<Vec<u8>> {
-        let checkpoint = self.build_raft_snapshot_checkpoint().await?;
-        checkpoint_to_bytes(&checkpoint)
     }
 
     pub fn check_write_throughput_limit(&self) -> anyhow::Result<()> {

--- a/crates/database/src/lib.rs
+++ b/crates/database/src/lib.rs
@@ -29,6 +29,7 @@ mod preloaded;
 pub mod query;
 pub mod raft_node;
 pub mod raft_partition;
+pub mod raft_snapshot;
 pub mod raft_state_machine;
 pub mod raft_storage;
 pub mod raft_transport;
@@ -76,6 +77,7 @@ pub mod test_helpers;
 pub mod tests;
 pub mod text_index_worker;
 pub use committer::{
+    recover_staged_raft_snapshot_install,
     table_dependency_sort_key,
     CommitterClient,
 };

--- a/crates/database/src/raft_node.rs
+++ b/crates/database/src/raft_node.rs
@@ -287,10 +287,13 @@ impl RaftNode {
     }
 
     fn record_snapshot_applied_index(&mut self, index: u64) -> anyhow::Result<()> {
-        if index > self.durable_applied_index {
-            self.storage.set_applied_index(index)?;
-            self.durable_applied_index = index;
-        }
+        anyhow::ensure!(
+            self.storage.applied_index()? == index,
+            "Raft snapshot metadata committed index {} but storage reports applied index {}",
+            index,
+            self.storage.applied_index()?,
+        );
+        self.durable_applied_index = self.durable_applied_index.max(index);
         self.applied_indexes_pending_persistence
             .retain(|pending_index| *pending_index > index);
         Ok(())
@@ -418,8 +421,8 @@ impl RaftNode {
     /// tick → receive messages → propose → process ready → advance.
     pub async fn run(
         &mut self,
-        mut on_committed: impl FnMut(&[u8]) -> anyhow::Result<()> + Send + 'static,
-        mut on_snapshot: impl FnMut(&[u8]) -> anyhow::Result<()>,
+        mut on_committed: impl FnMut(u64, &[u8]) -> anyhow::Result<()> + Send + 'static,
+        mut on_snapshot: impl FnMut(&Snapshot) -> anyhow::Result<()>,
     ) -> anyhow::Result<()> {
         let tick_interval = RaftNodeConfig::TICK_INTERVAL;
         let leader_serving_lease_duration = self.config.leader_serving_lease_duration();
@@ -431,7 +434,7 @@ impl RaftNode {
         let (applied_tx, mut applied_rx) = mpsc::unbounded_channel::<StateMachineApplyResult>();
         let _apply_worker = tokio::task::spawn_blocking(move || {
             while let Some(job) = apply_rx.blocking_recv() {
-                let result = on_committed(&job.data);
+                let result = on_committed(job.index, &job.data);
                 let should_stop = result.is_err();
                 if applied_tx
                     .send(StateMachineApplyResult {
@@ -634,12 +637,16 @@ impl RaftNode {
                     let snapshot_timer = metrics::raft_snapshot_apply_timer();
                     let snapshot_bytes = ready.snapshot().get_data().len();
                     metrics::log_raft_snapshot_apply_bytes(snapshot_bytes);
-                    if let Err(e) = on_snapshot(ready.snapshot().get_data()) {
+                    if let Err(e) = self.storage.stage_snapshot(ready.snapshot(), ready.hs()) {
+                        tracing::error!("Failed to stage snapshot install intent: {e}");
+                        drop(snapshot_timer);
+                        return Err(e);
+                    } else if let Err(e) = on_snapshot(ready.snapshot()) {
                         tracing::error!("Failed to apply snapshot to state machine: {e}");
                         drop(snapshot_timer);
                         return Err(e);
-                    } else if let Err(e) = self.storage.apply_snapshot(ready.snapshot()) {
-                        tracing::error!("Failed to persist snapshot: {e}");
+                    } else if let Err(e) = self.storage.commit_pending_snapshot_install() {
+                        tracing::error!("Failed to commit staged snapshot metadata: {e}");
                         drop(snapshot_timer);
                         return Err(e);
                     } else if let Err(e) =
@@ -1004,7 +1011,7 @@ mod tests {
         node.process_ready_test();
         assert!(node.is_leader());
 
-        let run_task = tokio::spawn(async move { node.run(|_| Ok(()), |_| Ok(())).await });
+        let run_task = tokio::spawn(async move { node.run(|_, _| Ok(()), |_| Ok(())).await });
         let (result_tx, result_rx) = tokio::sync::oneshot::channel();
         tx.send(RaftMessage::Propose(RaftProposal {
             data: b"mailbox proposal".to_vec(),
@@ -1053,7 +1060,7 @@ mod tests {
         let run_task = tokio::spawn(async move {
             let mut entered_tx = Some(entered_tx);
             node.run(
-                move |_| {
+                move |_, _| {
                     if let Some(entered_tx) = entered_tx.take() {
                         let _ = entered_tx.send(());
                     }
@@ -1202,6 +1209,71 @@ mod tests {
             "committed-but-unapplied entry should replay after restart: {committed:?}",
         );
         assert_eq!(node.storage.applied_index().unwrap(), 1);
+    }
+
+    #[tokio::test]
+    async fn test_restart_after_snapshot_applies_each_later_entry_exactly_once() {
+        let config = RaftNodeConfig {
+            node_id: 1,
+            partition_id: PartitionId(0),
+            peers: vec![1],
+            election_tick: 10,
+            heartbeat_tick: 3,
+        };
+        let engine = test_engine();
+
+        {
+            let mut storage =
+                ConvexRaftStorage::new(PartitionId(0), engine.clone(), 1, vec![1], None).unwrap();
+            let mut metadata = SnapshotMetadata::default();
+            metadata.index = 8;
+            metadata.term = 2;
+            metadata.set_conf_state(ConfState::from((vec![1], vec![])));
+            let mut snapshot = Snapshot::default();
+            snapshot.set_metadata(metadata);
+            snapshot.set_data(
+                crate::raft_snapshot::test_snapshot_bytes(8, 2)
+                    .unwrap()
+                    .into(),
+            );
+            storage.apply_snapshot(&snapshot).unwrap();
+
+            let mut entry = Entry::default();
+            entry.set_index(9);
+            entry.set_term(3);
+            entry.set_data(b"after snapshot".to_vec().into());
+            let mut hard_state = HardState::default();
+            hard_state.set_term(3);
+            hard_state.set_vote(1);
+            hard_state.set_commit(9);
+            storage
+                .append_entries_and_hardstate(&[entry], &hard_state)
+                .unwrap();
+        }
+
+        {
+            let (_tx, rx) = mpsc::unbounded_channel();
+            let mut node =
+                RaftNode::new(config.clone(), engine.clone(), rx, HashMap::new(), None).unwrap();
+            assert_eq!(node.raw_node.raft.raft_log.applied, 8);
+            let committed = node.process_ready_test();
+            assert_eq!(
+                committed
+                    .iter()
+                    .filter(|data| data.as_slice() == b"after snapshot")
+                    .count(),
+                1,
+            );
+            assert_eq!(node.storage.applied_index().unwrap(), 9);
+        }
+
+        let (_tx, rx) = mpsc::unbounded_channel();
+        let mut restarted = RaftNode::new(config, engine, rx, HashMap::new(), None).unwrap();
+        assert_eq!(restarted.raw_node.raft.raft_log.applied, 9);
+        assert!(
+            restarted.process_ready_test().is_empty(),
+            "a second restart must not replay an entry already durably applied",
+        );
     }
 
     #[tokio::test]

--- a/crates/database/src/raft_snapshot.rs
+++ b/crates/database/src/raft_snapshot.rs
@@ -1,0 +1,226 @@
+//! Versioned payload and durable generation binding for Raft snapshots.
+
+use anyhow::Context;
+#[cfg(test)]
+use common::types::Timestamp;
+use common::{
+    persistence::{
+        PersistenceGlobalWrite,
+        PersistenceReader,
+    },
+    sha256::Sha256,
+};
+use prost::Message;
+
+use crate::{
+    checkpoint::CheckpointData,
+    snapshot_checkpointer::{
+        checkpoint_from_bytes,
+        checkpoint_to_bytes,
+    },
+};
+
+pub const RAFT_STATE_MACHINE_INDEX_KEY: &str = "raft_state_machine_index";
+const RAFT_SNAPSHOT_FORMAT_VERSION: u32 = 1;
+
+#[derive(Debug)]
+pub struct RaftSnapshotTemporarilyUnavailable;
+
+impl std::fmt::Display for RaftSnapshotTemporarilyUnavailable {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(
+            "Raft snapshot generation is temporarily unavailable while commits are in flight",
+        )
+    }
+}
+
+impl std::error::Error for RaftSnapshotTemporarilyUnavailable {}
+
+#[derive(Clone)]
+pub struct DecodedRaftSnapshot {
+    pub raft_index: u64,
+    pub raft_term: u64,
+    pub state_machine_index: u64,
+    pub checkpoint: CheckpointData,
+}
+
+#[derive(Clone, PartialEq, Message)]
+struct RaftSnapshotEnvelope {
+    #[prost(uint32, tag = "1")]
+    format_version: u32,
+    #[prost(uint64, tag = "2")]
+    raft_index: u64,
+    #[prost(uint64, tag = "3")]
+    raft_term: u64,
+    #[prost(uint64, tag = "4")]
+    state_machine_index: u64,
+    #[prost(uint64, tag = "5")]
+    checkpoint_timestamp: u64,
+    #[prost(bytes, tag = "6")]
+    checkpoint_bytes: Vec<u8>,
+    #[prost(string, tag = "7")]
+    checkpoint_sha256: String,
+}
+
+pub fn state_machine_index_persistence_write(index: u64) -> PersistenceGlobalWrite {
+    PersistenceGlobalWrite::new(RAFT_STATE_MACHINE_INDEX_KEY, index.into())
+}
+
+pub async fn load_state_machine_index(reader: &dyn PersistenceReader) -> anyhow::Result<u64> {
+    let Some(value) = reader
+        .get_persistence_global_raw(RAFT_STATE_MACHINE_INDEX_KEY)
+        .await?
+    else {
+        return Ok(0);
+    };
+    value.as_u64().with_context(|| {
+        format!(
+            "Invalid durable Raft state-machine index value for {RAFT_STATE_MACHINE_INDEX_KEY}: \
+             {value}"
+        )
+    })
+}
+
+pub fn encode_snapshot(
+    raft_index: u64,
+    raft_term: u64,
+    state_machine_index: u64,
+    checkpoint: &CheckpointData,
+) -> anyhow::Result<Vec<u8>> {
+    anyhow::ensure!(
+        state_machine_index <= raft_index,
+        "Raft snapshot index {raft_index} cannot precede state-machine index {state_machine_index}",
+    );
+    let checkpoint_bytes = checkpoint_to_bytes(checkpoint)?;
+    let checkpoint_sha256 = hex::encode(Sha256::hash(&checkpoint_bytes));
+    Ok(RaftSnapshotEnvelope {
+        format_version: RAFT_SNAPSHOT_FORMAT_VERSION,
+        raft_index,
+        raft_term,
+        state_machine_index,
+        checkpoint_timestamp: u64::from(checkpoint.timestamp),
+        checkpoint_bytes,
+        checkpoint_sha256,
+    }
+    .encode_to_vec())
+}
+
+pub fn decode_snapshot(
+    bytes: &[u8],
+    expected_raft_index: u64,
+    expected_raft_term: u64,
+) -> anyhow::Result<DecodedRaftSnapshot> {
+    let envelope = RaftSnapshotEnvelope::decode(bytes)
+        .context("Failed to decode versioned Raft snapshot envelope")?;
+    anyhow::ensure!(
+        envelope.format_version == RAFT_SNAPSHOT_FORMAT_VERSION,
+        "Unsupported Raft snapshot format version {}",
+        envelope.format_version,
+    );
+    anyhow::ensure!(
+        envelope.raft_index == expected_raft_index,
+        "Raft snapshot payload index {} does not match metadata index {}",
+        envelope.raft_index,
+        expected_raft_index,
+    );
+    anyhow::ensure!(
+        envelope.raft_term == expected_raft_term,
+        "Raft snapshot payload term {} does not match metadata term {}",
+        envelope.raft_term,
+        expected_raft_term,
+    );
+    anyhow::ensure!(
+        envelope.state_machine_index <= envelope.raft_index,
+        "Raft snapshot state-machine index {} exceeds snapshot index {}",
+        envelope.state_machine_index,
+        envelope.raft_index,
+    );
+    let actual_digest = hex::encode(Sha256::hash(&envelope.checkpoint_bytes));
+    anyhow::ensure!(
+        actual_digest == envelope.checkpoint_sha256,
+        "Raft snapshot checkpoint digest mismatch",
+    );
+    let checkpoint = checkpoint_from_bytes(&envelope.checkpoint_bytes)?;
+    anyhow::ensure!(
+        u64::from(checkpoint.timestamp) == envelope.checkpoint_timestamp,
+        "Raft snapshot checkpoint timestamp {} does not match envelope timestamp {}",
+        u64::from(checkpoint.timestamp),
+        envelope.checkpoint_timestamp,
+    );
+    let persisted_state_machine_index = checkpoint
+        .globals
+        .get(RAFT_STATE_MACHINE_INDEX_KEY)
+        .and_then(serde_json::Value::as_u64)
+        .unwrap_or(0);
+    anyhow::ensure!(
+        persisted_state_machine_index == envelope.state_machine_index,
+        "Raft snapshot checkpoint state-machine index {} does not match envelope index {}",
+        persisted_state_machine_index,
+        envelope.state_machine_index,
+    );
+    Ok(DecodedRaftSnapshot {
+        raft_index: envelope.raft_index,
+        raft_term: envelope.raft_term,
+        state_machine_index: envelope.state_machine_index,
+        checkpoint,
+    })
+}
+
+#[cfg(test)]
+pub(crate) fn test_snapshot_bytes(raft_index: u64, raft_term: u64) -> anyhow::Result<Vec<u8>> {
+    let checkpoint = CheckpointData {
+        timestamp: Timestamp::try_from(raft_index.max(1))?,
+        documents: Vec::new(),
+        globals: std::collections::BTreeMap::from([(
+            RAFT_STATE_MACHINE_INDEX_KEY.to_string(),
+            raft_index.into(),
+        )]),
+    };
+    encode_snapshot(raft_index, raft_term, raft_index, &checkpoint)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+
+    use super::*;
+
+    fn checkpoint(state_machine_index: u64) -> CheckpointData {
+        CheckpointData {
+            timestamp: Timestamp::must(42),
+            documents: Vec::new(),
+            globals: BTreeMap::from([(
+                RAFT_STATE_MACHINE_INDEX_KEY.to_string(),
+                state_machine_index.into(),
+            )]),
+        }
+    }
+
+    #[test]
+    fn test_snapshot_envelope_round_trip() -> anyhow::Result<()> {
+        let bytes = encode_snapshot(9, 3, 8, &checkpoint(8))?;
+        let decoded = decode_snapshot(&bytes, 9, 3)?;
+        assert_eq!(decoded.raft_index, 9);
+        assert_eq!(decoded.raft_term, 3);
+        assert_eq!(decoded.state_machine_index, 8);
+        assert_eq!(decoded.checkpoint.timestamp, Timestamp::must(42));
+        Ok(())
+    }
+
+    #[test]
+    fn test_snapshot_envelope_rejects_metadata_mismatch() -> anyhow::Result<()> {
+        let bytes = encode_snapshot(9, 3, 8, &checkpoint(8))?;
+        assert!(decode_snapshot(&bytes, 10, 3).is_err());
+        assert!(decode_snapshot(&bytes, 9, 4).is_err());
+        Ok(())
+    }
+
+    #[test]
+    fn test_snapshot_envelope_rejects_corruption() -> anyhow::Result<()> {
+        let bytes = encode_snapshot(9, 3, 8, &checkpoint(8))?;
+        let mut envelope = RaftSnapshotEnvelope::decode(bytes.as_slice())?;
+        envelope.checkpoint_bytes.push(0);
+        assert!(decode_snapshot(&envelope.encode_to_vec(), 9, 3).is_err());
+        Ok(())
+    }
+}

--- a/crates/database/src/raft_storage.rs
+++ b/crates/database/src/raft_storage.rs
@@ -45,18 +45,28 @@ const APPLIED_INDEX_KEY: &[u8] = b"applied_index";
 /// Key for storing the latest installed/generated snapshot in raft-engine's KV
 /// space.
 const SNAPSHOT_KEY: &[u8] = b"snapshot";
+/// Incoming snapshot staged before mutating Convex persistence. This is the
+/// durable cross-store install intent used to resume after a process crash.
+const PENDING_SNAPSHOT_KEY: &[u8] = b"pending_snapshot";
+const PENDING_SNAPSHOT_HARD_STATE_KEY: &[u8] = b"pending_snapshot_hard_state";
 
 pub trait RaftSnapshotProvider: Send + Sync {
-    fn snapshot_bytes(&self) -> anyhow::Result<Vec<u8>>;
+    fn snapshot_bytes(&self, raft_index: u64, raft_term: u64) -> anyhow::Result<Vec<u8>>;
 }
 
 impl<F> RaftSnapshotProvider for F
 where
-    F: Fn() -> anyhow::Result<Vec<u8>> + Send + Sync,
+    F: Fn(u64, u64) -> anyhow::Result<Vec<u8>> + Send + Sync,
 {
-    fn snapshot_bytes(&self) -> anyhow::Result<Vec<u8>> {
-        self()
+    fn snapshot_bytes(&self, raft_index: u64, raft_term: u64) -> anyhow::Result<Vec<u8>> {
+        self(raft_index, raft_term)
     }
+}
+
+#[derive(Clone, Debug)]
+pub struct PendingSnapshotInstall {
+    pub snapshot: Snapshot,
+    pub hard_state: HardState,
 }
 
 /// Bridge between raft-rs Entry type and raft-engine's MessageExt trait.
@@ -297,25 +307,150 @@ impl ConvexRaftStorage {
             .context("Failed to read Snapshot from raft-engine")
     }
 
-    pub fn apply_snapshot(&mut self, snapshot: &Snapshot) -> anyhow::Result<()> {
+    fn pending_snapshot_install_from_engine(
+        engine: &Engine,
+        region_id: u64,
+    ) -> anyhow::Result<Option<PendingSnapshotInstall>> {
+        let snapshot: Option<Snapshot> = engine
+            .get_message(region_id, PENDING_SNAPSHOT_KEY)
+            .context("Failed to read pending Raft snapshot install")?;
+        let hard_state: Option<HardState> = engine
+            .get_message(region_id, PENDING_SNAPSHOT_HARD_STATE_KEY)
+            .context("Failed to read pending Raft snapshot hard state")?;
+        match (snapshot, hard_state) {
+            (None, None) => Ok(None),
+            (Some(snapshot), Some(hard_state)) => Ok(Some(PendingSnapshotInstall {
+                snapshot,
+                hard_state,
+            })),
+            _ => anyhow::bail!("Incomplete durable Raft snapshot install intent"),
+        }
+    }
+
+    pub fn pending_snapshot_install_for_engine(
+        engine: &Engine,
+        partition_id: PartitionId,
+    ) -> anyhow::Result<Option<PendingSnapshotInstall>> {
+        Self::pending_snapshot_install_from_engine(engine, partition_id.0 as u64)
+    }
+
+    pub fn pending_snapshot_install(&self) -> anyhow::Result<Option<PendingSnapshotInstall>> {
+        Self::pending_snapshot_install_from_engine(&self.engine, self.region_id())
+    }
+
+    /// Durably stage the complete incoming snapshot before Convex persistence
+    /// is changed. The staged record survives every later install crash window.
+    pub fn stage_snapshot(
+        &self,
+        snapshot: &Snapshot,
+        ready_hard_state: Option<&HardState>,
+    ) -> anyhow::Result<()> {
         self.check_fail_next_write_for_test()?;
         let metadata = snapshot.get_metadata();
+        anyhow::ensure!(
+            metadata.index > self.applied_index()?,
+            "Rejecting stale Raft snapshot at index {} because durable applied index is {}",
+            metadata.index,
+            self.applied_index()?,
+        );
+        crate::raft_snapshot::decode_snapshot(snapshot.get_data(), metadata.index, metadata.term)?;
+        if let Some(pending) = self.pending_snapshot_install()? {
+            anyhow::ensure!(
+                pending.snapshot == *snapshot,
+                "A different Raft snapshot install is already pending at index {}",
+                pending.snapshot.get_metadata().index,
+            );
+            return Ok(());
+        }
+
+        let mut hard_state = ready_hard_state.cloned().unwrap_or(self.hard_state()?);
+        hard_state.commit = metadata.index;
         let mut batch = LogBatch::default();
-        batch.add_command(self.region_id(), raft_engine::Command::Clean);
         batch
-            .put_message(self.region_id(), SNAPSHOT_KEY.to_vec(), snapshot)
-            .context("Failed to add Snapshot to LogBatch")?;
+            .put_message(self.region_id(), PENDING_SNAPSHOT_KEY.to_vec(), snapshot)
+            .context("Failed to stage pending Snapshot")?;
         batch
             .put_message(
                 self.region_id(),
+                PENDING_SNAPSHOT_HARD_STATE_KEY.to_vec(),
+                &hard_state,
+            )
+            .context("Failed to stage pending snapshot HardState")?;
+        self.engine
+            .write(&mut batch, true)
+            .context("Failed to stage snapshot install in raft-engine")?;
+        Ok(())
+    }
+
+    fn commit_pending_snapshot_install_to_engine(
+        engine: &Engine,
+        region_id: u64,
+    ) -> anyhow::Result<PendingSnapshotInstall> {
+        let pending = Self::pending_snapshot_install_from_engine(engine, region_id)?
+            .context("No staged Raft snapshot install to commit")?;
+        let metadata = pending.snapshot.get_metadata();
+        crate::raft_snapshot::decode_snapshot(
+            pending.snapshot.get_data(),
+            metadata.index,
+            metadata.term,
+        )?;
+        anyhow::ensure!(
+            pending.hard_state.commit == metadata.index,
+            "Pending snapshot HardState commit {} does not match snapshot index {}",
+            pending.hard_state.commit,
+            metadata.index,
+        );
+
+        // `Clean` plus every replacement metadata key is one synced
+        // raft-engine batch. A restart observes either the old generation and
+        // pending intent, or the complete new generation, never a mixture.
+        let mut batch = LogBatch::default();
+        batch.add_command(region_id, raft_engine::Command::Clean);
+        batch
+            .put_message(region_id, SNAPSHOT_KEY.to_vec(), &pending.snapshot)
+            .context("Failed to add Snapshot to install batch")?;
+        batch
+            .put_message(
+                region_id,
                 CONF_STATE_KEY.to_vec(),
                 metadata.get_conf_state(),
             )
-            .context("Failed to add snapshot ConfState to LogBatch")?;
-        self.engine
+            .context("Failed to add snapshot ConfState to install batch")?;
+        batch
+            .put_message(region_id, HARD_STATE_KEY.to_vec(), &pending.hard_state)
+            .context("Failed to add snapshot HardState to install batch")?;
+        batch
+            .put(
+                region_id,
+                APPLIED_INDEX_KEY.to_vec(),
+                metadata.index.to_be_bytes().to_vec(),
+            )
+            .context("Failed to add snapshot applied index to install batch")?;
+        engine
             .write(&mut batch, true)
-            .context("Failed to write snapshot to raft-engine")?;
+            .context("Failed to atomically commit snapshot metadata to raft-engine")?;
+        Ok(pending)
+    }
+
+    pub fn commit_pending_snapshot_install_for_engine(
+        engine: &Engine,
+        partition_id: PartitionId,
+    ) -> anyhow::Result<PendingSnapshotInstall> {
+        Self::commit_pending_snapshot_install_to_engine(engine, partition_id.0 as u64)
+    }
+
+    pub fn commit_pending_snapshot_install(&mut self) -> anyhow::Result<u64> {
+        self.check_fail_next_write_for_test()?;
+        let pending =
+            Self::commit_pending_snapshot_install_to_engine(&self.engine, self.region_id())?;
+        let metadata = pending.snapshot.get_metadata();
         self.conf_state = metadata.get_conf_state().clone();
+        Ok(metadata.index)
+    }
+
+    pub fn apply_snapshot(&mut self, snapshot: &Snapshot) -> anyhow::Result<()> {
+        self.stage_snapshot(snapshot, None)?;
+        self.commit_pending_snapshot_install()?;
         Ok(())
     }
 
@@ -483,11 +618,17 @@ impl Storage for ConvexRaftStorage {
             ));
         }
         let snapshot_term = self.term(snapshot_index)?;
-        let snapshot_data = snapshot_provider.snapshot_bytes().map_err(|e| {
-            raft::Error::Store(StorageError::Other(Box::new(std::io::Error::other(
-                e.to_string(),
-            ))))
-        })?;
+        let snapshot_data = snapshot_provider
+            .snapshot_bytes(snapshot_index, snapshot_term)
+            .map_err(|e| {
+                if e.is::<crate::raft_snapshot::RaftSnapshotTemporarilyUnavailable>() {
+                    raft::Error::Store(StorageError::SnapshotTemporarilyUnavailable)
+                } else {
+                    raft::Error::Store(StorageError::Other(Box::new(std::io::Error::other(
+                        e.to_string(),
+                    ))))
+                }
+            })?;
 
         let mut metadata = SnapshotMetadata::default();
         metadata.index = snapshot_index;
@@ -508,6 +649,21 @@ mod tests {
     fn test_engine() -> Arc<Engine> {
         let dir = tempfile::tempdir().unwrap();
         ConvexRaftStorage::open_engine(dir.path().to_str().unwrap()).unwrap()
+    }
+
+    fn test_snapshot(index: u64, term: u64, voters: Vec<u64>) -> Snapshot {
+        let mut metadata = SnapshotMetadata::default();
+        metadata.index = index;
+        metadata.term = term;
+        metadata.set_conf_state(ConfState::from((voters, vec![])));
+        let mut snapshot = Snapshot::default();
+        snapshot.set_metadata(metadata);
+        snapshot.set_data(
+            crate::raft_snapshot::test_snapshot_bytes(index, term)
+                .unwrap()
+                .into(),
+        );
+        snapshot
     }
 
     #[test]
@@ -624,13 +780,14 @@ mod tests {
 
     #[test]
     fn test_snapshot_persists_and_reloads() {
-        let dir = tempfile::tempdir().unwrap();
-        let path = dir.path().to_str().unwrap();
+        let source_dir = tempfile::tempdir().unwrap();
+        let source_path = source_dir.path().to_str().unwrap();
 
-        {
-            let engine = ConvexRaftStorage::open_engine(path).unwrap();
-            let provider: Arc<dyn RaftSnapshotProvider> = Arc::new(|| Ok(b"checkpoint".to_vec()));
-            let mut storage =
+        let snapshot = {
+            let engine = ConvexRaftStorage::open_engine(source_path).unwrap();
+            let provider: Arc<dyn RaftSnapshotProvider> =
+                Arc::new(crate::raft_snapshot::test_snapshot_bytes);
+            let storage =
                 ConvexRaftStorage::new(PartitionId(0), engine, 1, vec![1, 2, 3], Some(provider))
                     .unwrap();
 
@@ -656,8 +813,17 @@ mod tests {
             let snapshot = storage.snapshot(5, 2).unwrap();
             assert_eq!(snapshot.get_metadata().index, 5);
             assert_eq!(snapshot.get_metadata().term, 2);
-            assert_eq!(snapshot.get_data(), b"checkpoint");
+            let decoded = crate::raft_snapshot::decode_snapshot(snapshot.get_data(), 5, 2).unwrap();
+            assert_eq!(decoded.state_machine_index, 5);
+            snapshot
+        };
 
+        let destination_dir = tempfile::tempdir().unwrap();
+        let destination_path = destination_dir.path().to_str().unwrap();
+        {
+            let engine = ConvexRaftStorage::open_engine(destination_path).unwrap();
+            let mut storage =
+                ConvexRaftStorage::new(PartitionId(0), engine, 2, vec![1, 2, 3], None).unwrap();
             storage.apply_snapshot(&snapshot).unwrap();
             assert_eq!(storage.first_index().unwrap(), 6);
             assert_eq!(storage.last_index().unwrap(), 5);
@@ -665,12 +831,75 @@ mod tests {
         }
 
         {
-            let engine = ConvexRaftStorage::open_engine(path).unwrap();
+            let engine = ConvexRaftStorage::open_engine(destination_path).unwrap();
             let storage =
                 ConvexRaftStorage::new(PartitionId(0), engine, 1, vec![1, 2, 3], None).unwrap();
             assert_eq!(storage.first_index().unwrap(), 6);
             assert_eq!(storage.last_index().unwrap(), 5);
             assert_eq!(storage.term(5).unwrap(), 2);
+            assert_eq!(storage.applied_index().unwrap(), 5);
+            assert_eq!(storage.hard_state().unwrap().commit, 5);
+            assert!(storage.pending_snapshot_install().unwrap().is_none());
         }
+    }
+
+    #[test]
+    fn test_staged_snapshot_survives_restart_and_finalize_retry() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().to_str().unwrap();
+        let snapshot = test_snapshot(5, 2, vec![1, 2, 3]);
+
+        {
+            let engine = ConvexRaftStorage::open_engine(path).unwrap();
+            let storage =
+                ConvexRaftStorage::new(PartitionId(0), engine, 2, vec![1, 2, 3], None).unwrap();
+            storage.set_applied_index(2).unwrap();
+            storage.stage_snapshot(&snapshot, None).unwrap();
+            assert_eq!(storage.applied_index().unwrap(), 2);
+            assert_eq!(
+                storage
+                    .pending_snapshot_install()
+                    .unwrap()
+                    .unwrap()
+                    .snapshot,
+                snapshot,
+            );
+        }
+
+        {
+            let engine = ConvexRaftStorage::open_engine(path).unwrap();
+            let mut storage =
+                ConvexRaftStorage::new(PartitionId(0), engine, 2, vec![1, 2, 3], None).unwrap();
+            storage.fail_next_write_for_test();
+            assert!(storage.commit_pending_snapshot_install().is_err());
+            assert_eq!(storage.applied_index().unwrap(), 2);
+            assert!(storage.pending_snapshot_install().unwrap().is_some());
+
+            assert_eq!(storage.commit_pending_snapshot_install().unwrap(), 5);
+            assert_eq!(storage.applied_index().unwrap(), 5);
+            assert_eq!(storage.hard_state().unwrap().commit, 5);
+            assert!(storage.pending_snapshot_install().unwrap().is_none());
+        }
+    }
+
+    #[test]
+    fn test_snapshot_stage_rejects_stale_mismatched_and_competing_generations() {
+        let engine = test_engine();
+        let storage =
+            ConvexRaftStorage::new(PartitionId(0), engine, 1, vec![1, 2, 3], None).unwrap();
+        storage.set_applied_index(5).unwrap();
+
+        let stale = test_snapshot(5, 2, vec![1, 2, 3]);
+        assert!(storage.stage_snapshot(&stale, None).is_err());
+
+        let mut mismatched = test_snapshot(6, 2, vec![1, 2, 3]);
+        mismatched.mut_metadata().index = 7;
+        assert!(storage.stage_snapshot(&mismatched, None).is_err());
+
+        let accepted = test_snapshot(6, 2, vec![1, 2, 3]);
+        storage.stage_snapshot(&accepted, None).unwrap();
+        storage.stage_snapshot(&accepted, None).unwrap();
+        let competing = test_snapshot(7, 2, vec![1, 2, 3]);
+        assert!(storage.stage_snapshot(&competing, None).is_err());
     }
 }

--- a/crates/database/src/replica.rs
+++ b/crates/database/src/replica.rs
@@ -29,6 +29,7 @@ use crate::{
         RetryableReplicaApplyError,
     },
     committer::CommitterClient,
+    partition::PartitionId,
 };
 
 const RETRYABLE_REPLICA_APPLY_NAK_DELAY: Duration = Duration::from_millis(250);
@@ -36,27 +37,33 @@ const RETRYABLE_REPLICA_APPLY_NAK_DELAY: Duration = Duration::from_millis(250);
 pub async fn apply_replication_message(
     committer: &CommitterClient,
     message: ReplicationMessage,
+    excluded_source_partition: Option<PartitionId>,
 ) -> anyhow::Result<(common::types::Timestamp, usize)> {
     let committer = committer.clone();
-    apply_replication_message_with(message, move |delta, transport_id| {
-        let committer = committer.clone();
-        async move {
-            match transport_id {
-                Some(transport_id) => {
-                    committer
-                        .apply_replica_delta_with_transport_id(delta, transport_id)
-                        .await
-                },
-                None => committer.apply_replica_delta(delta).await,
+    apply_replication_message_with(
+        message,
+        excluded_source_partition,
+        move |delta, transport_id| {
+            let committer = committer.clone();
+            async move {
+                match transport_id {
+                    Some(transport_id) => {
+                        committer
+                            .apply_replica_delta_with_transport_id(delta, transport_id)
+                            .await
+                    },
+                    None => committer.apply_replica_delta(delta).await,
+                }
             }
-        }
-    })
+        },
+    )
     .await
 }
 
 pub async fn consume_replication_stream<F>(
     stream: BoxStream<'static, anyhow::Result<ReplicationMessage>>,
     committer: CommitterClient,
+    excluded_source_partition: Option<PartitionId>,
     after_success: F,
 ) -> anyhow::Result<()>
 where
@@ -66,7 +73,9 @@ where
         stream,
         move |message| {
             let committer = committer.clone();
-            async move { apply_replication_message(&committer, message).await }
+            async move {
+                apply_replication_message(&committer, message, excluded_source_partition).await
+            }
         },
         after_success,
     )
@@ -100,6 +109,7 @@ where
 
 async fn apply_replication_message_with<F, Fut>(
     message: ReplicationMessage,
+    excluded_source_partition: Option<PartitionId>,
     mut apply: F,
 ) -> anyhow::Result<(common::types::Timestamp, usize)>
 where
@@ -109,6 +119,24 @@ where
     let (delta, transport_id, ack) = message.into_parts();
     let ts = delta.ts;
     let num_updates = delta.document_updates.len();
+
+    if let Some(excluded_source_partition) = excluded_source_partition {
+        if delta.source_partition == Some(excluded_source_partition) {
+            tracing::debug!(
+                source_partition = excluded_source_partition.0,
+                origin_ts = u64::from(ts),
+                "Acknowledging same-partition NATS delta without applying it; Raft is \
+                 authoritative"
+            );
+            ack.ack().await.with_context(|| {
+                format!(
+                    "Failed to ack same-partition NATS delta at ts={}",
+                    u64::from(ts),
+                )
+            })?;
+            return Ok((ts, 0));
+        }
+    }
 
     match apply(delta, transport_id).await {
         Ok(applied_ts) => {
@@ -222,7 +250,7 @@ impl ReplicaDeltaConsumer {
 
         tracing::info!("ReplicaDeltaConsumer subscribed, waiting for deltas...");
 
-        consume_replication_stream(stream, committer, |applied_ts, num_updates| {
+        consume_replication_stream(stream, committer, None, |applied_ts, num_updates| {
             tracing::info!(
                 "Applied replica delta: ts={}, {} updates",
                 u64::from(applied_ts),
@@ -262,6 +290,7 @@ mod tests {
             ReplicationMessage,
             RetryableReplicaApplyError,
         },
+        partition::PartitionId,
         write_log::WriteSource,
     };
 
@@ -303,6 +332,14 @@ mod tests {
     }
 
     fn test_message(ts: Timestamp, counts: Arc<AckCounts>) -> ReplicationMessage {
+        test_message_from_partition(ts, None, counts)
+    }
+
+    fn test_message_from_partition(
+        ts: Timestamp,
+        source_partition: Option<PartitionId>,
+        counts: Arc<AckCounts>,
+    ) -> ReplicationMessage {
         ReplicationMessage::new(
             CommitDelta {
                 ts,
@@ -312,7 +349,7 @@ mod tests {
                 write_source: WriteSource::unknown(),
                 write_bytes: 0,
                 tablet_id_to_table_name: BTreeMap::new(),
-                source_partition: None,
+                source_partition,
             },
             Box::new(RecordingAck { counts }),
         )
@@ -324,6 +361,7 @@ mod tests {
         let ts = Timestamp::try_from(42u64)?;
         let (applied_ts, num_updates) = apply_replication_message_with(
             test_message(ts, counts.clone()),
+            None,
             |delta, _transport_id| async move { Ok(delta.ts) },
         )
         .await?;
@@ -338,11 +376,45 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn same_partition_nats_delta_is_acked_without_apply() -> anyhow::Result<()> {
+        let counts = Arc::new(AckCounts::default());
+        let attempts = Arc::new(AtomicUsize::new(0));
+        let ts = Timestamp::try_from(42u64)?;
+        let local_partition = PartitionId(1);
+
+        let (applied_ts, num_updates) = apply_replication_message_with(
+            test_message_from_partition(ts, Some(local_partition), counts.clone()),
+            Some(local_partition),
+            {
+                let attempts = attempts.clone();
+                move |delta, _transport_id| {
+                    let attempts = attempts.clone();
+                    async move {
+                        attempts.fetch_add(1, Ordering::SeqCst);
+                        Ok(delta.ts)
+                    }
+                }
+            },
+        )
+        .await?;
+
+        assert_eq!(applied_ts, ts);
+        assert_eq!(num_updates, 0);
+        assert_eq!(attempts.load(Ordering::SeqCst), 0);
+        assert_eq!(counts.ack.load(Ordering::SeqCst), 1);
+        assert_eq!(counts.nak.load(Ordering::SeqCst), 0);
+        assert_eq!(counts.delayed_nak.load(Ordering::SeqCst), 0);
+        assert_eq!(counts.term.load(Ordering::SeqCst), 0);
+        Ok(())
+    }
+
+    #[tokio::test]
     async fn apply_replication_message_naks_after_apply_failure() -> anyhow::Result<()> {
         let counts = Arc::new(AckCounts::default());
         let ts = Timestamp::try_from(42u64)?;
         let err = apply_replication_message_with(
             test_message(ts, counts.clone()),
+            None,
             |_delta, _transport_id| async move { anyhow::bail!("forced apply failure") },
         )
         .await
@@ -367,7 +439,7 @@ mod tests {
         let ts = Timestamp::try_from(42u64)?;
         let attempts = Arc::new(AtomicUsize::new(0));
 
-        let err = apply_replication_message_with(test_message(ts, counts.clone()), {
+        let err = apply_replication_message_with(test_message(ts, counts.clone()), None, {
             let attempts = attempts.clone();
             move |_delta, _transport_id| {
                 let attempts = attempts.clone();
@@ -411,6 +483,7 @@ mod tests {
 
         let first_attempt = apply_replication_message_with(
             test_message(ts, counts.clone()),
+            None,
             |_delta, _transport_id| async move {
                 Err(anyhow::Error::new(RetryableReplicaApplyError::new(
                     "prepared transaction still unresolved",
@@ -425,6 +498,7 @@ mod tests {
 
         let (applied_ts, num_updates) = apply_replication_message_with(
             test_message(ts, counts.clone()),
+            None,
             |delta, _transport_id| async move { Ok(delta.ts) },
         )
         .await?;
@@ -456,7 +530,7 @@ mod tests {
             move |message| {
                 let attempts = attempts.clone();
                 async move {
-                    apply_replication_message_with(message, |delta, _transport_id| {
+                    apply_replication_message_with(message, None, |delta, _transport_id| {
                         let attempts = attempts.clone();
                         async move {
                             if attempts.fetch_add(1, Ordering::SeqCst) == 0 {
@@ -496,6 +570,7 @@ mod tests {
 
         let first_attempt = apply_replication_message_with(
             test_message(ts, counts.clone()),
+            None,
             |_delta, _transport_id| async move { anyhow::bail!("transient apply failure") },
         )
         .await;
@@ -505,6 +580,7 @@ mod tests {
 
         let (applied_ts, _) = apply_replication_message_with(
             test_message(ts, counts.clone()),
+            None,
             |delta, _transport_id| async move { Ok(delta.ts) },
         )
         .await?;
@@ -534,7 +610,7 @@ mod tests {
             move |message| {
                 let attempts = attempts.clone();
                 async move {
-                    apply_replication_message_with(message, |delta, _transport_id| {
+                    apply_replication_message_with(message, None, |delta, _transport_id| {
                         let attempts = attempts.clone();
                         async move {
                             if attempts.fetch_add(1, Ordering::SeqCst) == 0 {

--- a/crates/database/src/tests/raft_failover_tests.rs
+++ b/crates/database/src/tests/raft_failover_tests.rs
@@ -50,7 +50,7 @@ fn create_three_node_group() -> Vec<RaftNode> {
     let peer_ids = vec![1u64, 2, 3];
     let mut nodes = Vec::new();
     let snapshot_provider: Arc<dyn crate::raft_storage::RaftSnapshotProvider> =
-        Arc::new(|| Ok(Vec::new()));
+        Arc::new(crate::raft_snapshot::test_snapshot_bytes);
 
     for &id in &peer_ids {
         let engine = test_engine();

--- a/crates/database/src/tests/write_scaling_tests.rs
+++ b/crates/database/src/tests/write_scaling_tests.rs
@@ -84,6 +84,12 @@ use pb::replication::{
     TwoPcValidateReadsRequest,
     TwoPcValidateReadsResponse,
 };
+use raft::prelude::{
+    ConfState,
+    HardState,
+    Snapshot as RaftSnapshot,
+    SnapshotMetadata,
+};
 use rand::{
     Rng,
     SeedableRng,
@@ -149,7 +155,12 @@ use crate::{
         RaftProposalResult,
     },
     raft_partition::RaftPartitionState,
+    raft_snapshot::{
+        decode_snapshot as decode_raft_snapshot,
+        RAFT_STATE_MACHINE_INDEX_KEY,
+    },
     raft_state_machine::RaftStateMachineEntry,
+    raft_storage::ConvexRaftStorage,
     snapshot_manager::partition_timestamp_map_from_json,
     table_number_allocator::{
         testing::InMemoryTableNumberAllocator,
@@ -342,6 +353,17 @@ async fn create_node_with_custom_distributed_log(
     let handle = db.start_search_and_vector_bootstrap();
     handle.join().await?;
     Ok(db)
+}
+
+fn raft_snapshot_for_test(index: u64, term: u64, bytes: Vec<u8>) -> RaftSnapshot {
+    let mut metadata = SnapshotMetadata::default();
+    metadata.index = index;
+    metadata.term = term;
+    metadata.set_conf_state(ConfState::from((vec![1, 2, 3], vec![])));
+    let mut snapshot = RaftSnapshot::default();
+    snapshot.set_metadata(metadata);
+    snapshot.set_data(bytes.into());
+    snapshot
 }
 
 #[derive(Default)]
@@ -1425,7 +1447,7 @@ async fn assert_raft_replay_is_idempotent_across_crash_window(
     let snapshot_before_replay = *restarted.now_ts_for_reads();
     let replay_ts = restarted
         .committer_for_test()
-        .apply_raft_commit_delta(delta.clone())
+        .apply_raft_commit_delta(7, delta.clone())
         .await?;
     assert_eq!(
         replay_ts, delta.ts,
@@ -1633,7 +1655,7 @@ async fn test_raft_prepared_commit_replay_after_crash_is_idempotent(
     let snapshot_before_replay = *restarted.now_ts_for_reads();
     let replay_ts = restarted
         .committer_for_test()
-        .apply_raft_commit_delta(delta)
+        .apply_raft_commit_delta(11, delta)
         .await?;
     assert_eq!(replay_ts, prepare_ts);
     assert_eq!(
@@ -3600,7 +3622,7 @@ async fn test_raft_apply_records_nats_outbox_when_publish_unavailable(
 
     follower
         .committer_for_test()
-        .apply_raft_commit_delta(delta)
+        .apply_raft_commit_delta(1, delta)
         .await?;
 
     let records = follower_persistence
@@ -4364,7 +4386,7 @@ async fn test_raft_delta_apply_preserves_full_system_state(rt: TestRuntime) -> a
 
     raft_follower
         .committer_for_test()
-        .apply_raft_commit_delta(system_delta)
+        .apply_raft_commit_delta(1, system_delta)
         .await?;
     let raft_docs = global_table_scan_or_empty(raft_follower, "_environment_variables").await?;
     assert_eq!(
@@ -4598,7 +4620,7 @@ async fn test_raft_prepared_redo_apply_can_commit_after_failover(
     )?;
 
     node.committer_for_test()
-        .apply_raft_prepared_redo(redo)
+        .apply_raft_prepared_redo(1, redo)
         .await?;
     let committed_ts = node
         .committer_for_test()
@@ -4695,7 +4717,7 @@ async fn test_watcher_recovers_staged_prepare_after_participant_leader_failover(
 
     new_leader
         .committer_for_test()
-        .apply_raft_prepared_redo(redo.clone())
+        .apply_raft_prepared_redo(1, redo.clone())
         .await
         .context("new participant leader should replay the Raft-prepared redo")?;
     let staging = TwoPhaseDecision::staging(
@@ -4822,7 +4844,7 @@ async fn test_remote_table_catalog_writes_follow_owner_prepare_redo(
 
     owner
         .committer_for_test()
-        .apply_raft_prepared_redo(redo)
+        .apply_raft_prepared_redo(1, redo)
         .await?;
     let committed_ts = owner.committer_for_test().commit_prepared(txn_id).await?;
     assert_eq!(committed_ts, prepare_ts);
@@ -4968,7 +4990,7 @@ async fn test_raft_commit_delta_cleans_prepared_redo_on_follower(
 
     follower
         .committer_for_test()
-        .apply_raft_prepared_redo(redo)
+        .apply_raft_prepared_redo(1, redo)
         .await?;
     source
         .committer_for_test()
@@ -5118,7 +5140,7 @@ async fn test_raft_prepared_redo_rewrites_when_follower_floor_advanced_by_replic
     )?;
     let prepare_result = follower
         .committer_for_test()
-        .apply_raft_prepared_redo(redo)
+        .apply_raft_prepared_redo(1, redo)
         .await?;
     assert_eq!(prepare_result.prepare_ts, prepare_ts);
 
@@ -5164,7 +5186,7 @@ async fn test_raft_prepared_redo_rewrites_when_follower_floor_advanced_by_replic
         .context("prepared commit should publish a delta")?;
     follower
         .committer_for_test()
-        .apply_raft_commit_delta(delta)
+        .apply_raft_commit_delta(2, delta)
         .await?;
     follower
         .committer_for_test()
@@ -5304,10 +5326,10 @@ async fn test_raft_prepared_redo_rewrite_allocates_unique_local_prepare_timestam
         .apply_replica_delta(foreign_delta)
         .await?;
 
-    for (_, prepare_ts, redo) in redos.iter().cloned() {
+    for (raft_index, (_, prepare_ts, redo)) in (1..).zip(redos.iter().cloned()) {
         let prepare_result = follower
             .committer_for_test()
-            .apply_raft_prepared_redo(redo)
+            .apply_raft_prepared_redo(raft_index, redo)
             .await?;
         assert_eq!(prepare_result.prepare_ts, prepare_ts);
     }
@@ -5582,7 +5604,7 @@ async fn test_raft_prepared_redo_rewrites_when_pre_replay_heartbeat_advances_ret
     )?;
     let prepare_result = follower
         .committer_for_test()
-        .apply_raft_prepared_redo(redo)
+        .apply_raft_prepared_redo(1, redo)
         .await?;
     assert_eq!(prepare_result.prepare_ts, prepare_ts);
 
@@ -5604,7 +5626,7 @@ async fn test_raft_prepared_redo_rewrites_when_pre_replay_heartbeat_advances_ret
         .context("prepared commit should publish a delta")?;
     follower
         .committer_for_test()
-        .apply_raft_commit_delta(delta)
+        .apply_raft_commit_delta(2, delta)
         .await?;
 
     let projects = run_query(
@@ -5710,7 +5732,7 @@ async fn test_raft_prepared_redo_replay_uses_local_anchor_when_begin_ts_is_out_o
     )?;
     let prepare_result = follower
         .committer_for_test()
-        .apply_raft_prepared_redo(redo)
+        .apply_raft_prepared_redo(1, redo)
         .await?;
     assert_eq!(prepare_result.prepare_ts, prepare_ts);
 
@@ -5732,7 +5754,7 @@ async fn test_raft_prepared_redo_replay_uses_local_anchor_when_begin_ts_is_out_o
         .context("prepared commit should publish a delta")?;
     follower
         .committer_for_test()
-        .apply_raft_commit_delta(delta)
+        .apply_raft_commit_delta(2, delta)
         .await?;
 
     let projects = run_query(
@@ -5824,7 +5846,7 @@ async fn test_raft_prepared_redo_rewrites_when_heartbeat_advances_last_assigned(
     )?;
     let prepare_result = follower
         .committer_for_test()
-        .apply_raft_prepared_redo(redo)
+        .apply_raft_prepared_redo(1, redo)
         .await?;
     assert_eq!(prepare_result.prepare_ts, prepare_ts);
 
@@ -5861,7 +5883,7 @@ async fn test_raft_prepared_redo_rewrites_when_heartbeat_advances_last_assigned(
         .context("prepared commit should publish a delta")?;
     let applied_ts = follower
         .committer_for_test()
-        .apply_raft_commit_delta(delta)
+        .apply_raft_commit_delta(2, delta)
         .await?;
     assert!(
         applied_ts > heartbeat_ts,
@@ -8650,4 +8672,240 @@ fn test_idle_remote_read_frontier_heartbeat_tso_failure_is_nonfatal() -> anyhow:
 
         Ok(())
     })
+}
+
+#[convex_macro::test_runtime]
+async fn test_raft_snapshot_barrier_includes_prior_pending_commit(
+    rt: TestRuntime,
+    pause: PauseController,
+) -> anyhow::Result<()> {
+    let partition_map = partitioned_map(PartitionId(0));
+    let source = create_node(
+        &rt,
+        Arc::new(InMemoryDistributedLog::new()),
+        Some(partition_map.clone()),
+    )
+    .await?;
+    insert_doc(&source, "messages", assert_obj!("text" => "before-barrier")).await?;
+
+    let hold = pause.hold(AFTER_PENDING_WRITE_SNAPSHOT);
+    let source_for_commit = source.clone();
+    let commit = tokio::spawn(async move {
+        insert_doc(
+            &source_for_commit,
+            "messages",
+            assert_obj!("text" => "pending-at-barrier"),
+        )
+        .await
+    });
+    let pause_guard = hold
+        .wait_for_blocked()
+        .await
+        .context("commit did not reach the pending snapshot boundary")?;
+
+    let busy_error = source
+        .committer_for_test()
+        .build_raft_snapshot(5, 2)
+        .await
+        .expect_err("snapshot generation must not block the Raft loop behind an in-flight commit");
+    assert!(
+        busy_error.is::<crate::raft_snapshot::RaftSnapshotTemporarilyUnavailable>(),
+        "busy snapshot generation should signal Raft to retry: {busy_error:#}",
+    );
+
+    pause_guard.unpause();
+    commit.await??;
+    let bytes = source
+        .committer_for_test()
+        .build_raft_snapshot(5, 2)
+        .await?;
+    let decoded = decode_raft_snapshot(&bytes, 5, 2)?;
+
+    let restored = create_node(
+        &rt,
+        Arc::new(InMemoryDistributedLog::new()),
+        Some(partition_map),
+    )
+    .await?;
+    restored
+        .committer_for_test()
+        .install_raft_snapshot(decoded.checkpoint)
+        .await?;
+    let messages = run_query(
+        restored,
+        TableNamespace::root_component(),
+        Query::full_table_scan("messages".parse()?, Order::Asc),
+    )
+    .await?;
+    assert_eq!(messages.len(), 2);
+    assert!(messages.iter().any(|message| {
+        message.value().0.get("text") == Some(&assert_val!("pending-at-barrier"))
+    }));
+    Ok(())
+}
+
+#[convex_macro::test_runtime]
+async fn test_staged_raft_snapshot_recovers_every_cross_store_crash_window(
+    rt: TestRuntime,
+) -> anyhow::Result<()> {
+    let partition_map = partitioned_map(PartitionId(0));
+    let source_persistence = Arc::new(TestPersistence::new());
+    let source = create_node_with_persistence(
+        &rt,
+        source_persistence.clone(),
+        Arc::new(InMemoryDistributedLog::new()),
+        Some(partition_map.clone()),
+        None,
+        Arc::new(NoopTwoPhaseDecisionLog),
+        None,
+    )
+    .await?;
+    insert_doc(&source, "messages", assert_obj!("text" => "generation-7")).await?;
+    source_persistence
+        .write_persistence_global_raw(RAFT_STATE_MACHINE_INDEX_KEY, 7.into())
+        .await?;
+    let first_bytes = source
+        .committer_for_test()
+        .build_raft_snapshot(7, 2)
+        .await?;
+    let first_snapshot = raft_snapshot_for_test(7, 2, first_bytes);
+
+    let destination_persistence = Arc::new(TestPersistence::new());
+    let raft_dir = tempfile::tempdir()?;
+    let engine = ConvexRaftStorage::open_engine(
+        raft_dir
+            .path()
+            .to_str()
+            .context("temporary raft-engine path was not UTF-8")?,
+    )?;
+    let storage = ConvexRaftStorage::new(PartitionId(0), engine.clone(), 2, vec![1, 2, 3], None)?;
+    let mut first_hard_state = HardState::default();
+    first_hard_state.term = 2;
+    first_hard_state.commit = 7;
+    storage.stage_snapshot(&first_snapshot, Some(&first_hard_state))?;
+    drop(storage);
+
+    assert!(
+        crate::recover_staged_raft_snapshot_install(
+            engine.clone(),
+            PartitionId(0),
+            destination_persistence.clone(),
+            rt.clone(),
+            Default::default(),
+            Some(partition_map.clone()),
+        )
+        .await?,
+        "startup should recover a snapshot staged before Convex persistence changed",
+    );
+    let first_storage =
+        ConvexRaftStorage::new(PartitionId(0), engine.clone(), 2, vec![1, 2, 3], None)?;
+    assert_eq!(first_storage.applied_index()?, 7);
+    assert!(first_storage.pending_snapshot_install()?.is_none());
+    drop(first_storage);
+
+    let destination = create_node_with_persistence(
+        &rt,
+        destination_persistence.clone(),
+        Arc::new(InMemoryDistributedLog::new()),
+        Some(partition_map.clone()),
+        None,
+        Arc::new(NoopTwoPhaseDecisionLog),
+        None,
+    )
+    .await?;
+    assert_eq!(
+        run_query(
+            destination.clone(),
+            TableNamespace::root_component(),
+            Query::full_table_scan("messages".parse()?, Order::Asc),
+        )
+        .await?
+        .len(),
+        1,
+    );
+
+    insert_doc(&source, "messages", assert_obj!("text" => "generation-8")).await?;
+    source_persistence
+        .write_persistence_global_raw(RAFT_STATE_MACHINE_INDEX_KEY, 8.into())
+        .await?;
+    let stale_generation = source
+        .committer_for_test()
+        .build_raft_snapshot(7, 3)
+        .await
+        .expect_err("snapshot generation must reject state beyond the requested Raft prefix");
+    assert!(format!("{stale_generation:#}").contains("beyond requested snapshot index"));
+
+    let second_bytes = source
+        .committer_for_test()
+        .build_raft_snapshot(8, 3)
+        .await?;
+    let second_decoded = decode_raft_snapshot(&second_bytes, 8, 3)?;
+    let second_snapshot = raft_snapshot_for_test(8, 3, second_bytes);
+    let second_storage =
+        ConvexRaftStorage::new(PartitionId(0), engine.clone(), 2, vec![1, 2, 3], None)?;
+    let mut second_hard_state = HardState::default();
+    second_hard_state.term = 3;
+    second_hard_state.commit = 8;
+    second_storage.stage_snapshot(&second_snapshot, Some(&second_hard_state))?;
+
+    destination
+        .committer_for_test()
+        .install_raft_snapshot(second_decoded.checkpoint)
+        .await?;
+    destination.shutdown().await?;
+    drop(destination);
+    drop(second_storage);
+
+    assert!(
+        crate::recover_staged_raft_snapshot_install(
+            engine.clone(),
+            PartitionId(0),
+            destination_persistence.clone(),
+            rt.clone(),
+            Default::default(),
+            Some(partition_map.clone()),
+        )
+        .await?,
+        "startup should idempotently recover after Convex state changed but before Raft metadata",
+    );
+    assert!(
+        !crate::recover_staged_raft_snapshot_install(
+            engine.clone(),
+            PartitionId(0),
+            destination_persistence.clone(),
+            rt.clone(),
+            Default::default(),
+            Some(partition_map.clone()),
+        )
+        .await?,
+        "a finalized snapshot generation must not replay again",
+    );
+
+    let restarted = create_node_with_persistence(
+        &rt,
+        destination_persistence.clone(),
+        Arc::new(InMemoryDistributedLog::new()),
+        Some(partition_map),
+        None,
+        Arc::new(NoopTwoPhaseDecisionLog),
+        None,
+    )
+    .await?;
+    let messages = run_query(
+        restarted,
+        TableNamespace::root_component(),
+        Query::full_table_scan("messages".parse()?, Order::Asc),
+    )
+    .await?;
+    assert_eq!(messages.len(), 2);
+    assert_eq!(
+        crate::raft_snapshot::load_state_machine_index(destination_persistence.reader().as_ref(),)
+            .await?,
+        8,
+    );
+    let finalized_storage = ConvexRaftStorage::new(PartitionId(0), engine, 2, vec![1, 2, 3], None)?;
+    assert_eq!(finalized_storage.applied_index()?, 8);
+    assert_eq!(finalized_storage.hard_state()?.commit, 8);
+    assert!(finalized_storage.pending_snapshot_install()?.is_none());
+    Ok(())
 }

--- a/crates/local_backend/src/lib.rs
+++ b/crates/local_backend/src/lib.rs
@@ -20,6 +20,7 @@ use ::storage::{
     Storage,
     StorageUseCase,
 };
+use anyhow::Context;
 use application::{
     self,
     api::ApplicationApi,
@@ -608,6 +609,33 @@ pub async fn make_app(
             },
         )
     });
+    let initial_partition_map = config.partition_id.map(|id| {
+        static_placement_metadata
+            .as_ref()
+            .expect("partitioned startup should have placement metadata")
+            .into_partition_map(database::partition::PartitionId(id))
+    });
+
+    // Snapshot installation spans Convex persistence and raft-engine. Recover
+    // any durable cross-store install intent before Database::load exposes the
+    // partially installed persistence generation to normal workers.
+    let raft_engine = if config.raft_node_id.is_some() && config.raft_peers.is_some() {
+        let engine =
+            database::raft_storage::ConvexRaftStorage::open_engine("/convex/data/raft-engine")?;
+        let partition_id = database::partition::PartitionId(config.partition_id.unwrap_or(0));
+        database::recover_staged_raft_snapshot_install(
+            engine.clone(),
+            partition_id,
+            persistence.clone(),
+            runtime.clone(),
+            virtual_system_mapping().clone(),
+            initial_partition_map.clone(),
+        )
+        .await?;
+        Some(engine)
+    } else {
+        None
+    };
 
     let database = Database::load(
         persistence.clone(),
@@ -623,12 +651,7 @@ pub async fn make_app(
         deleted_tablet_sender,
         distributed_log.clone(),
         config.replication_mode == "replica",
-        config.partition_id.map(|id| {
-            static_placement_metadata
-                .as_ref()
-                .expect("partitioned startup should have placement metadata")
-                .into_partition_map(database::partition::PartitionId(id))
-        }),
+        initial_partition_map,
         static_node_addresses.clone(),
         two_phase_decision_log,
         Some(cluster_grpc_auth.clone()),
@@ -1054,6 +1077,8 @@ pub async fn make_app(
             let from_ts =
                 replica_delta_consumer_start_ts(*database.now_ts_for_reads(), config.partition_id);
             let consumer_name = config.name();
+            let excluded_source_partition =
+                config.partition_id.map(database::partition::PartitionId);
             let consumer_runtime = runtime.clone();
             runtime.spawn_background("replica_delta_consumer_setup", async move {
                 let mut backoff = Duration::from_millis(250);
@@ -1107,6 +1132,7 @@ pub async fn make_app(
                             let result = database::replica::consume_replication_stream(
                                 stream,
                                 committer.clone(),
+                                excluded_source_partition,
                                 |ts, n| {
                                     if use_selective_node_targeting {
                                         database::log_selective_delivery_shadow_receive();
@@ -1174,7 +1200,6 @@ pub async fn make_app(
             raft_node::RaftNodeConfig,
             raft_partition::RaftPartitionManager,
             raft_state_machine::RaftStateMachineEntry,
-            raft_storage::ConvexRaftStorage,
             raft_transport,
         };
 
@@ -1214,12 +1239,9 @@ pub async fn make_app(
             heartbeat_tick: 3, // 300ms
         };
 
-        // Open raft-engine for persistent Raft log storage (TiKV pattern).
-        // One engine per node, shared across all partitions. Data survives
-        // restarts — this prevents the "to_commit X out of range" panic
-        // that MemStorage caused.
-        let raft_engine_path = "/convex/data/raft-engine";
-        let raft_engine = ConvexRaftStorage::open_engine(raft_engine_path)?;
+        let raft_engine = raft_engine
+            .clone()
+            .context("Raft was configured without an initialized raft-engine")?;
 
         // Create transport channels for peer communication.
         let (peer_senders, transport_clients) = raft_transport::create_transport(
@@ -1229,11 +1251,13 @@ pub async fn make_app(
         );
 
         let snapshot_provider = {
-            let database = database.clone();
-            Arc::new(move || {
+            let committer = database.committer_client();
+            Arc::new(move |raft_index, raft_term| {
                 common::runtime::block_in_place(|| {
                     let rt = tokio::runtime::Handle::current();
-                    rt.block_on(async { database.build_raft_snapshot_bytes().await })
+                    rt.block_on(async {
+                        committer.build_raft_snapshot(raft_index, raft_term).await
+                    })
                 })
             }) as Arc<dyn database::raft_storage::RaftSnapshotProvider>
         };
@@ -1267,7 +1291,7 @@ pub async fn make_app(
                 let committer_for_snapshots = committer.clone();
                 if let Err(e) = node
                     .run(
-                        move |data| {
+                        move |raft_index, data| {
                             match RaftStateMachineEntry::from_bytes(data)? {
                                 RaftStateMachineEntry::CommitDelta { envelope } => {
                                     let proposed_locally =
@@ -1284,13 +1308,14 @@ pub async fn make_app(
                                     let committer = committer_for_entries.clone();
                                     let rt = tokio::runtime::Handle::current();
                                     rt.block_on(async {
-                                        committer.apply_raft_commit_delta(delta).await.map_err(
-                                            |e| {
+                                        committer
+                                            .apply_raft_commit_delta(raft_index, delta)
+                                            .await
+                                            .map_err(|e| {
                                                 anyhow::anyhow!(
                                                     "Raft state-machine apply failed: {e:#}"
                                                 )
-                                            },
-                                        )
+                                            })
                                     })?;
                                 },
                                 RaftStateMachineEntry::TwoPhasePrepare { redo } => {
@@ -1303,28 +1328,31 @@ pub async fn make_app(
                                     let committer = committer_for_entries.clone();
                                     let rt = tokio::runtime::Handle::current();
                                     rt.block_on(async {
-                                        committer.apply_raft_prepared_redo(redo).await.map_err(
-                                            |e| {
+                                        committer
+                                            .apply_raft_prepared_redo(raft_index, redo)
+                                            .await
+                                            .map_err(|e| {
                                                 anyhow::anyhow!(
                                                     "Raft 2PC prepare apply failed: {e:#}"
                                                 )
-                                            },
-                                        )
+                                            })
                                     })?;
                                 },
                             }
 
                             Ok(())
                         },
-                        move |snapshot_bytes| {
-                            let checkpoint =
-                                database::snapshot_checkpointer::checkpoint_from_bytes(
-                                    snapshot_bytes,
-                                )?;
+                        move |snapshot| {
+                            let metadata = snapshot.get_metadata();
+                            let decoded = database::raft_snapshot::decode_snapshot(
+                                snapshot.get_data(),
+                                metadata.index,
+                                metadata.term,
+                            )?;
                             let committer = committer_for_snapshots.clone();
                             let rt = tokio::runtime::Handle::current();
                             rt.block_on(async {
-                                committer.install_snapshot(checkpoint).await?;
+                                committer.install_raft_snapshot(decoded.checkpoint).await?;
                                 Ok::<_, anyhow::Error>(())
                             })
                         },

--- a/npm-packages/@convex-dev/platform/public-deployment-openapi.json
+++ b/npm-packages/@convex-dev/platform/public-deployment-openapi.json
@@ -326,6 +326,50 @@
           }
         }
       },
+      "ReadAfterWriteFenceToken": {
+        "type": "object",
+        "required": [
+          "ts"
+        ],
+        "properties": {
+          "sourcePartition": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "int32",
+            "minimum": 0
+          },
+          "ts": {
+            "$ref": "#/components/schemas/SerializedTs"
+          }
+        }
+      },
+      "ReadAfterWriteToken": {
+        "type": "object",
+        "required": [
+          "ts"
+        ],
+        "properties": {
+          "participantFences": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ReadAfterWriteFenceToken"
+            }
+          },
+          "sourcePartition": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "int32",
+            "minimum": 0
+          },
+          "ts": {
+            "$ref": "#/components/schemas/SerializedTs"
+          }
+        }
+      },
       "SerializedTs": {
         "type": "string"
       },
@@ -358,6 +402,16 @@
           },
           "path": {
             "type": "string"
+          },
+          "readAfterWrite": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/ReadAfterWriteToken"
+              }
+            ]
           }
         }
       },
@@ -426,6 +480,16 @@
           "path": {
             "type": "string"
           },
+          "readAfterWrite": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/ReadAfterWriteToken"
+              }
+            ]
+          },
           "ts": {
             "$ref": "#/components/schemas/SerializedTs"
           }
@@ -445,6 +509,16 @@
                 "items": {
                   "type": "string"
                 }
+              },
+              "readAfterWrite": {
+                "oneOf": [
+                  {
+                    "type": "null"
+                  },
+                  {
+                    "$ref": "#/components/schemas/ReadAfterWriteToken"
+                  }
+                ]
               },
               "status": {
                 "type": "string",


### PR DESCRIPTION
## Summary

- bind every Raft snapshot payload to its Raft index, term, durable state-machine index, checkpoint timestamp, and SHA-256 digest
- stage a recoverable snapshot-install intent in raft-engine before mutating Convex persistence, then atomically finalize snapshot, hard state, conf state, and applied index
- recover interrupted cross-store installs before `Database::load`, reject stale or inconsistent generations, and make retries idempotent
- serialize exact snapshot capture and installation through the Committer so concurrent writes cannot leak across the captured Raft prefix
- preserve Raft-owned 2PC redo/outbox state and replication metadata across installation
- keep Raft authoritative for same-partition state by acknowledging, but not reapplying, that partition's duplicate NATS delivery
- refresh the generated OpenAPI schema for the previously merged read-after-write token contract

## Why

The prior path did not durably bind a Convex checkpoint generation to the Raft applied index, and raft-engine metadata could advance separately from Convex persistence across a crash. That could make restart skip an unapplied entry or replay an already-installed entry. During full-cluster validation, the new invariant also exposed a second path applying same-partition state through NATS before Raft replay; this PR removes that competing apply path instead of weakening the invariant.

## Validation

- `cargo test -p database`: 574 passed, 2 intentionally ignored, 0 failed
- `cargo test -p local_backend`: 100 passed, 0 failed
- `git diff --check`
- rebuilt local backend image: `sha256:9eb3945786b93551d4fbb0d6b580719fd91090fd620dd39cb7781ea482c6c192`
- proved all six healthy backend containers used that exact image
- `BACKEND_PULL_POLICY=never bash self-hosted/docker/test.sh`
  - write-scaling suite: 146/146 passed
  - Raft failover suite: 24/24 passed
  - all suites passed

Closes #276

## Validation after integrating current dev

- merged `dev` through PR #299 into this branch at `118111a`
- `cargo test -p database --lib`: 586 passed, 2 intentionally ignored, 0 failed
- `cargo test -p local_backend --lib`: 100 passed, 0 failed
- rebuilt local backend image: `sha256:cf5c2dc0ce0565d94757fc4ec72e17eb1fe8c115d2aa2e09f98bb0b39c4a47c6`
- verified all six healthy backend containers used that exact image and revision `118111a755af94ccd465dd48e93a671e8164dec7` with `BACKEND_PULL_POLICY=never`
- full Docker write-scaling suite: 149/149 passed
- full Docker Raft failover suite: 24/24 passed
- all suites passed