### PR TITLE
refactor(reads): make partition owners authoritative

### DIFF
--- a/crates/database/src/committer.rs
+++ b/crates/database/src/committer.rs
@@ -6169,6 +6169,15 @@ impl CommitterClient {
             .map(|placement_state| placement_state.local_partition())
     }
 
+    /// Snapshot the placement map for one transaction or internal request.
+    /// Callers keep this value pinned so a placement refresh cannot split one
+    /// operation across ownership versions.
+    pub fn partition_map(&self) -> Option<crate::partition::PartitionMap> {
+        self.placement_state
+            .as_ref()
+            .map(|placement_state| placement_state.partition_map())
+    }
+
     pub async fn finish_search_and_vector_bootstrap(
         &self,
         bootstrapped_indexes: BootstrappedSearchIndexes,

--- a/crates/database/src/database.rs
+++ b/crates/database/src/database.rs
@@ -127,6 +127,7 @@ use indexing::{
         BackendInMemoryIndexes,
         DatabaseIndexSnapshot,
         NoInMemoryIndexes,
+        RangeRequest,
         TimestampedIndexCache,
     },
     index_cache::SharedIndexCache,
@@ -187,6 +188,12 @@ use crate::{
         load_indexes_into_memory_timer,
         vector::vector_search_with_retries_timer,
         verify_invariants_timer,
+    },
+    owner_read::{
+        GrpcOwnerReadClient,
+        OwnerIndexEntry,
+        OwnerIndexRangeResult,
+        OwnerReadClient,
     },
     retention::{
         LeaderRetentionManager,
@@ -302,6 +309,7 @@ pub struct Database<RT: Runtime> {
     shared_index_cache: Option<SharedIndexCache>,
     virtual_system_mapping: VirtualSystemMapping,
     table_number_allocator: Arc<dyn TableNumberAllocator>,
+    owner_read_client: Option<Arc<dyn OwnerReadClient>>,
     pub bootstrap_metadata: BootstrapMetadata,
     // Caches of snapshot TableMapping and by_id index ids, which are used repeatedly by
     // /api/list_snapshot.
@@ -1126,6 +1134,7 @@ impl<RT: Runtime> Database<RT> {
         } else {
             distributed_log.clone()
         };
+        let owner_read_cluster_auth = cluster_grpc_auth.clone();
         let committer = Committer::start(
             log_writer,
             snapshot_writer,
@@ -1146,6 +1155,12 @@ impl<RT: Runtime> Database<RT> {
             applied_data_delta_ids,
             raft_apply_markers,
         );
+        let owner_read_client = committer.local_partition().map(|_| {
+            Arc::new(GrpcOwnerReadClient::new(
+                committer.clone(),
+                owner_read_cluster_auth,
+            )) as Arc<dyn OwnerReadClient>
+        });
         let table_mapping_snapshot_cache =
             AsyncLru::new(runtime.clone(), 20, 2, "table_mapping_snapshot");
         let by_id_indexes_snapshot_cache =
@@ -1168,6 +1183,7 @@ impl<RT: Runtime> Database<RT> {
             shared_index_cache,
             virtual_system_mapping,
             table_number_allocator,
+            owner_read_client,
             bootstrap_metadata,
             table_mapping_snapshot_cache,
             by_id_indexes_snapshot_cache,
@@ -1200,6 +1216,16 @@ impl<RT: Runtime> Database<RT> {
     #[cfg(test)]
     pub(crate) fn committer_for_test(&self) -> CommitterClient {
         self.committer.clone()
+    }
+
+    /// Return a test-only view that reads this node's local replica directly.
+    /// Public transactions must keep owner reads enabled; replication tests use
+    /// this only to inspect the state that an apply operation materialized.
+    #[cfg(test)]
+    pub(crate) fn with_local_replica_reads_for_test(&self) -> Self {
+        let mut database = self.clone();
+        database.owner_read_client = None;
+        database
     }
 
     #[cfg(test)]
@@ -1713,6 +1739,81 @@ impl<RT: Runtime> Database<RT> {
         Ok((entries, cursor))
     }
 
+    /// Read index ranges from this partition's authoritative MVCC state.
+    ///
+    /// The caller has already pinned placement and verified ownership. We wait
+    /// briefly for the local state machine to reach the requested logical
+    /// timestamp, then read every range from one repeatable snapshot. We never
+    /// lower the timestamp or substitute a replica mirror.
+    pub async fn authoritative_index_ranges(
+        &self,
+        snapshot_ts: Timestamp,
+        ranges: Vec<RangeRequest>,
+    ) -> anyhow::Result<Vec<OwnerIndexRangeResult>> {
+        if *self.now_ts_for_reads() < snapshot_ts {
+            let target = snapshot_ts.pred()?;
+            let wait = self.snapshot_manager.lock().wait_for_higher_ts(target);
+            tokio::time::timeout(*REMOTE_READ_FRONTIER_WAIT_TIMEOUT, wait)
+                .await
+                .with_context(|| {
+                    format!(
+                        "Timed out after {:?} waiting for owner snapshot {}",
+                        *REMOTE_READ_FRONTIER_WAIT_TIMEOUT, snapshot_ts,
+                    )
+                })?;
+        }
+
+        let latest_ts = self.now_ts_for_reads();
+        anyhow::ensure!(
+            *latest_ts >= snapshot_ts,
+            "Owner cannot serve snapshot {} because its applied state is only at {}",
+            snapshot_ts,
+            latest_ts,
+        );
+        let repeatable_ts = latest_ts.prior_ts(snapshot_ts)?;
+        let snapshot = self.snapshot_manager.lock().snapshot(*repeatable_ts)?;
+
+        for range in &ranges {
+            anyhow::ensure!(
+                !range.printable_index_name.table().is_system(),
+                "Owner read RPC only serves partitioned user tables; system table {} uses its \
+                 route-specific authority",
+                range.printable_index_name.table(),
+            );
+        }
+        let persistence_snapshot = RepeatablePersistence::new(
+            self.reader.clone(),
+            repeatable_ts,
+            self.retention_validator(),
+        )
+        .read_snapshot(repeatable_ts)?;
+        let mut database_index_snapshot = DatabaseIndexSnapshot::new(
+            snapshot.index_registry,
+            Arc::new(snapshot.in_memory_indexes),
+            snapshot.table_registry.table_mapping().clone(),
+            Arc::new(persistence_snapshot),
+            self.shared_index_cache.clone(),
+            None,
+        );
+        let range_refs: Vec<_> = ranges.iter().collect();
+        let results = database_index_snapshot.range_batch(&range_refs).await;
+        results
+            .into_iter()
+            .map(|result| {
+                let (entries, cursor) = result?;
+                let entries = entries
+                    .into_iter()
+                    .map(|(key, ts, document)| OwnerIndexEntry {
+                        key,
+                        ts,
+                        document: document.pack(),
+                    })
+                    .collect();
+                Ok(OwnerIndexRangeResult { entries, cursor })
+            })
+            .collect()
+    }
+
     pub fn now_ts_for_reads(&self) -> RepeatableTimestamp {
         let snapshot_manager = self.snapshot_manager.lock();
         snapshot_manager.latest_ts()
@@ -2007,30 +2108,47 @@ impl<RT: Runtime> Database<RT> {
         let begin_ts = cmp::max(latest_ts.succ()?, self.runtime.generate_timestamp()?);
         let creation_time = CreationTime::try_from(begin_ts)?;
         let id_generator = TransactionIdGenerator::new(&self.runtime)?;
-        let transaction_index = TransactionIndex::new(
+        let database_index_snapshot = DatabaseIndexSnapshot::new(
             snapshot.index_registry.clone(),
-            DatabaseIndexSnapshot::new(
-                snapshot.index_registry.clone(),
-                Arc::new(snapshot.in_memory_indexes),
-                snapshot.table_registry.table_mapping().clone(),
-                Arc::new(
-                    RepeatablePersistence::new(
-                        self.reader.clone(),
-                        repeatable_ts,
-                        self.retention_manager.clone(),
-                    )
-                    .read_snapshot(repeatable_ts)?,
-                ),
-                self.shared_index_cache.clone(),
-                index_cache,
+            Arc::new(snapshot.in_memory_indexes),
+            snapshot.table_registry.table_mapping().clone(),
+            Arc::new(
+                RepeatablePersistence::new(
+                    self.reader.clone(),
+                    repeatable_ts,
+                    self.retention_manager.clone(),
+                )
+                .read_snapshot(repeatable_ts)?,
             ),
-            Arc::new(TextIndexManagerSnapshot::new(
-                snapshot.index_registry,
-                snapshot.text_indexes,
-                self.searcher.clone(),
-                self.search_storage.clone(),
-            )),
+            self.shared_index_cache.clone(),
+            index_cache,
         );
+        let text_index_snapshot = Arc::new(TextIndexManagerSnapshot::new(
+            snapshot.index_registry.clone(),
+            snapshot.text_indexes,
+            self.searcher.clone(),
+            self.search_storage.clone(),
+        ));
+        let transaction_index = match (
+            self.owner_read_client.clone(),
+            self.committer.partition_map(),
+        ) {
+            (Some(owner_read_client), Some(partition_map)) => {
+                TransactionIndex::new_with_owner_reads(
+                    snapshot.index_registry.clone(),
+                    database_index_snapshot,
+                    text_index_snapshot,
+                    owner_read_client,
+                    partition_map,
+                    *repeatable_ts,
+                )
+            },
+            _ => TransactionIndex::new(
+                snapshot.index_registry.clone(),
+                database_index_snapshot,
+                text_index_snapshot,
+            ),
+        };
         let count_snapshot = Arc::new(snapshot.table_summaries);
         let tx = Transaction::new_with_table_number_allocator(
             identity,

--- a/crates/database/src/lib.rs
+++ b/crates/database/src/lib.rs
@@ -22,6 +22,7 @@ mod execution_size;
 pub mod membership;
 mod metrics;
 pub mod nats_distributed_log;
+pub mod owner_read;
 pub mod partition;
 pub mod patch;
 pub mod persistence_helpers;

--- a/crates/database/src/owner_read.rs
+++ b/crates/database/src/owner_read.rs
@@ -1,0 +1,427 @@
+//! Authoritative cross-partition reads.
+//!
+//! A node-local NATS mirror is a cache, not a source of truth. Transactions use
+//! this module to fetch remote index ranges from the partition that owns the
+//! table at the transaction's pinned placement version and snapshot timestamp.
+
+use std::{
+    collections::BTreeMap,
+    sync::Arc,
+    time::Duration,
+};
+
+use anyhow::Context;
+use async_trait::async_trait;
+use common::{
+    document::{
+        PackedDocument,
+        ResolvedDocument,
+    },
+    grpc::ClusterGrpcAuth,
+    index::IndexKeyBytes,
+    interval::{
+        BinaryKey,
+        End,
+        Interval,
+        StartIncluded,
+    },
+    query::{
+        CursorPosition,
+        Order,
+    },
+    types::{
+        IndexDescriptor,
+        IndexName,
+        TabletIndexName,
+        Timestamp,
+    },
+};
+use indexing::backend_in_memory_indexes::RangeRequest;
+use pb::{
+    common::{
+        interval::End as IntervalEndProto,
+        Interval as IntervalProto,
+        Order as OrderProto,
+    },
+    replication::{
+        owner_read_index_range_result::Cursor as CursorProto,
+        owner_read_service_client::OwnerReadServiceClient as TonicOwnerReadClient,
+        OwnerReadIndexEntry,
+        OwnerReadIndexRange,
+        OwnerReadIndexRangeResult,
+        OwnerReadIndexRangesRequest,
+        OwnerReadIndexRangesResponse,
+    },
+};
+use tokio::sync::Mutex;
+use tonic::{
+    transport::{
+        Channel,
+        Endpoint,
+    },
+    Request,
+};
+use value::TabletId;
+
+use crate::{
+    committer::CommitterClient,
+    partition::{
+        PartitionId,
+        PlacementVersion,
+    },
+};
+
+const OWNER_READ_GRPC_TIMEOUT: Duration = Duration::from_secs(5);
+
+// A transaction may read 16 MiB by default, so leave room for protobuf
+// overhead and multi-range responses instead of inheriting tonic's 4 MiB cap.
+pub const OWNER_READ_GRPC_MAX_MESSAGE_SIZE: usize = 1 << 26;
+
+#[derive(Clone, Debug)]
+pub struct OwnerIndexEntry {
+    pub key: IndexKeyBytes,
+    pub ts: Timestamp,
+    pub document: PackedDocument,
+}
+
+#[derive(Clone, Debug)]
+pub struct OwnerIndexRangeResult {
+    pub entries: Vec<OwnerIndexEntry>,
+    pub cursor: CursorPosition,
+}
+
+#[async_trait]
+pub trait OwnerReadClient: Send + Sync + 'static {
+    async fn read_index_ranges(
+        &self,
+        owner_partition: PartitionId,
+        placement_version: PlacementVersion,
+        snapshot_ts: Timestamp,
+        ranges: Vec<RangeRequest>,
+    ) -> anyhow::Result<Vec<OwnerIndexRangeResult>>;
+}
+
+fn tablet_id_to_bytes(tablet_id: TabletId) -> Vec<u8> {
+    tablet_id.0 .0.to_vec()
+}
+
+pub fn tablet_id_from_bytes(bytes: Vec<u8>) -> anyhow::Result<TabletId> {
+    Ok(TabletId(bytes.try_into()?))
+}
+
+pub fn index_names_from_wire(
+    tablet_id: TabletId,
+    table_name: String,
+    descriptor: String,
+) -> anyhow::Result<(TabletIndexName, IndexName)> {
+    let table_name = table_name.parse()?;
+    let names = match descriptor.as_str() {
+        "by_id" => (
+            TabletIndexName::by_id(tablet_id),
+            IndexName::by_id(table_name),
+        ),
+        "by_creation_time" => (
+            TabletIndexName::by_creation_time(tablet_id),
+            IndexName::by_creation_time(table_name),
+        ),
+        _ => {
+            let descriptor = IndexDescriptor::new(descriptor)?;
+            (
+                TabletIndexName::new(tablet_id, descriptor.clone())?,
+                IndexName::new(table_name, descriptor)?,
+            )
+        },
+    };
+    Ok(names)
+}
+
+fn interval_to_proto(interval: Interval) -> IntervalProto {
+    let end = match interval.end {
+        End::Excluded(end) => IntervalEndProto::Exclusive(end.into()),
+        End::Unbounded => IntervalEndProto::AfterAll(()),
+    };
+    IntervalProto {
+        start_inclusive: interval.start.0.into(),
+        end: Some(end),
+    }
+}
+
+pub fn interval_from_proto(interval: IntervalProto) -> anyhow::Result<Interval> {
+    let end = match interval.end.context("Owner read interval missing end")? {
+        IntervalEndProto::Exclusive(end) => End::Excluded(BinaryKey::from(end)),
+        IntervalEndProto::AfterAll(()) => End::Unbounded,
+    };
+    Ok(Interval {
+        start: StartIncluded(BinaryKey::from(interval.start_inclusive)),
+        end,
+    })
+}
+
+fn order_to_proto(order: Order) -> i32 {
+    match order {
+        Order::Asc => OrderProto::Asc as i32,
+        Order::Desc => OrderProto::Desc as i32,
+    }
+}
+
+pub fn order_from_proto(order: i32) -> anyhow::Result<Order> {
+    match OrderProto::try_from(order).context("Invalid owner read order")? {
+        OrderProto::Asc => Ok(Order::Asc),
+        OrderProto::Desc => Ok(Order::Desc),
+    }
+}
+
+fn range_to_proto(range: RangeRequest) -> OwnerReadIndexRange {
+    OwnerReadIndexRange {
+        tablet_id: tablet_id_to_bytes(*range.index_name.table()),
+        descriptor: range.index_name.descriptor().to_string(),
+        table_name: range.printable_index_name.table().to_string(),
+        interval: Some(interval_to_proto(range.interval)),
+        order: order_to_proto(range.order),
+        max_size: range.max_size.try_into().unwrap_or(u64::MAX),
+    }
+}
+
+fn result_from_proto(result: OwnerReadIndexRangeResult) -> anyhow::Result<OwnerIndexRangeResult> {
+    let entries = result
+        .entries
+        .into_iter()
+        .map(
+            |OwnerReadIndexEntry {
+                 index_key,
+                 commit_ts,
+                 document,
+             }| {
+                let document = ResolvedDocument::try_from(
+                    document.context("Owner read entry missing document")?,
+                )?;
+                Ok(OwnerIndexEntry {
+                    key: IndexKeyBytes(index_key),
+                    ts: commit_ts.try_into()?,
+                    document: PackedDocument::pack(&document),
+                })
+            },
+        )
+        .collect::<anyhow::Result<Vec<_>>>()?;
+    let cursor = match result.cursor.context("Owner read result missing cursor")? {
+        CursorProto::After(key) => CursorPosition::After(IndexKeyBytes(key)),
+        CursorProto::End(()) => CursorPosition::End,
+    };
+    Ok(OwnerIndexRangeResult { entries, cursor })
+}
+
+pub fn result_to_proto(result: OwnerIndexRangeResult) -> anyhow::Result<OwnerReadIndexRangeResult> {
+    let entries = result
+        .entries
+        .into_iter()
+        .map(|entry| {
+            Ok(OwnerReadIndexEntry {
+                index_key: entry.key.0,
+                commit_ts: u64::from(entry.ts),
+                document: Some(entry.document.unpack().try_into()?),
+            })
+        })
+        .collect::<anyhow::Result<Vec<_>>>()?;
+    let cursor = Some(match result.cursor {
+        CursorPosition::After(key) => CursorProto::After(key.0),
+        CursorPosition::End => CursorProto::End(()),
+    });
+    Ok(OwnerReadIndexRangeResult { entries, cursor })
+}
+
+struct OwnerReadGrpcClient {
+    client: TonicOwnerReadClient<Channel>,
+    cluster_auth: Option<ClusterGrpcAuth>,
+}
+
+impl OwnerReadGrpcClient {
+    async fn connect(addr: &str, cluster_auth: Option<ClusterGrpcAuth>) -> anyhow::Result<Self> {
+        let addr = if addr.contains("://") {
+            addr.to_string()
+        } else {
+            format!("http://{addr}")
+        };
+        let endpoint = Endpoint::from_shared(addr.clone())
+            .with_context(|| format!("Invalid owner-read service address {addr}"))?
+            .connect_timeout(OWNER_READ_GRPC_TIMEOUT)
+            .timeout(OWNER_READ_GRPC_TIMEOUT);
+        let channel = endpoint
+            .connect()
+            .await
+            .with_context(|| format!("Failed to connect to owner-read service at {addr}"))?;
+        Ok(Self {
+            client: TonicOwnerReadClient::new(channel)
+                .max_decoding_message_size(OWNER_READ_GRPC_MAX_MESSAGE_SIZE)
+                .max_encoding_message_size(OWNER_READ_GRPC_MAX_MESSAGE_SIZE),
+            cluster_auth,
+        })
+    }
+
+    async fn read_index_ranges(
+        &self,
+        owner_partition: PartitionId,
+        placement_version: PlacementVersion,
+        snapshot_ts: Timestamp,
+        ranges: Vec<RangeRequest>,
+    ) -> anyhow::Result<Vec<OwnerIndexRangeResult>> {
+        let request = OwnerReadIndexRangesRequest {
+            owner_partition: owner_partition.0,
+            placement_version: u64::from(placement_version),
+            snapshot_ts: u64::from(snapshot_ts),
+            ranges: ranges.into_iter().map(range_to_proto).collect(),
+        };
+        let request = match &self.cluster_auth {
+            Some(auth) => auth.request(request),
+            None => Request::new(request),
+        };
+        let OwnerReadIndexRangesResponse { results } = self
+            .client
+            .clone()
+            .read_index_ranges(request)
+            .await
+            .context("gRPC owner read failed")?
+            .into_inner();
+        results.into_iter().map(result_from_proto).collect()
+    }
+}
+
+#[derive(Clone)]
+struct OwnerReadGrpcClientPool {
+    cluster_auth: Option<ClusterGrpcAuth>,
+    clients: Arc<Mutex<BTreeMap<String, Arc<OwnerReadGrpcClient>>>>,
+}
+
+impl OwnerReadGrpcClientPool {
+    fn new(cluster_auth: Option<ClusterGrpcAuth>) -> Self {
+        Self {
+            cluster_auth,
+            clients: Arc::new(Mutex::new(BTreeMap::new())),
+        }
+    }
+
+    async fn client(&self, addr: &str) -> anyhow::Result<Arc<OwnerReadGrpcClient>> {
+        if let Some(client) = self.clients.lock().await.get(addr).cloned() {
+            return Ok(client);
+        }
+        let client = Arc::new(OwnerReadGrpcClient::connect(addr, self.cluster_auth.clone()).await?);
+        let mut clients = self.clients.lock().await;
+        Ok(clients
+            .entry(addr.to_string())
+            .or_insert_with(|| client.clone())
+            .clone())
+    }
+}
+
+/// Dynamic, retrying owner-read router. Membership refreshes update the
+/// `CommitterClient`'s address snapshot, so transactions do not pin node
+/// addresses even though they pin a placement version.
+#[derive(Clone)]
+pub struct GrpcOwnerReadClient {
+    committer: CommitterClient,
+    pool: OwnerReadGrpcClientPool,
+}
+
+impl GrpcOwnerReadClient {
+    pub fn new(committer: CommitterClient, cluster_auth: Option<ClusterGrpcAuth>) -> Self {
+        Self {
+            committer,
+            pool: OwnerReadGrpcClientPool::new(cluster_auth),
+        }
+    }
+}
+
+#[async_trait]
+impl OwnerReadClient for GrpcOwnerReadClient {
+    async fn read_index_ranges(
+        &self,
+        owner_partition: PartitionId,
+        placement_version: PlacementVersion,
+        snapshot_ts: Timestamp,
+        ranges: Vec<RangeRequest>,
+    ) -> anyhow::Result<Vec<OwnerIndexRangeResult>> {
+        let addresses = self
+            .committer
+            .node_addresses()
+            .and_then(|addresses| addresses.addresses_for(owner_partition).map(<[_]>::to_vec))
+            .with_context(|| {
+                format!("No live owner-read candidates for partition {owner_partition}")
+            })?;
+        let mut failures = Vec::new();
+        for address in addresses {
+            let attempt = async {
+                self.pool
+                    .client(&address)
+                    .await?
+                    .read_index_ranges(
+                        owner_partition,
+                        placement_version,
+                        snapshot_ts,
+                        ranges.clone(),
+                    )
+                    .await
+            }
+            .await;
+            match attempt {
+                Ok(results) => return Ok(results),
+                Err(error) => failures.push(format!("{address}: {error:#}")),
+            }
+        }
+        anyhow::bail!(
+            "All owner-read candidates for partition {} failed: {}",
+            owner_partition,
+            failures.join("; "),
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use common::{
+        assert_obj,
+        document::CreationTime,
+        interval::Interval,
+        query::Order,
+        testing::TestIdGenerator,
+        types::Timestamp,
+    };
+
+    use super::*;
+
+    #[test]
+    fn owner_read_wire_round_trip_preserves_rows_and_cursor() -> anyhow::Result<()> {
+        let mut ids = TestIdGenerator::new();
+        let id = ids.user_generate(&"messages".parse()?);
+        let document = ResolvedDocument::new(id, CreationTime::ONE, assert_obj!("body" => "hi"))?;
+        let result = OwnerIndexRangeResult {
+            entries: vec![OwnerIndexEntry {
+                key: IndexKeyBytes(vec![1, 2, 3]),
+                ts: Timestamp::must(42),
+                document: PackedDocument::pack(&document),
+            }],
+            cursor: CursorPosition::After(IndexKeyBytes(vec![4, 5, 6])),
+        };
+
+        let decoded = result_from_proto(result_to_proto(result)?)?;
+        assert_eq!(decoded.entries.len(), 1);
+        assert_eq!(decoded.entries[0].key, IndexKeyBytes(vec![1, 2, 3]));
+        assert_eq!(decoded.entries[0].ts, Timestamp::must(42));
+        assert_eq!(decoded.entries[0].document.unpack(), document);
+        assert_eq!(
+            decoded.cursor,
+            CursorPosition::After(IndexKeyBytes(vec![4, 5, 6]))
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn owner_read_interval_and_order_round_trip() -> anyhow::Result<()> {
+        let interval = Interval::prefix(BinaryKey::from(vec![1, 2, 3]));
+        assert_eq!(
+            interval_from_proto(interval_to_proto(interval.clone()))?,
+            interval
+        );
+        assert_eq!(order_from_proto(order_to_proto(Order::Asc))?, Order::Asc);
+        assert_eq!(order_from_proto(order_to_proto(Order::Desc))?, Order::Desc);
+        Ok(())
+    }
+}

--- a/crates/database/src/tests/write_scaling_tests.rs
+++ b/crates/database/src/tests/write_scaling_tests.rs
@@ -192,6 +192,19 @@ async fn create_node(
     create_node_with_options(rt, distributed_log, partition_map, None, None).await
 }
 
+async fn run_local_replica_query(
+    database: Database<TestRuntime>,
+    namespace: TableNamespace,
+    query: Query,
+) -> anyhow::Result<Vec<ResolvedDocument>> {
+    run_query(
+        database.with_local_replica_reads_for_test(),
+        namespace,
+        query,
+    )
+    .await
+}
+
 async fn create_node_with_options(
     rt: &TestRuntime,
     distributed_log: Arc<InMemoryDistributedLog>,
@@ -2561,13 +2574,13 @@ async fn test_cross_partition_replica_delta_waits_behind_unresolved_prepared_tra
         .apply_replica_delta(racing_delta)
         .await?;
 
-    let tasks = run_query(
+    let tasks = run_local_replica_query(
         node_b.clone(),
         TableNamespace::root_component(),
         Query::full_table_scan("tasks".parse()?, Order::Asc),
     )
     .await?;
-    let messages = run_query(
+    let messages = run_local_replica_query(
         node_b,
         TableNamespace::root_component(),
         Query::full_table_scan("messages".parse()?, Order::Asc),
@@ -3311,7 +3324,7 @@ impl SeededReplicaApplySimulation {
         self.last_read_frontier = read_frontier;
         self.last_write_frontier = write_frontier;
 
-        let projects = run_query(
+        let projects = run_local_replica_query(
             target.clone(),
             TableNamespace::root_component(),
             Query::full_table_scan("projects".parse()?, Order::Asc),
@@ -3750,7 +3763,7 @@ async fn test_frontier_heartbeat_does_not_dedupe_later_data_delta(
         "late data should apply at a fresh local timestamp after the heartbeat",
     );
 
-    let projects = run_query(
+    let projects = run_local_replica_query(
         target.clone(),
         TableNamespace::root_component(),
         Query::full_table_scan("projects".parse()?, Order::Asc),
@@ -3871,7 +3884,7 @@ async fn test_late_outbox_replay_data_delta_not_deduped_by_newer_data_watermark(
         "older origin delta should still apply at a fresh local timestamp after a newer watermark",
     );
 
-    let projects = run_query(
+    let projects = run_local_replica_query(
         target.clone(),
         TableNamespace::root_component(),
         Query::full_table_scan("projects".parse()?, Order::Asc),
@@ -4008,7 +4021,7 @@ async fn test_ordered_transport_ids_skip_redelivery_after_origin_ids_pruned(
         "contiguous transport ids should not leave exact-id metadata behind",
     );
 
-    let projects = run_query(
+    let projects = run_local_replica_query(
         target.clone(),
         TableNamespace::root_component(),
         Query::full_table_scan("projects".parse()?, Order::Asc),
@@ -5907,7 +5920,7 @@ async fn test_remote_read_frontier_heartbeat_does_not_advance_snapshot_ts(
     let snapshot_ts_before = *node_a.now_ts_for_reads();
     let persisted_repeatable_before = *node_a.persisted_max_repeatable_ts_for_test();
     let write_frontier_before = node_a.replication_write_frontier_for_test(PartitionId(1));
-    let projects = run_query(
+    let projects = run_local_replica_query(
         node_a.clone(),
         TableNamespace::root_component(),
         Query::full_table_scan("projects".parse()?, Order::Asc),
@@ -5964,7 +5977,7 @@ async fn test_remote_read_frontier_heartbeat_does_not_advance_snapshot_ts(
         "waiting for local write visibility should stay blocked on a frontier-only heartbeat",
     );
 
-    let projects_after = run_query(
+    let projects_after = run_local_replica_query(
         node_a,
         TableNamespace::root_component(),
         Query::full_table_scan("projects".parse()?, Order::Asc),
@@ -6064,7 +6077,7 @@ async fn test_replica_delta_timestamp_translation_records_origin_watermark(
         duplicate_apply_ts, remote_ts,
         "duplicate detection uses the persisted data idempotency watermark",
     );
-    let projects = run_query(
+    let projects = run_local_replica_query(
         target,
         TableNamespace::root_component(),
         Query::full_table_scan("projects".parse()?, Order::Asc),
@@ -6232,7 +6245,10 @@ async fn test_replica_preserves_global_table_numbers_for_embedded_ids(
         .apply_replica_delta(user_delta)
         .await?;
 
-    let mut tx = node_b.begin(Identity::system()).await?;
+    let mut tx = node_b
+        .with_local_replica_reads_for_test()
+        .begin(Identity::system())
+        .await?;
     let replica_user_id =
         tx.resolve_developer_id(&user_public_id, TableNamespace::root_component())?;
     assert_eq!(
@@ -6261,7 +6277,7 @@ async fn test_replica_preserves_global_table_numbers_for_embedded_ids(
         .apply_replica_delta(task_delta)
         .await?;
 
-    let tasks = run_query(
+    let tasks = run_local_replica_query(
         node_a,
         TableNamespace::root_component(),
         Query::full_table_scan("tasks".parse()?, Order::Asc),

--- a/crates/database/src/transaction_index.rs
+++ b/crates/database/src/transaction_index.rs
@@ -41,9 +41,11 @@ use common::{
         IndexId,
         IndexName,
         TabletIndexName,
+        Timestamp,
         WriteTimestamp,
     },
 };
+use futures::future::join_all;
 use imbl::OrdMap;
 use indexing::{
     backend_in_memory_indexes::{
@@ -72,6 +74,11 @@ use value::{
 };
 
 use crate::{
+    owner_read::{
+        OwnerIndexRangeResult,
+        OwnerReadClient,
+    },
+    partition::PartitionMap,
     preloaded::PreloadedIndexRange,
     query::IndexRangeResponse,
     reads::TransactionReadSet,
@@ -102,6 +109,13 @@ pub struct TransactionIndex {
     // on top of the transaction base snapshot.
     text_index_snapshot: Arc<dyn TransactionTextSnapshot>,
     text_index_updates: OrdMap<IndexId, Vec<DocumentUpdate>>,
+
+    // Cluster reads pin placement and snapshot metadata for the lifetime of a
+    // transaction. Local NATS mirrors remain useful caches, but remote ranges
+    // are fetched from their placement owner and never fall back to a mirror.
+    owner_read_client: Option<Arc<dyn OwnerReadClient>>,
+    partition_map: Option<PartitionMap>,
+    snapshot_ts: Timestamp,
 }
 
 impl PendingWrites for TransactionIndex {}
@@ -119,6 +133,30 @@ impl TransactionIndex {
             database_index_updates: OrdMap::new(),
             text_index_snapshot,
             text_index_updates: OrdMap::new(),
+            owner_read_client: None,
+            partition_map: None,
+            snapshot_ts: Timestamp::MIN,
+        }
+    }
+
+    pub fn new_with_owner_reads(
+        index_registry: IndexRegistry,
+        database_index_snapshot: DatabaseIndexSnapshot,
+        text_index_snapshot: Arc<dyn TransactionTextSnapshot>,
+        owner_read_client: Arc<dyn OwnerReadClient>,
+        partition_map: PartitionMap,
+        snapshot_ts: Timestamp,
+    ) -> Self {
+        Self {
+            index_registry,
+            index_registry_updated: false,
+            database_index_snapshot,
+            database_index_updates: OrdMap::new(),
+            text_index_snapshot,
+            text_index_updates: OrdMap::new(),
+            owner_read_client: Some(owner_read_client),
+            partition_map: Some(partition_map),
+            snapshot_ts,
         }
     }
 
@@ -168,9 +206,10 @@ impl TransactionIndex {
         // Resolve singleton ranges that have pending writes without
         // hitting persistence.
         let mut pre_resolved = Vec::with_capacity(batch_size);
-        let mut persistence_ranges: Vec<&RangeRequest> = Vec::new();
+        let mut local_ranges: Vec<(usize, &RangeRequest)> = Vec::new();
+        let mut remote_ranges = BTreeMap::new();
 
-        for &range_request in ranges.iter() {
+        for (request_index, &range_request) in ranges.iter().enumerate() {
             if range_request.interval.is_singleton().is_some() {
                 let pending_result = Self::pending_iter_for_request(
                     &self.index_registry,
@@ -202,28 +241,134 @@ impl TransactionIndex {
             }
 
             pre_resolved.push(None);
-            persistence_ranges.push(range_request);
+            let table_name = range_request.printable_index_name.table();
+            let remote_owner = self.partition_map.as_ref().and_then(|partition_map| {
+                // System tables have route-specific authority and node-local
+                // physical IDs. Owner routing is only for partitioned user data.
+                if table_name.is_system() {
+                    return None;
+                }
+                let owner = partition_map.partition_for_table(table_name);
+                (owner != partition_map.local_partition()).then_some(owner)
+            });
+            if let Some(owner) = remote_owner {
+                remote_ranges
+                    .entry(owner)
+                    .or_insert_with(Vec::new)
+                    .push((request_index, range_request.clone()));
+            } else {
+                local_ranges.push((request_index, range_request));
+            }
         }
 
-        // Fetch only the ranges that weren't resolved from pending writes.
-        let snapshot_results = self
-            .database_index_snapshot
-            .range_batch(&persistence_ranges)
-            .await;
+        type SnapshotResult = anyhow::Result<(
+            Vec<(IndexKeyBytes, Timestamp, LazyDocument)>,
+            CursorPosition,
+        )>;
+        let mut snapshot_results: Vec<Option<SnapshotResult>> =
+            std::iter::repeat_with(|| None).take(batch_size).collect();
 
-        let mut persistence_iter = snapshot_results.into_iter();
+        // Local ownership continues to use the transaction's local snapshot.
+        let local_requests: Vec<_> = local_ranges.iter().map(|(_, range)| *range).collect();
+        let local_results = self
+            .database_index_snapshot
+            .range_batch(&local_requests)
+            .await;
+        for ((request_index, _), result) in local_ranges.into_iter().zip(local_results) {
+            snapshot_results[request_index] = Some(result);
+        }
+
+        // Fetch every remote range from its placement owner. Errors are
+        // returned to the transaction; consulting the node-local NATS mirror
+        // here would silently weaken a strong read into an unbounded stale read.
+        if !remote_ranges.is_empty() {
+            if let (Some(client), Some(partition_map)) =
+                (self.owner_read_client.clone(), self.partition_map.as_ref())
+            {
+                let placement_version = partition_map.placement_version();
+                let snapshot_ts = self.snapshot_ts;
+                let fetches = remote_ranges.into_iter().map(|(owner, indexed_ranges)| {
+                    let client = client.clone();
+                    let requests = indexed_ranges
+                        .iter()
+                        .map(|(_, range)| range.clone())
+                        .collect();
+                    async move {
+                        let result = client
+                            .read_index_ranges(owner, placement_version, snapshot_ts, requests)
+                            .await;
+                        (owner, indexed_ranges, result)
+                    }
+                });
+                for (owner, indexed_ranges, fetch_result) in join_all(fetches).await {
+                    match fetch_result {
+                        Ok(owner_results) if owner_results.len() == indexed_ranges.len() => {
+                            for ((request_index, _), owner_result) in
+                                indexed_ranges.into_iter().zip(owner_results)
+                            {
+                                let OwnerIndexRangeResult { entries, cursor } = owner_result;
+                                let entries = entries
+                                    .into_iter()
+                                    .map(|entry| {
+                                        (entry.key, entry.ts, LazyDocument::Packed(entry.document))
+                                    })
+                                    .collect();
+                                snapshot_results[request_index] = Some(Ok((entries, cursor)));
+                            }
+                        },
+                        Ok(owner_results) => {
+                            let error = format!(
+                                "Owner {} returned {} range results for {} requests",
+                                owner,
+                                owner_results.len(),
+                                indexed_ranges.len(),
+                            );
+                            for (request_index, _) in indexed_ranges {
+                                snapshot_results[request_index] =
+                                    Some(Err(anyhow::anyhow!(error.clone())));
+                            }
+                        },
+                        Err(error) => {
+                            let error = format!(
+                                "Authoritative read from {} failed; local replica was not used: \
+                                 {error:#}",
+                                owner,
+                            );
+                            for (request_index, _) in indexed_ranges {
+                                snapshot_results[request_index] =
+                                    Some(Err(anyhow::anyhow!(error.clone())));
+                            }
+                        },
+                    }
+                }
+            } else {
+                for (owner, indexed_ranges) in remote_ranges {
+                    let error = format!(
+                        "No authoritative read client configured for remote owner {owner}; local \
+                         replica was not used"
+                    );
+                    for (request_index, _) in indexed_ranges {
+                        snapshot_results[request_index] = Some(Err(anyhow::anyhow!(error.clone())));
+                    }
+                }
+            }
+        }
 
         let mut results = Vec::with_capacity(batch_size);
-        for (&range_request, resolved) in ranges.iter().zip(pre_resolved) {
+        for (request_index, (&range_request, resolved)) in
+            ranges.iter().zip(pre_resolved).enumerate()
+        {
             // We need to preserve the order of the ranges.
             if let Some(resolved) = resolved {
                 results.push(resolved);
                 continue;
             }
 
-            let snapshot_result = persistence_iter
-                .next()
-                .unwrap_or_else(|| Err(anyhow::anyhow!("fewer persistence results than expected")));
+            let snapshot_result = snapshot_results[request_index].take().unwrap_or_else(|| {
+                Err(anyhow::anyhow!(
+                    "missing snapshot result for range request {request_index}"
+                ))
+            });
 
             let result = try_anyhow!({
                 let (snapshot_result_vec, cursor) = snapshot_result?;
@@ -349,9 +494,20 @@ impl TransactionIndex {
         // transactions if the search index is removed. In practice, that should
         // only happen as part of a push that would separately invalidate user
         // transactions anyway.
+        let printable_index_name = query.printable_index_name()?;
+        if let Some(partition_map) = &self.partition_map {
+            let table_name = printable_index_name.table();
+            let owner = partition_map.partition_for_table(table_name);
+            anyhow::ensure!(
+                table_name.is_system() || owner == partition_map.local_partition(),
+                "Text search on remote table {} requires an authoritative owner-search path; \
+                 local replica was not used",
+                table_name,
+            );
+        }
         let index = self
             .index_registry
-            .require_enabled(&index_name, &query.printable_index_name()?)?;
+            .require_enabled(&index_name, &printable_index_name)?;
         let empty = vec![];
         let pending_updates = self.text_index_updates.get(&index.id()).unwrap_or(&empty);
         let results = self
@@ -858,10 +1014,12 @@ mod tests {
         str::FromStr,
         sync::{
             Arc,
+            Mutex as StdMutex,
             OnceLock,
         },
     };
 
+    use async_trait::async_trait;
     use common::{
         bootstrap_model::index::{
             database_index::IndexedFields,
@@ -924,12 +1082,61 @@ mod tests {
     };
     use value::assert_obj;
 
-    use super::TextIndexManagerSnapshot;
+    use super::{
+        SearchNotEnabled,
+        TextIndexManagerSnapshot,
+    };
     use crate::{
+        owner_read::{
+            OwnerIndexEntry,
+            OwnerIndexRangeResult,
+            OwnerReadClient,
+        },
+        partition::{
+            PartitionId,
+            PartitionMap,
+            PlacementVersion,
+        },
         query::IndexRangeResponse,
         transaction_index::TransactionIndex,
         FollowerRetentionManager,
     };
+
+    #[derive(Clone)]
+    struct OwnerReadCall {
+        owner: PartitionId,
+        placement_version: PlacementVersion,
+        snapshot_ts: Timestamp,
+        ranges: Vec<RangeRequest>,
+    }
+
+    struct FakeOwnerReadClient {
+        calls: Arc<StdMutex<Vec<OwnerReadCall>>>,
+        results: Vec<OwnerIndexRangeResult>,
+        failure: Option<String>,
+    }
+
+    #[async_trait]
+    impl OwnerReadClient for FakeOwnerReadClient {
+        async fn read_index_ranges(
+            &self,
+            owner_partition: PartitionId,
+            placement_version: PlacementVersion,
+            snapshot_ts: Timestamp,
+            ranges: Vec<RangeRequest>,
+        ) -> anyhow::Result<Vec<OwnerIndexRangeResult>> {
+            self.calls.lock().unwrap().push(OwnerReadCall {
+                owner: owner_partition,
+                placement_version,
+                snapshot_ts,
+                ranges,
+            });
+            if let Some(failure) = &self.failure {
+                anyhow::bail!(failure.clone());
+            }
+            Ok(self.results.clone())
+        }
+    }
 
     fn next_document_id(
         id_generator: &mut TestIdGenerator,
@@ -983,6 +1190,184 @@ mod tests {
             TextIndexManager::new(TextIndexManagerState::Bootstrapping, persistence.version());
 
         Ok((index_registry, index, search, index_id_by_name))
+    }
+
+    #[convex_macro::prod_rt_test]
+    async fn test_remote_ranges_use_owner_and_never_stale_local_mirror(
+        rt: ProdRuntime,
+    ) -> anyhow::Result<()> {
+        let mut id_generator = TestIdGenerator::new();
+        let table: TableName = "projects".parse()?;
+        let tablet_id = id_generator.user_table_id(&table).tablet_id;
+        let by_id = TabletIndexName::by_id(tablet_id);
+        let printable_by_id = IndexName::by_id(table.clone());
+        let persistence = Arc::new(TestPersistence::new());
+        let retention_manager =
+            Arc::new(FollowerRetentionManager::new(rt.clone(), persistence.clone()).await?);
+        let initial_ts = rt.generate_timestamp()?;
+        let repeatable = RepeatablePersistence::new(
+            persistence.clone(),
+            unchecked_repeatable_ts(initial_ts),
+            retention_manager.clone(),
+        );
+        let (mut index_registry, mut in_memory_indexes, _search, _) = bootstrap_index(
+            &mut id_generator,
+            vec![IndexMetadata::new_enabled(
+                by_id.clone(),
+                IndexedFields::by_id(),
+            )],
+            repeatable,
+        )
+        .await?;
+
+        let stale = ResolvedDocument::new(
+            next_document_id(&mut id_generator, "projects")?,
+            CreationTime::ONE,
+            assert_obj!("name" => "stale mirror"),
+        )?;
+        let stale_ts = initial_ts.succ()?;
+        index_registry.update(None, Some(&stale))?;
+        let index_updates =
+            in_memory_indexes.update(&index_registry, stale_ts, None, Some(stale.clone()));
+        persistence
+            .write(
+                &[DocumentLogEntry {
+                    ts: stale_ts,
+                    id: stale.id_with_table_id(),
+                    value: Some(stale.clone()),
+                    prev_ts: None,
+                }],
+                &index_updates
+                    .into_iter()
+                    .map(|update| PersistenceIndexEntry::from_index_update(stale_ts, &update))
+                    .collect_vec(),
+                ConflictStrategy::Error,
+            )
+            .await?;
+        id_generator.write_tables(persistence.clone()).await?;
+
+        let snapshot_ts = stale_ts.succ()?;
+        let persistence_snapshot = RepeatablePersistence::new(
+            persistence,
+            unchecked_repeatable_ts(snapshot_ts),
+            retention_manager,
+        )
+        .read_snapshot(unchecked_repeatable_ts(snapshot_ts))?;
+        let database_index_snapshot = DatabaseIndexSnapshot::new(
+            index_registry.clone(),
+            Arc::new(in_memory_indexes),
+            id_generator.clone(),
+            Arc::new(persistence_snapshot),
+            None,
+            None,
+        );
+
+        let fresh = ResolvedDocument::new(
+            stale.id(),
+            CreationTime::ONE,
+            assert_obj!("name" => "authoritative owner"),
+        )?;
+        let owner_ts = snapshot_ts;
+        let owner_result = OwnerIndexRangeResult {
+            entries: vec![OwnerIndexEntry {
+                key: fresh.index_key(&IndexedFields::by_id()[..]).to_bytes(),
+                ts: owner_ts,
+                document: PackedDocument::pack(&fresh),
+            }],
+            cursor: CursorPosition::End,
+        };
+        let calls = Arc::new(StdMutex::new(Vec::new()));
+        let owner_client = Arc::new(FakeOwnerReadClient {
+            calls: calls.clone(),
+            results: vec![owner_result],
+            failure: None,
+        });
+        let placement_version = PlacementVersion::new(9);
+        let partition_map = PartitionMap::from_config_with_version(
+            "projects=1",
+            PartitionId(0),
+            2,
+            placement_version,
+        );
+        let mut index = TransactionIndex::new_with_owner_reads(
+            index_registry.clone(),
+            database_index_snapshot.clone(),
+            Arc::new(SearchNotEnabled),
+            owner_client,
+            partition_map.clone(),
+            snapshot_ts,
+        );
+        let request = RangeRequest {
+            index_name: by_id.clone(),
+            printable_index_name: printable_by_id.clone(),
+            interval: Interval::all(),
+            order: Order::Asc,
+            max_size: 100,
+        };
+        let result = index.range(request.clone()).await?;
+        assert_eq!(result.page.len(), 1);
+        assert_eq!(result.page[0].1.unpack(), fresh);
+        assert_eq!(result.page[0].2, WriteTimestamp::Committed(owner_ts));
+        let recorded_calls = calls.lock().unwrap();
+        assert_eq!(recorded_calls.len(), 1);
+        assert_eq!(recorded_calls[0].owner, PartitionId(1));
+        assert_eq!(recorded_calls[0].placement_version, placement_version);
+        assert_eq!(recorded_calls[0].snapshot_ts, snapshot_ts);
+        assert_eq!(recorded_calls[0].ranges.len(), 1);
+        drop(recorded_calls);
+
+        let system_by_id =
+            TabletIndexName::by_id(id_generator.system_table_id(&INDEX_TABLE).tablet_id);
+        let system_request = RangeRequest {
+            index_name: system_by_id,
+            printable_index_name: IndexName::by_id((*INDEX_TABLE).clone()),
+            interval: Interval::all(),
+            order: Order::Asc,
+            max_size: 100,
+        };
+        index.range(system_request).await?;
+        assert_eq!(
+            calls.lock().unwrap().len(),
+            1,
+            "system-table ranges must retain route-specific local authority",
+        );
+
+        let pending = ResolvedDocument::new(
+            stale.id(),
+            CreationTime::ONE,
+            assert_obj!("name" => "transaction pending write"),
+        )?;
+        index
+            .begin_update(Some(fresh.clone()), Some(pending.clone()))?
+            .apply();
+        let overlaid = index.range(request.clone()).await?;
+        assert_eq!(overlaid.page.len(), 1);
+        assert_eq!(overlaid.page[0].1.unpack(), pending);
+        assert_eq!(overlaid.page[0].2, WriteTimestamp::Pending);
+        assert_eq!(calls.lock().unwrap().len(), 2);
+
+        let failing_client = Arc::new(FakeOwnerReadClient {
+            calls: Arc::new(StdMutex::new(Vec::new())),
+            results: Vec::new(),
+            failure: Some("owner unavailable".to_string()),
+        });
+        let mut index = TransactionIndex::new_with_owner_reads(
+            index_registry,
+            database_index_snapshot,
+            Arc::new(SearchNotEnabled),
+            failing_client,
+            partition_map,
+            snapshot_ts,
+        );
+        let error = match index.range(request).await {
+            Ok(_) => anyhow::bail!("stale local mirror unexpectedly satisfied owner read"),
+            Err(error) => error,
+        };
+        let error = format!("{error:#}");
+        assert!(error.contains("owner unavailable"), "{error}");
+        assert!(error.contains("local replica was not used"), "{error}");
+
+        Ok(())
     }
 
     #[convex_macro::prod_rt_test]

--- a/crates/local_backend/build.rs
+++ b/crates/local_backend/build.rs
@@ -1,12 +1,23 @@
 use vergen::EmitBuilder;
 
 fn main() -> anyhow::Result<()> {
+    println!("cargo:rerun-if-env-changed=VERGEN_GIT_SHA");
+    println!("cargo:rerun-if-env-changed=VERGEN_GIT_COMMIT_TIMESTAMP");
+
     // Recompile when there's a new git hash for beacon.
     // This is a workaround for https://github.com/rustyhorde/vergen/issues/174
-    // In docker builds, we need a way to pass overrides to Vergen when there's no
-    // actual git repo. We'll try emitting as usual, then fall back to env vars
-    // that might have been set in the docker build before falling back to empty
-    // strings.
+    // Docker builds have no Git checkout, so explicit build arguments must take
+    // precedence over Vergen's repository discovery.
+    if let (Ok(git_sha), Ok(git_commit_timestamp)) = (
+        std::env::var("VERGEN_GIT_SHA"),
+        std::env::var("VERGEN_GIT_COMMIT_TIMESTAMP"),
+    ) {
+        println!("cargo:rustc-env=VERGEN_GIT_SHA={git_sha}");
+        println!("cargo:rustc-env=VERGEN_GIT_COMMIT_TIMESTAMP={git_commit_timestamp}");
+        return Ok(());
+    }
+
+    // Fall back to explicit unknown values if repository discovery fails too.
     if EmitBuilder::builder()
         .git_sha(false)
         .git_commit_timestamp()
@@ -17,11 +28,11 @@ fn main() -> anyhow::Result<()> {
         println!("cargo:rerun-if-changed=build.rs");
         println!(
             "cargo:rustc-env=VERGEN_GIT_SHA={}",
-            option_env!("VERGEN_GIT_SHA").unwrap_or_else(|| "unknown")
+            std::env::var("VERGEN_GIT_SHA").unwrap_or_else(|_| "unknown".to_string())
         );
         println!(
             "cargo:rustc-env=VERGEN_GIT_COMMIT_TIMESTAMP={}",
-            option_env!("VERGEN_GIT_COMMIT_TIMESTAMP").unwrap_or_else(|| "unknown")
+            std::env::var("VERGEN_GIT_COMMIT_TIMESTAMP").unwrap_or_else(|_| "unknown".to_string())
         );
     }
     Ok(())

--- a/crates/local_backend/src/lib.rs
+++ b/crates/local_backend/src/lib.rs
@@ -104,6 +104,7 @@ pub mod logs;
 mod metrics;
 pub mod mutation_forwarder;
 pub mod node_action_callbacks;
+pub mod owner_read_service;
 pub mod parse;
 pub mod proxy;
 pub mod public_api;

--- a/crates/local_backend/src/main.rs
+++ b/crates/local_backend/src/main.rs
@@ -26,6 +26,7 @@ use local_backend::{
     config::LocalConfig,
     make_app,
     mutation_forwarder::MutationForwarderService,
+    owner_read_service::OwnerReadGrpcService,
     proxy::dev_site_proxy,
     router::router,
     two_phase_service,
@@ -150,6 +151,13 @@ async fn run_server_inner(runtime: ProdRuntime, config: LocalConfig) -> anyhow::
             st.placement_metadata_store.clone(),
             cluster_grpc_auth.clone(),
         );
+        let owner_reads = OwnerReadGrpcService::new(
+            st.application.database().clone(),
+            st.application.database().committer_client(),
+            st.raft_state.clone(),
+            st.placement_metadata_store.clone(),
+            cluster_grpc_auth.clone(),
+        );
 
         // Add Raft transport server if Raft is enabled.
         let raft_transport = st.raft_mailbox_tx.as_ref().map(|mailbox_tx| {
@@ -164,7 +172,8 @@ async fn run_server_inner(runtime: ProdRuntime, config: LocalConfig) -> anyhow::
             tracing::info!("Starting gRPC services on {grpc_addr}");
             let mut builder = tonic::transport::Server::builder()
                 .add_service(forwarder.into_server())
-                .add_service(two_pc.into_server());
+                .add_service(two_pc.into_server())
+                .add_service(owner_reads.into_server());
 
             if let Some(raft) = raft_transport {
                 builder = builder.add_service(raft.into_service());

--- a/crates/local_backend/src/owner_read_service.rs
+++ b/crates/local_backend/src/owner_read_service.rs
@@ -1,0 +1,248 @@
+//! Authoritative cross-partition index reads.
+//!
+//! Transactions send remote ranges to the partition that owns their table.
+//! Only that partition's current Raft leader may answer, and every range is
+//! evaluated at the request's pinned placement version and snapshot timestamp.
+
+use std::sync::Arc;
+
+use common::grpc::ClusterGrpcAuth;
+use database::{
+    owner_read::{
+        index_names_from_wire,
+        interval_from_proto,
+        order_from_proto,
+        result_to_proto,
+        tablet_id_from_bytes,
+        OWNER_READ_GRPC_MAX_MESSAGE_SIZE,
+    },
+    partition::{
+        PartitionId,
+        PartitionMap,
+        PlacementMetadataStore,
+        PlacementVersion,
+    },
+    raft_partition::RaftPartitionState,
+    CommitterClient,
+    Database,
+};
+use indexing::backend_in_memory_indexes::RangeRequest;
+use pb::replication::{
+    owner_read_service_server::{
+        OwnerReadService,
+        OwnerReadServiceServer as TonicOwnerReadServer,
+    },
+    OwnerReadIndexRange,
+    OwnerReadIndexRangesRequest,
+    OwnerReadIndexRangesResponse,
+};
+use runtime::prod::ProdRuntime;
+use tonic::{
+    Request,
+    Response,
+    Status,
+};
+
+pub struct OwnerReadGrpcService {
+    database: Database<ProdRuntime>,
+    committer: CommitterClient,
+    raft_state: Option<RaftPartitionState>,
+    placement_metadata_store: Option<Arc<dyn PlacementMetadataStore>>,
+    cluster_auth: Option<ClusterGrpcAuth>,
+}
+
+impl OwnerReadGrpcService {
+    pub fn new(
+        database: Database<ProdRuntime>,
+        committer: CommitterClient,
+        raft_state: Option<RaftPartitionState>,
+        placement_metadata_store: Option<Arc<dyn PlacementMetadataStore>>,
+        cluster_auth: Option<ClusterGrpcAuth>,
+    ) -> Self {
+        Self {
+            database,
+            committer,
+            raft_state,
+            placement_metadata_store,
+            cluster_auth,
+        }
+    }
+
+    pub fn into_server(self) -> TonicOwnerReadServer<Self> {
+        TonicOwnerReadServer::new(self)
+            .max_decoding_message_size(OWNER_READ_GRPC_MAX_MESSAGE_SIZE)
+            .max_encoding_message_size(OWNER_READ_GRPC_MAX_MESSAGE_SIZE)
+    }
+
+    fn authenticate<T>(&self, request: &Request<T>) -> Result<(), Status> {
+        if let Some(auth) = &self.cluster_auth {
+            auth.authenticate(request)?;
+        }
+        Ok(())
+    }
+
+    async fn refresh_placement_metadata(&self) -> Result<(), Status> {
+        let Some(store) = self.placement_metadata_store.as_ref() else {
+            return Ok(());
+        };
+        let Some(metadata) = store.load().await.map_err(|error| {
+            Status::unavailable(format!(
+                "Failed to refresh placement metadata before owner read: {error:#}"
+            ))
+        })?
+        else {
+            return Ok(());
+        };
+        self.committer
+            .refresh_placement_metadata(metadata)
+            .map_err(|error| {
+                Status::failed_precondition(format!(
+                    "Refreshed placement metadata is invalid: {error:#}"
+                ))
+            })
+    }
+
+    async fn ensure_placement_version(
+        &self,
+        placement_version: PlacementVersion,
+    ) -> Result<(), Status> {
+        match self.committer.ensure_placement_version(placement_version) {
+            Ok(()) => Ok(()),
+            Err(original_error) => {
+                self.refresh_placement_metadata().await?;
+                self.committer
+                    .ensure_placement_version(placement_version)
+                    .map_err(|error| {
+                        Status::failed_precondition(format!(
+                            "Owner read rejected after placement refresh: {error:#}. Original \
+                             rejection: {original_error:#}"
+                        ))
+                    })
+            },
+        }
+    }
+
+    fn ensure_serving_leader(&self) -> Result<(), Status> {
+        let Some(raft_state) = self.raft_state.as_ref() else {
+            return Ok(());
+        };
+        if !raft_state.is_leader() {
+            return Err(Status::unavailable(format!(
+                "Partition {} owner read reached Raft follower {}; current leader is {}",
+                raft_state.partition_id(),
+                raft_state.node_id(),
+                raft_state.leader_id(),
+            )));
+        }
+        if !raft_state.has_leader_serving_lease() {
+            return Err(Status::unavailable(format!(
+                "Partition {} leader {} has no valid serving lease",
+                raft_state.partition_id(),
+                raft_state.node_id(),
+            )));
+        }
+        Ok(())
+    }
+
+    fn decode_range(
+        partition_map: &PartitionMap,
+        owner_partition: PartitionId,
+        range: OwnerReadIndexRange,
+    ) -> Result<RangeRequest, Status> {
+        let table_name = range.table_name.parse().map_err(|error| {
+            Status::invalid_argument(format!("Invalid owner-read table name: {error:#}"))
+        })?;
+        let actual_owner = partition_map.partition_for_table(&table_name);
+        if actual_owner != owner_partition {
+            return Err(Status::failed_precondition(format!(
+                "Table {} belongs to {}, not requested owner {}",
+                table_name, actual_owner, owner_partition,
+            )));
+        }
+        let tablet_id = tablet_id_from_bytes(range.tablet_id).map_err(|error| {
+            Status::invalid_argument(format!("Invalid owner-read tablet ID: {error:#}"))
+        })?;
+        let (index_name, printable_index_name) =
+            index_names_from_wire(tablet_id, range.table_name, range.descriptor).map_err(
+                |error| Status::invalid_argument(format!("Invalid owner-read index: {error:#}")),
+            )?;
+        let interval = interval_from_proto(
+            range
+                .interval
+                .ok_or_else(|| Status::invalid_argument("Owner-read range missing interval"))?,
+        )
+        .map_err(|error| {
+            Status::invalid_argument(format!("Invalid owner-read interval: {error:#}"))
+        })?;
+        let order = order_from_proto(range.order).map_err(|error| {
+            Status::invalid_argument(format!("Invalid owner-read order: {error:#}"))
+        })?;
+        let max_size = usize::try_from(range.max_size)
+            .map_err(|_| Status::invalid_argument("Owner-read max_size exceeds usize"))?;
+        Ok(RangeRequest {
+            index_name,
+            printable_index_name,
+            interval,
+            order,
+            max_size,
+        })
+    }
+}
+
+#[tonic::async_trait]
+impl OwnerReadService for OwnerReadGrpcService {
+    async fn read_index_ranges(
+        &self,
+        request: Request<OwnerReadIndexRangesRequest>,
+    ) -> Result<Response<OwnerReadIndexRangesResponse>, Status> {
+        self.authenticate(&request)?;
+        let request = request.into_inner();
+        let owner_partition = PartitionId(request.owner_partition);
+        let local_partition = self.committer.local_partition().ok_or_else(|| {
+            Status::failed_precondition("Owner-read service requires a partitioned node")
+        })?;
+        if owner_partition != local_partition {
+            return Err(Status::failed_precondition(format!(
+                "Owner read for {} reached {}",
+                owner_partition, local_partition,
+            )));
+        }
+
+        let placement_version = PlacementVersion::from(request.placement_version);
+        self.ensure_placement_version(placement_version).await?;
+        self.ensure_serving_leader()?;
+        let partition_map = self.committer.partition_map().ok_or_else(|| {
+            Status::failed_precondition("Owner-read service requires partition placement")
+        })?;
+        if partition_map.placement_version() != placement_version {
+            return Err(Status::failed_precondition(format!(
+                "Placement changed from {} before owner read could pin it",
+                placement_version,
+            )));
+        }
+
+        let snapshot_ts = request.snapshot_ts.try_into().map_err(|error| {
+            Status::invalid_argument(format!("Invalid owner-read snapshot timestamp: {error:#}"))
+        })?;
+        let ranges = request
+            .ranges
+            .into_iter()
+            .map(|range| Self::decode_range(&partition_map, owner_partition, range))
+            .collect::<Result<Vec<_>, _>>()?;
+        let results = self
+            .database
+            .authoritative_index_ranges(snapshot_ts, ranges)
+            .await
+            .map_err(|error| {
+                Status::unavailable(format!("Authoritative owner read failed: {error:#}"))
+            })?
+            .into_iter()
+            .map(result_to_proto)
+            .collect::<anyhow::Result<Vec<_>>>()
+            .map_err(|error| {
+                Status::internal(format!("Failed to encode owner-read response: {error:#}"))
+            })?;
+
+        Ok(Response::new(OwnerReadIndexRangesResponse { results }))
+    }
+}

--- a/crates/pb/protos/replication.proto
+++ b/crates/pb/protos/replication.proto
@@ -4,6 +4,7 @@ package replication;
 
 import "convex_identity.proto";
 import "common.proto";
+import "google/protobuf/empty.proto";
 import "searchlight.proto";
 
 // Service for forwarding mutations from Replica nodes to the Primary.
@@ -133,6 +134,47 @@ message QueryError {
 
   // Log lines captured during execution.
   common.RedactedLogLines log_lines = 2;
+}
+
+// Internal strong-read service. A transaction coordinator uses this service
+// when an index range belongs to another partition. NATS-delivered mirrors are
+// never authoritative for these requests.
+service OwnerReadService {
+  rpc ReadIndexRanges(OwnerReadIndexRangesRequest) returns (OwnerReadIndexRangesResponse);
+}
+
+message OwnerReadIndexRangesRequest {
+  uint32 owner_partition = 1;
+  uint64 placement_version = 2;
+  uint64 snapshot_ts = 3;
+  repeated OwnerReadIndexRange ranges = 4;
+}
+
+message OwnerReadIndexRange {
+  bytes tablet_id = 1;
+  string descriptor = 2;
+  string table_name = 3;
+  common.Interval interval = 4;
+  common.Order order = 5;
+  uint64 max_size = 6;
+}
+
+message OwnerReadIndexRangesResponse {
+  repeated OwnerReadIndexRangeResult results = 1;
+}
+
+message OwnerReadIndexRangeResult {
+  repeated OwnerReadIndexEntry entries = 1;
+  oneof cursor {
+    bytes after = 2;
+    google.protobuf.Empty end = 3;
+  }
+}
+
+message OwnerReadIndexEntry {
+  bytes index_key = 1;
+  uint64 commit_ts = 2;
+  common.ResolvedDocument document = 3;
 }
 
 // Two-Phase Commit service for cross-partition writes (Vitess 2PC pattern).

--- a/npm-packages/@convex-dev/platform/public-deployment-openapi.json
+++ b/npm-packages/@convex-dev/platform/public-deployment-openapi.json
@@ -326,6 +326,50 @@
           }
         }
       },
+      "ReadAfterWriteFenceToken": {
+        "type": "object",
+        "required": [
+          "ts"
+        ],
+        "properties": {
+          "sourcePartition": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "int32",
+            "minimum": 0
+          },
+          "ts": {
+            "$ref": "#/components/schemas/SerializedTs"
+          }
+        }
+      },
+      "ReadAfterWriteToken": {
+        "type": "object",
+        "required": [
+          "ts"
+        ],
+        "properties": {
+          "participantFences": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ReadAfterWriteFenceToken"
+            }
+          },
+          "sourcePartition": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "int32",
+            "minimum": 0
+          },
+          "ts": {
+            "$ref": "#/components/schemas/SerializedTs"
+          }
+        }
+      },
       "SerializedTs": {
         "type": "string"
       },
@@ -358,6 +402,16 @@
           },
           "path": {
             "type": "string"
+          },
+          "readAfterWrite": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/ReadAfterWriteToken"
+              }
+            ]
           }
         }
       },
@@ -426,6 +480,16 @@
           "path": {
             "type": "string"
           },
+          "readAfterWrite": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/ReadAfterWriteToken"
+              }
+            ]
+          },
           "ts": {
             "$ref": "#/components/schemas/SerializedTs"
           }
@@ -445,6 +509,16 @@
                 "items": {
                   "type": "string"
                 }
+              },
+              "readAfterWrite": {
+                "oneOf": [
+                  {
+                    "type": "null"
+                  },
+                  {
+                    "$ref": "#/components/schemas/ReadAfterWriteToken"
+                  }
+                ]
               },
               "status": {
                 "type": "string",

--- a/self-hosted/docker/test-write-scaling.sh
+++ b/self-hosted/docker/test-write-scaling.sh
@@ -2858,6 +2858,20 @@ echo -e "${BOLD}Test 26: NATS Partition Simulation${NC}"
 echo "  Pausing NATS for 3 seconds..."
 docker pause docker-nats-1 > /dev/null 2>&1
 
+# Strong remote reads use the partition owner directly, not the NATS-maintained
+# local mirror. The task was written to partition 1 in Test 25, so querying it
+# through partition 0 must remain available while NATS is paused.
+OWNER_READ_DURING_NATS=$(curl --max-time 10 -sf "$NODE_A_URL/api/query" \
+    -H "Authorization: Convex $NODE_A_KEY" \
+    -H "Content-Type: application/json" \
+    -d "{\"path\":\"messages:countTasksByTitle\",\"args\":{\"title\":\"$DJ_KEY\"}}" 2>/dev/null || true)
+OWNER_READ_DURING_NATS_COUNT=$(python3 -c "import sys,json; print(int(json.load(sys.stdin)['value']))" \
+    <<< "$OWNER_READ_DURING_NATS" 2>/dev/null || echo -1)
+[ "$OWNER_READ_DURING_NATS_COUNT" -eq 1 ] \
+    && pass "Partition 0 read partition-1-owned data while NATS was unavailable" \
+    || fail "Owner-authoritative remote read depended on NATS or stale local state" \
+        "expected task count 1, got $OWNER_READ_DURING_NATS_COUNT; response=$OWNER_READ_DURING_NATS"
+
 # Write during NATS outage. It may fail closed if the TSO/decision path cannot
 # make progress, but if it is accepted then the Raft/NATS outbox must replay it
 # after recovery.


### PR DESCRIPTION
## Summary

- add an authenticated internal owner-read gRPC service for batched index ranges
- pin placement version and snapshot timestamp for each transaction
- route remote user-table ranges to the owning partition's current Raft leader
- merge authoritative rows with transaction-local pending writes
- fail closed when the owner is unavailable instead of consulting a stale NATS mirror
- keep system-table reads under their existing route-specific authority
- fail closed for remote text search until an owner-search path exists
- configure owner-read gRPC messages for valid Convex transaction read sizes
- make Docker revision overrides authoritative in build metadata
- refresh the generated public read-after-write OpenAPI schema

## Correctness properties

The local NATS/Raft mirror is no longer a correctness authority for public cross-partition index reads. The owner service verifies cluster authentication, exact placement version, table ownership, Raft leadership, and a valid serving lease before reading all requested ranges from one exact MVCC snapshot.

This intentionally does not define the cluster-wide safe read timestamp. That broader invariant remains tracked by #278. It also does not silently run remote text search against a mirror; those requests fail explicitly until an authoritative search path is implemented.

## Validation

- `cargo check -p database -p local_backend`
- `cargo test -p database --lib`: 568 passed, 2 ignored
- `cargo test -p local_backend --lib`: 100 passed
- focused owner-read wire and stale-mirror semantic tests
- rebuilt local backend image `sha256:4470a569014b04f513997e0c6396c651aa51d5a9bf9d4d42adefb1ebd9141b0b`
- all six containers reported compiled revision `issue-285-working-6`
- full cluster harness: 147/147 write-scaling assertions
- full Raft harness: 24/24 failover assertions
- NATS-paused regression: partition 0 successfully read partition-1-owned data while the replication transport was unavailable

Closes #285