### PR TITLE
feat(reads): add cluster-safe snapshot timestamps

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ What is implemented today:
 - shared-secret authentication for internal cluster gRPC calls;
 - route authority checks that fail closed for unsafe clustered routes;
 - write-owner mutation routing so clients do not have to hand-route simple writes;
+- owner-coordinated safe snapshot timestamps for atomic latest queries and
+  reactive reruns across partitions;
 - selective-delivery groundwork for reducing replication fanout;
 - cluster observability metrics and an issue journal for validation history and open correctness work.
 
@@ -52,7 +54,8 @@ Important work still remains:
 - replicate full intra-partition state needed for failover;
 - harden 2PC prepare durability, rollback, and decision retention;
 - gate background workers with cluster authority or leases;
-- unify timestamp domains for portable read-after-write fences;
+- unify timestamp domains for historical cursor portability and
+  identity-preserving replica apply;
 - define distributed index metadata and backfill correctness;
 - mature selective delivery into distributed reactive invalidation;
 - add formal Jepsen / Elle coverage and real cloud benchmarks.
@@ -74,6 +77,8 @@ Project-wide goals: [docs/project-goals.md](docs/project-goals.md)
 Issue journal: [docs/issue-journal.md](docs/issue-journal.md)
 
 Cluster authority routing: [docs/cluster-authority-routing.md](docs/cluster-authority-routing.md)
+
+Cluster-safe read timestamps: [docs/cluster-safe-read-timestamps.md](docs/cluster-safe-read-timestamps.md)
 
 ## Architecture
 

--- a/crates/application/src/api.rs
+++ b/crates/application/src/api.rs
@@ -317,7 +317,7 @@ impl<RT: Runtime> ApplicationApi for Application<RT> {
             }
         }
         let ts = match ts {
-            ExecuteQueryTimestamp::Latest => *self.now_ts_for_reads(),
+            ExecuteQueryTimestamp::Latest => *self.database.cluster_safe_read_ts().await?,
             ExecuteQueryTimestamp::At(ts) => ts,
         };
         self.read_only_udf_at_ts(
@@ -348,7 +348,7 @@ impl<RT: Runtime> ApplicationApi for Application<RT> {
             "Only admin or system users can call functions on non-root components directly"
         );
         let ts = match ts {
-            ExecuteQueryTimestamp::Latest => *self.now_ts_for_reads(),
+            ExecuteQueryTimestamp::Latest => *self.database.cluster_safe_read_ts().await?,
             ExecuteQueryTimestamp::At(ts) => ts,
         };
         self.read_only_udf_at_ts(
@@ -485,7 +485,7 @@ impl<RT: Runtime> ApplicationApi for Application<RT> {
         _host: &ResolvedHostname,
         _request_id: RequestId,
     ) -> anyhow::Result<RepeatableTimestamp> {
-        Ok(self.now_ts_for_reads())
+        self.database.cluster_safe_read_ts().await
     }
 
     async fn execute_http_action(

--- a/crates/application/src/application_function_runner/mod.rs
+++ b/crates/application/src/application_function_runner/mod.rs
@@ -1974,7 +1974,7 @@ impl<RT: Runtime> ActionCallbacks for ApplicationFunctionRunner<RT> {
         args: SerializedArgs,
         context: ExecutionContext,
     ) -> anyhow::Result<FunctionResult> {
-        let ts = self.database.now_ts_for_reads();
+        let ts = self.database.cluster_safe_read_ts().await?;
         let result = self
             .run_query_at_ts(
                 context.request_id,

--- a/crates/application/src/lib.rs
+++ b/crates/application/src/lib.rs
@@ -1296,7 +1296,7 @@ impl<RT: Runtime> Application<RT> {
         identity: Identity,
         caller: FunctionCaller,
     ) -> anyhow::Result<RedactedQueryReturn> {
-        let ts = *self.now_ts_for_reads();
+        let ts = *self.database.cluster_safe_read_ts().await?;
         self.read_only_udf_at_ts(request_id, path, args, identity, ts, None, caller)
             .await
     }

--- a/crates/database/src/committer.rs
+++ b/crates/database/src/committer.rs
@@ -7,7 +7,13 @@ use std::{
     },
     future::Future,
     ops::Bound,
-    sync::Arc,
+    sync::{
+        atomic::{
+            AtomicBool,
+            Ordering,
+        },
+        Arc,
+    },
     time::Duration,
 };
 
@@ -207,6 +213,7 @@ const RAFT_NATS_OUTBOX_REPLAY_INTERVAL: Duration = Duration::from_secs(1);
 pub(crate) const RAFT_NATS_OUTBOX_KEY_PREFIX: &str = "raft_nats_outbox/";
 pub(crate) const RAFT_APPLY_MARKER_KEY_PREFIX: &str = "raft_apply_marker/";
 const MAX_APPLIED_DATA_ORIGIN_TIMESTAMPS_PER_PARTITION: usize = 1024;
+const MAX_CLOSED_READ_TIMESTAMPS: usize = 4096;
 
 type LegacyRaftNatsOutboxRecords = BTreeMap<String, serde_json::Value>;
 
@@ -425,6 +432,27 @@ pub struct CommitOutcome {
     pub read_after_write_partitions: Vec<crate::partition::PartitionId>,
 }
 
+/// Result of asking one partition leader to make an exact timestamp readable.
+///
+/// A cluster read barrier is complete only when every partition returns
+/// [`Closed`](Self::Closed) for the same timestamp.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ReadTimestampClosure {
+    Closed(Timestamp),
+    /// This node's translated local timeline is already ahead of the requested
+    /// timestamp. The coordinator must choose a newer common timestamp.
+    RetryAt(Timestamp),
+    /// A prepared transaction at or below the requested timestamp is
+    /// unresolved. Retrying the same barrier after the decision resolves is
+    /// safe.
+    Blocked(Timestamp),
+}
+
+enum RepeatableTimestampResult {
+    Background(oneshot::Sender<Timestamp>),
+    ClusterReadBarrier(oneshot::Sender<anyhow::Result<ReadTimestampClosure>>),
+}
+
 enum PersistenceWrite {
     Commit {
         pending_write: PendingWriteHandle,
@@ -458,7 +486,7 @@ enum PersistenceWrite {
     MaxRepeatableTimestamp {
         new_max_repeatable: Timestamp,
         timer: Timer<VMHistogram>,
-        result: oneshot::Sender<Timestamp>,
+        result: RepeatableTimestampResult,
         commit_id: usize,
     },
     /// Replica delta persistence write. Goes through the same ordered pipeline
@@ -970,6 +998,14 @@ pub struct Committer<RT: Runtime> {
     runtime: RT,
 
     last_assigned_ts: Timestamp,
+    // Highest exact read barrier admitted by this committer. Unlike
+    // `last_assigned_ts`, ordinary timestamp allocation does not advance this
+    // floor, so a coordinator may allocate T and then prepare at T.
+    read_barrier_floor: Timestamp,
+    // Exact cluster barriers certified by this leader. We intentionally do not
+    // infer that every timestamp below the maximum is safe under timestamp
+    // translation.
+    closed_read_timestamps: BTreeSet<Timestamp>,
 
     persistence_writes: FuturesOrdered<BoxFuture<'static, anyhow::Result<PersistenceWrite>>>,
 
@@ -992,6 +1028,7 @@ pub struct Committer<RT: Runtime> {
     // ensuring globally unique timestamps across all nodes.
     // None means single-node mode (local clock, existing behavior).
     timestamp_oracle: Option<Arc<dyn crate::timestamp_oracle::TimestampOracle>>,
+    maintenance_tso_refill_in_flight: Arc<AtomicBool>,
 
     // 2PC prepared transactions awaiting CommitPrepared or RollbackPrepared.
     // Keyed by TwoPhaseTransactionId, storing the prepared intent and metadata
@@ -1127,6 +1164,7 @@ impl<RT: Runtime> Committer<RT> {
         let persistence_reader = persistence.reader();
         let (tx, rx) = mpsc::channel(*COMMITTER_QUEUE_SIZE);
         let snapshot_reader = snapshot_manager.reader();
+        let read_barrier_floor = *snapshot_manager.read().persisted_max_repeatable_ts();
         let placement_state =
             partition_map.map(crate::partition::PlacementState::from_partition_map);
         let client_placement_state = placement_state.clone();
@@ -1139,6 +1177,8 @@ impl<RT: Runtime> Committer<RT> {
             persistence,
             runtime: runtime.clone(),
             last_assigned_ts: Timestamp::MIN,
+            read_barrier_floor,
+            closed_read_timestamps: BTreeSet::new(),
             persistence_writes: FuturesOrdered::new(),
             retention_validator: retention_validator.clone(),
             virtual_system_mapping,
@@ -1146,6 +1186,7 @@ impl<RT: Runtime> Committer<RT> {
             distributed_log,
             placement_state,
             timestamp_oracle,
+            maintenance_tso_refill_in_flight: Arc::new(AtomicBool::new(false)),
             prepared_transactions: std::collections::HashMap::new(),
             prepared_commit_waiters: std::collections::HashMap::new(),
             queued_snapshots: VecDeque::new(),
@@ -1272,8 +1313,14 @@ impl<RT: Runtime> Committer<RT> {
                     // establish a recent repeatable snapshot.
                     next_bump_wait = None;
                     let (tx, _rx) = oneshot::channel();
-                    self.bump_max_repeatable_ts(tx, commit_id, committer_span);
-                    commit_id += 1;
+                    if self.bump_max_repeatable_ts(tx, commit_id, committer_span) {
+                        commit_id += 1;
+                    } else {
+                        // No locally reserved TSO value can satisfy the floor.
+                        // Retry maintenance later while an asynchronous refill
+                        // runs outside the committer loop.
+                        next_bump_wait = Some(*MAX_REPEATABLE_TIMESTAMP_COMMIT_DELAY);
+                    }
                     last_bumped_repeatable_ts = self.runtime.monotonic_now();
                 }
                 _ = remote_read_frontier_heartbeat_fut.fuse() => {
@@ -1604,16 +1651,57 @@ impl<RT: Runtime> Committer<RT> {
                                 next_bump_wait = Some(
                                     self.runtime.rng().random_range(base_period..base_period * 2),
                                 );
-                                let _ = result.send(current);
+                                match result {
+                                    RepeatableTimestampResult::Background(result) => {
+                                        let _ = result.send(current);
+                                    },
+                                    RepeatableTimestampResult::ClusterReadBarrier(result) => {
+                                        let _ = result.send(Ok(ReadTimestampClosure::Blocked(
+                                            min_prepared_ts,
+                                        )));
+                                    },
+                                }
+                                drop(timer);
+                                continue;
+                            }
+                            let is_cluster_read_barrier = matches!(
+                                &result,
+                                RepeatableTimestampResult::ClusterReadBarrier(_)
+                            );
+                            if is_cluster_read_barrier
+                                && let Err(err) = self.ensure_leader_for_read_barrier()
+                            {
+                                if let RepeatableTimestampResult::ClusterReadBarrier(result) =
+                                    result
+                                {
+                                    let _ = result.send(Err(err));
+                                }
                                 drop(timer);
                                 continue;
                             }
                             self.publish_max_repeatable_ts(new_max_repeatable)?;
+                            if is_cluster_read_barrier {
+                                self.closed_read_timestamps.insert(new_max_repeatable);
+                                while self.closed_read_timestamps.len()
+                                    > MAX_CLOSED_READ_TIMESTAMPS
+                                {
+                                    self.closed_read_timestamps.pop_first();
+                                }
+                            }
                             let base_period = *MAX_REPEATABLE_TIMESTAMP_IDLE_FREQUENCY;
                             next_bump_wait = Some(
                                 self.runtime.rng().random_range(base_period..base_period * 2),
                             );
-                            let _ = result.send(new_max_repeatable);
+                            match result {
+                                RepeatableTimestampResult::Background(result) => {
+                                    let _ = result.send(new_max_repeatable);
+                                },
+                                RepeatableTimestampResult::ClusterReadBarrier(result) => {
+                                    let _ = result.send(Ok(ReadTimestampClosure::Closed(
+                                        new_max_repeatable,
+                                    )));
+                                },
+                            }
                             drop(timer);
                         },
                         PersistenceWrite::ReplicaDelta {
@@ -1847,6 +1935,8 @@ impl<RT: Runtime> Committer<RT> {
                             self.queued_snapshots.clear();
                             self.log.reset(snapshot_ts);
                             self.last_assigned_ts = snapshot_ts;
+                            self.read_barrier_floor = snapshot_ts;
+                            self.closed_read_timestamps.clear();
                             self.applied_delta_watermarks = applied_delta_watermarks.clone();
                             self.applied_data_delta_watermarks = applied_data_delta_watermarks;
                             self.applied_data_delta_ids = applied_data_delta_ids;
@@ -1961,8 +2051,9 @@ impl<RT: Runtime> Committer<RT> {
                         #[cfg(any(test, feature = "testing"))]
                         Some(CommitterMessage::BumpMaxRepeatableTs { result }) => {
                             let span = Span::noop();
-                            self.bump_max_repeatable_ts(result, commit_id, &span);
-                            commit_id += 1;
+                            if self.bump_max_repeatable_ts(result, commit_id, &span) {
+                                commit_id += 1;
+                            }
                         },
                         #[cfg(any(test, feature = "testing"))]
                         Some(CommitterMessage::TickIdleRemoteReadFrontierHeartbeat { result }) => {
@@ -2056,11 +2147,16 @@ impl<RT: Runtime> Committer<RT> {
                             );
                             let _ = result.send(r);
                         },
-                        Some(CommitterMessage::AllocateCommitTs { result }) => {
+                        Some(CommitterMessage::AllocateCommitTs { min_ts, result }) => {
                             let r = self
                                 .ensure_leader_for_writes()
-                                .and_then(|_| self.next_commit_ts());
+                                .and_then(|_| self.next_commit_ts_at_or_after(min_ts));
                             let _ = result.send(r);
+                        },
+                        Some(CommitterMessage::CloseReadTimestamp { target, result }) => {
+                            let span = Span::noop();
+                            self.close_read_timestamp(target, result, commit_id, &span);
+                            commit_id += 1;
                         },
                         Some(CommitterMessage::CommitPrepared {
                             transaction_id,
@@ -2289,13 +2385,101 @@ impl<RT: Runtime> Committer<RT> {
         result: oneshot::Sender<Timestamp>,
         commit_id: usize,
         root_span: &Span,
-    ) {
+    ) -> bool {
         let timer = metrics::bump_repeatable_ts_timer();
         // next_max_repeatable_ts bumps the last_assigned_ts, so all future commits on
         // this committer will be after new_max_repeatable.
-        let new_max_repeatable = self
-            .next_max_repeatable_ts()
-            .expect("new_max_repeatable should exist");
+        let new_max_repeatable = match self.try_next_max_repeatable_ts() {
+            Ok(Some(ts)) => ts,
+            Ok(None) => {
+                let current = *self.snapshot_manager.read().persisted_max_repeatable_ts();
+                let _ = result.send(current);
+                return false;
+            },
+            Err(error) => {
+                tracing::warn!(
+                    error = %format!("{error:#}"),
+                    "Skipping optional max repeatable timestamp maintenance",
+                );
+                let current = *self.snapshot_manager.read().persisted_max_repeatable_ts();
+                let _ = result.send(current);
+                return false;
+            },
+        };
+        self.enqueue_max_repeatable_ts(
+            new_max_repeatable,
+            RepeatableTimestampResult::Background(result),
+            commit_id,
+            root_span,
+            timer,
+        );
+        true
+    }
+
+    fn close_read_timestamp(
+        &mut self,
+        target: Timestamp,
+        result: oneshot::Sender<anyhow::Result<ReadTimestampClosure>>,
+        commit_id: usize,
+        root_span: &Span,
+    ) {
+        if let Err(err) = self.ensure_leader_for_read_barrier() {
+            let _ = result.send(Err(err));
+            return;
+        }
+        if self.closed_read_timestamps.contains(&target) {
+            let _ = result.send(Ok(ReadTimestampClosure::Closed(target)));
+            return;
+        }
+
+        let latest_ts = *self.snapshot_manager.read().latest_ts();
+        let mut minimum = cmp::max(
+            self.last_assigned_ts,
+            cmp::max(self.log.max_ts(), latest_ts),
+        );
+        if let Some((queued_ts, _)) = self.latest_queued_snapshot() {
+            minimum = cmp::max(minimum, queued_ts);
+        }
+        if let Some((pending_ts, _)) = self.pending_writes.latest() {
+            minimum = cmp::max(minimum, pending_ts);
+        }
+        if let Some(prepared_ts) = self.prepared_writes.max_ts() {
+            minimum = cmp::max(minimum, prepared_ts);
+        }
+
+        if minimum > target {
+            let _ = result.send(Ok(ReadTimestampClosure::RetryAt(minimum)));
+            return;
+        }
+        if let Some(prepared_ts) = self.prepared_writes.min_ts()
+            && prepared_ts <= target
+        {
+            let _ = result.send(Ok(ReadTimestampClosure::Blocked(prepared_ts)));
+            return;
+        }
+
+        // From this point onward every locally allocated commit is above the
+        // barrier. Persistence writes already queued before this message are
+        // ordered before the barrier by `FuturesOrdered`.
+        self.last_assigned_ts = target;
+        self.read_barrier_floor = target;
+        self.enqueue_max_repeatable_ts(
+            target,
+            RepeatableTimestampResult::ClusterReadBarrier(result),
+            commit_id,
+            root_span,
+            metrics::bump_repeatable_ts_timer(),
+        );
+    }
+
+    fn enqueue_max_repeatable_ts(
+        &mut self,
+        new_max_repeatable: Timestamp,
+        result: RepeatableTimestampResult,
+        commit_id: usize,
+        root_span: &Span,
+        timer: Timer<VMHistogram>,
+    ) {
         let persistence = self.persistence.clone();
         let span = Span::enter_with_parent("bump_max_repeatable_ts", root_span);
         let runtime = self.runtime.clone();
@@ -2470,7 +2654,7 @@ impl<RT: Runtime> Committer<RT> {
             return Ok(None);
         }
 
-        Ok(Some(self.next_max_repeatable_ts()?))
+        self.try_next_max_repeatable_ts()
     }
 
     fn ensure_leader_for_writes(&self) -> anyhow::Result<()> {
@@ -2485,6 +2669,19 @@ impl<RT: Runtime> Committer<RT> {
                     leader,
                 );
             }
+        }
+        Ok(())
+    }
+
+    fn ensure_leader_for_read_barrier(&self) -> anyhow::Result<()> {
+        self.ensure_leader_for_writes()?;
+        if let Some(raft) = self.raft_state.as_ref() {
+            anyhow::ensure!(
+                raft.has_leader_serving_lease(),
+                "Raft leader {} for partition {} has no valid serving lease",
+                raft.node_id(),
+                raft.partition_id(),
+            );
         }
         Ok(())
     }
@@ -6034,8 +6231,15 @@ impl<RT: Runtime> Committer<RT> {
     }
 
     fn next_commit_ts(&mut self) -> anyhow::Result<Timestamp> {
+        self.next_commit_ts_at_or_after(Timestamp::MIN)
+    }
+
+    fn next_commit_ts_at_or_after(
+        &mut self,
+        requested_floor: Timestamp,
+    ) -> anyhow::Result<Timestamp> {
         let _timer = next_commit_ts_seconds();
-        let local_floor = self.local_commit_floor()?;
+        let local_floor = cmp::max(self.local_commit_floor()?, requested_floor);
         let timestamp_stage_path = if self.timestamp_oracle.is_some() {
             "tso"
         } else {
@@ -6090,14 +6294,15 @@ impl<RT: Runtime> Committer<RT> {
     fn explicit_prepare_commit_floor(&self) -> anyhow::Result<Timestamp> {
         let log_floor = self.log.max_ts().succ()?;
         let latest_ts = self.snapshot_manager.read().latest_ts();
+        let read_barrier_floor = self.read_barrier_floor.succ()?;
         let queued_floor = self
             .latest_queued_snapshot()
             .map(|(ts, _)| ts.succ())
             .transpose()?
             .unwrap_or(Timestamp::MIN);
         Ok(cmp::max(
-            log_floor,
-            cmp::max(latest_ts.succ()?, queued_floor),
+            read_barrier_floor,
+            cmp::max(log_floor, cmp::max(latest_ts.succ()?, queued_floor)),
         ))
     }
 
@@ -6116,7 +6321,7 @@ impl<RT: Runtime> Committer<RT> {
         ))
     }
 
-    fn next_max_repeatable_ts(&mut self) -> anyhow::Result<Timestamp> {
+    fn try_next_max_repeatable_ts(&mut self) -> anyhow::Result<Option<Timestamp>> {
         if !self.prepared_transactions.is_empty() {
             let current = *self.snapshot_manager.read().persisted_max_repeatable_ts();
             tracing::debug!(
@@ -6125,18 +6330,64 @@ impl<RT: Runtime> Committer<RT> {
                 "Skipping max repeatable timestamp bump while 2PC prepared transactions are \
                  unresolved",
             );
-            Ok(current)
+            Ok(Some(current))
         } else if let Some(min_pending) = self.pending_writes.min_ts() {
             // If there's a pending write, push max_repeatable_ts to be right
             // before the pending write, so followers can choose recent
             // timestamps but can't read at the timestamp of the pending write.
             anyhow::ensure!(min_pending <= self.last_assigned_ts);
-            min_pending.pred()
+            Ok(Some(min_pending.pred()?))
         } else {
-            // If there are no pending writes, bump last_assigned_ts and write
-            // to persistence and snapshot manager as a commit would.
-            self.next_commit_ts()
+            // Optional maintenance may use the same globally reserved timestamp
+            // space as commits, but it must not wait indefinitely for a new TSO
+            // batch while holding the single-threaded committer loop.
+            self.try_next_maintenance_ts()
         }
+    }
+
+    fn try_next_maintenance_ts(&mut self) -> anyhow::Result<Option<Timestamp>> {
+        let Some(tso) = self.timestamp_oracle.clone() else {
+            return self.next_commit_ts().map(Some);
+        };
+        let local_floor = self.local_commit_floor()?;
+        let ts = match tso.try_next_ts_at_or_after(local_floor)? {
+            Some(ts) => ts,
+            None => {
+                self.prefetch_maintenance_tso_batch(tso, local_floor);
+                return Ok(None);
+            },
+        };
+        anyhow::ensure!(
+            ts >= local_floor,
+            "TSO returned maintenance ts={} below requested local floor {}",
+            ts,
+            local_floor,
+        );
+        self.last_assigned_ts = ts;
+        Ok(Some(ts))
+    }
+
+    fn prefetch_maintenance_tso_batch(
+        &self,
+        tso: Arc<dyn crate::timestamp_oracle::TimestampOracle>,
+        local_floor: Timestamp,
+    ) {
+        if self
+            .maintenance_tso_refill_in_flight
+            .swap(true, Ordering::AcqRel)
+        {
+            return;
+        }
+        let refill_in_flight = self.maintenance_tso_refill_in_flight.clone();
+        tokio_spawn("prefetch_maintenance_tso_batch", async move {
+            if let Err(error) = tso.prefetch_ts_at_or_after(local_floor).await {
+                tracing::warn!(
+                    error = %format!("{error:#}"),
+                    "Failed to prefetch timestamp batch for optional maintenance",
+                );
+            }
+            refill_in_flight.store(false, Ordering::Release);
+        });
     }
 }
 
@@ -6621,8 +6872,28 @@ impl CommitterClient {
     }
 
     pub async fn allocate_commit_ts(&self) -> anyhow::Result<Timestamp> {
+        self.allocate_commit_ts_at_or_after(Timestamp::MIN).await
+    }
+
+    pub async fn allocate_commit_ts_at_or_after(
+        &self,
+        min_ts: Timestamp,
+    ) -> anyhow::Result<Timestamp> {
         let (tx, rx) = oneshot::channel();
-        let message = CommitterMessage::AllocateCommitTs { result: tx };
+        let message = CommitterMessage::AllocateCommitTs { min_ts, result: tx };
+        self.sender.try_send(message).map_err(|e| match e {
+            TrySendError::Full(..) => metrics::committer_full_error().into(),
+            TrySendError::Closed(..) => metrics::shutdown_error(),
+        })?;
+        rx.await.map_err(|_| metrics::shutdown_error())?
+    }
+
+    pub async fn close_read_timestamp(
+        &self,
+        target: Timestamp,
+    ) -> anyhow::Result<ReadTimestampClosure> {
+        let (tx, rx) = oneshot::channel();
+        let message = CommitterMessage::CloseReadTimestamp { target, result: tx };
         self.sender.try_send(message).map_err(|e| match e {
             TrySendError::Full(..) => metrics::committer_full_error().into(),
             TrySendError::Closed(..) => metrics::shutdown_error(),
@@ -6905,7 +7176,12 @@ enum CommitterMessage {
         result: oneshot::Sender<anyhow::Result<()>>,
     },
     AllocateCommitTs {
+        min_ts: Timestamp,
         result: oneshot::Sender<anyhow::Result<Timestamp>>,
+    },
+    CloseReadTimestamp {
+        target: Timestamp,
+        result: oneshot::Sender<anyhow::Result<ReadTimestampClosure>>,
     },
     /// 2PC CommitPrepared: finalize a previously prepared transaction.
     /// Writes to persistence, publishes commit, deletes redo log.

--- a/crates/database/src/database.rs
+++ b/crates/database/src/database.rs
@@ -114,7 +114,10 @@ use errors::{
     ErrorMetadataAnyhowExt,
 };
 use futures::{
-    future::Either,
+    future::{
+        join_all,
+        Either,
+    },
     pin_mut,
     stream::BoxStream,
     FutureExt,
@@ -178,6 +181,7 @@ use crate::{
     committer::{
         Committer,
         CommitterClient,
+        ReadTimestampClosure,
     },
     defaults::{
         bootstrap_system_tables,
@@ -191,6 +195,7 @@ use crate::{
     },
     owner_read::{
         GrpcOwnerReadClient,
+        OwnerAwareIndexReader,
         OwnerIndexEntry,
         OwnerIndexRangeResult,
         OwnerReadClient,
@@ -1229,6 +1234,16 @@ impl<RT: Runtime> Database<RT> {
     }
 
     #[cfg(test)]
+    pub(crate) fn with_owner_read_client_for_test(
+        &self,
+        owner_read_client: Arc<dyn OwnerReadClient>,
+    ) -> Self {
+        let mut database = self.clone();
+        database.owner_read_client = Some(owner_read_client);
+        database
+    }
+
+    #[cfg(test)]
     pub(crate) fn replication_frontier_for_test(
         &self,
         partition: crate::partition::PartitionId,
@@ -1819,6 +1834,147 @@ impl<RT: Runtime> Database<RT> {
         snapshot_manager.latest_ts()
     }
 
+    /// Build the index reader used while user code executes in Funrun.
+    ///
+    /// The function runner normally constructs its own persistence snapshot,
+    /// which is only authoritative for tables owned by this partition. In
+    /// cluster mode, replace that reader with one that sends remote user-table
+    /// ranges to their owner at the transaction's certified timestamp.
+    pub fn function_runner_index_reader(
+        &self,
+        ts: RepeatableTimestamp,
+    ) -> anyhow::Result<Option<Arc<dyn indexing::backend_in_memory_indexes::IndexReader>>> {
+        let (Some(owner_read_client), Some(partition_map)) = (
+            self.owner_read_client.clone(),
+            self.committer.partition_map(),
+        ) else {
+            return Ok(None);
+        };
+        if partition_map.num_partitions() <= 1 {
+            return Ok(None);
+        }
+
+        let snapshot = self.snapshot(ts)?;
+        let persistence_snapshot =
+            RepeatablePersistence::new(self.reader.clone(), ts, self.retention_validator())
+                .read_snapshot(ts)?;
+        Ok(Some(Arc::new(OwnerAwareIndexReader::new(
+            ts,
+            Arc::new(persistence_snapshot),
+            owner_read_client,
+            partition_map,
+            snapshot.table_registry.table_mapping().clone(),
+            snapshot.index_registry,
+        ))))
+    }
+
+    /// Establish one exact MVCC timestamp on every partition owner.
+    ///
+    /// TSO allocation alone is not a safe read timestamp: replica apply may
+    /// translate an origin timestamp forward in a node's local timeline. This
+    /// barrier raises the candidate until every current owner can persist and
+    /// serve the exact same timestamp without crossing unresolved 2PC state.
+    pub async fn cluster_safe_read_ts(&self) -> anyhow::Result<RepeatableTimestamp> {
+        let Some(partition_map) = self.committer.partition_map() else {
+            return Ok(self.now_ts_for_reads());
+        };
+        if partition_map.num_partitions() <= 1 {
+            return Ok(self.now_ts_for_reads());
+        }
+
+        let deadline = Instant::now() + *REMOTE_READ_FRONTIER_WAIT_TIMEOUT;
+        // Read barriers do not consume write timestamps. Start from the local
+        // readable floor and let owners raise the candidate until every leader
+        // can close the same timestamp. This keeps reads available when the
+        // NATS-backed write timestamp oracle is unavailable.
+        let mut candidate = *self.now_ts_for_reads();
+        loop {
+            anyhow::ensure!(
+                Instant::now() < deadline,
+                "Timed out after {:?} establishing a cluster-safe read timestamp",
+                *REMOTE_READ_FRONTIER_WAIT_TIMEOUT,
+            );
+            match self
+                .close_cluster_read_timestamp(&partition_map, candidate)
+                .await?
+            {
+                ReadTimestampClosure::Closed(closed) => {
+                    anyhow::ensure!(
+                        closed == candidate,
+                        "Cluster read barrier closed at {} instead of requested {}",
+                        closed,
+                        candidate,
+                    );
+                    anyhow::ensure!(
+                        self.committer.placement_version() == partition_map.placement_version(),
+                        "Placement changed from {} while closing cluster read timestamp {}",
+                        partition_map.placement_version(),
+                        candidate,
+                    );
+                    let latest = self.now_ts_for_reads();
+                    return latest.prior_ts(candidate);
+                },
+                ReadTimestampClosure::RetryAt(retry_at) => candidate = retry_at,
+                ReadTimestampClosure::Blocked(_) => {
+                    self.runtime.wait(Duration::from_millis(5)).await;
+                },
+            }
+        }
+    }
+
+    async fn close_cluster_read_timestamp(
+        &self,
+        partition_map: &crate::partition::PartitionMap,
+        target: Timestamp,
+    ) -> anyhow::Result<ReadTimestampClosure> {
+        let owner_read_client = self
+            .owner_read_client
+            .as_ref()
+            .with_context(|| "Cluster-safe reads require the authoritative owner-read client")?;
+        let local_partition = partition_map.local_partition();
+        let placement_version = partition_map.placement_version();
+        let remote_closures = join_all(
+            partition_map
+                .all_partitions()
+                .into_iter()
+                .filter(|partition| *partition != local_partition)
+                .map(|partition| {
+                    owner_read_client.close_read_timestamp(partition, placement_version, target)
+                }),
+        );
+        let (local, remotes) =
+            futures::join!(self.committer.close_read_timestamp(target), remote_closures,);
+        let mut closures = Vec::with_capacity(partition_map.num_partitions() as usize);
+        closures.push(local?);
+        closures.extend(remotes.into_iter().collect::<anyhow::Result<Vec<_>>>()?);
+
+        let mut retry_at = None;
+        let mut blocked_at = None;
+        for closure in closures {
+            match closure {
+                ReadTimestampClosure::Closed(closed) => anyhow::ensure!(
+                    closed == target,
+                    "Partition closed read timestamp {} instead of requested {}",
+                    closed,
+                    target,
+                ),
+                ReadTimestampClosure::RetryAt(ts) => {
+                    retry_at = Some(retry_at.map_or(ts, |current| cmp::max(current, ts)));
+                },
+                ReadTimestampClosure::Blocked(ts) => {
+                    blocked_at = Some(blocked_at.map_or(ts, |current| cmp::min(current, ts)));
+                },
+            }
+        }
+        if let Some(ts) = retry_at {
+            Ok(ReadTimestampClosure::RetryAt(ts))
+        } else if let Some(ts) = blocked_at {
+            Ok(ReadTimestampClosure::Blocked(ts))
+        } else {
+            Ok(ReadTimestampClosure::Closed(target))
+        }
+    }
+
     /// Waits until the given write timestamp is observable for new
     /// transactions. Used by retry loops to ensure they observe the write.
     pub async fn wait_for_write_ts(&self, write_ts: Timestamp) {
@@ -2343,6 +2499,17 @@ impl<RT: Runtime> Database<RT> {
         self.read_set_table_names(token.reads())
     }
 
+    fn token_reads_remote_partition(&self, token: &Token) -> anyhow::Result<bool> {
+        let Some(partition_map) = self.committer.partition_map() else {
+            return Ok(false);
+        };
+        let local_partition = partition_map.local_partition();
+        Ok(self
+            .token_table_names(token)?
+            .iter()
+            .any(|table| partition_map.partition_for_table(table) != local_partition))
+    }
+
     pub fn note_recent_delta_interest_for_token(
         &self,
         token: &Token,
@@ -2832,6 +2999,14 @@ impl<RT: Runtime> Database<RT> {
         ts: Timestamp,
     ) -> anyhow::Result<Result<Token, Option<Timestamp>>> {
         let _timer = metrics::refresh_token_timer();
+        if token.ts() < ts && self.token_reads_remote_partition(&token)? {
+            // The local write log only reflects remote-owner writes after
+            // replication applies them. It therefore cannot prove that a
+            // cached result containing remote reads stayed valid through `ts`.
+            // Force a rerun, which reads remote ranges from their owners at the
+            // cluster-certified timestamp instead of serving a stale cache hit.
+            return Ok(Err(Some(token.ts().succ()?)));
+        }
         self.log.refresh_token(token, ts)
     }
 

--- a/crates/database/src/lib.rs
+++ b/crates/database/src/lib.rs
@@ -79,6 +79,7 @@ pub mod text_index_worker;
 pub use committer::{
     table_dependency_sort_key,
     CommitterClient,
+    ReadTimestampClosure,
 };
 pub use component_registry::ComponentRegistry;
 pub use database_index_workers::{

--- a/crates/database/src/owner_read.rs
+++ b/crates/database/src/owner_read.rs
@@ -31,12 +31,23 @@ use common::{
     },
     types::{
         IndexDescriptor,
+        IndexId,
         IndexName,
+        RepeatableTimestamp,
         TabletIndexName,
         Timestamp,
     },
+    value::TableMapping,
 };
-use indexing::backend_in_memory_indexes::RangeRequest;
+use indexing::{
+    backend_in_memory_indexes::{
+        IndexEntry,
+        IndexPage,
+        IndexReader,
+        RangeRequest,
+    },
+    index_registry::IndexRegistry,
+};
 use pb::{
     common::{
         interval::End as IntervalEndProto,
@@ -44,8 +55,11 @@ use pb::{
         Order as OrderProto,
     },
     replication::{
+        close_read_timestamp_response::Outcome as CloseReadTimestampOutcome,
         owner_read_index_range_result::Cursor as CursorProto,
         owner_read_service_client::OwnerReadServiceClient as TonicOwnerReadClient,
+        CloseReadTimestampRequest,
+        CloseReadTimestampResponse,
         OwnerReadIndexEntry,
         OwnerReadIndexRange,
         OwnerReadIndexRangeResult,
@@ -64,7 +78,10 @@ use tonic::{
 use value::TabletId;
 
 use crate::{
-    committer::CommitterClient,
+    committer::{
+        CommitterClient,
+        ReadTimestampClosure,
+    },
     partition::{
         PartitionId,
         PlacementVersion,
@@ -92,6 +109,13 @@ pub struct OwnerIndexRangeResult {
 
 #[async_trait]
 pub trait OwnerReadClient: Send + Sync + 'static {
+    async fn close_read_timestamp(
+        &self,
+        owner_partition: PartitionId,
+        placement_version: PlacementVersion,
+        target_ts: Timestamp,
+    ) -> anyhow::Result<ReadTimestampClosure>;
+
     async fn read_index_ranges(
         &self,
         owner_partition: PartitionId,
@@ -99,6 +123,110 @@ pub trait OwnerReadClient: Send + Sync + 'static {
         snapshot_ts: Timestamp,
         ranges: Vec<RangeRequest>,
     ) -> anyhow::Result<Vec<OwnerIndexRangeResult>>;
+}
+
+/// Index reader used by the in-process function runner in a partitioned
+/// deployment. Local and system-table reads retain the normal persistence
+/// path, while remote user-table reads go directly to their placement owner.
+pub(crate) struct OwnerAwareIndexReader {
+    timestamp: RepeatableTimestamp,
+    local_reader: Arc<dyn IndexReader>,
+    owner_read_client: Arc<dyn OwnerReadClient>,
+    partition_map: crate::partition::PartitionMap,
+    table_mapping: TableMapping,
+    index_registry: IndexRegistry,
+}
+
+impl OwnerAwareIndexReader {
+    pub(crate) fn new(
+        timestamp: RepeatableTimestamp,
+        local_reader: Arc<dyn IndexReader>,
+        owner_read_client: Arc<dyn OwnerReadClient>,
+        partition_map: crate::partition::PartitionMap,
+        table_mapping: TableMapping,
+        index_registry: IndexRegistry,
+    ) -> Self {
+        Self {
+            timestamp,
+            local_reader,
+            owner_read_client,
+            partition_map,
+            table_mapping,
+            index_registry,
+        }
+    }
+}
+
+#[async_trait]
+impl IndexReader for OwnerAwareIndexReader {
+    async fn index_page(
+        &self,
+        index_id: IndexId,
+        tablet_id: TabletId,
+        interval: &Interval,
+        order: Order,
+        max_results: usize,
+    ) -> anyhow::Result<IndexPage> {
+        let table_name = self.table_mapping.tablet_name(tablet_id)?;
+        let owner = self.partition_map.partition_for_table(&table_name);
+        if table_name.is_system() || owner == self.partition_map.local_partition() {
+            return self
+                .local_reader
+                .index_page(index_id, tablet_id, interval, order, max_results)
+                .await;
+        }
+
+        let tablet_index_name = self
+            .index_registry
+            .enabled_index_by_index_id(&index_id)
+            .with_context(|| format!("Missing enabled index {index_id} for owner read"))?
+            .name();
+        anyhow::ensure!(
+            tablet_index_name.table() == &tablet_id,
+            "Index {index_id} belongs to tablet {}, not requested tablet {tablet_id}",
+            tablet_index_name.table(),
+        );
+        let printable_index_name = tablet_index_name
+            .clone()
+            .map_table(&self.table_mapping.tablet_to_name())?;
+        let mut results = self
+            .owner_read_client
+            .read_index_ranges(
+                owner,
+                self.partition_map.placement_version(),
+                *self.timestamp,
+                vec![RangeRequest {
+                    index_name: tablet_index_name,
+                    printable_index_name,
+                    interval: interval.clone(),
+                    order,
+                    max_size: max_results,
+                }],
+            )
+            .await?;
+        anyhow::ensure!(
+            results.len() == 1,
+            "Owner {owner} returned {} index pages for one request",
+            results.len(),
+        );
+        let result = results.pop().expect("result count checked above");
+        Ok(IndexPage {
+            entries: result
+                .entries
+                .into_iter()
+                .map(|entry| IndexEntry {
+                    key: entry.key,
+                    ts: entry.ts,
+                    value: entry.document,
+                })
+                .collect(),
+            cursor: result.cursor,
+        })
+    }
+
+    fn timestamp(&self) -> RepeatableTimestamp {
+        self.timestamp
+    }
 }
 
 fn tablet_id_to_bytes(tablet_id: TabletId) -> Vec<u8> {
@@ -283,6 +411,41 @@ impl OwnerReadGrpcClient {
             .into_inner();
         results.into_iter().map(result_from_proto).collect()
     }
+
+    async fn close_read_timestamp(
+        &self,
+        owner_partition: PartitionId,
+        placement_version: PlacementVersion,
+        target_ts: Timestamp,
+    ) -> anyhow::Result<ReadTimestampClosure> {
+        let request = CloseReadTimestampRequest {
+            owner_partition: owner_partition.0,
+            placement_version: u64::from(placement_version),
+            target_ts: u64::from(target_ts),
+        };
+        let request = match &self.cluster_auth {
+            Some(auth) => auth.request(request),
+            None => Request::new(request),
+        };
+        let CloseReadTimestampResponse { outcome } = self
+            .client
+            .clone()
+            .close_read_timestamp(request)
+            .await
+            .context("gRPC owner read barrier failed")?
+            .into_inner();
+        match outcome.context("Owner read barrier response missing outcome")? {
+            CloseReadTimestampOutcome::ClosedTs(ts) => {
+                Ok(ReadTimestampClosure::Closed(ts.try_into()?))
+            },
+            CloseReadTimestampOutcome::RetryAtTs(ts) => {
+                Ok(ReadTimestampClosure::RetryAt(ts.try_into()?))
+            },
+            CloseReadTimestampOutcome::BlockedTs(ts) => {
+                Ok(ReadTimestampClosure::Blocked(ts.try_into()?))
+            },
+        }
+    }
 }
 
 #[derive(Clone)]
@@ -332,6 +495,41 @@ impl GrpcOwnerReadClient {
 
 #[async_trait]
 impl OwnerReadClient for GrpcOwnerReadClient {
+    async fn close_read_timestamp(
+        &self,
+        owner_partition: PartitionId,
+        placement_version: PlacementVersion,
+        target_ts: Timestamp,
+    ) -> anyhow::Result<ReadTimestampClosure> {
+        let addresses = self
+            .committer
+            .node_addresses()
+            .and_then(|addresses| addresses.addresses_for(owner_partition).map(<[_]>::to_vec))
+            .with_context(|| {
+                format!("No live owner-read candidates for partition {owner_partition}")
+            })?;
+        let mut failures = Vec::new();
+        for address in addresses {
+            let attempt = async {
+                self.pool
+                    .client(&address)
+                    .await?
+                    .close_read_timestamp(owner_partition, placement_version, target_ts)
+                    .await
+            }
+            .await;
+            match attempt {
+                Ok(result) => return Ok(result),
+                Err(error) => failures.push(format!("{address}: {error:#}")),
+            }
+        }
+        anyhow::bail!(
+            "All owner-read barrier candidates for partition {} failed: {}",
+            owner_partition,
+            failures.join("; "),
+        )
+    }
+
     async fn read_index_ranges(
         &self,
         owner_partition: PartitionId,

--- a/crates/database/src/tests/write_scaling_tests.rs
+++ b/crates/database/src/tests/write_scaling_tests.rs
@@ -68,6 +68,7 @@ use futures::{
     stream::BoxStream,
     TryStreamExt,
 };
+use indexing::backend_in_memory_indexes::RangeRequest;
 use keybroker::Identity;
 use parking_lot::Mutex;
 use pb::replication::{
@@ -122,6 +123,7 @@ use crate::{
     },
     committer::{
         CommitterClient,
+        ReadTimestampClosure,
         AFTER_PENDING_WRITE_SNAPSHOT,
         AFTER_RAFT_APPLIED_INDEX_PERSISTENCE,
         AFTER_RAFT_CONVEX_PERSISTENCE,
@@ -136,6 +138,10 @@ use crate::{
         NodeMembership,
     },
     nats_distributed_log::DeltaEnvelope,
+    owner_read::{
+        OwnerIndexRangeResult,
+        OwnerReadClient,
+    },
     partition::{
         PartitionId,
         PartitionMap,
@@ -396,6 +402,76 @@ impl DistributedLog for SwitchableDistributedLog {
 
 fn partitioned_map(local_partition: PartitionId) -> PartitionMap {
     PartitionMap::from_config("messages=0,projects=1", local_partition, 2)
+}
+
+struct RetryOnceOwnerReadClient {
+    calls: AtomicUsize,
+    targets: Mutex<Vec<Timestamp>>,
+}
+
+impl RetryOnceOwnerReadClient {
+    fn new() -> Self {
+        Self {
+            calls: AtomicUsize::new(0),
+            targets: Mutex::new(Vec::new()),
+        }
+    }
+}
+
+#[async_trait]
+impl OwnerReadClient for RetryOnceOwnerReadClient {
+    async fn close_read_timestamp(
+        &self,
+        _owner_partition: PartitionId,
+        _placement_version: PlacementVersion,
+        target_ts: Timestamp,
+    ) -> anyhow::Result<ReadTimestampClosure> {
+        self.targets.lock().push(target_ts);
+        if self.calls.fetch_add(1, Ordering::SeqCst) == 0 {
+            Ok(ReadTimestampClosure::RetryAt(target_ts.succ()?))
+        } else {
+            Ok(ReadTimestampClosure::Closed(target_ts))
+        }
+    }
+
+    async fn read_index_ranges(
+        &self,
+        _owner_partition: PartitionId,
+        _placement_version: PlacementVersion,
+        _snapshot_ts: Timestamp,
+        _ranges: Vec<RangeRequest>,
+    ) -> anyhow::Result<Vec<OwnerIndexRangeResult>> {
+        anyhow::bail!("read_index_ranges is not used by the read barrier test")
+    }
+}
+
+struct PlacementChangingOwnerReadClient {
+    committer: CommitterClient,
+    replacement: PlacementMetadata,
+}
+
+#[async_trait]
+impl OwnerReadClient for PlacementChangingOwnerReadClient {
+    async fn close_read_timestamp(
+        &self,
+        _owner_partition: PartitionId,
+        _placement_version: PlacementVersion,
+        target_ts: Timestamp,
+    ) -> anyhow::Result<ReadTimestampClosure> {
+        self.committer
+            .refresh_placement_metadata(self.replacement.clone())?;
+        Ok(ReadTimestampClosure::Closed(target_ts))
+    }
+
+    async fn read_index_ranges(
+        &self,
+        _owner_partition: PartitionId,
+        _placement_version: PlacementVersion,
+        _snapshot_ts: Timestamp,
+        _ranges: Vec<RangeRequest>,
+    ) -> anyhow::Result<Vec<OwnerIndexRangeResult>> {
+        anyhow::bail!("read_index_ranges is not used by the read barrier test")
+    }
 }
 
 fn partitioned_map_with_version(
@@ -1106,6 +1182,23 @@ impl TimestampOracle for FailingTimestampOracle {
 
     async fn advance_committed_ts(&self, _ts: Timestamp) -> anyhow::Result<()> {
         anyhow::bail!("TSO unavailable during idle heartbeat test");
+    }
+}
+
+struct HangingTimestampOracle;
+
+#[async_trait]
+impl TimestampOracle for HangingTimestampOracle {
+    async fn next_ts_at_or_after(&self, _min_ts: Timestamp) -> anyhow::Result<Timestamp> {
+        std::future::pending().await
+    }
+
+    async fn max_committed_ts(&self) -> anyhow::Result<Timestamp> {
+        std::future::pending().await
+    }
+
+    async fn advance_committed_ts(&self, _ts: Timestamp) -> anyhow::Result<()> {
+        std::future::pending().await
     }
 }
 
@@ -2500,6 +2593,300 @@ async fn test_max_repeatable_bump_does_not_overtake_prepared_commit(
     .await?;
     assert_eq!(messages.len(), 1);
 
+    Ok(())
+}
+
+#[convex_macro::test_runtime]
+async fn test_cluster_read_barrier_waits_for_prepared_transaction(
+    rt: TestRuntime,
+) -> anyhow::Result<()> {
+    let log = Arc::new(InMemoryDistributedLog::new());
+    let node = create_node(&rt, log, Some(partitioned_map(PartitionId(0)))).await?;
+
+    let mut tx = node.begin(Identity::system()).await?;
+    TestFacingModel::new(&mut tx)
+        .insert(&"messages".parse()?, assert_obj!("text" => "prepared"))
+        .await?;
+    let txn_id = TwoPhaseTransactionId::new();
+    let prepare = node
+        .committer_for_test()
+        .prepare(
+            txn_id.clone(),
+            tx.finalize()?,
+            WriteSource::new("read_barrier_prepared_test"),
+        )
+        .await?;
+    let target = prepare.prepare_ts.succ()?;
+
+    assert_eq!(
+        node.committer_for_test()
+            .close_read_timestamp(target)
+            .await?,
+        ReadTimestampClosure::Blocked(prepare.prepare_ts),
+    );
+
+    node.committer_for_test().rollback_prepared(txn_id).await?;
+    assert_eq!(
+        node.committer_for_test()
+            .close_read_timestamp(target)
+            .await?,
+        ReadTimestampClosure::Closed(target),
+    );
+    assert_eq!(*node.now_ts_for_reads(), target);
+    Ok(())
+}
+
+#[convex_macro::test_runtime]
+async fn test_cluster_read_barrier_retries_above_local_timeline(
+    rt: TestRuntime,
+) -> anyhow::Result<()> {
+    let log = Arc::new(InMemoryDistributedLog::new());
+    let node = create_node(&rt, log, Some(partitioned_map(PartitionId(0)))).await?;
+    let lower = node.committer_for_test().allocate_commit_ts().await?;
+    let higher = node.committer_for_test().allocate_commit_ts().await?;
+
+    assert_eq!(
+        node.committer_for_test()
+            .close_read_timestamp(lower)
+            .await?,
+        ReadTimestampClosure::RetryAt(higher),
+    );
+    assert_eq!(
+        node.committer_for_test()
+            .close_read_timestamp(higher)
+            .await?,
+        ReadTimestampClosure::Closed(higher),
+    );
+    Ok(())
+}
+
+#[convex_macro::test_runtime]
+async fn test_cluster_read_barrier_retries_all_owners_at_one_new_timestamp(
+    rt: TestRuntime,
+) -> anyhow::Result<()> {
+    let log = Arc::new(InMemoryDistributedLog::new());
+    let node = create_node(&rt, log, Some(partitioned_map(PartitionId(0)))).await?;
+    let owner = Arc::new(RetryOnceOwnerReadClient::new());
+    let database = node.with_owner_read_client_for_test(owner.clone());
+    let initial_local_ts = *database.now_ts_for_reads();
+
+    let safe_ts = database.cluster_safe_read_ts().await?;
+    let targets = owner.targets.lock();
+    assert_eq!(targets.len(), 2);
+    assert_eq!(targets[0], initial_local_ts);
+    assert!(targets[1] > targets[0]);
+    assert_eq!(*safe_ts, targets[1]);
+    Ok(())
+}
+
+#[convex_macro::test_runtime]
+async fn test_cluster_read_barrier_fails_closed_across_placement_change(
+    rt: TestRuntime,
+) -> anyhow::Result<()> {
+    let log = Arc::new(InMemoryDistributedLog::new());
+    let node = create_node(&rt, log, Some(partitioned_map(PartitionId(0)))).await?;
+    let replacement = PlacementMetadata::from_static_config(StaticPlacementConfig {
+        table_assignments: "messages=0,projects=1",
+        num_partitions: 2,
+        placement_version: PlacementVersion::new(1),
+    });
+    let database =
+        node.with_owner_read_client_for_test(Arc::new(PlacementChangingOwnerReadClient {
+            committer: node.committer_for_test(),
+            replacement,
+        }));
+
+    let err = database
+        .cluster_safe_read_ts()
+        .await
+        .expect_err("a read barrier must not span placement versions");
+    assert!(
+        format!("{err:#}").contains("Placement changed from"),
+        "unexpected error: {err:#}",
+    );
+    Ok(())
+}
+
+#[convex_macro::test_runtime]
+async fn test_cluster_read_barrier_requires_fresh_raft_serving_lease(
+    rt: TestRuntime,
+) -> anyhow::Result<()> {
+    let log = Arc::new(InMemoryDistributedLog::new());
+    let node = create_node(&rt, log, Some(partitioned_map(PartitionId(0)))).await?;
+    let (raft_state, _raft_rx) =
+        RaftPartitionState::new_with_mailbox_for_test(true, 1, PartitionId(0), 1);
+    node.attach_raft_state(raft_state.clone()).await?;
+    raft_state.expire_leader_serving_lease_for_test();
+    let target = node.committer_for_test().allocate_commit_ts().await?;
+
+    let err = node
+        .committer_for_test()
+        .close_read_timestamp(target)
+        .await
+        .expect_err("a stale Raft leader must not certify a read barrier");
+    assert!(
+        format!("{err:#}").contains("has no valid serving lease"),
+        "unexpected error: {err:#}",
+    );
+    Ok(())
+}
+
+#[convex_macro::test_runtime]
+async fn test_cluster_read_barrier_floor_survives_restart(rt: TestRuntime) -> anyhow::Result<()> {
+    let log = Arc::new(InMemoryDistributedLog::new());
+    let persistence = Arc::new(TestPersistence::new());
+    let node = create_node_with_persistence(
+        &rt,
+        persistence.clone(),
+        log.clone(),
+        Some(partitioned_map(PartitionId(0))),
+        None,
+        Arc::new(NoopTwoPhaseDecisionLog),
+        None,
+    )
+    .await?;
+    let target = node.now_ts_for_reads().succ()?;
+    assert_eq!(
+        node.committer_for_test()
+            .close_read_timestamp(target)
+            .await?,
+        ReadTimestampClosure::Closed(target),
+    );
+    assert_eq!(*node.persisted_max_repeatable_ts_for_test(), target);
+    node.shutdown().await?;
+
+    let restarted_tso = Arc::new(RecordingTimestampOracle::new());
+    let restarted = create_node_with_persistence(
+        &rt,
+        persistence,
+        log,
+        Some(partitioned_map(PartitionId(0))),
+        None,
+        Arc::new(NoopTwoPhaseDecisionLog),
+        Some(restarted_tso.clone()),
+    )
+    .await?;
+    let next_commit_ts = restarted.committer_for_test().allocate_commit_ts().await?;
+
+    assert!(next_commit_ts > target);
+    assert_eq!(
+        restarted_tso.requested_floors().last().copied(),
+        Some(target.succ()?),
+        "a future leader must allocate commits above the persisted read barrier",
+    );
+    Ok(())
+}
+
+#[convex_macro::test_runtime]
+async fn test_remote_read_token_cannot_refresh_from_local_write_log(
+    rt: TestRuntime,
+) -> anyhow::Result<()> {
+    let log = Arc::new(InMemoryDistributedLog::new());
+    let node = create_node(
+        &rt,
+        log,
+        Some(partitioned_map_with_version(
+            PartitionId(1),
+            PlacementVersion::new(1),
+        )),
+    )
+    .await?;
+    insert_doc(&node, "projects", assert_obj!("name" => "cached remotely")).await?;
+
+    let mut read_tx = node.begin(Identity::system()).await?;
+    let mut query = ResolvedQuery::new(
+        &mut read_tx,
+        TableNamespace::root_component(),
+        Query::full_table_scan("projects".parse()?, Order::Asc),
+    )?;
+    while query.next(&mut read_tx, Some(2)).await?.is_some() {}
+    let token = read_tx.into_token()?;
+    let original_ts = token.ts();
+    let target = node.committer_for_test().allocate_commit_ts().await?;
+    assert_eq!(
+        node.committer_for_test()
+            .close_read_timestamp(target)
+            .await?,
+        ReadTimestampClosure::Closed(target),
+    );
+
+    // Move the table to the other partition without changing its local table
+    // metadata. A local-log-only refresh would incorrectly certify this token.
+    node.committer_for_test()
+        .refresh_placement_metadata(PlacementMetadata::from_static_config(
+            StaticPlacementConfig {
+                table_assignments: "messages=1,projects=0",
+                num_partitions: 2,
+                placement_version: PlacementVersion::new(2),
+            },
+        ))?;
+
+    assert_eq!(
+        node.refresh_token(token, target).await?,
+        Err(Some(original_ts.succ()?)),
+        "remote reads must rerun against their owner rather than refresh from the local mirror",
+    );
+    Ok(())
+}
+
+#[convex_macro::test_runtime]
+async fn test_live_prepare_rejects_timestamp_closed_for_cluster_reads(
+    rt: TestRuntime,
+) -> anyhow::Result<()> {
+    let log = Arc::new(InMemoryDistributedLog::new());
+    let node = create_node(&rt, log, Some(partitioned_map(PartitionId(1)))).await?;
+    insert_doc(
+        &node,
+        "projects",
+        assert_obj!("name" => "seed-before-read-barrier"),
+    )
+    .await?;
+
+    let mut tx = node.begin(Identity::system()).await?;
+    TestFacingModel::new(&mut tx)
+        .insert(
+            &"projects".parse()?,
+            assert_obj!("name" => "must-commit-after-read-barrier"),
+        )
+        .await?;
+    let final_tx = tx.finalize()?;
+    let write_indexes: Vec<_> = final_tx
+        .writes
+        .coalesced_writes()
+        .enumerate()
+        .map(|(index, _)| index)
+        .collect();
+    let write_source = WriteSource::new("prepare_after_read_barrier_test");
+    let participant_tx = ParticipantTransaction::from_final_transaction(
+        &final_tx,
+        PartitionId(1),
+        &write_indexes,
+        &partitioned_map(PartitionId(1)),
+        &write_source,
+    )?;
+    let barrier_ts = node.committer_for_test().allocate_commit_ts().await?;
+    assert_eq!(
+        node.committer_for_test()
+            .close_read_timestamp(barrier_ts)
+            .await?,
+        ReadTimestampClosure::Closed(barrier_ts),
+    );
+
+    let err = node
+        .committer_for_test()
+        .prepare_remote(
+            TwoPhaseTransactionId::new(),
+            participant_tx,
+            write_source,
+            barrier_ts,
+            vec![PartitionId(1)],
+        )
+        .await
+        .expect_err("a late prepare must not cross an already-certified read barrier");
+    assert!(
+        format!("{err:#}").contains("2PC Prepare assigned ts="),
+        "unexpected error: {err:#}",
+    );
     Ok(())
 }
 
@@ -8663,6 +9050,43 @@ fn test_idle_remote_read_frontier_heartbeat_tso_failure_is_nonfatal() -> anyhow:
         committer
             .tick_idle_remote_read_frontier_heartbeat_for_test()
             .await?;
+
+        Ok(())
+    })
+}
+
+#[test]
+fn test_idle_frontier_maintenance_cannot_block_owner_read_barrier() -> anyhow::Result<()> {
+    let td = TestDriver::new_with_io();
+    let rt = td.rt();
+    td.run_until(async move {
+        let log = Arc::new(InMemoryDistributedLog::new());
+        let tso: Arc<dyn TimestampOracle> = Arc::new(HangingTimestampOracle);
+        let node = create_node_with_options(
+            &rt,
+            log,
+            Some(partitioned_map(PartitionId(0))),
+            None,
+            Some(tso),
+        )
+        .await?;
+
+        let committer = node.committer_for_test();
+        tokio::time::timeout(
+            Duration::from_secs(1),
+            committer.tick_idle_remote_read_frontier_heartbeat_for_test(),
+        )
+        .await
+        .context("idle frontier maintenance blocked the committer")??;
+
+        let target = *node.now_ts_for_reads();
+        let closure = tokio::time::timeout(
+            Duration::from_secs(1),
+            committer.close_read_timestamp(target),
+        )
+        .await
+        .context("owner read barrier was blocked behind TSO maintenance")??;
+        assert_eq!(closure, ReadTimestampClosure::Closed(target));
 
         Ok(())
     })

--- a/crates/database/src/timestamp_oracle.rs
+++ b/crates/database/src/timestamp_oracle.rs
@@ -55,6 +55,25 @@ pub trait TimestampOracle: Send + Sync + 'static {
     /// callers to bump a returned timestamp outside the reserved range.
     async fn next_ts_at_or_after(&self, min_ts: Timestamp) -> anyhow::Result<Timestamp>;
 
+    /// Assign a timestamp only when doing so requires no network I/O.
+    ///
+    /// Optional maintenance runs this method from the single committer loop.
+    /// Batch-based implementations return `None` when their local reservation
+    /// cannot satisfy the floor; callers may then request an asynchronous
+    /// refill without blocking commits, reads, or replicated apply.
+    fn try_next_ts_at_or_after(&self, _min_ts: Timestamp) -> anyhow::Result<Option<Timestamp>> {
+        Ok(None)
+    }
+
+    /// Ensure a future nonblocking allocation can satisfy `min_ts`.
+    ///
+    /// This may perform network I/O and must therefore be called outside the
+    /// single-threaded committer loop. Implementations that do not batch may
+    /// leave the default no-op behavior.
+    async fn prefetch_ts_at_or_after(&self, _min_ts: Timestamp) -> anyhow::Result<()> {
+        Ok(())
+    }
+
     /// Get the current maximum committed timestamp across all nodes.
     /// Used for read-after-write consistency.
     async fn max_committed_ts(&self) -> anyhow::Result<Timestamp>;
@@ -110,6 +129,17 @@ impl<RT: Runtime> TimestampOracle for LocalTimestampOracle<RT> {
         Ok(next)
     }
 
+    fn try_next_ts_at_or_after(&self, min_ts: Timestamp) -> anyhow::Result<Option<Timestamp>> {
+        let mut state = self.state.lock();
+        let system_ts = self.runtime.generate_timestamp()?;
+        let next = std::cmp::max(
+            std::cmp::max(system_ts, min_ts),
+            std::cmp::max(state.last_assigned.succ()?, state.max_committed.succ()?),
+        );
+        state.last_assigned = next;
+        Ok(Some(next))
+    }
+
     async fn max_committed_ts(&self) -> anyhow::Result<Timestamp> {
         Ok(self.state.lock().max_committed)
     }
@@ -142,6 +172,7 @@ pub struct BatchTimestampOracle {
     kv: async_nats::jetstream::kv::Store,
     batch_size: u64,
     state: Mutex<BatchState>,
+    reservation_lock: tokio::sync::Mutex<()>,
 }
 
 struct BatchState {
@@ -154,6 +185,10 @@ struct BatchState {
     /// Force the next assignment to refresh the global committed floor before
     /// reserving or consuming any batch.
     refresh_committed_floor: bool,
+    /// Invalidates a reservation that was in flight when Raft leadership
+    /// changed. Such a range is safely leaked rather than installed in a newer
+    /// leadership epoch.
+    reservation_epoch: u64,
 }
 
 const TSO_COUNTER_KEY: &str = "tso_counter";
@@ -189,6 +224,7 @@ fn discard_batch_state_for_leadership_change(state: &mut BatchState) {
     state.current = 0;
     state.upper_bound = 0;
     state.refresh_committed_floor = true;
+    state.reservation_epoch = state.reservation_epoch.wrapping_add(1);
 }
 
 fn refresh_committed_floor(state: &mut BatchState, committed_floor: Timestamp) {
@@ -247,7 +283,9 @@ impl BatchTimestampOracle {
                 upper_bound: 0,
                 max_committed: Timestamp::MIN,
                 refresh_committed_floor: false,
+                reservation_epoch: 0,
             }),
+            reservation_lock: tokio::sync::Mutex::new(()),
         })
     }
 
@@ -304,20 +342,71 @@ impl BatchTimestampOracle {
         anyhow::bail!("TSO: Failed to reserve batch after 10 attempts")
     }
 
-    fn assign_from_reserved_batch(
+    fn try_assign_from_reserved_batch(
         &self,
-        lower: u64,
-        upper: u64,
-        min_next: u64,
-    ) -> anyhow::Result<Timestamp> {
+        min_ts: Timestamp,
+    ) -> anyhow::Result<Option<Timestamp>> {
         let mut state = self.state.lock();
-        state.current = lower;
-        state.upper_bound = upper;
-        let (ts, next_current) =
+        if state.refresh_committed_floor {
+            return Ok(None);
+        }
+        let min_next = local_min_next_from_floor(min_ts, state.max_committed)?;
+        let Some((ts, next_current)) =
             next_ts_from_reserved_batch(state.current, state.upper_bound, min_next)
-                .context("TSO: Reserved batch cannot satisfy requested floor")?;
+        else {
+            return Ok(None);
+        };
         state.current = next_current;
-        Timestamp::try_from(ts)
+        Ok(Some(Timestamp::try_from(ts)?))
+    }
+
+    async fn ensure_reserved_batch_at_or_above(&self, min_ts: Timestamp) -> anyhow::Result<()> {
+        let _reservation_guard = self.reservation_lock.lock().await;
+        loop {
+            if self.try_assignable_from_reserved_batch(min_ts)? {
+                return Ok(());
+            }
+
+            let committed_floor = self.max_committed_ts().await?;
+            let (min_next, reservation_epoch) = {
+                let mut state = self.state.lock();
+                refresh_committed_floor(&mut state, committed_floor);
+                let min_next = local_min_next_from_floor(min_ts, state.max_committed)?;
+                if reserved_batch_can_satisfy_local_floor(
+                    state.current,
+                    state.upper_bound,
+                    min_next,
+                ) {
+                    return Ok(());
+                }
+                (min_next, state.reservation_epoch)
+            };
+
+            let (lower, upper) = self.reserve_batch_at_or_above(min_next).await?;
+            let mut state = self.state.lock();
+            if state.reservation_epoch != reservation_epoch {
+                // Leadership changed while NATS was reserving this range. Do not
+                // install it into the newer epoch; loop and fence against the
+                // latest committed floor instead.
+                continue;
+            }
+            state.current = lower;
+            state.upper_bound = upper;
+            return Ok(());
+        }
+    }
+
+    fn try_assignable_from_reserved_batch(&self, min_ts: Timestamp) -> anyhow::Result<bool> {
+        let state = self.state.lock();
+        if state.refresh_committed_floor {
+            return Ok(false);
+        }
+        let min_next = local_min_next_from_floor(min_ts, state.max_committed)?;
+        Ok(reserved_batch_can_satisfy_local_floor(
+            state.current,
+            state.upper_bound,
+            min_next,
+        ))
     }
 }
 
@@ -327,57 +416,10 @@ impl TimestampOracle for BatchTimestampOracle {
         let timer = metrics::tso_operation_timer("next_ts_at_or_after");
         let result = async {
             loop {
-                if self.state.lock().refresh_committed_floor {
-                    let committed_floor = self.max_committed_ts().await?;
-                    let mut state = self.state.lock();
-                    refresh_committed_floor(&mut state, committed_floor);
+                if let Some(ts) = self.try_assign_from_reserved_batch(min_ts)? {
+                    return Ok(ts);
                 }
-
-                let local_min_next = {
-                    let state = self.state.lock();
-                    local_min_next_from_floor(min_ts, state.max_committed)?
-                };
-
-                let can_assign_from_reserved_batch = {
-                    let state = self.state.lock();
-                    reserved_batch_can_satisfy_local_floor(
-                        state.current,
-                        state.upper_bound,
-                        local_min_next,
-                    )
-                };
-
-                if !can_assign_from_reserved_batch {
-                    let committed_floor = self.max_committed_ts().await?;
-                    let min_next = {
-                        let mut state = self.state.lock();
-                        refresh_committed_floor(&mut state, committed_floor);
-                        u64::from(std::cmp::max(min_ts, state.max_committed.succ()?))
-                    };
-
-                    let (lower, upper) = self.reserve_batch_at_or_above(min_next).await?;
-                    return self.assign_from_reserved_batch(lower, upper, min_next);
-                }
-
-                let candidate = {
-                    let mut state = self.state.lock();
-                    if let Some((ts, next_current)) = next_ts_from_reserved_batch(
-                        state.current,
-                        state.upper_bound,
-                        local_min_next,
-                    ) {
-                        state.current = next_current;
-                        Some(ts)
-                    } else {
-                        None
-                    }
-                };
-
-                if let Some(ts) = candidate {
-                    return Timestamp::try_from(ts);
-                }
-
-                continue;
+                self.ensure_reserved_batch_at_or_above(min_ts).await?;
             }
         }
         .await;
@@ -385,6 +427,14 @@ impl TimestampOracle for BatchTimestampOracle {
             timer.finish();
         }
         result
+    }
+
+    fn try_next_ts_at_or_after(&self, min_ts: Timestamp) -> anyhow::Result<Option<Timestamp>> {
+        self.try_assign_from_reserved_batch(min_ts)
+    }
+
+    async fn prefetch_ts_at_or_after(&self, min_ts: Timestamp) -> anyhow::Result<()> {
+        self.ensure_reserved_batch_at_or_above(min_ts).await
     }
 
     async fn max_committed_ts(&self) -> anyhow::Result<Timestamp> {
@@ -523,6 +573,16 @@ pub mod testing {
             Ok(next)
         }
 
+        fn try_next_ts_at_or_after(&self, min_ts: Timestamp) -> anyhow::Result<Option<Timestamp>> {
+            let mut state = self.state.lock();
+            let next = std::cmp::max(
+                min_ts,
+                std::cmp::max(state.last_assigned.succ()?, state.max_committed.succ()?),
+            );
+            state.last_assigned = next;
+            Ok(Some(next))
+        }
+
         async fn max_committed_ts(&self) -> anyhow::Result<Timestamp> {
             Ok(self.state.lock().max_committed)
         }
@@ -599,6 +659,7 @@ mod tests {
             upper_bound: 200,
             max_committed: Timestamp::must(120),
             refresh_committed_floor: false,
+            reservation_epoch: 0,
         };
 
         discard_batch_state_for_leadership_change(&mut state);
@@ -616,6 +677,7 @@ mod tests {
             upper_bound: 200,
             max_committed: Timestamp::must(120),
             refresh_committed_floor: false,
+            reservation_epoch: 0,
         };
 
         discard_batch_state_for_leadership_change(&mut state);

--- a/crates/database/src/transaction_index.rs
+++ b/crates/database/src/transaction_index.rs
@@ -1065,6 +1065,7 @@ mod tests {
         backend_in_memory_indexes::{
             BackendInMemoryIndexes,
             DatabaseIndexSnapshot,
+            IndexReader,
             RangeRequest,
         },
         index_registry::IndexRegistry,
@@ -1088,6 +1089,7 @@ mod tests {
     };
     use crate::{
         owner_read::{
+            OwnerAwareIndexReader,
             OwnerIndexEntry,
             OwnerIndexRangeResult,
             OwnerReadClient,
@@ -1100,6 +1102,7 @@ mod tests {
         query::IndexRangeResponse,
         transaction_index::TransactionIndex,
         FollowerRetentionManager,
+        ReadTimestampClosure,
     };
 
     #[derive(Clone)]
@@ -1118,6 +1121,15 @@ mod tests {
 
     #[async_trait]
     impl OwnerReadClient for FakeOwnerReadClient {
+        async fn close_read_timestamp(
+            &self,
+            _owner_partition: PartitionId,
+            _placement_version: PlacementVersion,
+            target_ts: Timestamp,
+        ) -> anyhow::Result<ReadTimestampClosure> {
+            Ok(ReadTimestampClosure::Closed(target_ts))
+        }
+
         async fn read_index_ranges(
             &self,
             owner_partition: PartitionId,
@@ -1210,15 +1222,16 @@ mod tests {
             unchecked_repeatable_ts(initial_ts),
             retention_manager.clone(),
         );
-        let (mut index_registry, mut in_memory_indexes, _search, _) = bootstrap_index(
-            &mut id_generator,
-            vec![IndexMetadata::new_enabled(
-                by_id.clone(),
-                IndexedFields::by_id(),
-            )],
-            repeatable,
-        )
-        .await?;
+        let (mut index_registry, mut in_memory_indexes, _search, index_id_by_name) =
+            bootstrap_index(
+                &mut id_generator,
+                vec![IndexMetadata::new_enabled(
+                    by_id.clone(),
+                    IndexedFields::by_id(),
+                )],
+                repeatable,
+            )
+            .await?;
 
         let stale = ResolvedDocument::new(
             next_document_id(&mut id_generator, "projects")?,
@@ -1253,11 +1266,12 @@ mod tests {
             retention_manager,
         )
         .read_snapshot(unchecked_repeatable_ts(snapshot_ts))?;
+        let local_reader: Arc<dyn IndexReader> = Arc::new(persistence_snapshot);
         let database_index_snapshot = DatabaseIndexSnapshot::new(
             index_registry.clone(),
             Arc::new(in_memory_indexes),
             id_generator.clone(),
-            Arc::new(persistence_snapshot),
+            local_reader.clone(),
             None,
             None,
         );
@@ -1276,12 +1290,6 @@ mod tests {
             }],
             cursor: CursorPosition::End,
         };
-        let calls = Arc::new(StdMutex::new(Vec::new()));
-        let owner_client = Arc::new(FakeOwnerReadClient {
-            calls: calls.clone(),
-            results: vec![owner_result],
-            failure: None,
-        });
         let placement_version = PlacementVersion::new(9);
         let partition_map = PartitionMap::from_config_with_version(
             "projects=1",
@@ -1289,6 +1297,38 @@ mod tests {
             2,
             placement_version,
         );
+        let runner_calls = Arc::new(StdMutex::new(Vec::new()));
+        let runner_reader = OwnerAwareIndexReader::new(
+            unchecked_repeatable_ts(snapshot_ts),
+            local_reader,
+            Arc::new(FakeOwnerReadClient {
+                calls: runner_calls.clone(),
+                results: vec![owner_result.clone()],
+                failure: None,
+            }),
+            partition_map.clone(),
+            id_generator.clone(),
+            index_registry.clone(),
+        );
+        let page = runner_reader
+            .index_page(
+                index_id_by_name[&by_id].internal_id(),
+                tablet_id,
+                &Interval::all(),
+                Order::Asc,
+                100,
+            )
+            .await?;
+        assert_eq!(page.entries.len(), 1);
+        assert_eq!(page.entries[0].value.unpack(), fresh);
+        assert_eq!(runner_calls.lock().unwrap().len(), 1);
+
+        let calls = Arc::new(StdMutex::new(Vec::new()));
+        let owner_client = Arc::new(FakeOwnerReadClient {
+            calls: calls.clone(),
+            results: vec![owner_result],
+            failure: None,
+        });
         let mut index = TransactionIndex::new_with_owner_reads(
             index_registry.clone(),
             database_index_snapshot.clone(),

--- a/crates/function_runner/src/in_process_function_runner.rs
+++ b/crates/function_runner/src/in_process_function_runner.rs
@@ -256,7 +256,7 @@ impl<RT: Runtime> FunctionRunner<RT> for InProcessFunctionRunner<RT> {
             default_system_env_vars,
             in_memory_index_last_modified,
             context,
-            index_reader_override: None,
+            index_reader_override: self.database.function_runner_index_reader(ts)?,
         };
 
         // NOTE: We run the function without checking retention until after the

--- a/crates/local_backend/src/lib.rs
+++ b/crates/local_backend/src/lib.rs
@@ -175,6 +175,19 @@ pub struct BackendAppState {
 }
 
 impl BackendAppState {
+    pub fn cluster_aware_api(&self) -> Arc<dyn ApplicationApi> {
+        Arc::new(query_forwarding_api::SelectiveQueryForwardingApi::new(
+            Arc::new(self.application.clone()),
+            self.application.database().clone(),
+            self.replica_mode,
+            self.partition_id,
+            self.node_addresses.clone(),
+            self.raft_state.clone(),
+            self.raft_peer_grpc_urls.clone(),
+            self.cluster_grpc_auth.clone(),
+        ))
+    }
+
     pub async fn shutdown(self) -> anyhow::Result<()> {
         self.application.shutdown().await?;
 

--- a/crates/local_backend/src/main.rs
+++ b/crates/local_backend/src/main.rs
@@ -139,8 +139,7 @@ async fn run_server_inner(runtime: ProdRuntime, config: LocalConfig) -> anyhow::
     // Start gRPC services (mutation forwarder + 2PC + Raft transport).
     if config.replication_mode == "primary" && config.nats_url.is_some() {
         let grpc_addr = format!("0.0.0.0:{}", config.grpc_port).parse()?;
-        let api: std::sync::Arc<dyn application::api::ApplicationApi> =
-            std::sync::Arc::new(st.application.clone());
+        let api = st.cluster_aware_api();
         let cluster_grpc_auth = st.cluster_grpc_auth.clone();
         let forwarder =
             MutationForwarderService::new(api, st.instance_name.clone(), cluster_grpc_auth.clone());

--- a/crates/local_backend/src/owner_read_service.rs
+++ b/crates/local_backend/src/owner_read_service.rs
@@ -25,13 +25,17 @@ use database::{
     raft_partition::RaftPartitionState,
     CommitterClient,
     Database,
+    ReadTimestampClosure,
 };
 use indexing::backend_in_memory_indexes::RangeRequest;
 use pb::replication::{
+    close_read_timestamp_response::Outcome as CloseReadTimestampOutcome,
     owner_read_service_server::{
         OwnerReadService,
         OwnerReadServiceServer as TonicOwnerReadServer,
     },
+    CloseReadTimestampRequest,
+    CloseReadTimestampResponse,
     OwnerReadIndexRange,
     OwnerReadIndexRangesRequest,
     OwnerReadIndexRangesResponse,
@@ -191,6 +195,52 @@ impl OwnerReadGrpcService {
 
 #[tonic::async_trait]
 impl OwnerReadService for OwnerReadGrpcService {
+    async fn close_read_timestamp(
+        &self,
+        request: Request<CloseReadTimestampRequest>,
+    ) -> Result<Response<CloseReadTimestampResponse>, Status> {
+        self.authenticate(&request)?;
+        let request = request.into_inner();
+        let owner_partition = PartitionId(request.owner_partition);
+        let local_partition = self.committer.local_partition().ok_or_else(|| {
+            Status::failed_precondition("Owner-read service requires a partitioned node")
+        })?;
+        if owner_partition != local_partition {
+            return Err(Status::failed_precondition(format!(
+                "Read barrier for {} reached {}",
+                owner_partition, local_partition,
+            )));
+        }
+
+        let placement_version = PlacementVersion::from(request.placement_version);
+        self.ensure_placement_version(placement_version).await?;
+        self.ensure_serving_leader()?;
+        let target_ts = request.target_ts.try_into().map_err(|error| {
+            Status::invalid_argument(format!("Invalid read barrier timestamp: {error:#}"))
+        })?;
+        let outcome = self
+            .committer
+            .close_read_timestamp(target_ts)
+            .await
+            .map_err(|error| {
+                Status::unavailable(format!("Failed to close owner read timestamp: {error:#}"))
+            })?;
+        // Recheck after the asynchronous persistence barrier. A leader that lost
+        // its lease while closing must not certify a cluster snapshot.
+        self.ensure_placement_version(placement_version).await?;
+        self.ensure_serving_leader()?;
+        let outcome = Some(match outcome {
+            ReadTimestampClosure::Closed(ts) => CloseReadTimestampOutcome::ClosedTs(u64::from(ts)),
+            ReadTimestampClosure::RetryAt(ts) => {
+                CloseReadTimestampOutcome::RetryAtTs(u64::from(ts))
+            },
+            ReadTimestampClosure::Blocked(ts) => {
+                CloseReadTimestampOutcome::BlockedTs(u64::from(ts))
+            },
+        });
+        Ok(Response::new(CloseReadTimestampResponse { outcome }))
+    }
+
     async fn read_index_ranges(
         &self,
         request: Request<OwnerReadIndexRangesRequest>,
@@ -224,6 +274,36 @@ impl OwnerReadService for OwnerReadGrpcService {
         let snapshot_ts = request.snapshot_ts.try_into().map_err(|error| {
             Status::invalid_argument(format!("Invalid owner-read snapshot timestamp: {error:#}"))
         })?;
+        match self
+            .committer
+            .close_read_timestamp(snapshot_ts)
+            .await
+            .map_err(|error| {
+                Status::unavailable(format!(
+                    "Owner could not verify read barrier {snapshot_ts}: {error:#}"
+                ))
+            })? {
+            ReadTimestampClosure::Closed(closed) if closed == snapshot_ts => {},
+            ReadTimestampClosure::Closed(closed) => {
+                return Err(Status::internal(format!(
+                    "Owner certified read barrier {closed} instead of {snapshot_ts}"
+                )));
+            },
+            ReadTimestampClosure::RetryAt(local_floor) => {
+                return Err(Status::unavailable(format!(
+                    "Owner read barrier {snapshot_ts} is not portable to this leader; local floor \
+                     is {local_floor}"
+                )));
+            },
+            ReadTimestampClosure::Blocked(prepared_ts) => {
+                return Err(Status::unavailable(format!(
+                    "Owner read barrier {snapshot_ts} is blocked by prepared transaction at \
+                     {prepared_ts}"
+                )));
+            },
+        }
+        self.ensure_placement_version(placement_version).await?;
+        self.ensure_serving_leader()?;
         let ranges = request
             .ranges
             .into_iter()

--- a/crates/local_backend/src/router.rs
+++ b/crates/local_backend/src/router.rs
@@ -1,6 +1,5 @@
 use std::{
     convert::Infallible,
-    sync::Arc,
     time::Duration,
 };
 
@@ -548,18 +547,7 @@ pub fn router(st: BackendAppState) -> Router {
     let public_openapi_spec = public_openapi.to_pretty_json().unwrap();
 
     let router_state = RouterState {
-        api: Arc::new(
-            crate::query_forwarding_api::SelectiveQueryForwardingApi::new(
-                Arc::new(st.application.clone()),
-                st.application.database().clone(),
-                st.replica_mode,
-                st.partition_id,
-                st.node_addresses.clone(),
-                st.raft_state.clone(),
-                st.raft_peer_grpc_urls.clone(),
-                st.cluster_grpc_auth.clone(),
-            ),
-        ),
+        api: st.cluster_aware_api(),
         database: st.application.database().clone(),
         runtime: st.application.runtime(),
         replica_mode: st.replica_mode,

--- a/crates/pb/protos/replication.proto
+++ b/crates/pb/protos/replication.proto
@@ -141,6 +141,21 @@ message QueryError {
 // never authoritative for these requests.
 service OwnerReadService {
   rpc ReadIndexRanges(OwnerReadIndexRangesRequest) returns (OwnerReadIndexRangesResponse);
+  rpc CloseReadTimestamp(CloseReadTimestampRequest) returns (CloseReadTimestampResponse);
+}
+
+message CloseReadTimestampRequest {
+  uint32 owner_partition = 1;
+  uint64 placement_version = 2;
+  uint64 target_ts = 3;
+}
+
+message CloseReadTimestampResponse {
+  oneof outcome {
+    uint64 closed_ts = 1;
+    uint64 retry_at_ts = 2;
+    uint64 blocked_ts = 3;
+  }
 }
 
 message OwnerReadIndexRangesRequest {

--- a/docs/cluster-safe-read-timestamps.md
+++ b/docs/cluster-safe-read-timestamps.md
@@ -1,0 +1,139 @@
+# Cluster-Safe Read Timestamps
+
+Convex queries must observe one database snapshot. A horizontally scaled query
+must not combine a new value from one partition with an old value from another
+partition, including while a two-phase commit is finishing.
+
+## Three Timestamp Meanings
+
+The cluster intentionally distinguishes three timestamps:
+
+1. **Origin commit timestamp**: the TSO timestamp assigned once to the logical
+   write by its source partition. It remains the replication identity used for
+   deduplication and source-partition progress.
+2. **Local apply timestamp**: the timestamp at which a receiving node installs
+   that write in its own MVCC timeline. Replica apply may translate the origin
+   timestamp upward to preserve strict local ordering.
+3. **Client snapshot timestamp**: an exact timestamp certified by every current
+   partition owner for one placement version. Latest queries and subscription
+   reruns use this timestamp.
+
+An origin timestamp is not automatically a safe client snapshot. A local
+replication frontier or `max_repeatable_ts` is also not a cluster-wide proof.
+
+## Exact Read Barrier
+
+For a latest clustered read, the coordinator performs this protocol:
+
+1. Pin the current placement map and its version.
+2. Start with the coordinator's current local readable timestamp as candidate
+   `R`. Read barriers do not allocate write timestamps.
+3. Ask every partition's current Raft serving leader to close its local MVCC
+   timeline at exactly `R`.
+4. Each owner returns one of:
+   - `Closed(R)`: all earlier ordered persistence work is complete, no prepared
+     transaction can cross `R`, and future live commits must be greater than
+     `R`.
+   - `RetryAt(T)`: the owner's translated local timeline is already above `R`.
+     The coordinator raises the common candidate to the greatest returned
+     owner floor and retries every owner.
+   - `Blocked(P)`: an unresolved 2PC participant is prepared at `P <= R`. The
+     coordinator waits for that decision and retries the same candidate.
+5. Return `R` only if every owner returns `Closed(R)` and the placement version
+   remains unchanged.
+
+Closure is inserted into the Committer's ordered persistence pipeline. It is
+therefore ordered after writes already admitted by that owner. The persisted
+repeatable timestamp also forces future leaders and future live prepares above
+the barrier. A leader or serving-lease change during closure rejects the
+barrier.
+
+The coordinator currently closes all partitions because an arbitrary Convex
+JavaScript query can discover its read set while it runs. Once `R` is certified,
+local ranges are read locally and remote ranges are fetched from their
+authoritative owners at the same `R`. The system does not depend on every local
+NATS mirror having caught up to serve this read.
+
+The negotiation itself uses the cached cluster membership snapshot and direct
+owner gRPC calls. It does not contact the NATS-backed timestamp oracle, so
+latest reads remain available during a NATS outage while the Raft owners and
+their previously discovered addresses remain reachable.
+
+Idle frontier heartbeats and background repeatable-timestamp advancement also
+cannot turn into a hidden TSO dependency for reads. Optional maintenance may
+consume an already-reserved local TSO value, but batch exhaustion only starts a
+coalesced asynchronous refill and schedules maintenance to retry. It never
+waits for NATS from the single-threaded committer loop. Live writes continue to
+use the normal fail-closed TSO allocation path.
+
+## 2PC Atomicity
+
+The barrier handles every relevant 2PC state:
+
+- If no participant has committed, all owners can close before the transaction
+  or report the unresolved prepare as blocked.
+- If some participants have committed and another remains prepared, the
+  unresolved owner returns `Blocked`; no query starts.
+- After the remaining participant commits, every owner closes at one timestamp
+  above the complete transaction.
+- Once a timestamp is closed, a late live prepare at or below it is rejected.
+
+As a result, a latest query or reactive rerun cannot observe only one half of a
+2PC transaction.
+
+## Query Surfaces
+
+The barrier is used by:
+
+- public and admin latest queries;
+- query batches, which obtain one timestamp and run every query at it;
+- every sync worker transition, including WebSocket subscription reruns;
+- `ctx.runQuery` calls made from actions, including internal action callbacks.
+
+Query-cache tokens containing remote-owner reads are never refreshed from the
+coordinator's local write log. That log can lag the owner even after a new
+cluster timestamp is certified, so such tokens force a query rerun against the
+owner at the new certified timestamp.
+
+Read-after-write fences from #140 and participant fences from #242 remain
+session-freshness guarantees. They are complementary to this barrier: a fence
+proves a particular write is visible, while the barrier proves the complete
+cross-partition snapshot is atomic.
+
+## Explicit Timestamp Contract
+
+`query_at_ts` does not silently translate a client timestamp. Every owner must
+be able to certify that exact timestamp on its current leader. If a leadership
+change, certificate eviction, placement change, or translated local timeline
+makes that impossible, the request fails closed and the client must obtain a
+new latest timestamp.
+
+Each leader retains a bounded set of exact barrier certificates. Certificates
+are deliberately not inferred from `timestamp <= max_closed_timestamp`, because
+timestamp translation means an arbitrary older value is not necessarily a
+portable point on every local timeline.
+
+This preserves correctness now without claiming cross-node timestamp identity.
+A future identity-preserving global apply order could make historical cursors
+portable across failover without this re-certification rule.
+
+## Relationship To Other Work
+
+- #132 can distribute reactive invalidation ownership, but every rerun still
+  needs this common snapshot contract.
+- #133 may reduce changefeed fanout, but selective delivery cannot be used as
+  proof that a query snapshot is complete.
+- #139 defined the origin/local timestamp translation model used here.
+- #140 and #242 provide portable session fences, not a global closed timestamp.
+- #278 adds the missing cluster-wide atomic snapshot proof.
+
+## References
+
+- CockroachDB permits follower reads only at or below a closed timestamp:
+  <https://www.cockroachlabs.com/docs/stable/follower-reads>
+- FoundationDB obtains one read version and evaluates transaction reads against
+  that version across storage owners:
+  <https://apple.github.io/foundationdb/architecture.html>
+- Spanner uses a single timestamp for a read-only transaction across all data it
+  reads:
+  <https://research.google/pubs/spanner-googles-globally-distributed-database-2/>

--- a/docs/issue-journal.md
+++ b/docs/issue-journal.md
@@ -920,6 +920,43 @@ own for distributed changes.
   - `BACKEND_PULL_POLICY=never bash self-hosted/docker/test.sh`
     passed write-scaling `146/146`, Raft failover `24/24`, `ALL SUITES PASSED`
 
+### 2026-07 — Added an owner-coordinated cluster-safe read timestamp
+
+- **Status:** complete
+- **Related issue:** `#278`
+- **What this fixes:** a latest query or reactive rerun could choose one node's
+  local repeatable timestamp without proving that every partition owner could
+  serve that exact point. During a delayed 2PC participant delta, that left no
+  cluster-wide proof against combining one committed half with one older half.
+- **Behavior:** the coordinator now starts from its current readable timestamp
+  and asks every current partition's Raft serving leader to close its ordered
+  MVCC state at exactly that value. Owners negotiate the candidate upward above
+  newer local timelines, block behind unresolved prepared transactions, and
+  fail closed across placement or leader lease changes. The read barrier does
+  not consume a TSO timestamp, so direct owner reads remain available during a
+  NATS outage. Optional frontier and repeatable-timestamp maintenance also uses
+  only locally reserved TSO values from the committer loop; batch refill runs
+  asynchronously and cannot block owner barriers. Public/admin latest queries,
+  query batches, sync reruns, and action `ctx.runQuery` callbacks all use the
+  certified timestamp. Remote-read cache tokens rerun against owners instead
+  of refreshing from a stale local mirror. Explicit historical timestamps are
+  re-certified rather than silently translated.
+- **Validation:**
+  - `cargo test -p database cluster_read_barrier -- --nocapture`
+  - `cargo test -p database test_live_prepare_rejects_timestamp_closed_for_cluster_reads -- --nocapture`
+  - `cargo test -p database test_cluster_read_barrier_floor_survives_restart -- --nocapture`
+  - `cargo test -p database test_idle_frontier_maintenance_cannot_block_owner_read_barrier -- --nocapture`
+  - `cargo test -p database test_idle_remote_read_frontier_heartbeat_tso_failure_is_nonfatal -- --nocapture`
+  - Docker test 9m pauses one coordinator's remote JetStream consumer while a
+    cross-partition 2PC commits, then asserts both latest HTTP queries and a live
+    WebSocket subscription observe the pair atomically.
+  - Built `ghcr.io/martinkalema/convex-horizontal-scaling:backend-latest` and
+    verified all six backend containers ran local image
+    `sha256:c4c1362b860cf377f56c98c623c6ae158d337c92c67e99a4ea91b669dd230f8e`
+    with registry pulls disabled.
+  - `BACKEND_PULL_POLICY=never bash self-hosted/docker/test.sh` passed
+    write-scaling `149/149`, Raft failover `24/24`, `ALL SUITES PASSED`.
+
 ## Open Issues
 
 - `#74` is no longer blocked on follower self-sufficiency. The current

--- a/docs/tso-replica-timestamp-fix.md
+++ b/docs/tso-replica-timestamp-fix.md
@@ -91,6 +91,23 @@ No TSO (reserved for local commits), no system clock (would leap ahead of TSO ra
 
 This is a translation model, not timestamp identity. It is safe for the current single read-authority/fail-closed routing model, but portable client cursors and follower-safe reads must use the follow-up read-fencing work before relying on timestamps across nodes.
 
+Latest clustered reads now use the exact owner-coordinated barrier described in
+[`cluster-safe-read-timestamps.md`](cluster-safe-read-timestamps.md). That
+barrier does not erase timestamp translation. It finds one exact timestamp that
+every current owner can serve, blocks behind unresolved 2PC prepares, and fails
+closed when an explicit historical timestamp cannot be certified. The barrier
+negotiates from owner timeline floors rather than allocating from the TSO, so a
+healthy set of Raft owners can continue serving latest reads while NATS is
+unavailable.
+
+The same availability boundary applies to periodic frontier and
+`max_repeatable_ts` maintenance. These optional tasks use only an already
+reserved local batch value while running in the committer loop. If the batch is
+missing or exhausted, they trigger one coalesced asynchronous reservation and
+retry later instead of waiting for NATS. Commit timestamp allocation remains on
+the ordinary fail-closed path and may wait for a reservation because a write
+cannot safely proceed without a globally unique timestamp.
+
 ## Why System Clock Was Also Wrong (Second Fix)
 
 The first attempt replaced the TSO call with the single-node formula: `max(latest_ts + 1, system_clock, last_assigned_ts + 1)`. This still crashed under concurrent load. The reason:

--- a/self-hosted/docker/test-write-scaling.sh
+++ b/self-hosted/docker/test-write-scaling.sh
@@ -26,6 +26,7 @@
 #   9j. 2PC Exactness During Repeated NATS Flaps
 #   9k. Post-Ack 2PC Exactness After Cleanup-Window Restarts
 #   9l. Parallel 2PC Early-Ack Code-Path Proof
+#   9m. Cluster-Safe Latest Reads With Delayed Participant Delta
 #  10. Rapid-Fire Writes Under Load (Jepsen stress)
 #  11. Write-Then-Immediate-Read Consistency (stale read detection)
 #  12. Double Node Restart (crash recovery stress)
@@ -358,6 +359,18 @@ export const countTasksByTitle = query({
   },
 });
 
+export const safeSnapshotPair = query({
+  args: { text: v.string(), taskTitle: v.string() },
+  handler: async (ctx, args) => {
+    const messages = await ctx.db.query("messages").collect();
+    const tasks = await ctx.db.query("tasks").collect();
+    return {
+      messages: messages.filter((message: any) => message.text === args.text).length,
+      tasks: tasks.filter((task: any) => task.title === args.taskTitle).length,
+    };
+  },
+});
+
 // Concurrent counter: multiple increments, verify total.
 export const incrementCounter = mutation({
   args: { name: v.string() },
@@ -453,6 +466,58 @@ export const count = query({
 });
 TSEOF
 
+cat > "$DEPLOY_DIR/safe-snapshot-subscription.mjs" << 'JSEOF'
+import { ConvexClient } from "convex/browser";
+import { api } from "./convex/_generated/api.js";
+
+const [url, text, taskTitle] = process.argv.slice(2);
+const client = new ConvexClient(url, { unsavedChangesWarning: false });
+let subscription;
+let finished = false;
+let sawInitial = false;
+
+const finish = async (code, event, details = {}) => {
+  if (finished) return;
+  finished = true;
+  console.log(JSON.stringify({ event, ...details }));
+  subscription?.unsubscribe();
+  await Promise.race([
+    client.close(),
+    new Promise((resolve) => setTimeout(resolve, 1000)),
+  ]);
+  process.exit(code);
+};
+
+subscription = client.onUpdate(
+  api.messages.safeSnapshotPair,
+  { text, taskTitle },
+  async (value) => {
+    console.log(JSON.stringify({ event: "value", value }));
+    if (value.messages !== value.tasks) {
+      await finish(2, "torn", { value });
+      return;
+    }
+    if (!sawInitial) {
+      if (value.messages !== 0) {
+        await finish(3, "unexpected-initial", { value });
+        return;
+      }
+      sawInitial = true;
+      console.log(JSON.stringify({ event: "ready" }));
+      return;
+    }
+    if (value.messages === 1) {
+      await finish(0, "complete", { value });
+    }
+  },
+  async (error) => {
+    await finish(4, "error", { message: String(error) });
+  },
+);
+
+setTimeout(() => void finish(5, "timeout"), 25000);
+JSEOF
+
 deploy_functions_with_retry() {
     local key="$1"
     local url="$2"
@@ -493,6 +558,53 @@ query_api() {
         -H "Authorization: Convex $2" \
         -H "Content-Type: application/json" \
         -d "{\"path\":\"$3\",\"args\":{}}"
+}
+
+set_jetstream_consumer_pause() {
+    local consumer="$1"
+    local seconds="$2"
+    python3 - "$consumer" "$seconds" << 'PYEOF'
+import datetime
+import json
+import socket
+import sys
+import uuid
+
+consumer = sys.argv[1]
+seconds = int(sys.argv[2])
+pause_until = datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(seconds=seconds)
+payload = json.dumps(
+    {"pause_until": pause_until.isoformat().replace("+00:00", "Z")},
+    separators=(",", ":"),
+).encode()
+subject = f"$JS.API.CONSUMER.PAUSE.CONVEX_COMMITS.{consumer}"
+inbox = f"_INBOX.{uuid.uuid4().hex}"
+
+with socket.create_connection(("127.0.0.1", 4222), timeout=5) as connection:
+    protocol = connection.makefile("rb")
+    if not protocol.readline().startswith(b"INFO "):
+        raise RuntimeError("NATS did not send INFO during consumer pause request")
+    command = (
+        f'CONNECT {{"verbose":false,"pedantic":false}}\r\n'
+        f"SUB {inbox} 1\r\n"
+        f"PUB {subject} {inbox} {len(payload)}\r\n"
+    ).encode() + payload + b"\r\nPING\r\n"
+    connection.sendall(command)
+    while True:
+        line = protocol.readline()
+        if not line:
+            raise RuntimeError("NATS closed before consumer pause response")
+        if line.startswith(b"MSG "):
+            size = int(line.split()[-1])
+            response = json.loads(protocol.read(size))
+            protocol.read(2)
+            if "error" in response:
+                raise RuntimeError(f"JetStream consumer pause failed: {response['error']}")
+            expected_paused = seconds > 0
+            if bool(response.get("paused")) != expected_paused:
+                raise RuntimeError(f"Unexpected JetStream pause response: {response}")
+            break
+PYEOF
 }
 
 query_with_args() {
@@ -566,6 +678,13 @@ two_pc_counts_match_response() {
     local msg_b="$3"
     local task_a="$4"
     local task_b="$5"
+    local count
+
+    for count in "$msg_a" "$msg_b" "$task_a" "$task_b"; do
+        case "$count" in
+            ''|*[!0-9]*) return 1 ;;
+        esac
+    done
 
     if echo "$response" | grep -q '"status":"success"'; then
         [ "$msg_a" -eq 1 ] && [ "$msg_b" -eq 1 ] && [ "$task_a" -eq 1 ] && [ "$task_b" -eq 1 ]
@@ -1271,6 +1390,127 @@ done
 if $MONO_OK; then
     pass "Monotonic reads: values never went backward (last=$LAST_SEEN)"
 fi
+
+# ============================================================
+echo ""
+echo -e "${BOLD}Test 9m: Cluster-Safe Latest Reads With Delayed Participant Delta${NC}"
+# ============================================================
+# Discover the current partition-0 serving leader, then pause only that node's
+# partition-1 JetStream consumer. NATS KV remains available for the 2PC
+# decision, so the write can commit while the coordinator's local mirror is
+# deliberately missing the remote participant half.
+# Latest reads and sync reruns must use authoritative owners at one certified
+# timestamp and therefore expose either neither half or both halves.
+
+SAFE_SNAPSHOT_RUN="safe-snapshot-$(date +%s)-$$"
+SAFE_SNAPSHOT_TEXT="$SAFE_SNAPSHOT_RUN-msg"
+SAFE_SNAPSHOT_TASK="$SAFE_SNAPSHOT_RUN-task"
+SAFE_SNAPSHOT_SUB_LOG=$(mktemp)
+SAFE_SNAPSHOT_COORDINATOR_FOUND=false
+SAFE_SNAPSHOT_URL=""
+SAFE_SNAPSHOT_KEY=""
+SAFE_SNAPSHOT_CONTAINER=""
+for entry in \
+    "docker-node-p0a-1|$NODE_P0A_URL|$NODE_P0A_KEY" \
+    "docker-node-p0b-1|$NODE_P0B_URL|$NODE_P0B_KEY" \
+    "docker-node-p0c-1|$NODE_P0C_URL|$NODE_P0C_KEY"; do
+    IFS='|' read -r candidate_container candidate_url candidate_key <<< "$entry"
+    status=$(curl --max-time 2 -s -o /dev/null -w "%{http_code}" \
+        -H "Connection: Upgrade" \
+        -H "Upgrade: websocket" \
+        -H "Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==" \
+        -H "Sec-WebSocket-Version: 13" \
+        "$candidate_url/api/1.34.1/sync" 2>/dev/null || true)
+    if [ "$status" = "101" ]; then
+        SAFE_SNAPSHOT_COORDINATOR_FOUND=true
+        SAFE_SNAPSHOT_URL="$candidate_url"
+        SAFE_SNAPSHOT_KEY="$candidate_key"
+        SAFE_SNAPSHOT_CONTAINER="$candidate_container"
+        break
+    fi
+done
+
+if $SAFE_SNAPSHOT_COORDINATOR_FOUND; then
+    # Partition 0 uses Config::name() directly for its durable replication
+    # consumer, which is sourced from INSTANCE_NAME in the container.
+    SAFE_SNAPSHOT_NATS_CONSUMER=$(docker exec "$SAFE_SNAPSHOT_CONTAINER" \
+        printenv INSTANCE_NAME 2>/dev/null)
+
+    (cd "$DEPLOY_DIR" && node safe-snapshot-subscription.mjs \
+        "$SAFE_SNAPSHOT_URL" "$SAFE_SNAPSHOT_TEXT" "$SAFE_SNAPSHOT_TASK" \
+        > "$SAFE_SNAPSHOT_SUB_LOG" 2>&1) &
+    SAFE_SNAPSHOT_SUB_PID=$!
+else
+    SAFE_SNAPSHOT_SUB_PID=""
+fi
+
+SAFE_SNAPSHOT_SUB_READY=false
+if $SAFE_SNAPSHOT_COORDINATOR_FOUND; then
+    for _ in $(seq 1 100); do
+        if grep -q '"event":"ready"' "$SAFE_SNAPSHOT_SUB_LOG"; then
+            SAFE_SNAPSHOT_SUB_READY=true
+            break
+        fi
+        if ! kill -0 "$SAFE_SNAPSHOT_SUB_PID" 2>/dev/null; then
+            break
+        fi
+        sleep 0.1
+    done
+fi
+
+if $SAFE_SNAPSHOT_SUB_READY; then
+    set_jetstream_consumer_pause "$SAFE_SNAPSHOT_NATS_CONSUMER" 30
+    SAFE_SNAPSHOT_RESPONSE=$(mutation_response \
+        "$SAFE_SNAPSHOT_URL" "$SAFE_SNAPSHOT_KEY" "messages:crossPartitionWrite" \
+        "{\"text\":\"$SAFE_SNAPSHOT_TEXT\",\"taskTitle\":\"$SAFE_SNAPSHOT_TASK\"}")
+
+    SAFE_SNAPSHOT_HTTP_OK=true
+    SAFE_SNAPSHOT_HTTP_DETAILS=""
+    for _ in $(seq 1 5); do
+        SAFE_SNAPSHOT_PAIR=$(query_with_args \
+            "$SAFE_SNAPSHOT_URL" "$SAFE_SNAPSHOT_KEY" "messages:safeSnapshotPair" \
+            "{\"text\":\"$SAFE_SNAPSHOT_TEXT\",\"taskTitle\":\"$SAFE_SNAPSHOT_TASK\"}")
+        read -r SAFE_SNAPSHOT_MESSAGES SAFE_SNAPSHOT_TASKS <<< "$(python3 -c \
+            'import json,sys; value=json.load(sys.stdin)["value"]; print(int(value["messages"]), int(value["tasks"]))' \
+            <<< "$SAFE_SNAPSHOT_PAIR")"
+        if [ "$SAFE_SNAPSHOT_MESSAGES" -ne "$SAFE_SNAPSHOT_TASKS" ] || \
+            [ "$SAFE_SNAPSHOT_MESSAGES" -ne 1 ]; then
+            SAFE_SNAPSHOT_HTTP_OK=false
+            SAFE_SNAPSHOT_HTTP_DETAILS="$SAFE_SNAPSHOT_HTTP_DETAILS [$SAFE_SNAPSHOT_MESSAGES,$SAFE_SNAPSHOT_TASKS]"
+        fi
+    done
+
+    SAFE_SNAPSHOT_SUB_STATUS=0
+    wait "$SAFE_SNAPSHOT_SUB_PID" || SAFE_SNAPSHOT_SUB_STATUS=$?
+    set_jetstream_consumer_pause "$SAFE_SNAPSHOT_NATS_CONSUMER" 0
+
+    if echo "$SAFE_SNAPSHOT_RESPONSE" | grep -q '"status":"success"' && \
+        $SAFE_SNAPSHOT_HTTP_OK; then
+        pass "Latest HTTP reads stayed atomic while the participant delta was delayed"
+    else
+        fail "Latest HTTP read exposed or failed to recover the delayed 2PC pair" \
+            "response=$SAFE_SNAPSHOT_RESPONSE observations=$SAFE_SNAPSHOT_HTTP_DETAILS"
+    fi
+
+    if [ "$SAFE_SNAPSHOT_SUB_STATUS" -eq 0 ] && \
+        grep -q '"event":"complete"' "$SAFE_SNAPSHOT_SUB_LOG" && \
+        ! grep -q '"event":"torn"' "$SAFE_SNAPSHOT_SUB_LOG"; then
+        pass "WebSocket subscription rerun stayed atomic with delayed participant delivery"
+    else
+        fail "WebSocket subscription observed a torn or missing 2PC pair" \
+            "$(tr '\n' ' ' < "$SAFE_SNAPSHOT_SUB_LOG")"
+    fi
+else
+    if [ -n "$SAFE_SNAPSHOT_SUB_PID" ]; then
+        kill "$SAFE_SNAPSHOT_SUB_PID" 2>/dev/null || true
+        wait "$SAFE_SNAPSHOT_SUB_PID" 2>/dev/null || true
+    fi
+    fail "WebSocket safe-snapshot probe did not reach its initial state" \
+        "coordinator_found=$SAFE_SNAPSHOT_COORDINATOR_FOUND $(tr '\n' ' ' < "$SAFE_SNAPSHOT_SUB_LOG")"
+    fail "Latest HTTP delayed-participant test could not start" \
+        "subscription setup failed before the participant delta was delayed"
+fi
+rm -f "$SAFE_SNAPSHOT_SUB_LOG"
 
 # ============================================================
 echo ""


### PR DESCRIPTION
## Summary

- establish one exact read timestamp across every current partition owner before latest queries or reactive reruns execute
- fence barriers with placement versions, Raft serving leases, ordered persistence, unresolved 2PC prepares, and durable future-commit floors
- execute remote user-table index ranges at their authoritative owner, including the inner in-process function-runner path
- apply the certified timestamp to public/admin queries, batches, sync transitions, and action `ctx.runQuery` callbacks
- force remote-read query tokens to rerun instead of being refreshed from a potentially stale local replication log
- keep owner reads available during NATS outages by moving optional TSO batch refill outside the single-threaded committer loop
- add exact historical timestamp re-certification and bounded leader-local certificates

## Convex semantics preserved

A query still observes one logical database snapshot. It cannot combine one committed half of a cross-partition 2PC transaction with an older half from another partition, and clients do not need to know which node owns each table.

## Validation

- `cargo check -p local_backend` completed warning-free
- `cargo test -p database`: 577 passed, 2 ignored, 0 failed
- `cargo test -p local_backend`: 100 passed, 0 failed
- focused hanging-TSO, barrier retry/blocking, placement-change, leader-lease, token invalidation, and restart-floor regressions passed
- built local image `sha256:c4c1362b860cf377f56c98c623c6ae158d337c92c67e99a4ea91b669dd230f8e`
- proved all six healthy backend containers used that exact image with `BACKEND_PULL_POLICY=never`
- `BACKEND_PULL_POLICY=never bash self-hosted/docker/test.sh`: write scaling 149/149, Raft failover 24/24, all suites passed
- `git diff --check` and `bash -n self-hosted/docker/test-write-scaling.sh` passed

## Follow-up

Fresh implicit creation of a remotely owned table exposed a separate catalog-coherence gap, tracked in #298 and linked to the versioned catalog work in #286.

Closes #278