### PR TITLE
fix(database): preserve implicit catalog coherence across partitions

### DIFF
--- a/crates/database/src/committer.rs
+++ b/crates/database/src/committer.rs
@@ -5574,12 +5574,8 @@ impl<RT: Runtime> Committer<RT> {
         require_leader: bool,
         allow_explicit_ts_rewrite: bool,
     ) -> anyhow::Result<crate::two_phase::PrepareResult> {
-        let local_table_mapping = self
-            .snapshot_manager
-            .read()
-            .latest_snapshot()
-            .table_mapping()
-            .clone();
+        let local_snapshot = self.base_snapshot_for_new_writes();
+        let local_table_mapping = local_snapshot.table_mapping().clone();
         Self::validate_participant_catalog_creations(
             &transaction,
             &local_table_mapping,
@@ -5587,11 +5583,18 @@ impl<RT: Runtime> Committer<RT> {
         )?;
         let mut table_mapping = local_table_mapping.clone();
         transaction.augment_table_mapping(&mut table_mapping)?;
-        let writes = Self::remap_participant_system_table_writes(
+        let mut writes = Self::remap_participant_system_table_writes(
             transaction.writes,
             &table_mapping,
             &local_table_mapping,
         )?;
+        if allow_explicit_ts_rewrite {
+            writes = Self::filter_satisfied_replayed_catalog_creations(
+                writes,
+                &table_mapping,
+                &local_snapshot,
+            )?;
+        }
         self.stage_prepared_transaction(
             transaction_id,
             *transaction.begin_timestamp,
@@ -5654,6 +5657,86 @@ impl<RT: Runtime> Committer<RT> {
             }
         }
         Ok(())
+    }
+
+    fn filter_satisfied_replayed_catalog_creations(
+        writes: Vec<DocumentUpdateWithPrevTs>,
+        table_mapping: &TableMapping,
+        local_snapshot: &Snapshot,
+    ) -> anyhow::Result<Vec<DocumentUpdateWithPrevTs>> {
+        let tables_tablet = table_mapping
+            .namespace(value::TableNamespace::Global)
+            .id(&TABLES_TABLE)?
+            .tablet_id;
+        let index_tablet = table_mapping
+            .namespace(value::TableNamespace::Global)
+            .id(&common::bootstrap_model::index::INDEX_TABLE)?
+            .tablet_id;
+        let local_mapping = local_snapshot.table_mapping();
+        let mut filtered = Vec::with_capacity(writes.len());
+
+        for write in writes {
+            let is_insert = write.old_document.is_none() && write.new_document.is_some();
+            if is_insert && write.id.tablet_id == tables_tablet {
+                let new_document = write
+                    .new_document
+                    .as_ref()
+                    .expect("catalog insert should have a new document");
+                let metadata: ParsedDocument<TableMetadata> = new_document.parse()?;
+                let metadata = metadata.into_value();
+                let proposed_tablet = value::TabletId(write.id.internal_id());
+                if local_mapping.tablet_id_exists(proposed_tablet) {
+                    anyhow::ensure!(
+                        local_mapping.tablet_namespace(proposed_tablet)? == metadata.namespace
+                            && local_mapping.tablet_number(proposed_tablet)? == metadata.number
+                            && local_mapping.tablet_name(proposed_tablet)? == metadata.name,
+                        "2PC replay found tablet {:?} already mapped to a different table than \
+                         '{}'",
+                        proposed_tablet,
+                        metadata.name,
+                    );
+                    tracing::info!(
+                        "2PC replay: catalog creation for table '{}' is already materialized with \
+                         stable tablet {:?} and table number {}; staging the remaining intent",
+                        metadata.name,
+                        proposed_tablet,
+                        u32::from(metadata.number),
+                    );
+                    continue;
+                }
+            } else if is_insert && write.id.tablet_id == index_tablet {
+                let new_document = write
+                    .new_document
+                    .as_ref()
+                    .expect("index catalog insert should have a new document");
+                let metadata = common::bootstrap_model::index::TabletIndexMetadata::from_document(
+                    new_document.clone(),
+                )?;
+                let existing = [
+                    local_snapshot.index_registry.get_enabled(&metadata.name),
+                    local_snapshot.index_registry.get_pending(&metadata.name),
+                ]
+                .into_iter()
+                .flatten()
+                .find(|existing| existing.id() == metadata.id().internal_id());
+                if let Some(existing) = existing {
+                    anyhow::ensure!(
+                        existing.metadata().config.same_spec(&metadata.config),
+                        "2PC replay found index {} with the same stable id but a different spec",
+                        metadata.name,
+                    );
+                    tracing::info!(
+                        "2PC replay: catalog creation for index {} is already materialized with \
+                         stable id {}; staging the remaining intent",
+                        metadata.name,
+                        existing.id(),
+                    );
+                    continue;
+                }
+            }
+            filtered.push(write);
+        }
+        Ok(filtered)
     }
 
     fn validate_participant_reads(

--- a/crates/database/src/committer.rs
+++ b/crates/database/src/committer.rs
@@ -2667,9 +2667,19 @@ impl<RT: Runtime> Committer<RT> {
                                 .and_then(|_| self.next_commit_ts_at_or_after(min_ts));
                             let _ = result.send(r);
                         },
-                        Some(CommitterMessage::CloseReadTimestamp { target, result }) => {
+                        Some(CommitterMessage::CloseReadTimestamp {
+                            target,
+                            include_latest_floor,
+                            result,
+                        }) => {
                             let span = Span::noop();
-                            self.close_read_timestamp(target, result, commit_id, &span);
+                            self.close_read_timestamp(
+                                target,
+                                include_latest_floor,
+                                result,
+                                commit_id,
+                                &span,
+                            );
                             commit_id += 1;
                         },
                         Some(CommitterMessage::CommitPrepared {
@@ -2941,6 +2951,7 @@ impl<RT: Runtime> Committer<RT> {
     fn close_read_timestamp(
         &mut self,
         target: Timestamp,
+        include_latest_floor: bool,
         result: oneshot::Sender<anyhow::Result<ReadTimestampClosure>>,
         commit_id: usize,
         root_span: &Span,
@@ -2949,7 +2960,10 @@ impl<RT: Runtime> Committer<RT> {
             let _ = result.send(Err(err));
             return;
         }
-        if self.closed_read_timestamps.contains(&target) {
+        // An exact historical read may reuse a timestamp that was fenced before
+        // later commits. A latest-read barrier must first discover those later
+        // commits so it cannot mistake an old cached fence for the cluster tip.
+        if !include_latest_floor && self.closed_read_timestamps.contains(&target) {
             let _ = result.send(Ok(ReadTimestampClosure::Closed(target)));
             return;
         }
@@ -2971,6 +2985,10 @@ impl<RT: Runtime> Committer<RT> {
 
         if minimum > target {
             let _ = result.send(Ok(ReadTimestampClosure::RetryAt(minimum)));
+            return;
+        }
+        if self.closed_read_timestamps.contains(&target) {
+            let _ = result.send(Ok(ReadTimestampClosure::Closed(target)));
             return;
         }
         if let Some(prepared_ts) = self.prepared_writes.min_ts()
@@ -7729,8 +7747,29 @@ impl CommitterClient {
         &self,
         target: Timestamp,
     ) -> anyhow::Result<ReadTimestampClosure> {
+        self.close_read_timestamp_with_latest_floor(target, false)
+            .await
+    }
+
+    pub async fn close_latest_read_timestamp(
+        &self,
+        target: Timestamp,
+    ) -> anyhow::Result<ReadTimestampClosure> {
+        self.close_read_timestamp_with_latest_floor(target, true)
+            .await
+    }
+
+    async fn close_read_timestamp_with_latest_floor(
+        &self,
+        target: Timestamp,
+        include_latest_floor: bool,
+    ) -> anyhow::Result<ReadTimestampClosure> {
         let (tx, rx) = oneshot::channel();
-        let message = CommitterMessage::CloseReadTimestamp { target, result: tx };
+        let message = CommitterMessage::CloseReadTimestamp {
+            target,
+            include_latest_floor,
+            result: tx,
+        };
         self.sender.try_send(message).map_err(|e| match e {
             TrySendError::Full(..) => metrics::committer_full_error().into(),
             TrySendError::Closed(..) => metrics::shutdown_error(),
@@ -8068,6 +8107,7 @@ enum CommitterMessage {
     },
     CloseReadTimestamp {
         target: Timestamp,
+        include_latest_floor: bool,
         result: oneshot::Sender<anyhow::Result<ReadTimestampClosure>>,
     },
     /// 2PC CommitPrepared: finalize a previously prepared transaction.

--- a/crates/database/src/committer.rs
+++ b/crates/database/src/committer.rs
@@ -438,6 +438,7 @@ pub struct CommitOutcome {
     pub ts: Timestamp,
     pub source_partition: Option<crate::partition::PartitionId>,
     pub read_after_write_partitions: Vec<crate::partition::PartitionId>,
+    pub invalidated_tables: BTreeSet<TableName>,
 }
 
 /// Result of asking one partition leader to make an exact timestamp readable.
@@ -1845,6 +1846,12 @@ impl<RT: Runtime> Committer<RT> {
                                     .delta
                                     .source_partition
                                     .into_iter()
+                                    .collect(),
+                                invalidated_tables: published_commit
+                                    .delta
+                                    .tablet_id_to_table_name
+                                    .values()
+                                    .cloned()
                                     .collect(),
                             }));
 
@@ -6742,6 +6749,7 @@ impl<RT: Runtime> Committer<RT> {
                     .as_ref()
                     .map(|placement_state| placement_state.local_partition()),
                 read_after_write_partitions: Vec::new(),
+                invalidated_tables: BTreeSet::new(),
             }));
             return None;
         }

--- a/crates/database/src/committer.rs
+++ b/crates/database/src/committer.rs
@@ -2609,20 +2609,22 @@ impl<RT: Runtime> Committer<RT> {
                             transaction_id,
                             result,
                         }) => {
-                            let r = self.handle_rollback_prepared(transaction_id.clone());
-                            if r.is_ok()
-                                && let Err(err) = Self::delete_two_phase_redo(
-                                    self.persistence.clone(),
-                                    &transaction_id,
-                                )
-                                .await
-                            {
-                                tracing::warn!(
-                                    "2PC RollbackPrepared: rolled back txn={} but failed to \
-                                     delete redo: {err:#}",
+                            let r = self
+                                .handle_rollback_prepared_through_raft(transaction_id)
+                                .await;
+                            let _ = result.send(r);
+                        },
+                        Some(CommitterMessage::ApplyRaftRollback {
+                            raft_state_machine_index,
+                            transaction_id,
+                            result,
+                        }) => {
+                            let r = self
+                                .handle_raft_rollback(
+                                    raft_state_machine_index,
                                     transaction_id,
-                                );
-                            }
+                                )
+                                .await;
                             let _ = result.send(r);
                         },
                     }
@@ -3713,6 +3715,26 @@ impl<RT: Runtime> Committer<RT> {
         }
     }
 
+    async fn wait_for_raft_rollback(
+        raft_commit_waiter: RaftCommitWaiter,
+        transaction_id: &crate::two_phase::TwoPhaseTransactionId,
+    ) -> anyhow::Result<Option<u64>> {
+        let Some(raft_commit_waiter) = raft_commit_waiter else {
+            return Ok(None);
+        };
+        match raft_commit_waiter.await {
+            Ok(RaftProposalResult::Committed { index }) => Ok(Some(index)),
+            Ok(RaftProposalResult::Rejected) => anyhow::bail!(
+                "Raft rejected 2PC rollback for txn={} before quorum commit",
+                transaction_id,
+            ),
+            Err(_) => anyhow::bail!(
+                "Raft proposal result channel closed before 2PC rollback txn={} reached quorum",
+                transaction_id,
+            ),
+        }
+    }
+
     fn block_on_current_runtime<F: Future>(future: F) -> F::Output {
         block_in_place(|| {
             let rt = tokio::runtime::Handle::current();
@@ -4171,6 +4193,50 @@ impl<RT: Runtime> Committer<RT> {
             format!(
                 "Failed to propose 2PC prepare for txn={} to Raft partition {}",
                 redo.transaction_id,
+                raft.partition_id(),
+            )
+        })?;
+        Ok(Some(rx))
+    }
+
+    fn propose_two_phase_rollback_to_raft(
+        &self,
+        transaction_id: &crate::two_phase::TwoPhaseTransactionId,
+    ) -> anyhow::Result<RaftCommitWaiter> {
+        let Some(raft) = self.raft_state.as_ref() else {
+            return Ok(None);
+        };
+        anyhow::ensure!(
+            raft.is_cluster_genesis_ready(),
+            "Cluster genesis is not ready for partition {}",
+            raft.partition_id(),
+        );
+        if !raft.is_leader_ready() {
+            anyhow::bail!(
+                "Raft leader is not ready before proposing 2PC rollback for txn={} on partition {}",
+                transaction_id,
+                raft.partition_id(),
+            );
+        }
+        let data = RaftStateMachineEntry::two_phase_rollback(transaction_id.clone())
+            .to_bytes()
+            .with_context(|| {
+                format!(
+                    "Failed to serialize 2PC rollback for txn={} for Raft proposal",
+                    transaction_id,
+                )
+            })?;
+        let (tx, rx) = oneshot::channel();
+        raft.send(crate::raft_node::RaftMessage::Propose(
+            crate::raft_node::RaftProposal {
+                data,
+                result_tx: tx,
+            },
+        ))
+        .with_context(|| {
+            format!(
+                "Failed to propose 2PC rollback for txn={} to Raft partition {}",
+                transaction_id,
                 raft.partition_id(),
             )
         })?;
@@ -5303,6 +5369,32 @@ impl<RT: Runtime> Committer<RT> {
         Ok(())
     }
 
+    async fn persist_two_phase_rollback_with_state_machine_index(
+        persistence: Arc<dyn Persistence>,
+        transaction_id: &crate::two_phase::TwoPhaseTransactionId,
+        raft_state_machine_index: u64,
+    ) -> anyhow::Result<()> {
+        let mut records = Self::load_two_phase_redo_records(persistence.clone()).await?;
+        records.remove(&transaction_id.0);
+        let redo_value = serde_json::to_value(records)
+            .context("2PC: Failed to serialize Raft-applied rollback redo records")?;
+        persistence
+            .write_with_persistence_globals(
+                &[],
+                &[],
+                ConflictStrategy::Overwrite,
+                &[
+                    PersistenceGlobalWrite::new(
+                        String::from(PersistenceGlobalKey::TwoPhaseRedoRecords),
+                        redo_value,
+                    ),
+                    state_machine_index_persistence_write(raft_state_machine_index),
+                ],
+            )
+            .await
+            .context("2PC: Failed to atomically persist rollback and Raft state-machine index")
+    }
+
     async fn redo_entry_is_already_committed(
         persistence_reader: Arc<dyn PersistenceReader>,
         retention_validator: Arc<dyn RetentionValidator>,
@@ -5356,6 +5448,11 @@ impl<RT: Runtime> Committer<RT> {
             .latest_snapshot()
             .table_mapping()
             .clone();
+        Self::validate_participant_catalog_creations(
+            &transaction,
+            &local_table_mapping,
+            &write_source,
+        )?;
         let mut table_mapping = local_table_mapping.clone();
         transaction.augment_table_mapping(&mut table_mapping)?;
         let writes = Self::remap_participant_system_table_writes(
@@ -5374,6 +5471,57 @@ impl<RT: Runtime> Committer<RT> {
             require_leader,
             allow_explicit_ts_rewrite,
         )
+    }
+
+    fn validate_participant_catalog_creations(
+        transaction: &crate::two_phase::ParticipantTransaction,
+        local_mapping: &TableMapping,
+        write_source: &WriteSource,
+    ) -> anyhow::Result<()> {
+        for write in &transaction.writes {
+            if write.old_document.is_some() {
+                continue;
+            }
+            let Some(new_document) = write.new_document.as_ref() else {
+                continue;
+            };
+            let Some(catalog_metadata) = transaction.tablet_metadata.get(&write.id.tablet_id)
+            else {
+                continue;
+            };
+            if &catalog_metadata.table_name != &*TABLES_TABLE {
+                continue;
+            }
+
+            let metadata: ParsedDocument<TableMetadata> =
+                new_document.parse().with_context(|| {
+                    format!(
+                        "failed to parse _tables metadata while validating 2PC catalog write {:?}",
+                        write.id
+                    )
+                })?;
+            let metadata = metadata.into_value();
+            if metadata.name.is_system() || !metadata.is_active() {
+                continue;
+            }
+
+            let proposed_tablet = value::TabletId(write.id.internal_id());
+            let existing_tablet = local_mapping
+                .namespace(metadata.namespace)
+                .id_if_exists(&metadata.name);
+            if existing_tablet.is_some_and(|existing| existing != proposed_tablet) {
+                let error = ErrorMetadata::system_occ(
+                    Some(u64::from(*transaction.begin_timestamp)),
+                    write_source.as_str().map(str::to_string),
+                );
+                anyhow::bail!(anyhow::anyhow!(error).context(format!(
+                    "2PC catalog create for table '{}' lost a concurrent creation race; retry \
+                     against the committed catalog",
+                    metadata.name,
+                )));
+            }
+        }
+        Ok(())
     }
 
     fn validate_participant_reads(
@@ -6296,15 +6444,13 @@ impl<RT: Runtime> Committer<RT> {
             return Ok(());
         }
 
-        let prepared = self
-            .prepared_transactions
-            .remove(&transaction_id)
-            .ok_or_else(|| {
-                anyhow::anyhow!(
-                    "2PC RollbackPrepared: unknown transaction {}",
-                    transaction_id
-                )
-            })?;
+        let Some(prepared) = self.prepared_transactions.remove(&transaction_id) else {
+            tracing::debug!(
+                "2PC RollbackPrepared: txn={} was already absent on this Raft replica",
+                transaction_id,
+            );
+            return Ok(());
+        };
 
         tracing::info!(
             "2PC RollbackPrepared: txn={}, ts={}",
@@ -6326,6 +6472,66 @@ impl<RT: Runtime> Committer<RT> {
             })?;
 
         Ok(())
+    }
+
+    async fn handle_rollback_prepared_through_raft(
+        &mut self,
+        transaction_id: crate::two_phase::TwoPhaseTransactionId,
+    ) -> anyhow::Result<()> {
+        self.ensure_leader_for_writes()?;
+        anyhow::ensure!(
+            !self.prepared_commit_waiters.contains_key(&transaction_id),
+            "2PC RollbackPrepared: transaction {} is already committing",
+            transaction_id,
+        );
+
+        // A prepare is a replicated state-machine entry, so its abort must be
+        // one too. The local leader may no longer have the intent after a
+        // failover, but followers can still have replayed it; always append the
+        // idempotent rollback marker before declaring the partition resolved.
+        let raft_rollback_waiter = self.propose_two_phase_rollback_to_raft(&transaction_id)?;
+        let raft_applied_index =
+            Self::wait_for_raft_rollback(raft_rollback_waiter, &transaction_id).await?;
+
+        self.handle_rollback_prepared(transaction_id.clone())?;
+        if let Some(raft_applied_index) = raft_applied_index {
+            Self::persist_two_phase_rollback_with_state_machine_index(
+                self.persistence.clone(),
+                &transaction_id,
+                raft_applied_index,
+            )
+            .await?;
+            let Some(raft_state) = self.raft_state.as_ref() else {
+                anyhow::bail!(
+                    "2PC RollbackPrepared txn={} returned Raft applied index {} without Raft state",
+                    transaction_id,
+                    raft_applied_index,
+                );
+            };
+            raft_state.mark_applied(raft_applied_index).await?;
+        } else {
+            Self::delete_two_phase_redo(self.persistence.clone(), &transaction_id).await?;
+        }
+        Ok(())
+    }
+
+    async fn handle_raft_rollback(
+        &mut self,
+        raft_state_machine_index: u64,
+        transaction_id: crate::two_phase::TwoPhaseTransactionId,
+    ) -> anyhow::Result<()> {
+        tracing::info!(
+            "2PC Raft Rollback Apply: txn={}, index={}",
+            transaction_id,
+            raft_state_machine_index,
+        );
+        self.handle_rollback_prepared(transaction_id.clone())?;
+        Self::persist_two_phase_rollback_with_state_machine_index(
+            self.persistence.clone(),
+            &transaction_id,
+            raft_state_machine_index,
+        )
+        .await
     }
 
     fn handle_raft_prepared_redo(
@@ -6997,6 +7203,25 @@ impl CommitterClient {
         rx.await.map_err(|_| metrics::shutdown_error())?
     }
 
+    /// Apply an idempotent 2PC rollback marker committed through Raft.
+    pub async fn apply_raft_rollback(
+        &self,
+        raft_state_machine_index: u64,
+        transaction_id: crate::two_phase::TwoPhaseTransactionId,
+    ) -> anyhow::Result<()> {
+        let (tx, rx) = oneshot::channel();
+        let message = CommitterMessage::ApplyRaftRollback {
+            raft_state_machine_index,
+            transaction_id,
+            result: tx,
+        };
+        self.sender.try_send(message).map_err(|e| match e {
+            TrySendError::Full(..) => metrics::committer_full_error().into(),
+            TrySendError::Closed(..) => metrics::shutdown_error(),
+        })?;
+        rx.await.map_err(|_| metrics::shutdown_error())?
+    }
+
     pub async fn set_raft_state(
         &self,
         raft_state: crate::raft_partition::RaftPartitionState,
@@ -7642,6 +7867,11 @@ enum CommitterMessage {
         raft_state_machine_index: u64,
         redo: crate::two_phase::TwoPhaseRedoEntry,
         result: oneshot::Sender<anyhow::Result<crate::two_phase::PrepareResult>>,
+    },
+    ApplyRaftRollback {
+        raft_state_machine_index: u64,
+        transaction_id: crate::two_phase::TwoPhaseTransactionId,
+        result: oneshot::Sender<anyhow::Result<()>>,
     },
     SetRaftState {
         raft_state: crate::raft_partition::RaftPartitionState,

--- a/crates/database/src/committer.rs
+++ b/crates/database/src/committer.rs
@@ -1433,6 +1433,25 @@ impl<RT: Runtime> Committer<RT> {
             .unwrap_or(crate::partition::PartitionId(0))
     }
 
+    fn prepare_admission_blocker_ts(&self) -> Option<Timestamp> {
+        let pending_write_ts = self.pending_writes.min_ts();
+        let committing_prepared_ts = self
+            .prepared_commit_waiters
+            .keys()
+            .filter_map(|transaction_id| {
+                self.prepared_transactions
+                    .get(transaction_id)
+                    .map(|prepared| prepared.commit_ts)
+            })
+            .min();
+        match (pending_write_ts, committing_prepared_ts) {
+            (Some(pending), Some(prepared)) => Some(cmp::min(pending, prepared)),
+            (Some(pending), None) => Some(pending),
+            (None, Some(prepared)) => Some(prepared),
+            (None, None) => None,
+        }
+    }
+
     fn dequeue_snapshot(&mut self, commit_id: usize) {
         let (queued_commit_id, ..) = self
             .queued_snapshots
@@ -1593,7 +1612,7 @@ impl<RT: Runtime> Committer<RT> {
                 || pending_snapshot_install.is_some()
                 || snapshot_install_in_progress;
             if !snapshot_barrier_active
-                && self.pending_writes.min_ts().is_none()
+                && self.prepare_admission_blocker_ts().is_none()
                 && let Some(deferred_prepare) = deferred_prepares.pop_front()
             {
                 self.handle_deferred_prepare(deferred_prepare).await;
@@ -2402,7 +2421,7 @@ impl<RT: Runtime> Committer<RT> {
                                 redo,
                                 result,
                             };
-                            if let Some(min_pending_ts) = self.pending_writes.min_ts() {
+                            if let Some(min_pending_ts) = self.prepare_admission_blocker_ts() {
                                 Self::defer_prepare_admission(
                                     &mut deferred_prepares,
                                     deferred_prepare,
@@ -2513,7 +2532,7 @@ impl<RT: Runtime> Committer<RT> {
                                 write_source,
                                 result,
                             };
-                            if let Some(min_pending_ts) = self.pending_writes.min_ts() {
+                            if let Some(min_pending_ts) = self.prepare_admission_blocker_ts() {
                                 Self::defer_prepare_admission(
                                     &mut deferred_prepares,
                                     deferred_prepare,
@@ -2539,7 +2558,7 @@ impl<RT: Runtime> Committer<RT> {
                                 participants,
                                 result,
                             };
-                            if let Some(min_pending_ts) = self.pending_writes.min_ts() {
+                            if let Some(min_pending_ts) = self.prepare_admission_blocker_ts() {
                                 Self::defer_prepare_admission(
                                     &mut deferred_prepares,
                                     deferred_prepare,
@@ -5924,14 +5943,14 @@ impl<RT: Runtime> Committer<RT> {
     fn defer_prepare_admission(
         deferred_prepares: &mut VecDeque<DeferredPrepare>,
         deferred_prepare: DeferredPrepare,
-        min_pending_ts: Timestamp,
+        blocking_ts: Timestamp,
     ) {
         tracing::debug!(
             transaction_id = %deferred_prepare.transaction_id(),
             kind = deferred_prepare.kind(),
-            min_pending_ts = u64::from(min_pending_ts),
+            blocking_ts = u64::from(blocking_ts),
             deferred_prepares = deferred_prepares.len() + 1,
-            "Deferring 2PC prepare admission behind older pending write",
+            "Deferring 2PC prepare admission behind earlier unpublished state-machine write",
         );
         deferred_prepares.push_back(deferred_prepare);
     }

--- a/crates/database/src/committer.rs
+++ b/crates/database/src/committer.rs
@@ -491,6 +491,16 @@ enum PersistenceWrite {
         commit_id: usize,
         err: anyhow::Error,
     },
+    PreparedRollback {
+        transaction_id: crate::two_phase::TwoPhaseTransactionId,
+        commit_id: usize,
+        raft_applied_index: Option<u64>,
+    },
+    PreparedRollbackRejected {
+        transaction_id: crate::two_phase::TwoPhaseTransactionId,
+        commit_id: usize,
+        err: anyhow::Error,
+    },
     MaxRepeatableTimestamp {
         new_max_repeatable: Timestamp,
         timer: Timer<VMHistogram>,
@@ -850,6 +860,8 @@ impl PersistenceWrite {
             Self::RejectedBeforePersistence { commit_id, .. } => *commit_id,
             Self::PreparedCommit { commit_id, .. } => *commit_id,
             Self::PreparedRejectedBeforePersistence { commit_id, .. } => *commit_id,
+            Self::PreparedRollback { commit_id, .. } => *commit_id,
+            Self::PreparedRollbackRejected { commit_id, .. } => *commit_id,
             Self::MaxRepeatableTimestamp { commit_id, .. } => *commit_id,
             Self::ReplicaDelta { commit_id, .. } => *commit_id,
             Self::RaftReplayRecovery { commit_id, .. } => *commit_id,
@@ -1351,6 +1363,14 @@ pub struct Committer<RT: Runtime> {
         Vec<oneshot::Sender<anyhow::Result<Timestamp>>>,
     >,
 
+    // Rollback is also a replicated state-machine operation. Keep duplicate
+    // requests attached to one in-flight marker and prevent a contradictory
+    // CommitPrepared from starting while that marker is unresolved.
+    prepared_rollback_waiters: std::collections::HashMap<
+        crate::two_phase::TwoPhaseTransactionId,
+        Vec<oneshot::Sender<anyhow::Result<()>>>,
+    >,
+
     // Snapshots for queued-but-not-yet-published state machine writes.
     // Local commits and replica deltas must both build on the latest queued
     // snapshot, not just the latest published one, or a later publish can
@@ -1514,6 +1534,7 @@ impl<RT: Runtime> Committer<RT> {
             maintenance_tso_refill_in_flight: Arc::new(AtomicBool::new(false)),
             prepared_transactions: std::collections::HashMap::new(),
             prepared_commit_waiters: std::collections::HashMap::new(),
+            prepared_rollback_waiters: std::collections::HashMap::new(),
             queued_snapshots: VecDeque::new(),
             raft_state,
             applied_delta_watermarks,
@@ -1984,6 +2005,63 @@ impl<RT: Runtime> Committer<RT> {
                             ..
                         } => {
                             self.send_prepared_commit_waiters(&transaction_id, Err(err));
+                        },
+                        PersistenceWrite::PreparedRollback {
+                            transaction_id,
+                            raft_applied_index,
+                            ..
+                        } => {
+                            let apply_result = async {
+                                self.handle_rollback_prepared(transaction_id.clone())?;
+                                if let Some(raft_applied_index) = raft_applied_index {
+                                    Self::persist_two_phase_rollback_with_state_machine_index(
+                                        self.persistence.clone(),
+                                        &transaction_id,
+                                        raft_applied_index,
+                                    )
+                                    .await?;
+                                    let Some(raft_state) = self.raft_state.as_ref() else {
+                                        anyhow::bail!(
+                                            "2PC RollbackPrepared txn={} returned Raft applied index {} without Raft state",
+                                            transaction_id,
+                                            raft_applied_index,
+                                        );
+                                    };
+                                    raft_state.mark_applied(raft_applied_index).await?;
+                                } else {
+                                    Self::delete_two_phase_redo(
+                                        self.persistence.clone(),
+                                        &transaction_id,
+                                    )
+                                    .await?;
+                                }
+                                Ok::<(), anyhow::Error>(())
+                            }
+                            .await;
+                            match apply_result {
+                                Ok(()) => self.send_prepared_rollback_waiters(
+                                    &transaction_id,
+                                    Ok(()),
+                                ),
+                                Err(err) => {
+                                    let message = format!(
+                                        "Failed to apply committed 2PC rollback for txn={}: {err:#}",
+                                        transaction_id,
+                                    );
+                                    self.send_prepared_rollback_waiters(
+                                        &transaction_id,
+                                        Err(anyhow::anyhow!(message.clone())),
+                                    );
+                                    anyhow::bail!(message);
+                                },
+                            }
+                        },
+                        PersistenceWrite::PreparedRollbackRejected {
+                            transaction_id,
+                            err,
+                            ..
+                        } => {
+                            self.send_prepared_rollback_waiters(&transaction_id, Err(err));
                         },
                         PersistenceWrite::MaxRepeatableTimestamp {
                             new_max_repeatable,
@@ -2609,10 +2687,16 @@ impl<RT: Runtime> Committer<RT> {
                             transaction_id,
                             result,
                         }) => {
-                            let r = self
-                                .handle_rollback_prepared_through_raft(transaction_id)
-                                .await;
-                            let _ = result.send(r);
+                            if let Some(persistence_write_future) =
+                                self.start_rollback_prepared_through_raft(
+                                    transaction_id,
+                                    result,
+                                    commit_id,
+                                )
+                            {
+                                self.persistence_writes.push_back(persistence_write_future);
+                                commit_id += 1;
+                            }
                         },
                         Some(CommitterMessage::ApplyRaftRollback {
                             raft_state_machine_index,
@@ -3772,6 +3856,29 @@ impl<RT: Runtime> Committer<RT> {
             Ok(commit_ts) => {
                 for waiter in waiters {
                     let _ = waiter.send(Ok(commit_ts));
+                }
+            },
+            Err(err) => {
+                let message = format!("{err:#}");
+                for waiter in waiters {
+                    let _ = waiter.send(Err(anyhow::anyhow!(message.clone())));
+                }
+            },
+        }
+    }
+
+    fn send_prepared_rollback_waiters(
+        &mut self,
+        transaction_id: &crate::two_phase::TwoPhaseTransactionId,
+        result: anyhow::Result<()>,
+    ) {
+        let Some(waiters) = self.prepared_rollback_waiters.remove(transaction_id) else {
+            return;
+        };
+        match result {
+            Ok(()) => {
+                for waiter in waiters {
+                    let _ = waiter.send(Ok(()));
                 }
             },
             Err(err) => {
@@ -6170,6 +6277,13 @@ impl<RT: Runtime> Committer<RT> {
         result: oneshot::Sender<anyhow::Result<Timestamp>>,
         commit_id: usize,
     ) -> Option<BoxFuture<'static, anyhow::Result<PersistenceWrite>>> {
+        if self.prepared_rollback_waiters.contains_key(&transaction_id) {
+            let _ = result.send(Err(anyhow::anyhow!(
+                "2PC CommitPrepared: transaction {} is already rolling back",
+                transaction_id,
+            )));
+            return None;
+        }
         if let Some(waiters) = self.prepared_commit_waiters.get_mut(&transaction_id) {
             tracing::debug!(
                 "2PC CommitPrepared: txn={} already committing; attaching duplicate waiter",
@@ -6474,45 +6588,63 @@ impl<RT: Runtime> Committer<RT> {
         Ok(())
     }
 
-    async fn handle_rollback_prepared_through_raft(
+    /// Queue a rollback marker without waiting inside the single committer
+    /// loop. Raft applies entries in order, so synchronously waiting here
+    /// can deadlock behind an earlier prepared commit that still needs this
+    /// loop to publish and send `MarkApplied`.
+    fn start_rollback_prepared_through_raft(
         &mut self,
         transaction_id: crate::two_phase::TwoPhaseTransactionId,
-    ) -> anyhow::Result<()> {
-        self.ensure_leader_for_writes()?;
-        anyhow::ensure!(
-            !self.prepared_commit_waiters.contains_key(&transaction_id),
-            "2PC RollbackPrepared: transaction {} is already committing",
-            transaction_id,
-        );
+        result: oneshot::Sender<anyhow::Result<()>>,
+        commit_id: usize,
+    ) -> Option<BoxFuture<'static, anyhow::Result<PersistenceWrite>>> {
+        if let Some(waiters) = self.prepared_rollback_waiters.get_mut(&transaction_id) {
+            waiters.push(result);
+            return None;
+        }
+        if self.prepared_commit_waiters.contains_key(&transaction_id) {
+            let _ = result.send(Err(anyhow::anyhow!(
+                "2PC RollbackPrepared: transaction {} is already committing",
+                transaction_id,
+            )));
+            return None;
+        }
+        if let Err(err) = self.ensure_leader_for_writes() {
+            let _ = result.send(Err(err));
+            return None;
+        }
 
         // A prepare is a replicated state-machine entry, so its abort must be
         // one too. The local leader may no longer have the intent after a
         // failover, but followers can still have replayed it; always append the
         // idempotent rollback marker before declaring the partition resolved.
-        let raft_rollback_waiter = self.propose_two_phase_rollback_to_raft(&transaction_id)?;
-        let raft_applied_index =
-            Self::wait_for_raft_rollback(raft_rollback_waiter, &transaction_id).await?;
+        let raft_rollback_waiter = match self.propose_two_phase_rollback_to_raft(&transaction_id) {
+            Ok(waiter) => waiter,
+            Err(err) => {
+                let _ = result.send(Err(err));
+                return None;
+            },
+        };
+        self.prepared_rollback_waiters
+            .insert(transaction_id.clone(), vec![result]);
 
-        self.handle_rollback_prepared(transaction_id.clone())?;
-        if let Some(raft_applied_index) = raft_applied_index {
-            Self::persist_two_phase_rollback_with_state_machine_index(
-                self.persistence.clone(),
-                &transaction_id,
-                raft_applied_index,
-            )
-            .await?;
-            let Some(raft_state) = self.raft_state.as_ref() else {
-                anyhow::bail!(
-                    "2PC RollbackPrepared txn={} returned Raft applied index {} without Raft state",
-                    transaction_id,
-                    raft_applied_index,
-                );
-            };
-            raft_state.mark_applied(raft_applied_index).await?;
-        } else {
-            Self::delete_two_phase_redo(self.persistence.clone(), &transaction_id).await?;
-        }
-        Ok(())
+        Some(
+            async move {
+                match Self::wait_for_raft_rollback(raft_rollback_waiter, &transaction_id).await {
+                    Ok(raft_applied_index) => Ok(PersistenceWrite::PreparedRollback {
+                        transaction_id,
+                        commit_id,
+                        raft_applied_index,
+                    }),
+                    Err(err) => Ok(PersistenceWrite::PreparedRollbackRejected {
+                        transaction_id,
+                        commit_id,
+                        err,
+                    }),
+                }
+            }
+            .boxed(),
+        )
     }
 
     async fn handle_raft_rollback(

--- a/crates/database/src/database.rs
+++ b/crates/database/src/database.rs
@@ -224,6 +224,10 @@ use crate::{
         SubscriptionsClient,
         SubscriptionsWorker,
     },
+    subscription_invalidation::{
+        GrpcSubscriptionInvalidationClient,
+        SubscriptionInvalidationClient,
+    },
     system_tables::{
         ErasedSystemIndex,
         SystemTable,
@@ -314,6 +318,7 @@ pub struct Database<RT: Runtime> {
     virtual_system_mapping: VirtualSystemMapping,
     table_number_allocator: Arc<dyn TableNumberAllocator>,
     owner_read_client: Option<Arc<dyn OwnerReadClient>>,
+    subscription_invalidation_client: Option<Arc<dyn SubscriptionInvalidationClient>>,
     pub bootstrap_metadata: BootstrapMetadata,
     // Caches of snapshot TableMapping and by_id index ids, which are used repeatedly by
     // /api/list_snapshot.
@@ -1139,6 +1144,7 @@ impl<RT: Runtime> Database<RT> {
             distributed_log.clone()
         };
         let owner_read_cluster_auth = cluster_grpc_auth.clone();
+        let subscription_invalidation_cluster_auth = cluster_grpc_auth.clone();
         let committer = Committer::start(
             log_writer,
             snapshot_writer,
@@ -1165,6 +1171,14 @@ impl<RT: Runtime> Database<RT> {
                 owner_read_cluster_auth,
             )) as Arc<dyn OwnerReadClient>
         });
+        let subscription_invalidation_client = (committer.local_partition().is_some()
+            && committer.node_addresses().is_some())
+        .then(|| {
+            Arc::new(GrpcSubscriptionInvalidationClient::new(
+                committer.clone(),
+                subscription_invalidation_cluster_auth,
+            )) as Arc<dyn SubscriptionInvalidationClient>
+        });
         let table_mapping_snapshot_cache =
             AsyncLru::new(runtime.clone(), 20, 2, "table_mapping_snapshot");
         let by_id_indexes_snapshot_cache =
@@ -1188,6 +1202,7 @@ impl<RT: Runtime> Database<RT> {
             virtual_system_mapping,
             table_number_allocator,
             owner_read_client,
+            subscription_invalidation_client,
             bootstrap_metadata,
             table_mapping_snapshot_cache,
             by_id_indexes_snapshot_cache,
@@ -1239,6 +1254,16 @@ impl<RT: Runtime> Database<RT> {
     ) -> Self {
         let mut database = self.clone();
         database.owner_read_client = Some(owner_read_client);
+        database
+    }
+
+    #[cfg(test)]
+    pub(crate) fn with_subscription_invalidation_client_for_test(
+        &self,
+        client: Arc<dyn SubscriptionInvalidationClient>,
+    ) -> Self {
+        let mut database = self.clone();
+        database.subscription_invalidation_client = Some(client);
         database
     }
 
@@ -2443,8 +2468,56 @@ impl<RT: Runtime> Database<RT> {
             .await?;
         if !readonly {
             self.write_commits_since_load.fetch_add(1, Ordering::SeqCst);
+            if !result.invalidated_tables.is_empty() {
+                match self.committer.local_partition() {
+                    Some(local_partition)
+                        if local_partition == crate::partition::PartitionId::DEFAULT =>
+                    {
+                        if let Err(error) = self.invalidate_subscriptions_for_tables(
+                            result.invalidated_tables.clone(),
+                            result.ts,
+                        ) {
+                            tracing::warn!(
+                                commit_ts = %result.ts,
+                                error = %error,
+                                "Failed to enqueue local cluster subscription invalidation; the \
+                                 durable replication path remains authoritative"
+                            );
+                        }
+                    },
+                    Some(_) => {
+                        if let Some(client) = self.subscription_invalidation_client.as_ref()
+                            && let Err(error) = client
+                                .invalidate_tables(
+                                    crate::partition::PartitionId::DEFAULT,
+                                    self.committer.placement_version(),
+                                    result.ts,
+                                    result.invalidated_tables.clone(),
+                                )
+                                .await
+                        {
+                            tracing::warn!(
+                                commit_ts = %result.ts,
+                                error = %error,
+                                "Failed to deliver direct cluster subscription invalidation; the \
+                                 durable replication path will retry visibility"
+                            );
+                        }
+                    },
+                    None => {},
+                }
+            }
         }
         Ok(result)
+    }
+
+    pub fn invalidate_subscriptions_for_tables(
+        &self,
+        table_names: BTreeSet<TableName>,
+        invalid_ts: Timestamp,
+    ) -> anyhow::Result<()> {
+        self.subscriptions
+            .invalidate_tables(table_names, invalid_ts)
     }
 
     #[fastrace::trace]

--- a/crates/database/src/database.rs
+++ b/crates/database/src/database.rs
@@ -1941,8 +1941,10 @@ impl<RT: Runtime> Database<RT> {
                     owner_read_client.close_read_timestamp(partition, placement_version, target)
                 }),
         );
-        let (local, remotes) =
-            futures::join!(self.committer.close_read_timestamp(target), remote_closures,);
+        let (local, remotes) = futures::join!(
+            self.committer.close_latest_read_timestamp(target),
+            remote_closures,
+        );
         let mut closures = Vec::with_capacity(partition_map.num_partitions() as usize);
         closures.push(local?);
         closures.extend(remotes.into_iter().collect::<anyhow::Result<Vec<_>>>()?);

--- a/crates/database/src/lib.rs
+++ b/crates/database/src/lib.rs
@@ -46,6 +46,7 @@ mod snapshot_manager;
 mod stack_traces;
 pub mod streaming_export_selection;
 pub mod subscription;
+pub mod subscription_invalidation;
 pub mod system_query;
 pub mod system_tables;
 mod table_number_allocator;

--- a/crates/database/src/partition.rs
+++ b/crates/database/src/partition.rs
@@ -236,6 +236,8 @@ impl PlacementMetadata {
             local_partition,
             num_partitions: self.num_partitions,
             placement_version: self.version,
+            #[cfg(any(test, feature = "testing"))]
+            enforce_catalog_coherence: true,
         }
     }
 }
@@ -371,6 +373,8 @@ impl PlacementMetadataStore for NatsPlacementMetadataStore {
 pub struct PlacementState {
     local_partition: PartitionId,
     metadata: Arc<RwLock<PlacementMetadata>>,
+    #[cfg(any(test, feature = "testing"))]
+    enforce_catalog_coherence: bool,
 }
 
 impl PlacementState {
@@ -379,10 +383,14 @@ impl PlacementState {
         Ok(Self {
             local_partition,
             metadata: Arc::new(RwLock::new(metadata)),
+            #[cfg(any(test, feature = "testing"))]
+            enforce_catalog_coherence: true,
         })
     }
 
     pub fn from_partition_map(partition_map: PartitionMap) -> Self {
+        #[cfg(any(test, feature = "testing"))]
+        let enforce_catalog_coherence = partition_map.enforces_catalog_coherence();
         let metadata = PlacementMetadata::from_partition_map(
             &partition_map,
             PlacementMetadataSource::StaticConfig,
@@ -390,14 +398,22 @@ impl PlacementState {
         Self {
             local_partition: partition_map.local_partition(),
             metadata: Arc::new(RwLock::new(metadata)),
+            #[cfg(any(test, feature = "testing"))]
+            enforce_catalog_coherence,
         }
     }
 
     pub fn partition_map(&self) -> PartitionMap {
-        self.metadata
+        let partition_map = self
+            .metadata
             .read()
             .expect("placement metadata lock poisoned")
-            .into_partition_map(self.local_partition)
+            .into_partition_map(self.local_partition);
+        #[cfg(any(test, feature = "testing"))]
+        if !self.enforce_catalog_coherence {
+            return partition_map.without_catalog_authority_for_test();
+        }
+        partition_map
     }
 
     pub fn refresh(&self, metadata: PlacementMetadata) -> anyhow::Result<()> {
@@ -463,6 +479,8 @@ pub struct PartitionMap {
     num_partitions: u32,
     /// Version of the placement metadata used to build this map.
     placement_version: PlacementVersion,
+    #[cfg(any(test, feature = "testing"))]
+    enforce_catalog_coherence: bool,
 }
 
 impl PartitionMap {
@@ -504,7 +522,28 @@ impl PartitionMap {
             local_partition: PartitionId::DEFAULT,
             num_partitions: 1,
             placement_version: PlacementVersion::STATIC,
+            #[cfg(any(test, feature = "testing"))]
+            enforce_catalog_coherence: true,
         }
+    }
+
+    pub(crate) fn enforces_catalog_coherence(&self) -> bool {
+        #[cfg(any(test, feature = "testing"))]
+        {
+            self.enforce_catalog_coherence
+        }
+        #[cfg(not(any(test, feature = "testing")))]
+        {
+            true
+        }
+    }
+
+    /// Isolated data-plane tests deliberately run one partition without its
+    /// metadata authority. Production maps never disable catalog coherence.
+    #[cfg(any(test, feature = "testing"))]
+    pub fn without_catalog_authority_for_test(mut self) -> Self {
+        self.enforce_catalog_coherence = false;
+        self
     }
 
     /// Get the partition that owns the given table.

--- a/crates/database/src/raft_node.rs
+++ b/crates/database/src/raft_node.rs
@@ -17,6 +17,7 @@ use std::{
     collections::{
         BTreeSet,
         HashMap,
+        VecDeque,
     },
     sync::Arc,
     time::{
@@ -406,6 +407,45 @@ impl RaftNode {
         Ok(())
     }
 
+    fn schedule_next_committed_entry(
+        &mut self,
+        deferred_committed_entries: &mut VecDeque<Entry>,
+        pending_state_machine_applies: &mut BTreeSet<u64>,
+        pending_local_applies: &mut BTreeSet<u64>,
+        apply_tx: &mpsc::UnboundedSender<StateMachineApplyJob>,
+    ) -> anyhow::Result<bool> {
+        if !pending_state_machine_applies.is_empty() || !pending_local_applies.is_empty() {
+            return Ok(false);
+        }
+
+        let mut made_progress = false;
+        while let Some(entry) = deferred_committed_entries.pop_front() {
+            made_progress = true;
+            let index = entry.index;
+            match self.classify_committed_entry(entry)? {
+                CommittedEntryAction::WaitForLocalApply => {
+                    pending_local_applies.insert(index);
+                    break;
+                },
+                CommittedEntryAction::MarkApplied(index) => {
+                    self.record_applied_index(index)?;
+                },
+                CommittedEntryAction::Apply(job) => {
+                    pending_state_machine_applies.insert(job.index);
+                    if apply_tx.send(job).is_err() {
+                        anyhow::bail!("Raft state-machine apply worker stopped");
+                    }
+                    break;
+                },
+            }
+        }
+
+        if made_progress {
+            self.raw_node.advance_apply_to(self.durable_applied_index);
+        }
+        Ok(made_progress)
+    }
+
     fn process_mailbox_message(
         &mut self,
         msg: RaftMessage,
@@ -491,6 +531,7 @@ impl RaftNode {
         let mut last_tick = Instant::now();
         let mut pending_state_machine_applies = BTreeSet::new();
         let mut pending_local_applies = BTreeSet::new();
+        let mut deferred_committed_entries = VecDeque::new();
         let (apply_tx, mut apply_rx) = mpsc::unbounded_channel::<StateMachineApplyJob>();
         let (applied_tx, mut applied_rx) = mpsc::unbounded_channel::<StateMachineApplyResult>();
         let _apply_worker = tokio::task::spawn_blocking(move || {
@@ -573,7 +614,18 @@ impl RaftNode {
 
             let mut processed_ready = false;
             while self.raw_node.has_ready() {
-                if !pending_state_machine_applies.is_empty() || !pending_local_applies.is_empty() {
+                // Snapshot installation replaces the database state machine, so it must remain
+                // serialized with application work. Ordinary Ready processing must continue while
+                // apply is pending so leaders can send heartbeats and retain a healthy quorum.
+                let apply_pending = !pending_state_machine_applies.is_empty()
+                    || !pending_local_applies.is_empty()
+                    || !deferred_committed_entries.is_empty();
+                if apply_pending
+                    && self
+                        .raw_node
+                        .snap()
+                        .is_some_and(|snapshot| !snapshot.is_empty())
+                {
                     break;
                 }
                 processed_ready = true;
@@ -767,22 +819,10 @@ impl RaftNode {
                     }
                 }
 
-                let mut applied_indexes = Vec::new();
-                let mut apply_jobs = Vec::new();
-
-                // 6. Classify committed entries. Entries that require Convex
-                // state-machine work are offloaded after append/persist progress
-                // has advanced.
-                for entry in ready.take_committed_entries() {
-                    let index = entry.index;
-                    match self.classify_committed_entry(entry)? {
-                        CommittedEntryAction::WaitForLocalApply => {
-                            pending_local_applies.insert(index);
-                        },
-                        CommittedEntryAction::MarkApplied(index) => applied_indexes.push(index),
-                        CommittedEntryAction::Apply(job) => apply_jobs.push(job),
-                    }
-                }
+                // 6. Preserve committed-entry order independently from append/transport
+                // progress. The state machine scheduler below releases only one blocking entry at
+                // a time, but Raft can continue processing Ready and sending heartbeats.
+                deferred_committed_entries.extend(ready.take_committed_entries());
 
                 // 7. Advance append/persist state without claiming
                 // state-machine apply completion. `advance_apply_to` is called
@@ -808,30 +848,7 @@ impl RaftNode {
                     }
                 }
 
-                // Classify remaining committed entries.
-                for entry in light_rd.take_committed_entries() {
-                    let index = entry.index;
-                    match self.classify_committed_entry(entry)? {
-                        CommittedEntryAction::WaitForLocalApply => {
-                            pending_local_applies.insert(index);
-                        },
-                        CommittedEntryAction::MarkApplied(index) => applied_indexes.push(index),
-                        CommittedEntryAction::Apply(job) => apply_jobs.push(job),
-                    }
-                }
-
-                for index in applied_indexes {
-                    self.record_applied_index(index)?;
-                }
-                if !apply_jobs.is_empty() {
-                    for job in apply_jobs {
-                        pending_state_machine_applies.insert(job.index);
-                        if apply_tx.send(job).is_err() {
-                            anyhow::bail!("Raft state-machine apply worker stopped");
-                        }
-                    }
-                }
-                self.raw_node.advance_apply_to(self.durable_applied_index);
+                deferred_committed_entries.extend(light_rd.take_committed_entries());
                 self.maybe_mark_leader_ready();
                 self.maybe_refresh_leader_serving_lease(
                     &recent_peer_responses,
@@ -839,7 +856,26 @@ impl RaftNode {
                 );
             }
 
-            if handled_message || handled_apply_result || should_tick || processed_ready {
+            let scheduled_committed_entry = self.schedule_next_committed_entry(
+                &mut deferred_committed_entries,
+                &mut pending_state_machine_applies,
+                &mut pending_local_applies,
+                &apply_tx,
+            )?;
+            if scheduled_committed_entry {
+                self.maybe_mark_leader_ready();
+                self.maybe_refresh_leader_serving_lease(
+                    &recent_peer_responses,
+                    leader_serving_lease_duration,
+                );
+            }
+
+            if handled_message
+                || handled_apply_result
+                || should_tick
+                || processed_ready
+                || scheduled_committed_entry
+            {
                 tokio::task::yield_now().await;
                 continue;
             }
@@ -1294,6 +1330,160 @@ mod tests {
                 anyhow::anyhow!("Raft run loop did not process shutdown while apply blocked")
             })???;
         unblock_tx.send(())?;
+        Ok(())
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 8)]
+    async fn test_leader_keeps_quorum_while_local_apply_is_pending() -> anyhow::Result<()> {
+        use std::sync::atomic::{
+            AtomicBool,
+            Ordering,
+        };
+
+        let peer_ids = vec![1u64, 2, 3];
+        let mut mailbox_txs = Vec::new();
+        let mut mailbox_rxs = Vec::new();
+        let mut transport_txs = Vec::new();
+        let mut transport_rxs = Vec::new();
+        for _ in &peer_ids {
+            let (mailbox_tx, mailbox_rx) = mpsc::unbounded_channel();
+            mailbox_txs.push(mailbox_tx);
+            mailbox_rxs.push(Some(mailbox_rx));
+
+            let (transport_tx, transport_rx) = mpsc::unbounded_channel::<Message>();
+            transport_txs.push(transport_tx);
+            transport_rxs.push(transport_rx);
+        }
+
+        let leader_ready = Arc::new(AtomicBool::new(false));
+        let leader_lost = Arc::new(AtomicBool::new(false));
+        let mut nodes = Vec::new();
+        for (node_index, node_id) in peer_ids.iter().copied().enumerate() {
+            let peer_senders = peer_ids
+                .iter()
+                .copied()
+                .enumerate()
+                .filter(|(_, peer_id)| *peer_id != node_id)
+                .map(|(peer_index, peer_id)| (peer_id, transport_txs[peer_index].clone()))
+                .collect();
+            let mut node = RaftNode::new(
+                RaftNodeConfig {
+                    node_id,
+                    partition_id: PartitionId(0),
+                    peers: peer_ids.clone(),
+                    election_tick: 10,
+                    heartbeat_tick: 3,
+                },
+                test_engine(),
+                mailbox_rxs[node_index].take().unwrap(),
+                peer_senders,
+                None,
+            )?;
+            if node_id == 1 {
+                let ready = leader_ready.clone();
+                let lost = leader_lost.clone();
+                node.set_leadership_callbacks(LeadershipCallbacks {
+                    on_leader_ready: Box::new(move || ready.store(true, Ordering::SeqCst)),
+                    on_lost_leadership: Box::new(move || lost.store(true, Ordering::SeqCst)),
+                    ..LeadershipCallbacks::default()
+                });
+            }
+            nodes.push(node);
+        }
+
+        nodes[0].raw_node.campaign()?;
+
+        let mut forward_tasks = Vec::new();
+        for (mut transport_rx, mailbox_tx) in
+            transport_rxs.into_iter().zip(mailbox_txs.iter().cloned())
+        {
+            forward_tasks.push(tokio::spawn(async move {
+                while let Some(message) = transport_rx.recv().await {
+                    if mailbox_tx.send(RaftMessage::Raft(message)).is_err() {
+                        break;
+                    }
+                }
+            }));
+        }
+
+        let mut run_tasks = Vec::new();
+        for mut node in nodes {
+            run_tasks.push(tokio::spawn(async move {
+                node.run(|_, _| Ok(()), |_| Ok(())).await
+            }));
+        }
+
+        tokio::time::timeout(Duration::from_secs(5), async {
+            while !leader_ready.load(Ordering::SeqCst) {
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+        })
+        .await
+        .map_err(|_| anyhow::anyhow!("node 1 did not become ready leader"))?;
+
+        let (first_result_tx, first_result_rx) = tokio::sync::oneshot::channel();
+        mailbox_txs[0].send(RaftMessage::Propose(RaftProposal {
+            data: b"slow local apply".to_vec(),
+            result_tx: first_result_tx,
+        }))?;
+        let first_index = match tokio::time::timeout(Duration::from_secs(5), first_result_rx)
+            .await
+            .map_err(|_| anyhow::anyhow!("first proposal did not commit"))??
+        {
+            RaftProposalResult::Committed { index } => index,
+            RaftProposalResult::Rejected => anyhow::bail!("ready leader rejected first proposal"),
+        };
+
+        // Hold the local database apply beyond the randomized election timeout. Consensus
+        // transport must continue independently or a healthy follower will start an election.
+        tokio::time::sleep(Duration::from_secs(3)).await;
+
+        let (mark_tx, mark_rx) = tokio::sync::oneshot::channel();
+        mailbox_txs[0].send(RaftMessage::MarkApplied {
+            index: first_index,
+            result_tx: mark_tx,
+        })?;
+        tokio::time::timeout(Duration::from_secs(2), mark_rx)
+            .await
+            .map_err(|_| anyhow::anyhow!("first local apply was not acknowledged"))???;
+
+        let (second_result_tx, second_result_rx) = tokio::sync::oneshot::channel();
+        mailbox_txs[0].send(RaftMessage::Propose(RaftProposal {
+            data: b"leader retained quorum".to_vec(),
+            result_tx: second_result_tx,
+        }))?;
+        let second_index = match tokio::time::timeout(Duration::from_secs(5), second_result_rx)
+            .await
+            .map_err(|_| anyhow::anyhow!("second proposal did not resolve"))??
+        {
+            RaftProposalResult::Committed { index } => index,
+            RaftProposalResult::Rejected => {
+                anyhow::bail!("leader lost quorum while local apply was pending")
+            },
+        };
+        anyhow::ensure!(
+            !leader_lost.load(Ordering::SeqCst),
+            "node 1 reported leadership loss while all three nodes were healthy"
+        );
+
+        let (mark_tx, mark_rx) = tokio::sync::oneshot::channel();
+        mailbox_txs[0].send(RaftMessage::MarkApplied {
+            index: second_index,
+            result_tx: mark_tx,
+        })?;
+        tokio::time::timeout(Duration::from_secs(2), mark_rx)
+            .await
+            .map_err(|_| anyhow::anyhow!("second local apply was not acknowledged"))???;
+
+        for mailbox_tx in &mailbox_txs {
+            let _ = mailbox_tx.send(RaftMessage::Shutdown);
+        }
+        for run_task in run_tasks {
+            run_task.await??;
+        }
+        for forward_task in forward_tasks {
+            forward_task.abort();
+        }
         Ok(())
     }
 

--- a/crates/database/src/raft_node.rs
+++ b/crates/database/src/raft_node.rs
@@ -615,8 +615,9 @@ impl RaftNode {
             let mut processed_ready = false;
             while self.raw_node.has_ready() {
                 // Snapshot installation replaces the database state machine, so it must remain
-                // serialized with application work. Ordinary Ready processing must continue while
-                // apply is pending so leaders can send heartbeats and retain a healthy quorum.
+                // serialized with application work. Ordinary Ready processing must continue
+                // while apply is pending so leaders can send heartbeats and
+                // retain a healthy quorum.
                 let apply_pending = !pending_state_machine_applies.is_empty()
                     || !pending_local_applies.is_empty()
                     || !deferred_committed_entries.is_empty();
@@ -820,8 +821,9 @@ impl RaftNode {
                 }
 
                 // 6. Preserve committed-entry order independently from append/transport
-                // progress. The state machine scheduler below releases only one blocking entry at
-                // a time, but Raft can continue processing Ready and sending heartbeats.
+                // progress. The state machine scheduler below releases only one blocking entry
+                // at a time, but Raft can continue processing Ready and sending
+                // heartbeats.
                 deferred_committed_entries.extend(ready.take_committed_entries());
 
                 // 7. Advance append/persist state without claiming
@@ -1434,8 +1436,9 @@ mod tests {
             RaftProposalResult::Rejected => anyhow::bail!("ready leader rejected first proposal"),
         };
 
-        // Hold the local database apply beyond the randomized election timeout. Consensus
-        // transport must continue independently or a healthy follower will start an election.
+        // Hold the local database apply beyond the randomized election timeout.
+        // Consensus transport must continue independently or a healthy follower
+        // will start an election.
         tokio::time::sleep(Duration::from_secs(3)).await;
 
         let (mark_tx, mark_rx) = tokio::sync::oneshot::channel();

--- a/crates/database/src/raft_state_machine.rs
+++ b/crates/database/src/raft_state_machine.rs
@@ -17,7 +17,10 @@ use crate::{
     },
     commit_delta::CommitDelta,
     nats_distributed_log::DeltaEnvelope,
-    two_phase::TwoPhaseRedoEntry,
+    two_phase::{
+        TwoPhaseRedoEntry,
+        TwoPhaseTransactionId,
+    },
 };
 
 /// Versioned Raft state-machine entry.
@@ -29,6 +32,9 @@ pub enum RaftStateMachineEntry {
     },
     TwoPhasePrepare {
         redo: TwoPhaseRedoEntry,
+    },
+    TwoPhaseRollback {
+        transaction_id: TwoPhaseTransactionId,
     },
     ClusterGenesis {
         manifest: ClusterGenesisManifest,
@@ -45,6 +51,10 @@ impl RaftStateMachineEntry {
 
     pub fn two_phase_prepare(redo: TwoPhaseRedoEntry) -> Self {
         Self::TwoPhasePrepare { redo }
+    }
+
+    pub fn two_phase_rollback(transaction_id: TwoPhaseTransactionId) -> Self {
+        Self::TwoPhaseRollback { transaction_id }
     }
 
     pub fn cluster_genesis(payload: &CanonicalGenesisPayload) -> Self {
@@ -105,6 +115,9 @@ mod tests {
             RaftStateMachineEntry::TwoPhasePrepare { .. } => {
                 panic!("expected commit delta entry")
             },
+            RaftStateMachineEntry::TwoPhaseRollback { .. } => {
+                panic!("expected commit delta entry")
+            },
             RaftStateMachineEntry::ClusterGenesis { .. } => {
                 panic!("expected commit delta entry")
             },
@@ -134,6 +147,9 @@ mod tests {
             RaftStateMachineEntry::TwoPhasePrepare { .. } => {
                 panic!("expected commit delta entry")
             },
+            RaftStateMachineEntry::TwoPhaseRollback { .. } => {
+                panic!("expected commit delta entry")
+            },
             RaftStateMachineEntry::ClusterGenesis { .. } => {
                 panic!("expected commit delta entry")
             },
@@ -159,6 +175,20 @@ mod tests {
                 assert_eq!(base64::decode(checkpoint_base64)?, payload.checkpoint_bytes);
             },
             _ => panic!("expected cluster genesis entry"),
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn two_phase_rollback_entry_roundtrips() -> anyhow::Result<()> {
+        let transaction_id = TwoPhaseTransactionId::new();
+        let bytes = RaftStateMachineEntry::two_phase_rollback(transaction_id.clone()).to_bytes()?;
+
+        match RaftStateMachineEntry::from_bytes(&bytes)? {
+            RaftStateMachineEntry::TwoPhaseRollback {
+                transaction_id: decoded,
+            } => assert_eq!(decoded, transaction_id),
+            _ => panic!("expected 2PC rollback entry"),
         }
         Ok(())
     }

--- a/crates/database/src/subscription.rs
+++ b/crates/database/src/subscription.rs
@@ -115,7 +115,7 @@ impl SubscriptionsClient {
             Err(invalid_ts) => return Ok(Subscription::invalid(invalid_ts)),
         };
         let (subscription, sender) = Subscription::new(&token);
-        let request = SubscriptionRequest {
+        let request = SubscriptionRequest::Subscribe {
             token,
             interested_tables,
             sender,
@@ -134,6 +134,35 @@ impl SubscriptionsClient {
             });
         }
         Ok(subscription)
+    }
+
+    pub fn invalidate_tables(
+        &self,
+        table_names: BTreeSet<TableName>,
+        invalid_ts: Timestamp,
+    ) -> anyhow::Result<()> {
+        let table_names = Arc::new(table_names);
+        let mut first_error = None;
+        for sender in &self.senders {
+            metrics::log_subscription_queue_length_delta(1);
+            let request = SubscriptionRequest::InvalidateTables {
+                table_names: table_names.clone(),
+                invalid_ts,
+            };
+            if let Err(error) = sender.try_send(request) {
+                metrics::log_subscription_queue_length_delta(-1);
+                if first_error.is_none() {
+                    first_error = Some(match error {
+                        TrySendError::Full(..) => metrics::subscriptions_worker_full_error().into(),
+                        TrySendError::Closed(..) => metrics::shutdown_error(),
+                    });
+                }
+            }
+        }
+        if let Some(error) = first_error {
+            return Err(error);
+        }
+        Ok(())
     }
 
     pub fn delta_interest_tracker(&self) -> DeltaInterestTracker {
@@ -182,11 +211,17 @@ impl SubscriptionSender {
     }
 }
 
-struct SubscriptionRequest {
-    token: Token,
-    interested_tables: Arc<BTreeSet<TableName>>,
-    sender: SubscriptionSender,
-    is_system: bool,
+enum SubscriptionRequest {
+    Subscribe {
+        token: Token,
+        interested_tables: Arc<BTreeSet<TableName>>,
+        sender: SubscriptionSender,
+        is_system: bool,
+    },
+    InvalidateTables {
+        table_names: Arc<BTreeSet<TableName>>,
+        invalid_ts: Timestamp,
+    },
 }
 
 /// Tracks the minimum processed_ts across all SubscriptionManagers to
@@ -333,7 +368,7 @@ impl SubscriptionManager {
                 },
                 request = rx.recv().fuse() => {
                     match request {
-                        Some(SubscriptionRequest {
+                        Some(SubscriptionRequest::Subscribe {
                             token,
                             interested_tables,
                             sender,
@@ -345,6 +380,12 @@ impl SubscriptionManager {
                                     report_error(&mut e).await;
                                 },
                             }
+                        },
+                        Some(SubscriptionRequest::InvalidateTables {
+                            table_names,
+                            invalid_ts,
+                        }) => {
+                            self.invalidate_tables(&table_names, invalid_ts);
                         },
                         None => {
                             tracing::info!("All clients have gone away, shutting down subscriptions worker...");
@@ -391,6 +432,11 @@ pub struct SubscriptionManager {
     // Invariant: All `ReadSet` in `subscribers` have a timestamp greater than or equal to
     // `processed_ts`.
     processed_ts: Timestamp,
+
+    // Latest direct cluster invalidation observed for each table. Keeping this
+    // watermark closes the race between a remote commit notification and a
+    // subscription being registered on this worker.
+    table_invalidation_watermarks: BTreeMap<TableName, Timestamp>,
 }
 
 struct Subscriber {
@@ -436,6 +482,7 @@ impl SubscriptionManager {
             delta_interest,
             retention_coordinator,
             processed_ts: initial_ts,
+            table_invalidation_watermarks: BTreeMap::new(),
         }
     }
 
@@ -470,6 +517,17 @@ impl SubscriptionManager {
         }
         assert!(token.ts() >= self.processed_ts);
 
+        if let Some(invalid_ts) = interested_tables
+            .iter()
+            .filter_map(|table_name| self.table_invalidation_watermarks.get(table_name))
+            .copied()
+            .filter(|invalid_ts| *invalid_ts > token.ts())
+            .max()
+        {
+            sender.drop_with_delay(None, Some(invalid_ts));
+            return Ok(usize::MAX);
+        }
+
         let entry = self.subscribers.vacant_entry();
         let subscriber_id = entry.key();
 
@@ -498,6 +556,32 @@ impl SubscriptionManager {
             .boxed(),
         );
         Ok(subscriber_id)
+    }
+
+    fn invalidate_tables(&mut self, table_names: &BTreeSet<TableName>, invalid_ts: Timestamp) {
+        for table_name in table_names {
+            self.table_invalidation_watermarks
+                .entry(table_name.clone())
+                .and_modify(|current| *current = (*current).max(invalid_ts))
+                .or_insert(invalid_ts);
+        }
+
+        let subscriber_ids = self
+            .subscribers
+            .iter()
+            .filter_map(|(subscriber_id, subscriber)| {
+                subscriber
+                    .interested_tables
+                    .iter()
+                    .any(|table_name| table_names.contains(table_name))
+                    .then_some(subscriber_id)
+            })
+            .collect_vec();
+        let invalidated = subscriber_ids.len();
+        for subscriber_id in subscriber_ids {
+            self._remove(subscriber_id, None, Some(invalid_ts));
+        }
+        log_subscriptions_invalidated(invalidated);
     }
 
     #[cfg(any(test, feature = "testing"))]
@@ -868,6 +952,7 @@ mod tests {
         },
         ops::Range,
         str::FromStr,
+        sync::Arc,
         time::Duration,
     };
 
@@ -921,6 +1006,7 @@ mod tests {
         FieldPath,
         PublicDocumentId,
         ResolvedDocumentId,
+        TableName,
         TableNumber,
         TabletId,
         TabletIdAndTableNumber,
@@ -930,6 +1016,7 @@ mod tests {
         subscription::{
             CountingReceiver,
             RetentionCoordinator,
+            Subscription,
             SubscriptionManager,
         },
         write_log::new_write_log,
@@ -1402,6 +1489,64 @@ mod tests {
             subscription.wait_for_invalidation().await,
             Some(Timestamp::must(120))
         );
+    }
+
+    #[tokio::test]
+    async fn test_direct_table_invalidation_covers_registration_races() -> anyhow::Result<()> {
+        let mut manager = SubscriptionManager::new_for_testing();
+        let watched_table: TableName = "projects".parse()?;
+        let unrelated_table: TableName = "messages".parse()?;
+        let token = Token::empty(Timestamp::must(100));
+        let (subscription, sender) = Subscription::new(&token);
+        manager.subscribe(
+            token,
+            Arc::new(btreeset! { watched_table.clone() }),
+            sender,
+            false,
+        )?;
+
+        manager.invalidate_tables(&btreeset! { unrelated_table }, Timestamp::must(110));
+        assert_eq!(subscription.current_ts(), Some(Timestamp::must(100)));
+
+        manager.invalidate_tables(&btreeset! { watched_table.clone() }, Timestamp::must(120));
+        assert_eq!(
+            subscription.wait_for_invalidation().await,
+            Some(Timestamp::must(120)),
+        );
+
+        // If the signal wins the race and reaches the manager first, its
+        // watermark must invalidate a subsequently registered older token.
+        let stale_token = Token::empty(Timestamp::must(115));
+        let (stale_subscription, stale_sender) = Subscription::new(&stale_token);
+        let stale_id = manager.subscribe(
+            stale_token,
+            Arc::new(btreeset! { watched_table.clone() }),
+            stale_sender,
+            false,
+        )?;
+        assert_eq!(stale_id, usize::MAX);
+        assert_eq!(
+            stale_subscription.wait_for_invalidation().await,
+            Some(Timestamp::must(120)),
+        );
+
+        // A query token at the invalidation timestamp already includes that
+        // commit and must remain subscribable.
+        let current_token = Token::empty(Timestamp::must(120));
+        let (current_subscription, current_sender) = Subscription::new(&current_token);
+        let current_id = manager.subscribe(
+            current_token,
+            Arc::new(btreeset! { watched_table }),
+            current_sender,
+            false,
+        )?;
+        assert_ne!(current_id, usize::MAX);
+        assert_eq!(
+            current_subscription.current_ts(),
+            Some(Timestamp::must(120)),
+        );
+
+        Ok(())
     }
 
     #[test]

--- a/crates/database/src/subscription_invalidation.rs
+++ b/crates/database/src/subscription_invalidation.rs
@@ -1,0 +1,207 @@
+//! Direct reactive invalidation delivery to the cluster subscription authority.
+//!
+//! NATS remains the durable data-replication path. This control-plane RPC
+//! closes the latency gap between a remote partition commit and the
+//! coordinator's next subscription rerun without copying remote data into the
+//! coordinator snapshot.
+
+use std::{
+    collections::{
+        BTreeMap,
+        BTreeSet,
+    },
+    sync::Arc,
+    time::Duration,
+};
+
+use anyhow::Context;
+use async_trait::async_trait;
+use common::{
+    grpc::ClusterGrpcAuth,
+    types::Timestamp,
+};
+use futures::{
+    stream::FuturesUnordered,
+    StreamExt,
+};
+use pb::replication::{
+    subscription_invalidation_service_client::SubscriptionInvalidationServiceClient,
+    InvalidateTablesRequest,
+};
+use tokio::sync::Mutex;
+use tonic::{
+    transport::{
+        Channel,
+        Endpoint,
+    },
+    Request,
+};
+use value::TableName;
+
+use crate::{
+    committer::CommitterClient,
+    partition::{
+        PartitionId,
+        PlacementVersion,
+    },
+};
+
+const INVALIDATION_GRPC_TIMEOUT: Duration = Duration::from_secs(5);
+
+#[async_trait]
+pub trait SubscriptionInvalidationClient: Send + Sync + 'static {
+    async fn invalidate_tables(
+        &self,
+        authority_partition: PartitionId,
+        placement_version: PlacementVersion,
+        commit_ts: Timestamp,
+        table_names: BTreeSet<TableName>,
+    ) -> anyhow::Result<()>;
+}
+
+struct SubscriptionInvalidationGrpcClient {
+    client: SubscriptionInvalidationServiceClient<Channel>,
+    cluster_auth: Option<ClusterGrpcAuth>,
+}
+
+impl SubscriptionInvalidationGrpcClient {
+    async fn connect(addr: &str, cluster_auth: Option<ClusterGrpcAuth>) -> anyhow::Result<Self> {
+        let addr = if addr.contains("://") {
+            addr.to_string()
+        } else {
+            format!("http://{addr}")
+        };
+        let endpoint = Endpoint::from_shared(addr.clone())
+            .with_context(|| format!("Invalid subscription invalidation address {addr}"))?
+            .connect_timeout(INVALIDATION_GRPC_TIMEOUT)
+            .timeout(INVALIDATION_GRPC_TIMEOUT);
+        let channel = endpoint.connect().await.with_context(|| {
+            format!("Failed to connect to subscription invalidation service at {addr}")
+        })?;
+        Ok(Self {
+            client: SubscriptionInvalidationServiceClient::new(channel),
+            cluster_auth,
+        })
+    }
+
+    async fn invalidate_tables(
+        &self,
+        authority_partition: PartitionId,
+        placement_version: PlacementVersion,
+        commit_ts: Timestamp,
+        table_names: BTreeSet<TableName>,
+    ) -> anyhow::Result<()> {
+        let request = InvalidateTablesRequest {
+            authority_partition: authority_partition.0,
+            placement_version: u64::from(placement_version),
+            commit_ts: u64::from(commit_ts),
+            table_names: table_names
+                .into_iter()
+                .map(|table_name| table_name.to_string())
+                .collect(),
+        };
+        let request = match &self.cluster_auth {
+            Some(auth) => auth.request(request),
+            None => Request::new(request),
+        };
+        self.client
+            .clone()
+            .invalidate_tables(request)
+            .await
+            .context("gRPC subscription invalidation failed")?;
+        Ok(())
+    }
+}
+
+#[derive(Clone)]
+pub struct GrpcSubscriptionInvalidationClient {
+    committer: CommitterClient,
+    cluster_auth: Option<ClusterGrpcAuth>,
+    clients: Arc<Mutex<BTreeMap<String, Arc<SubscriptionInvalidationGrpcClient>>>>,
+}
+
+impl GrpcSubscriptionInvalidationClient {
+    pub fn new(committer: CommitterClient, cluster_auth: Option<ClusterGrpcAuth>) -> Self {
+        Self {
+            committer,
+            cluster_auth,
+            clients: Arc::new(Mutex::new(BTreeMap::new())),
+        }
+    }
+
+    async fn client(
+        &self,
+        address: &str,
+    ) -> anyhow::Result<Arc<SubscriptionInvalidationGrpcClient>> {
+        if let Some(client) = self.clients.lock().await.get(address).cloned() {
+            return Ok(client);
+        }
+        let client = Arc::new(
+            SubscriptionInvalidationGrpcClient::connect(address, self.cluster_auth.clone()).await?,
+        );
+        let mut clients = self.clients.lock().await;
+        Ok(clients
+            .entry(address.to_string())
+            .or_insert_with(|| client.clone())
+            .clone())
+    }
+}
+
+#[async_trait]
+impl SubscriptionInvalidationClient for GrpcSubscriptionInvalidationClient {
+    async fn invalidate_tables(
+        &self,
+        authority_partition: PartitionId,
+        placement_version: PlacementVersion,
+        commit_ts: Timestamp,
+        table_names: BTreeSet<TableName>,
+    ) -> anyhow::Result<()> {
+        let addresses = self
+            .committer
+            .node_addresses()
+            .and_then(|addresses| {
+                addresses
+                    .addresses_for(authority_partition)
+                    .map(<[_]>::to_vec)
+            })
+            .with_context(|| {
+                format!(
+                    "No live subscription-authority candidates for partition {authority_partition}"
+                )
+            })?;
+        let mut attempts = FuturesUnordered::new();
+        for address in addresses {
+            let client_pool = self.clone();
+            let table_names = table_names.clone();
+            attempts.push(async move {
+                let result = match client_pool.client(&address).await {
+                    Ok(client) => {
+                        client
+                            .invalidate_tables(
+                                authority_partition,
+                                placement_version,
+                                commit_ts,
+                                table_names,
+                            )
+                            .await
+                    },
+                    Err(error) => Err(error),
+                };
+                (address, result)
+            });
+        }
+
+        let mut failures = Vec::new();
+        while let Some((address, attempt)) = attempts.next().await {
+            match attempt {
+                Ok(()) => return Ok(()),
+                Err(error) => failures.push(format!("{address}: {error:#}")),
+            }
+        }
+        anyhow::bail!(
+            "All subscription-authority candidates for partition {} failed: {}",
+            authority_partition,
+            failures.join("; "),
+        )
+    }
+}

--- a/crates/database/src/tests/write_scaling_tests.rs
+++ b/crates/database/src/tests/write_scaling_tests.rs
@@ -425,6 +425,11 @@ impl DistributedLog for SwitchableDistributedLog {
 
 fn partitioned_map(local_partition: PartitionId) -> PartitionMap {
     PartitionMap::from_config("messages=0,projects=1", local_partition, 2)
+        .without_catalog_authority_for_test()
+}
+
+fn strict_partitioned_map(local_partition: PartitionId) -> PartitionMap {
+    PartitionMap::from_config("messages=0,projects=1", local_partition, 2)
 }
 
 struct RetryOnceOwnerReadClient {
@@ -507,18 +512,22 @@ fn partitioned_map_with_version(
         2,
         placement_version,
     )
+    .without_catalog_authority_for_test()
 }
 
 fn partitioned_map_with_tasks(local_partition: PartitionId) -> PartitionMap {
     PartitionMap::from_config("messages=0,projects=1,tasks=1", local_partition, 2)
+        .without_catalog_authority_for_test()
 }
 
 fn partitioned_map_with_users_and_tasks(local_partition: PartitionId) -> PartitionMap {
     PartitionMap::from_config("users=0,tasks=1", local_partition, 2)
+        .without_catalog_authority_for_test()
 }
 
 fn three_partitioned_map(local_partition: PartitionId) -> PartitionMap {
     PartitionMap::from_config("messages=0,projects=1,tasks=2", local_partition, 3)
+        .without_catalog_authority_for_test()
 }
 
 async fn insert_doc_get_id(
@@ -1385,6 +1394,74 @@ where
     })
 }
 
+async fn create_strict_catalog_cluster(
+    rt: &TestRuntime,
+) -> anyhow::Result<(
+    Arc<InMemoryDistributedLog>,
+    Database<TestRuntime>,
+    Database<TestRuntime>,
+    TestGrpcServerHandle,
+    TestGrpcServerHandle,
+)> {
+    let log = Arc::new(InMemoryDistributedLog::new());
+    let tso: Arc<dyn TimestampOracle> = Arc::new(InMemoryTimestampOracle::new());
+    let table_number_allocator: Arc<dyn TableNumberAllocator> =
+        Arc::new(InMemoryTableNumberAllocator::default());
+    let decision_log = Arc::new(InMemoryTwoPhaseDecisionLog::new());
+    let authority = create_node_with_persistence_and_table_number_allocator(
+        rt,
+        Arc::new(TestPersistence::new()),
+        log.clone(),
+        Some(strict_partitioned_map(PartitionId(0))),
+        None,
+        decision_log.clone(),
+        Some(tso.clone()),
+        table_number_allocator.clone(),
+    )
+    .await?;
+    let owner = create_node_with_persistence_and_table_number_allocator(
+        rt,
+        Arc::new(TestPersistence::new()),
+        log.clone(),
+        Some(strict_partitioned_map(PartitionId(1))),
+        None,
+        decision_log,
+        Some(tso),
+        table_number_allocator,
+    )
+    .await?;
+    let authority_server = start_two_pc_server(TestTwoPhaseCommitGrpcService::new(
+        authority.committer_for_test(),
+    ))
+    .await?;
+    let owner_server = start_two_pc_server(TestTwoPhaseCommitGrpcService::new(
+        owner.committer_for_test(),
+    ))
+    .await?;
+    let membership = MembershipSnapshot::new(
+        MembershipVersion::new(1),
+        vec![
+            NodeMembership::new(
+                ClusterNodeId::new("catalog-authority")?,
+                PartitionId(0),
+                authority_server.addr(),
+            )?,
+            NodeMembership::new(
+                ClusterNodeId::new("catalog-owner")?,
+                PartitionId(1),
+                owner_server.addr(),
+            )?,
+        ],
+    );
+    authority
+        .committer_for_test()
+        .refresh_membership_snapshot(membership.clone())?;
+    owner
+        .committer_for_test()
+        .refresh_membership_snapshot(membership)?;
+    Ok((log, authority, owner, authority_server, owner_server))
+}
+
 /// Partitioned nodes should still fail closed when ownership routing is
 /// impossible because the cluster has no owner address map.
 #[convex_macro::test_runtime]
@@ -1394,21 +1471,19 @@ async fn test_partition_enforcement(rt: TestRuntime) -> anyhow::Result<()> {
     let node_a = create_node(
         &rt,
         log.clone(),
-        Some(PartitionMap::from_config(
-            "messages=0,projects=1",
-            PartitionId(0),
-            2,
-        )),
+        Some(
+            PartitionMap::from_config("messages=0,projects=1", PartitionId(0), 2)
+                .without_catalog_authority_for_test(),
+        ),
     )
     .await?;
     let node_b = create_node(
         &rt,
         log.clone(),
-        Some(PartitionMap::from_config(
-            "messages=0,projects=1",
-            PartitionId(1),
-            2,
-        )),
+        Some(
+            PartitionMap::from_config("messages=0,projects=1", PartitionId(1), 2)
+                .without_catalog_authority_for_test(),
+        ),
     )
     .await?;
 
@@ -5247,11 +5322,16 @@ async fn test_watcher_recovers_staged_prepare_after_participant_leader_failover(
 }
 
 #[convex_macro::test_runtime]
-async fn test_remote_table_catalog_writes_follow_owner_prepare_redo(
+async fn test_remote_table_catalog_writes_commit_on_authority_and_owner(
     rt: TestRuntime,
 ) -> anyhow::Result<()> {
     let log = Arc::new(InMemoryDistributedLog::new());
-    let source = create_node(&rt, log.clone(), Some(partitioned_map(PartitionId(0)))).await?;
+    let source = create_node(
+        &rt,
+        log.clone(),
+        Some(strict_partitioned_map(PartitionId(0))),
+    )
+    .await?;
 
     let mut tx = source.begin(Identity::system()).await?;
     TestFacingModel::new(&mut tx)
@@ -5262,22 +5342,37 @@ async fn test_remote_table_catalog_writes_follow_owner_prepare_redo(
         .await?;
     let final_tx = tx.finalize()?;
     let write_source = WriteSource::new("remote_catalog_owner_prepare_test");
-    let source_map = partitioned_map(PartitionId(0));
+    let source_map = strict_partitioned_map(PartitionId(0));
     let participant_indexes = crate::two_phase_coordinator::participant_write_indexes(
         &final_tx,
         &source_map,
         &write_source,
     )?;
+    let authority_writes = participant_indexes
+        .get(&PartitionId(0))
+        .expect("catalog metadata should route to partition 0");
     let owner_writes = participant_indexes
         .get(&PartitionId(1))
         .expect("projects writes and catalog metadata should route to partition 1");
-    assert_eq!(participant_indexes.len(), 1);
+    assert_eq!(participant_indexes.len(), 2);
+    assert_eq!(
+        authority_writes.len() + 1,
+        owner_writes.len(),
+        "the owner should additionally receive the first projects document",
+    );
     assert_eq!(
         owner_writes.len(),
         final_tx.writes.coalesced_writes().count()
     );
 
-    let owner = create_node(&rt, log, Some(partitioned_map(PartitionId(1)))).await?;
+    let owner = create_node(&rt, log, Some(strict_partitioned_map(PartitionId(1)))).await?;
+    let authority_tx = ParticipantTransaction::from_final_transaction(
+        &final_tx,
+        PartitionId(0),
+        authority_writes,
+        &source_map,
+        &write_source,
+    )?;
     let participant_tx = ParticipantTransaction::from_final_transaction(
         &final_tx,
         PartitionId(1),
@@ -5287,6 +5382,13 @@ async fn test_remote_table_catalog_writes_follow_owner_prepare_redo(
     )?;
     let txn_id = TwoPhaseTransactionId::new();
     let prepare_ts = owner.committer_for_test().allocate_commit_ts().await?;
+    let authority_redo = TwoPhaseRedoEntry::new(
+        &txn_id,
+        prepare_ts,
+        PartitionId(0),
+        authority_tx,
+        &write_source,
+    )?;
     let redo = TwoPhaseRedoEntry::new(
         &txn_id,
         prepare_ts,
@@ -5295,13 +5397,32 @@ async fn test_remote_table_catalog_writes_follow_owner_prepare_redo(
         &write_source,
     )?;
 
+    source
+        .committer_for_test()
+        .apply_raft_prepared_redo(1, authority_redo)
+        .await?;
     owner
         .committer_for_test()
         .apply_raft_prepared_redo(1, redo)
         .await?;
+    let authority_committed_ts = source
+        .committer_for_test()
+        .commit_prepared(txn_id.clone())
+        .await?;
     let committed_ts = owner.committer_for_test().commit_prepared(txn_id).await?;
+    assert_eq!(authority_committed_ts, prepare_ts);
     assert_eq!(committed_ts, prepare_ts);
 
+    let coordinator_projects = run_local_replica_query(
+        source,
+        TableNamespace::root_component(),
+        Query::full_table_scan("projects".parse()?, Order::Asc),
+    )
+    .await?;
+    assert!(
+        coordinator_projects.is_empty(),
+        "the coordinator should resolve the new catalog immediately without mirroring owner data",
+    );
     let projects = run_query(
         owner.clone(),
         TableNamespace::root_component(),
@@ -5310,6 +5431,205 @@ async fn test_remote_table_catalog_writes_follow_owner_prepare_redo(
     .await?;
     assert_eq!(projects.len(), 1);
     Ok(())
+}
+
+#[test]
+fn test_fresh_remote_table_commit_materializes_catalog_before_response() -> anyhow::Result<()> {
+    let td = TestDriver::new_with_io();
+    let rt = td.rt();
+    td.run_until(async move {
+        let log = Arc::new(InMemoryDistributedLog::new());
+        let tso: Arc<dyn TimestampOracle> = Arc::new(InMemoryTimestampOracle::new());
+        let table_number_allocator: Arc<dyn TableNumberAllocator> =
+            Arc::new(InMemoryTableNumberAllocator::default());
+        let decision_log = Arc::new(InMemoryTwoPhaseDecisionLog::new());
+
+        let owner = create_node_with_persistence_and_table_number_allocator(
+            &rt,
+            Arc::new(TestPersistence::new()),
+            log.clone(),
+            Some(strict_partitioned_map(PartitionId(1))),
+            None,
+            decision_log.clone(),
+            Some(tso.clone()),
+            table_number_allocator.clone(),
+        )
+        .await?;
+        let server = start_two_pc_server(TestTwoPhaseCommitGrpcService::new(
+            owner.committer_for_test(),
+        ))
+        .await?;
+        let authority = create_node_with_persistence_and_table_number_allocator(
+            &rt,
+            Arc::new(TestPersistence::new()),
+            log.clone(),
+            Some(strict_partitioned_map(PartitionId(0))),
+            Some(NodeAddresses::from_config(&format!("1={}", server.addr()))),
+            decision_log,
+            Some(tso),
+            table_number_allocator,
+        )
+        .await?;
+
+        let commit_ts = insert_doc(
+            &authority,
+            "projects",
+            assert_obj!("name" => "fresh-remote-project"),
+        )
+        .await?;
+
+        let local_catalog_view = run_local_replica_query(
+            authority.clone(),
+            TableNamespace::root_component(),
+            Query::full_table_scan("projects".parse()?, Order::Asc),
+        )
+        .await?;
+        assert!(
+            local_catalog_view.is_empty(),
+            "catalog authority should resolve the new table without mirroring its owner data",
+        );
+        let owner_rows = run_query(
+            owner,
+            TableNamespace::root_component(),
+            Query::full_table_scan("projects".parse()?, Order::Asc),
+        )
+        .await?;
+        assert_eq!(owner_rows.len(), 1);
+
+        let committed_deltas: Vec<_> = log
+            .deltas()
+            .into_iter()
+            .filter(|delta| delta.ts == commit_ts)
+            .collect();
+        assert_eq!(
+            committed_deltas.len(),
+            2,
+            "catalog authority and data owner should publish one committed half each",
+        );
+        assert!(
+            committed_deltas.iter().any(|delta| {
+                delta.source_partition == Some(PartitionId(0)) && !delta.document_updates.is_empty()
+            }),
+            "partition 0 must commit catalog metadata before the mutation returns",
+        );
+        assert!(
+            committed_deltas.iter().any(|delta| {
+                delta.source_partition == Some(PartitionId(1)) && delta.document_updates.len() > 1
+            }),
+            "partition 1 must atomically commit catalog metadata and the first document",
+        );
+
+        server.shutdown().await?;
+        Ok(())
+    })
+}
+
+#[test]
+fn test_owner_entrypoint_materializes_fresh_catalog_on_authority() -> anyhow::Result<()> {
+    let td = TestDriver::new_with_io();
+    let rt = td.rt();
+    td.run_until(async move {
+        let (_log, authority, owner, authority_server, owner_server) =
+            create_strict_catalog_cluster(&rt).await?;
+
+        insert_doc(
+            &owner,
+            "projects",
+            assert_obj!("name" => "owner-created-project"),
+        )
+        .await?;
+
+        let authority_catalog_view = run_local_replica_query(
+            authority,
+            TableNamespace::root_component(),
+            Query::full_table_scan("projects".parse()?, Order::Asc),
+        )
+        .await?;
+        assert!(
+            authority_catalog_view.is_empty(),
+            "partition 0 should resolve a table created through partition 1 without a NATS delta",
+        );
+        let owner_rows = run_query(
+            owner,
+            TableNamespace::root_component(),
+            Query::full_table_scan("projects".parse()?, Order::Asc),
+        )
+        .await?;
+        assert_eq!(owner_rows.len(), 1);
+
+        authority_server.shutdown().await?;
+        owner_server.shutdown().await?;
+        Ok(())
+    })
+}
+
+#[test]
+fn test_stale_same_name_creation_aborts_before_retrying_winning_catalog() -> anyhow::Result<()> {
+    let td = TestDriver::new_with_io();
+    let rt = td.rt();
+    td.run_until(async move {
+        let (_log, authority, owner, authority_server, owner_server) =
+            create_strict_catalog_cluster(&rt).await?;
+
+        let mut stale = owner.begin(Identity::system()).await?;
+        TestFacingModel::new(&mut stale)
+            .insert(
+                &"projects".parse()?,
+                assert_obj!("name" => "must-not-commit"),
+            )
+            .await?;
+
+        insert_doc(
+            &authority,
+            "projects",
+            assert_obj!("name" => "winning-first-write"),
+        )
+        .await?;
+
+        let stale_error = owner
+            .commit(stale)
+            .await
+            .expect_err("the stale same-name catalog proposal must not commit");
+        assert!(
+            format!("{stale_error:#}").contains("duplicate table"),
+            "stale creator should lose at the catalog authority: {stale_error:#}",
+        );
+
+        insert_doc(
+            &owner,
+            "projects",
+            assert_obj!("name" => "retry-after-catalog-refresh"),
+        )
+        .await?;
+
+        let mut authority_tx = authority.begin(Identity::system()).await?;
+        let authority_table = authority_tx
+            .table_mapping()
+            .namespace(TableNamespace::root_component())
+            .id(&"projects".parse()?)?;
+        let mut owner_tx = owner.begin(Identity::system()).await?;
+        let owner_table = owner_tx
+            .table_mapping()
+            .namespace(TableNamespace::root_component())
+            .id(&"projects".parse()?)?;
+        assert_eq!(authority_table, owner_table);
+
+        let owner_rows = run_query(
+            owner,
+            TableNamespace::root_component(),
+            Query::full_table_scan("projects".parse()?, Order::Asc),
+        )
+        .await?;
+        assert_eq!(
+            owner_rows.len(),
+            2,
+            "the aborted stale first write must stay hidden and the retry must commit once",
+        );
+
+        authority_server.shutdown().await?;
+        owner_server.shutdown().await?;
+        Ok(())
+    })
 }
 
 #[convex_macro::test_runtime]

--- a/crates/database/src/tests/write_scaling_tests.rs
+++ b/crates/database/src/tests/write_scaling_tests.rs
@@ -503,6 +503,32 @@ impl OwnerReadClient for PlacementChangingOwnerReadClient {
     }
 }
 
+struct CommitterBackedOwnerReadClient {
+    committer: CommitterClient,
+}
+
+#[async_trait]
+impl OwnerReadClient for CommitterBackedOwnerReadClient {
+    async fn close_read_timestamp(
+        &self,
+        _owner_partition: PartitionId,
+        _placement_version: PlacementVersion,
+        target_ts: Timestamp,
+    ) -> anyhow::Result<ReadTimestampClosure> {
+        self.committer.close_latest_read_timestamp(target_ts).await
+    }
+
+    async fn read_index_ranges(
+        &self,
+        _owner_partition: PartitionId,
+        _placement_version: PlacementVersion,
+        _snapshot_ts: Timestamp,
+        _ranges: Vec<RangeRequest>,
+    ) -> anyhow::Result<Vec<OwnerIndexRangeResult>> {
+        anyhow::bail!("read_index_ranges is not used by the read barrier test")
+    }
+}
+
 fn partitioned_map_with_version(
     local_partition: PartitionId,
     placement_version: PlacementVersion,
@@ -3258,6 +3284,38 @@ async fn test_cluster_read_barrier_retries_above_local_timeline(
 }
 
 #[convex_macro::test_runtime]
+async fn test_latest_read_barrier_does_not_reuse_stale_exact_fence(
+    rt: TestRuntime,
+) -> anyhow::Result<()> {
+    let log = Arc::new(InMemoryDistributedLog::new());
+    let node = create_node(&rt, log, Some(partitioned_map(PartitionId(0)))).await?;
+    let closed = node.committer_for_test().allocate_commit_ts().await?;
+    assert_eq!(
+        node.committer_for_test()
+            .close_latest_read_timestamp(closed)
+            .await?,
+        ReadTimestampClosure::Closed(closed),
+    );
+
+    let later_commit = node.committer_for_test().allocate_commit_ts().await?;
+    assert_eq!(
+        node.committer_for_test()
+            .close_read_timestamp(closed)
+            .await?,
+        ReadTimestampClosure::Closed(closed),
+        "an exact historical snapshot must remain readable",
+    );
+    assert_eq!(
+        node.committer_for_test()
+            .close_latest_read_timestamp(closed)
+            .await?,
+        ReadTimestampClosure::RetryAt(later_commit),
+        "a latest read must discover commits newer than a cached exact fence",
+    );
+    Ok(())
+}
+
+#[convex_macro::test_runtime]
 async fn test_cluster_read_barrier_retries_all_owners_at_one_new_timestamp(
     rt: TestRuntime,
 ) -> anyhow::Result<()> {
@@ -3273,6 +3331,30 @@ async fn test_cluster_read_barrier_retries_all_owners_at_one_new_timestamp(
     assert_eq!(targets[0], initial_local_ts);
     assert!(targets[1] > targets[0]);
     assert_eq!(*safe_ts, targets[1]);
+    Ok(())
+}
+
+#[convex_macro::test_runtime]
+async fn test_cluster_latest_read_advances_after_remote_owner_commit(
+    rt: TestRuntime,
+) -> anyhow::Result<()> {
+    let log = Arc::new(InMemoryDistributedLog::new());
+    let coordinator = create_node(&rt, log.clone(), Some(partitioned_map(PartitionId(0)))).await?;
+    let owner = create_node(&rt, log, Some(partitioned_map(PartitionId(1)))).await?;
+    let database =
+        coordinator.with_owner_read_client_for_test(Arc::new(CommitterBackedOwnerReadClient {
+            committer: owner.committer_for_test(),
+        }));
+
+    let first = database.cluster_safe_read_ts().await?;
+    let remote_commit = owner.committer_for_test().allocate_commit_ts().await?;
+    assert!(remote_commit > *first);
+
+    let next = database.cluster_safe_read_ts().await?;
+    assert!(
+        *next >= remote_commit,
+        "latest cluster read {next} did not include remote owner floor {remote_commit}",
+    );
     Ok(())
 }
 

--- a/crates/database/src/tests/write_scaling_tests.rs
+++ b/crates/database/src/tests/write_scaling_tests.rs
@@ -558,6 +558,44 @@ async fn insert_doc(
     db.commit(tx).await
 }
 
+async fn prepare_project_insert_for_test(
+    db: &Database<TestRuntime>,
+    committer: &CommitterClient,
+    name: &str,
+    write_source: &WriteSource,
+) -> anyhow::Result<(TwoPhaseTransactionId, Timestamp)> {
+    let mut tx = db.begin(Identity::system()).await?;
+    TestFacingModel::new(&mut tx)
+        .insert(&"projects".parse()?, assert_obj!("name" => name))
+        .await?;
+    let final_tx = tx.finalize()?;
+    let write_indexes: Vec<_> = final_tx
+        .writes
+        .coalesced_writes()
+        .enumerate()
+        .map(|(index, _)| index)
+        .collect();
+    let participant = ParticipantTransaction::from_final_transaction(
+        &final_tx,
+        PartitionId(1),
+        &write_indexes,
+        &partitioned_map(PartitionId(1)),
+        write_source,
+    )?;
+    let transaction_id = TwoPhaseTransactionId::new();
+    let prepare_ts = committer.allocate_commit_ts().await?;
+    committer
+        .prepare_remote(
+            transaction_id.clone(),
+            participant,
+            write_source.clone(),
+            prepare_ts,
+            vec![PartitionId(1)],
+        )
+        .await?;
+    Ok((transaction_id, prepare_ts))
+}
+
 async fn insert_global_system_doc(
     db: &Database<TestRuntime>,
     table: &str,
@@ -672,6 +710,22 @@ async fn commit_next_raft_rollback_for_test(
         .send(RaftProposalResult::Committed { index })
         .map_err(|_| anyhow::anyhow!("rollback waiter dropped before test Raft decision"))?;
     Ok(transaction_id)
+}
+
+async fn receive_next_raft_rollback_for_test(
+    raft_rx: &mut tokio::sync::mpsc::UnboundedReceiver<RaftMessage>,
+) -> anyhow::Result<(TwoPhaseTransactionId, oneshot::Sender<RaftProposalResult>)> {
+    let message = tokio::time::timeout(Duration::from_secs(1), raft_rx.recv())
+        .await?
+        .context("test Raft mailbox closed before receiving a rollback proposal")?;
+    let RaftMessage::Propose(proposal) = message else {
+        anyhow::bail!("expected a Raft proposal in the test mailbox")
+    };
+    let transaction_id = match RaftStateMachineEntry::from_bytes(&proposal.data)? {
+        RaftStateMachineEntry::TwoPhaseRollback { transaction_id } => transaction_id,
+        _ => anyhow::bail!("expected a 2PC rollback Raft entry"),
+    };
+    Ok((transaction_id, proposal.result_tx))
 }
 
 async fn acknowledge_next_raft_applied_for_test_ref(
@@ -1986,6 +2040,96 @@ async fn test_prepare_waits_for_raft_committed_prepared_write_publication(
     )
     .await?;
     assert_eq!(rows.len(), 2, "only the first prepared write should commit");
+    Ok(())
+}
+
+#[convex_macro::test_runtime]
+async fn test_rollback_does_not_block_prior_raft_commit_apply(
+    rt: TestRuntime,
+    pause: PauseController,
+) -> anyhow::Result<()> {
+    let log = Arc::new(InMemoryDistributedLog::new());
+    let node = create_node(&rt, log, Some(partitioned_map(PartitionId(1)))).await?;
+    insert_doc(&node, "projects", assert_obj!("name" => "seed")).await?;
+    let committer = node.committer_for_test();
+    let write_source = WriteSource::new("rollback_after_prior_raft_commit_test");
+    let (winner_id, winner_ts) =
+        prepare_project_insert_for_test(&node, &committer, "winner", &write_source).await?;
+    let (loser_id, _) =
+        prepare_project_insert_for_test(&node, &committer, "loser", &write_source).await?;
+
+    let (raft_state, mut raft_rx) =
+        RaftPartitionState::new_with_mailbox_for_test(true, 1, PartitionId(1), 1);
+    node.attach_raft_state(raft_state).await?;
+    let hold = pause.hold(AFTER_RAFT_CONVEX_PERSISTENCE);
+    let commit_task = {
+        let committer = committer.clone();
+        let winner_id = winner_id.clone();
+        tokio::spawn(async move { committer.commit_prepared(winner_id).await })
+    };
+    let winner_delta = commit_next_raft_delta_for_test(&mut raft_rx, 31).await?;
+    assert_eq!(winner_delta.ts, winner_ts);
+    let pause_guard = hold
+        .wait_for_blocked()
+        .await
+        .context("winner did not pause before local Raft apply")?;
+
+    let rollback_task = {
+        let committer = committer.clone();
+        let loser_id = loser_id.clone();
+        tokio::spawn(async move { committer.rollback_prepared(loser_id).await })
+    };
+    let (rollback_id, rollback_result) = receive_next_raft_rollback_for_test(&mut raft_rx).await?;
+    assert_eq!(rollback_id, loser_id);
+    let duplicate_rollback_task = {
+        let committer = committer.clone();
+        let loser_id = loser_id.clone();
+        tokio::spawn(async move { committer.rollback_prepared(loser_id).await })
+    };
+    assert!(
+        tokio::time::timeout(Duration::from_millis(50), raft_rx.recv())
+            .await
+            .is_err(),
+        "duplicate rollback must join the existing Raft proposal",
+    );
+    let contradictory_commit = tokio::time::timeout(
+        Duration::from_secs(1),
+        committer.commit_prepared(loser_id.clone()),
+    )
+    .await?
+    .expect_err("commit must not start after rollback has entered Raft");
+    assert!(
+        contradictory_commit
+            .to_string()
+            .contains("already rolling back"),
+        "unexpected contradictory decision error: {contradictory_commit:#}",
+    );
+
+    // Raft cannot apply the rollback marker until index 31 is marked applied.
+    // The committer must therefore finish the earlier commit without waiting
+    // synchronously for this later proposal's decision.
+    pause_guard.unpause();
+    acknowledge_next_raft_applied_for_test_ref(&mut raft_rx, 31).await?;
+    assert_eq!(commit_task.await??, winner_ts);
+
+    rollback_result
+        .send(RaftProposalResult::Committed { index: 32 })
+        .map_err(|_| anyhow::anyhow!("rollback waiter dropped before Raft decision"))?;
+    acknowledge_next_raft_applied_for_test_ref(&mut raft_rx, 32).await?;
+    rollback_task.await??;
+    duplicate_rollback_task.await??;
+
+    let rows = run_query(
+        node,
+        TableNamespace::root_component(),
+        Query::full_table_scan("projects".parse()?, Order::Asc),
+    )
+    .await?;
+    assert_eq!(
+        rows.len(),
+        2,
+        "the winner must commit and the loser must abort"
+    );
     Ok(())
 }
 

--- a/crates/database/src/tests/write_scaling_tests.rs
+++ b/crates/database/src/tests/write_scaling_tests.rs
@@ -612,6 +612,52 @@ async fn commit_next_raft_delta_for_test(
     Ok(delta)
 }
 
+async fn commit_next_raft_prepare_for_test(
+    raft_rx: &mut tokio::sync::mpsc::UnboundedReceiver<RaftMessage>,
+    index: u64,
+) -> anyhow::Result<TwoPhaseRedoEntry> {
+    let message = tokio::time::timeout(Duration::from_secs(1), raft_rx.recv())
+        .await?
+        .context("test Raft mailbox closed before receiving a proposal")?;
+    let RaftMessage::Propose(proposal) = message else {
+        anyhow::bail!("expected a Raft proposal in the test mailbox")
+    };
+    let redo = match RaftStateMachineEntry::from_bytes(&proposal.data)? {
+        RaftStateMachineEntry::TwoPhasePrepare { redo } => redo,
+        RaftStateMachineEntry::CommitDelta { .. } => {
+            anyhow::bail!("expected a 2PC prepare Raft entry")
+        },
+        RaftStateMachineEntry::ClusterGenesis { .. } => {
+            anyhow::bail!("expected a 2PC prepare, not cluster genesis")
+        },
+    };
+    proposal
+        .result_tx
+        .send(RaftProposalResult::Committed { index })
+        .map_err(|_| anyhow::anyhow!("prepare waiter dropped before test Raft decision"))?;
+    Ok(redo)
+}
+
+async fn acknowledge_next_raft_applied_for_test_ref(
+    raft_rx: &mut tokio::sync::mpsc::UnboundedReceiver<RaftMessage>,
+    expected_index: u64,
+) -> anyhow::Result<()> {
+    let message = tokio::time::timeout(Duration::from_secs(1), raft_rx.recv())
+        .await?
+        .context("test Raft mailbox closed before MarkApplied")?;
+    let RaftMessage::MarkApplied { index, result_tx } = message else {
+        anyhow::bail!("expected MarkApplied for index {expected_index}")
+    };
+    anyhow::ensure!(
+        index == expected_index,
+        "expected applied index {expected_index}, got {index}",
+    );
+    result_tx
+        .send(Ok(()))
+        .map_err(|_| anyhow::anyhow!("committer dropped Raft applied-index waiter"))?;
+    Ok(())
+}
+
 async fn acknowledge_next_raft_applied_for_test(
     mut raft_rx: tokio::sync::mpsc::UnboundedReceiver<RaftMessage>,
     expected_index: u64,
@@ -1775,6 +1821,126 @@ async fn test_raft_replay_after_crash_post_applied_index_is_idempotent(
         false,
     )
     .await
+}
+
+#[convex_macro::test_runtime]
+async fn test_prepare_waits_for_raft_committed_prepared_write_publication(
+    rt: TestRuntime,
+    pause: PauseController,
+) -> anyhow::Result<()> {
+    let log = Arc::new(InMemoryDistributedLog::new());
+    let node = create_node(&rt, log, Some(partitioned_map(PartitionId(1)))).await?;
+    insert_doc(&node, "projects", assert_obj!("name" => "seed")).await?;
+
+    let mut first_tx = node.begin(Identity::system()).await?;
+    TestFacingModel::new(&mut first_tx)
+        .insert(&"projects".parse()?, assert_obj!("name" => "first"))
+        .await?;
+    let first_final_tx = first_tx.finalize()?;
+    let first_write_indexes: Vec<_> = first_final_tx
+        .writes
+        .coalesced_writes()
+        .enumerate()
+        .map(|(index, _)| index)
+        .collect();
+    let write_source = WriteSource::new("prepared_commit_admission_barrier_test");
+    let first_participant = ParticipantTransaction::from_final_transaction(
+        &first_final_tx,
+        PartitionId(1),
+        &first_write_indexes,
+        &partitioned_map(PartitionId(1)),
+        &write_source,
+    )?;
+    let first_txn_id = TwoPhaseTransactionId::new();
+    let committer = node.committer_for_test();
+    let first_prepare_ts = committer.allocate_commit_ts().await?;
+    committer
+        .prepare_remote(
+            first_txn_id.clone(),
+            first_participant,
+            write_source.clone(),
+            first_prepare_ts,
+            vec![PartitionId(1)],
+        )
+        .await?;
+
+    let (raft_state, mut raft_rx) =
+        RaftPartitionState::new_with_mailbox_for_test(true, 1, PartitionId(1), 1);
+    node.attach_raft_state(raft_state).await?;
+    let hold = pause.hold(AFTER_RAFT_CONVEX_PERSISTENCE);
+    let first_txn_id_for_commit = first_txn_id.clone();
+    let committer_for_commit = committer.clone();
+    let commit_task = tokio::spawn(async move {
+        committer_for_commit
+            .commit_prepared(first_txn_id_for_commit)
+            .await
+    });
+    let first_delta = commit_next_raft_delta_for_test(&mut raft_rx, 11).await?;
+    assert_eq!(first_delta.ts, first_prepare_ts);
+    let pause_guard = hold
+        .wait_for_blocked()
+        .await
+        .context("prepared commit did not pause before local publication")?;
+
+    let mut second_tx = node.begin(Identity::system()).await?;
+    TestFacingModel::new(&mut second_tx)
+        .insert(&"projects".parse()?, assert_obj!("name" => "second"))
+        .await?;
+    let second_final_tx = second_tx.finalize()?;
+    let second_write_indexes: Vec<_> = second_final_tx
+        .writes
+        .coalesced_writes()
+        .enumerate()
+        .map(|(index, _)| index)
+        .collect();
+    let second_participant = ParticipantTransaction::from_final_transaction(
+        &second_final_tx,
+        PartitionId(1),
+        &second_write_indexes,
+        &partitioned_map(PartitionId(1)),
+        &write_source,
+    )?;
+    let second_txn_id = TwoPhaseTransactionId::new();
+    let second_prepare_ts = committer.allocate_commit_ts().await?;
+    let committer_for_prepare = committer.clone();
+    let second_txn_id_for_prepare = second_txn_id.clone();
+    let prepare_task = tokio::spawn(async move {
+        committer_for_prepare
+            .prepare_remote(
+                second_txn_id_for_prepare,
+                second_participant,
+                write_source,
+                second_prepare_ts,
+                vec![PartitionId(1)],
+            )
+            .await
+    });
+
+    assert!(
+        tokio::time::timeout(Duration::from_millis(100), raft_rx.recv())
+            .await
+            .is_err(),
+        "later prepare entered Raft before the earlier committed write became visible",
+    );
+
+    pause_guard.unpause();
+    acknowledge_next_raft_applied_for_test_ref(&mut raft_rx, 11).await?;
+    assert_eq!(commit_task.await??, first_prepare_ts);
+
+    let second_redo = commit_next_raft_prepare_for_test(&mut raft_rx, 12).await?;
+    assert_eq!(second_redo.transaction_id(), second_txn_id);
+    acknowledge_next_raft_applied_for_test_ref(&mut raft_rx, 12).await?;
+    assert_eq!(prepare_task.await??.prepare_ts, second_prepare_ts);
+    committer.rollback_prepared(second_txn_id).await?;
+
+    let rows = run_query(
+        node,
+        TableNamespace::root_component(),
+        Query::full_table_scan("projects".parse()?, Order::Asc),
+    )
+    .await?;
+    assert_eq!(rows.len(), 2, "only the first prepared write should commit");
+    Ok(())
 }
 
 #[convex_macro::test_runtime]

--- a/crates/database/src/tests/write_scaling_tests.rs
+++ b/crates/database/src/tests/write_scaling_tests.rs
@@ -6,6 +6,7 @@
 //! pattern).
 
 use std::{
+    collections::BTreeSet,
     sync::{
         atomic::{
             AtomicBool,
@@ -169,6 +170,7 @@ use crate::{
     raft_state_machine::RaftStateMachineEntry,
     raft_storage::ConvexRaftStorage,
     snapshot_manager::partition_timestamp_map_from_json,
+    subscription_invalidation::SubscriptionInvalidationClient,
     table_number_allocator::{
         testing::InMemoryTableNumberAllocator,
         TableNumberAllocator,
@@ -427,6 +429,37 @@ impl DistributedLog for SwitchableDistributedLog {
 fn partitioned_map(local_partition: PartitionId) -> PartitionMap {
     PartitionMap::from_config("messages=0,projects=1", local_partition, 2)
         .without_catalog_authority_for_test()
+}
+
+#[derive(Default)]
+struct RecordingSubscriptionInvalidationClient {
+    calls: Mutex<
+        Vec<(
+            PartitionId,
+            PlacementVersion,
+            Timestamp,
+            BTreeSet<TableName>,
+        )>,
+    >,
+}
+
+#[async_trait]
+impl SubscriptionInvalidationClient for RecordingSubscriptionInvalidationClient {
+    async fn invalidate_tables(
+        &self,
+        authority_partition: PartitionId,
+        placement_version: PlacementVersion,
+        commit_ts: Timestamp,
+        table_names: BTreeSet<TableName>,
+    ) -> anyhow::Result<()> {
+        self.calls.lock().push((
+            authority_partition,
+            placement_version,
+            commit_ts,
+            table_names,
+        ));
+        Ok(())
+    }
 }
 
 fn strict_partitioned_map(local_partition: PartitionId) -> PartitionMap {
@@ -2490,6 +2523,31 @@ async fn test_sequential_ordering(rt: TestRuntime) -> anyhow::Result<()> {
 
     assert!(ts2 > ts1, "second must commit after first");
     assert!(ts3 > ts2, "third must commit after second");
+
+    Ok(())
+}
+
+#[convex_macro::test_runtime]
+async fn test_remote_partition_commit_notifies_subscription_authority(
+    rt: TestRuntime,
+) -> anyhow::Result<()> {
+    let log = Arc::new(InMemoryDistributedLog::new());
+    let recorder = Arc::new(RecordingSubscriptionInvalidationClient::default());
+    let db = create_node(&rt, log, Some(partitioned_map(PartitionId(1))))
+        .await?
+        .with_subscription_invalidation_client_for_test(recorder.clone());
+
+    let commit_ts = insert_doc(&db, "projects", assert_obj!("name" => "notified")).await?;
+    let calls = recorder.calls.lock();
+    assert_eq!(calls.len(), 1);
+    let (authority_partition, placement_version, notified_ts, table_names) = &calls[0];
+    assert_eq!(*authority_partition, PartitionId::DEFAULT);
+    assert_eq!(
+        *placement_version,
+        db.committer_for_test().placement_version()
+    );
+    assert_eq!(*notified_ts, commit_ts);
+    assert!(table_names.contains(&"projects".parse()?));
 
     Ok(())
 }

--- a/crates/database/src/tests/write_scaling_tests.rs
+++ b/crates/database/src/tests/write_scaling_tests.rs
@@ -64,6 +64,7 @@ use common::{
         Timestamp,
     },
 };
+use errors::ErrorMetadataAnyhowExt;
 use futures::{
     stream::BoxStream,
     TryStreamExt,
@@ -601,6 +602,9 @@ async fn commit_next_raft_delta_for_test(
         RaftStateMachineEntry::TwoPhasePrepare { .. } => {
             anyhow::bail!("expected a commit delta Raft entry")
         },
+        RaftStateMachineEntry::TwoPhaseRollback { .. } => {
+            anyhow::bail!("expected a commit delta Raft entry")
+        },
         RaftStateMachineEntry::ClusterGenesis { .. } => {
             anyhow::bail!("expected a commit delta, not cluster genesis")
         },
@@ -627,6 +631,9 @@ async fn commit_next_raft_prepare_for_test(
         RaftStateMachineEntry::CommitDelta { .. } => {
             anyhow::bail!("expected a 2PC prepare Raft entry")
         },
+        RaftStateMachineEntry::TwoPhaseRollback { .. } => {
+            anyhow::bail!("expected a 2PC prepare Raft entry")
+        },
         RaftStateMachineEntry::ClusterGenesis { .. } => {
             anyhow::bail!("expected a 2PC prepare, not cluster genesis")
         },
@@ -636,6 +643,35 @@ async fn commit_next_raft_prepare_for_test(
         .send(RaftProposalResult::Committed { index })
         .map_err(|_| anyhow::anyhow!("prepare waiter dropped before test Raft decision"))?;
     Ok(redo)
+}
+
+async fn commit_next_raft_rollback_for_test(
+    raft_rx: &mut tokio::sync::mpsc::UnboundedReceiver<RaftMessage>,
+    index: u64,
+) -> anyhow::Result<TwoPhaseTransactionId> {
+    let message = tokio::time::timeout(Duration::from_secs(1), raft_rx.recv())
+        .await?
+        .context("test Raft mailbox closed before receiving a proposal")?;
+    let RaftMessage::Propose(proposal) = message else {
+        anyhow::bail!("expected a Raft proposal in the test mailbox")
+    };
+    let transaction_id = match RaftStateMachineEntry::from_bytes(&proposal.data)? {
+        RaftStateMachineEntry::TwoPhaseRollback { transaction_id } => transaction_id,
+        RaftStateMachineEntry::CommitDelta { .. } => {
+            anyhow::bail!("expected a 2PC rollback Raft entry")
+        },
+        RaftStateMachineEntry::TwoPhasePrepare { .. } => {
+            anyhow::bail!("expected a 2PC rollback Raft entry")
+        },
+        RaftStateMachineEntry::ClusterGenesis { .. } => {
+            anyhow::bail!("expected a 2PC rollback, not cluster genesis")
+        },
+    };
+    proposal
+        .result_tx
+        .send(RaftProposalResult::Committed { index })
+        .map_err(|_| anyhow::anyhow!("rollback waiter dropped before test Raft decision"))?;
+    Ok(transaction_id)
 }
 
 async fn acknowledge_next_raft_applied_for_test_ref(
@@ -1931,7 +1967,17 @@ async fn test_prepare_waits_for_raft_committed_prepared_write_publication(
     assert_eq!(second_redo.transaction_id(), second_txn_id);
     acknowledge_next_raft_applied_for_test_ref(&mut raft_rx, 12).await?;
     assert_eq!(prepare_task.await??.prepare_ts, second_prepare_ts);
-    committer.rollback_prepared(second_txn_id).await?;
+    let rollback_task = {
+        let committer = committer.clone();
+        let second_txn_id = second_txn_id.clone();
+        tokio::spawn(async move { committer.rollback_prepared(second_txn_id).await })
+    };
+    assert_eq!(
+        commit_next_raft_rollback_for_test(&mut raft_rx, 13).await?,
+        second_txn_id,
+    );
+    acknowledge_next_raft_applied_for_test_ref(&mut raft_rx, 13).await?;
+    rollback_task.await??;
 
     let rows = run_query(
         node,
@@ -1940,6 +1986,97 @@ async fn test_prepare_waits_for_raft_committed_prepared_write_publication(
     )
     .await?;
     assert_eq!(rows.len(), 2, "only the first prepared write should commit");
+    Ok(())
+}
+
+#[convex_macro::test_runtime]
+async fn test_rollback_prepared_is_replicated_and_idempotent(
+    rt: TestRuntime,
+) -> anyhow::Result<()> {
+    let log = Arc::new(InMemoryDistributedLog::new());
+    let node = create_node(&rt, log, Some(partitioned_map(PartitionId(1)))).await?;
+    insert_doc(&node, "projects", assert_obj!("name" => "seed")).await?;
+
+    let mut tx = node.begin(Identity::system()).await?;
+    TestFacingModel::new(&mut tx)
+        .insert(
+            &"projects".parse()?,
+            assert_obj!("name" => "must-never-commit"),
+        )
+        .await?;
+    let final_tx = tx.finalize()?;
+    let write_indexes: Vec<_> = final_tx
+        .writes
+        .coalesced_writes()
+        .enumerate()
+        .map(|(index, _)| index)
+        .collect();
+    let write_source = WriteSource::new("raft_replicated_rollback_test");
+    let participant = ParticipantTransaction::from_final_transaction(
+        &final_tx,
+        PartitionId(1),
+        &write_indexes,
+        &partitioned_map(PartitionId(1)),
+        &write_source,
+    )?;
+    let transaction_id = TwoPhaseTransactionId::new();
+    let committer = node.committer_for_test();
+    let prepare_ts = committer.allocate_commit_ts().await?;
+    let (raft_state, mut raft_rx) =
+        RaftPartitionState::new_with_mailbox_for_test(true, 1, PartitionId(1), 1);
+    node.attach_raft_state(raft_state).await?;
+
+    let prepare_task = {
+        let committer = committer.clone();
+        let transaction_id = transaction_id.clone();
+        let write_source = write_source.clone();
+        tokio::spawn(async move {
+            committer
+                .prepare_remote(
+                    transaction_id,
+                    participant,
+                    write_source,
+                    prepare_ts,
+                    vec![PartitionId(1)],
+                )
+                .await
+        })
+    };
+    let redo = commit_next_raft_prepare_for_test(&mut raft_rx, 21).await?;
+    acknowledge_next_raft_applied_for_test_ref(&mut raft_rx, 21).await?;
+    assert_eq!(prepare_task.await??.prepare_ts, prepare_ts);
+
+    let rollback_task = {
+        let committer = committer.clone();
+        let transaction_id = transaction_id.clone();
+        tokio::spawn(async move { committer.rollback_prepared(transaction_id).await })
+    };
+    assert_eq!(
+        commit_next_raft_rollback_for_test(&mut raft_rx, 22).await?,
+        transaction_id,
+    );
+    acknowledge_next_raft_applied_for_test_ref(&mut raft_rx, 22).await?;
+    rollback_task.await??;
+    assert!(committer.two_phase_redo_records().await?.is_empty());
+
+    // Exercise the follower callback path independently. Replaying the committed
+    // prepare followed by the rollback marker must clear the intent, and a
+    // duplicate rollback marker must remain a no-op.
+    committer.apply_raft_prepared_redo(23, redo).await?;
+    anyhow::ensure!(!committer.two_phase_redo_records().await?.is_empty());
+    committer
+        .apply_raft_rollback(24, transaction_id.clone())
+        .await?;
+    committer.apply_raft_rollback(25, transaction_id).await?;
+    assert!(committer.two_phase_redo_records().await?.is_empty());
+
+    let rows = run_query(
+        node,
+        TableNamespace::root_component(),
+        Query::full_table_scan("projects".parse()?, Order::Asc),
+    )
+    .await?;
+    assert_eq!(rows.len(), 1, "rolled-back writes must remain invisible");
     Ok(())
 }
 
@@ -5757,8 +5894,8 @@ fn test_stale_same_name_creation_aborts_before_retrying_winning_catalog() -> any
             .await
             .expect_err("the stale same-name catalog proposal must not commit");
         assert!(
-            format!("{stale_error:#}").contains("duplicate table"),
-            "stale creator should lose at the catalog authority: {stale_error:#}",
+            stale_error.is_occ(),
+            "stale creator should return a retryable OCC error: {stale_error:#}",
         );
 
         insert_doc(

--- a/crates/database/src/tests/write_scaling_tests.rs
+++ b/crates/database/src/tests/write_scaling_tests.rs
@@ -195,6 +195,7 @@ use crate::{
     },
     two_phase_coordinator::{
         coordinate_two_phase_commit_with_mode,
+        participant_write_indexes,
         TwoPhaseCommitMode,
     },
     Database,
@@ -6388,6 +6389,181 @@ async fn test_raft_commit_delta_cleans_prepared_redo_on_follower(
     )
     .await
     .context("follower should accept local writes after Raft commit delta cleaned the prepare")?;
+    Ok(())
+}
+
+#[convex_macro::test_runtime]
+async fn test_raft_prepared_catalog_replay_accepts_equivalent_cross_partition_catalog(
+    rt: TestRuntime,
+) -> anyhow::Result<()> {
+    let log = Arc::new(InMemoryDistributedLog::new());
+    let tso: Arc<dyn TimestampOracle> = Arc::new(InMemoryTimestampOracle::new());
+    let table_number_allocator: Arc<dyn TableNumberAllocator> =
+        Arc::new(InMemoryTableNumberAllocator::default());
+    let source = create_node_with_persistence_and_table_number_allocator(
+        &rt,
+        Arc::new(TestPersistence::new()),
+        log.clone(),
+        Some(strict_partitioned_map(PartitionId(0))),
+        None,
+        Arc::new(NoopTwoPhaseDecisionLog),
+        Some(tso.clone()),
+        table_number_allocator.clone(),
+    )
+    .await?;
+    let owner = create_node_with_persistence_and_table_number_allocator(
+        &rt,
+        Arc::new(TestPersistence::new()),
+        log.clone(),
+        Some(strict_partitioned_map(PartitionId(1))),
+        None,
+        Arc::new(NoopTwoPhaseDecisionLog),
+        Some(tso.clone()),
+        table_number_allocator.clone(),
+    )
+    .await?;
+    let follower = create_node_with_persistence_and_table_number_allocator(
+        &rt,
+        Arc::new(TestPersistence::new()),
+        log.clone(),
+        Some(strict_partitioned_map(PartitionId(0))),
+        None,
+        Arc::new(NoopTwoPhaseDecisionLog),
+        Some(tso),
+        table_number_allocator,
+    )
+    .await?;
+
+    let mut tx = source.begin(Identity::system()).await?;
+    TestFacingModel::new(&mut tx)
+        .insert(
+            &"projects".parse()?,
+            assert_obj!("name" => "catalog-arrived-before-raft-prepare"),
+        )
+        .await?;
+    let final_tx = tx.finalize()?;
+    let write_source = WriteSource::new("raft_prepared_catalog_replay_test");
+    let partition_map = strict_partitioned_map(PartitionId(0));
+    let write_indexes = participant_write_indexes(&final_tx, &partition_map, &write_source)?;
+    let authority_tx = ParticipantTransaction::from_final_transaction(
+        &final_tx,
+        PartitionId(0),
+        write_indexes
+            .get(&PartitionId(0))
+            .context("fresh remote table should have a catalog-authority participant")?,
+        &partition_map,
+        &write_source,
+    )?;
+    let owner_tx = ParticipantTransaction::from_final_transaction(
+        &final_tx,
+        PartitionId(1),
+        write_indexes
+            .get(&PartitionId(1))
+            .context("fresh remote table should have a data-owner participant")?,
+        &partition_map,
+        &write_source,
+    )?;
+    let transaction_id = TwoPhaseTransactionId::new();
+    let prepare_ts = source.committer_for_test().allocate_commit_ts().await?;
+    let participants = vec![PartitionId(0), PartitionId(1)];
+
+    source
+        .committer_for_test()
+        .prepare_remote(
+            transaction_id.clone(),
+            authority_tx.clone(),
+            write_source.clone(),
+            prepare_ts,
+            participants.clone(),
+        )
+        .await?;
+    owner
+        .committer_for_test()
+        .prepare_remote(
+            transaction_id.clone(),
+            owner_tx,
+            write_source.clone(),
+            prepare_ts,
+            participants,
+        )
+        .await?;
+    owner
+        .committer_for_test()
+        .commit_prepared(transaction_id.clone())
+        .await?;
+    let owner_delta = log
+        .deltas()
+        .into_iter()
+        .find(|delta| delta.ts == prepare_ts && delta.source_partition == Some(PartitionId(1)))
+        .context("owner commit should publish its catalog and first-document delta")?;
+    follower
+        .committer_for_test()
+        .apply_replica_delta(owner_delta)
+        .await?;
+
+    let redo = TwoPhaseRedoEntry::new_with_participants(
+        &transaction_id,
+        prepare_ts,
+        PartitionId(0),
+        &[PartitionId(0), PartitionId(1)],
+        authority_tx,
+        &write_source,
+    )?;
+    follower
+        .committer_for_test()
+        .apply_raft_prepared_redo(1, redo)
+        .await?;
+
+    source
+        .committer_for_test()
+        .commit_prepared(transaction_id.clone())
+        .await?;
+    let authority_delta = log
+        .deltas()
+        .into_iter()
+        .find(|delta| delta.ts == prepare_ts && delta.source_partition == Some(PartitionId(0)))
+        .context("catalog authority should publish its committed half")?;
+    follower
+        .committer_for_test()
+        .apply_raft_commit_delta(2, authority_delta)
+        .await?;
+
+    let rows = run_local_replica_query(
+        follower.clone(),
+        TableNamespace::root_component(),
+        Query::full_table_scan("projects".parse()?, Order::Asc),
+    )
+    .await?;
+    assert_eq!(
+        rows.len(),
+        1,
+        "the first remote document must remain visible"
+    );
+    let source_mapping = source
+        .begin(Identity::system())
+        .await?
+        .table_mapping()
+        .clone();
+    let follower_mapping = follower
+        .begin(Identity::system())
+        .await?
+        .table_mapping()
+        .clone();
+    assert_eq!(
+        source_mapping
+            .namespace(TableNamespace::root_component())
+            .id(&"projects".parse()?)?,
+        follower_mapping
+            .namespace(TableNamespace::root_component())
+            .id(&"projects".parse()?)?,
+        "catalog replay must preserve the stable tablet and table number",
+    );
+    let redo = follower
+        .committer_for_test()
+        .persistence_reader()
+        .get_persistence_global(PersistenceGlobalKey::TwoPhaseRedoRecords)
+        .await?;
+    assert_eq!(redo, Some(serde_json::json!({})));
     Ok(())
 }
 

--- a/crates/database/src/two_phase.rs
+++ b/crates/database/src/two_phase.rs
@@ -32,8 +32,21 @@ use async_nats::jetstream::kv::{
 };
 use async_trait::async_trait;
 use common::{
-    bootstrap_model::index::database_index::IndexedFields,
-    document::DocumentUpdateWithPrevTs,
+    bootstrap_model::{
+        index::{
+            database_index::IndexedFields,
+            TabletIndexMetadata,
+            INDEX_TABLE,
+        },
+        tables::{
+            TableMetadata,
+            TABLES_TABLE,
+        },
+    },
+    document::{
+        DocumentUpdateWithPrevTs,
+        ParseDocument,
+    },
     grpc::ClusterGrpcAuth,
     interval::IntervalSet,
     query::FilterValue,
@@ -1211,6 +1224,98 @@ pub struct ParticipantTabletMetadata {
     pub table_name: TableName,
 }
 
+pub(crate) fn user_catalog_write_target(
+    transaction: &FinalTransaction,
+    write: &DocumentUpdateWithPrevTs,
+) -> anyhow::Result<Option<ParticipantTabletMetadata>> {
+    let Some(catalog_table) = transaction
+        .table_mapping
+        .tablet_name(write.id.tablet_id)
+        .ok()
+    else {
+        return Ok(None);
+    };
+    if &catalog_table != &*TABLES_TABLE && &catalog_table != &*INDEX_TABLE {
+        return Ok(None);
+    }
+    let Some(document) = write
+        .new_document
+        .as_ref()
+        .or_else(|| write.old_document.as_ref().map(|(document, _)| document))
+    else {
+        return Ok(None);
+    };
+
+    let metadata = if &catalog_table == &*TABLES_TABLE {
+        let table: common::document::ParsedDocument<TableMetadata> =
+            document.parse().with_context(|| {
+                format!(
+                    "failed to parse _tables catalog metadata while routing write {:?}",
+                    write.id
+                )
+            })?;
+        let table = table.into_value();
+        ParticipantTabletMetadata {
+            tablet_id: TabletId(write.id.internal_id()),
+            namespace: table.namespace,
+            table_number: table.number,
+            table_name: table.name,
+        }
+    } else {
+        let index: common::document::ParsedDocument<TabletIndexMetadata> =
+            document.parse().with_context(|| {
+                format!(
+                    "failed to parse _index catalog metadata while routing write {:?}",
+                    write.id
+                )
+            })?;
+        let indexed_tablet = *index.into_value().name.table();
+        ParticipantTabletMetadata {
+            tablet_id: indexed_tablet,
+            namespace: transaction
+                .table_mapping
+                .tablet_namespace(indexed_tablet)
+                .with_context(|| {
+                    format!(
+                        "_index catalog metadata for write {:?} references unknown tablet {:?}",
+                        write.id, indexed_tablet
+                    )
+                })?,
+            table_number: transaction
+                .table_mapping
+                .tablet_number(indexed_tablet)
+                .with_context(|| {
+                    format!(
+                        "_index catalog metadata for write {:?} references unknown tablet {:?}",
+                        write.id, indexed_tablet
+                    )
+                })?,
+            table_name: transaction
+                .table_mapping
+                .tablet_name(indexed_tablet)
+                .with_context(|| {
+                    format!(
+                        "_index catalog metadata for write {:?} references unknown tablet {:?}",
+                        write.id, indexed_tablet
+                    )
+                })?,
+        }
+    };
+
+    Ok((!metadata.table_name.is_system()).then_some(metadata))
+}
+
+pub(crate) fn transaction_has_user_catalog_writes(
+    transaction: &FinalTransaction,
+) -> anyhow::Result<bool> {
+    for write in transaction.writes.coalesced_writes() {
+        if user_catalog_write_target(transaction, write)?.is_some() {
+            return Ok(true);
+        }
+    }
+    Ok(false)
+}
+
 #[derive(Clone, Debug)]
 #[cfg_attr(any(test, feature = "testing"), derive(PartialEq))]
 pub struct ParticipantTransaction {
@@ -1236,10 +1341,18 @@ impl ParticipantTransaction {
             .map(|(_, write)| write.clone())
             .collect();
 
+        let metadata_authority = (partition_map.enforces_catalog_coherence()
+            && transaction_has_user_catalog_writes(transaction)?)
+        .then(|| partition_map.partition_for_table(&TABLES_TABLE));
         let belongs_to_participant = |tablet_id: TabletId| -> bool {
             let Ok(table_name) = transaction.table_mapping.tablet_name(tablet_id) else {
                 return false;
             };
+            if metadata_authority.is_some()
+                && (&table_name == &*TABLES_TABLE || &table_name == &*INDEX_TABLE)
+            {
+                return metadata_authority == Some(participant);
+            }
             match routed_partition_for_table(&table_name, partition_map, write_source) {
                 Some(owner) => owner == participant,
                 None => participant == partition_map.local_partition(),
@@ -1288,8 +1401,18 @@ impl ParticipantTransaction {
         for (index_name, _) in reads.iter_search() {
             record_tablet(*index_name.table())?;
         }
+        let mut catalog_tablet_metadata = Vec::new();
         for write in &selected_writes {
             record_tablet(write.id.tablet_id)?;
+            if let Some(metadata) = user_catalog_write_target(transaction, write)? {
+                catalog_tablet_metadata.push(metadata);
+            }
+        }
+        drop(record_tablet);
+        for metadata in catalog_tablet_metadata {
+            tablet_metadata
+                .entry(metadata.tablet_id)
+                .or_insert(metadata);
         }
 
         Ok(Self {

--- a/crates/database/src/two_phase.rs
+++ b/crates/database/src/two_phase.rs
@@ -1844,16 +1844,13 @@ impl TwoPhaseCommitGrpcClient {
             placement_version: u64::from(placement_version),
             participants: participants.iter().map(|partition| partition.0).collect(),
         };
-        let response = self
-            .client
-            .clone()
-            .prepare(self.request(request))
-            .await
-            .context("gRPC Prepare failed")?;
+        let response =
+            common::grpc::handle_response(self.client.clone().prepare(self.request(request)).await)
+                .context("gRPC Prepare failed")?;
         let TwoPcPrepareResponse {
             prepare_ts,
             required_prepare_ts,
-        } = response.into_inner();
+        } = response;
         if let Some(required_prepare_ts) = required_prepare_ts {
             return Err(PrepareTimestampTooLow {
                 proposed_ts: prepare_ts.try_into()?,
@@ -1881,13 +1878,14 @@ impl TwoPhaseCommitGrpcClient {
             validate_ts: u64::from(validate_ts),
             placement_version: u64::from(placement_version),
         };
-        let response = self
-            .client
-            .clone()
-            .validate_reads(self.request(request))
-            .await
-            .context("gRPC ValidateReads failed")?;
-        if let Some(required_prepare_ts) = response.into_inner().required_prepare_ts {
+        let response = common::grpc::handle_response(
+            self.client
+                .clone()
+                .validate_reads(self.request(request))
+                .await,
+        )
+        .context("gRPC ValidateReads failed")?;
+        if let Some(required_prepare_ts) = response.required_prepare_ts {
             return Err(PrepareTimestampTooLow {
                 proposed_ts: validate_ts,
                 required_ts: required_prepare_ts.try_into()?,
@@ -1904,13 +1902,14 @@ impl TwoPhaseCommitGrpcClient {
         let request = TwoPcCommitRequest {
             transaction_id: transaction_id.0.clone(),
         };
-        let response = self
-            .client
-            .clone()
-            .commit_prepared(self.request(request))
-            .await
-            .context("gRPC CommitPrepared failed")?;
-        Ok(response.into_inner().commit_ts)
+        let response = common::grpc::handle_response(
+            self.client
+                .clone()
+                .commit_prepared(self.request(request))
+                .await,
+        )
+        .context("gRPC CommitPrepared failed")?;
+        Ok(response.commit_ts)
     }
 
     pub async fn rollback_prepared(
@@ -1920,11 +1919,13 @@ impl TwoPhaseCommitGrpcClient {
         let request = TwoPcRollbackRequest {
             transaction_id: transaction_id.0.clone(),
         };
-        self.client
-            .clone()
-            .rollback_prepared(self.request(request))
-            .await
-            .context("gRPC RollbackPrepared failed")?;
+        common::grpc::handle_response(
+            self.client
+                .clone()
+                .rollback_prepared(self.request(request))
+                .await,
+        )
+        .context("gRPC RollbackPrepared failed")?;
         Ok(())
     }
 }

--- a/crates/database/src/two_phase_coordinator.rs
+++ b/crates/database/src/two_phase_coordinator.rs
@@ -21,20 +21,10 @@ use anyhow::{
 };
 use common::{
     bootstrap_model::{
-        index::{
-            TabletIndexMetadata,
-            INDEX_TABLE,
-        },
-        tables::{
-            TableMetadata,
-            TABLES_TABLE,
-        },
+        index::INDEX_TABLE,
+        tables::TABLES_TABLE,
     },
-    document::{
-        DocumentUpdateWithPrevTs,
-        ParseDocument,
-        ResolvedDocument,
-    },
+    document::DocumentUpdateWithPrevTs,
     knobs::ENABLE_PARALLEL_2PC_EARLY_ACK,
     runtime::tokio_spawn,
     types::Timestamp,
@@ -58,6 +48,8 @@ use crate::{
     transaction::FinalTransaction,
     two_phase::{
         prepare_timestamp_too_low,
+        transaction_has_user_catalog_writes,
+        user_catalog_write_target,
         NodeAddresses,
         ParticipantTransaction,
         StagingRecoveryResult,
@@ -125,7 +117,7 @@ pub fn classify_transaction(
         transaction,
         partition_map,
         write_source,
-    ));
+    )?);
 
     Ok(if partitions.is_empty() {
         TransactionClassification::SinglePartition
@@ -152,15 +144,14 @@ pub(crate) fn participant_write_indexes(
     let mut participant_indexes: BTreeMap<PartitionId, Vec<usize>> = BTreeMap::new();
 
     for (index, write) in transaction.writes.coalesced_writes().enumerate() {
-        let Some(participant) =
-            routed_partition_for_write(transaction, write, partition_map, write_source)?
-        else {
-            continue;
-        };
-        participant_indexes
-            .entry(participant)
-            .or_default()
-            .push(index);
+        for participant in
+            routed_partitions_for_write(transaction, write, partition_map, write_source)?
+        {
+            participant_indexes
+                .entry(participant)
+                .or_default()
+                .push(index);
+        }
     }
 
     participant_indexes.retain(|_, indexes| !indexes.is_empty());
@@ -175,7 +166,7 @@ pub(crate) fn participant_prepare_indexes(
     let mut participant_indexes =
         participant_write_indexes(transaction, partition_map, write_source)?;
 
-    for participant in participant_read_owners(transaction, partition_map, write_source) {
+    for participant in participant_read_owners(transaction, partition_map, write_source)? {
         participant_indexes.entry(participant).or_default();
     }
 
@@ -186,12 +177,23 @@ fn participant_read_owners(
     transaction: &FinalTransaction,
     partition_map: &PartitionMap,
     write_source: &WriteSource,
-) -> BTreeSet<PartitionId> {
+) -> anyhow::Result<BTreeSet<PartitionId>> {
     let mut participants = BTreeSet::new();
+    let metadata_authority = (partition_map.enforces_catalog_coherence()
+        && transaction_has_user_catalog_writes(transaction)?)
+    .then(|| partition_map.partition_for_table(&TABLES_TABLE));
     let mut visit_tablet = |tablet_id| {
         let Ok(table_name) = transaction.table_mapping.tablet_name(tablet_id) else {
             return;
         };
+        if metadata_authority.is_some()
+            && (&table_name == &*TABLES_TABLE || &table_name == &*INDEX_TABLE)
+        {
+            if let Some(metadata_authority) = metadata_authority {
+                participants.insert(metadata_authority);
+            }
+            return;
+        }
         if let Some(partition) =
             routed_partition_for_table(&table_name, partition_map, write_source)
         {
@@ -206,26 +208,34 @@ fn participant_read_owners(
         visit_tablet(*index_name.table());
     }
 
-    participants
+    Ok(participants)
 }
 
-fn routed_partition_for_write(
+fn routed_partitions_for_write(
     transaction: &FinalTransaction,
     write: &DocumentUpdateWithPrevTs,
     partition_map: &PartitionMap,
     write_source: &WriteSource,
-) -> anyhow::Result<Option<PartitionId>> {
+) -> anyhow::Result<BTreeSet<PartitionId>> {
+    let mut participants = BTreeSet::new();
     let Some(table_name) = transaction
         .table_mapping
         .tablet_name(write.id.tablet_id)
         .ok()
     else {
-        return Ok(None);
+        return Ok(participants);
     };
-    if let Some(partition) = routed_partition_for_table(&table_name, partition_map, write_source) {
-        return Ok(Some(partition));
+    if let Some(owner) = routed_partition_for_catalog_write(transaction, write, partition_map)? {
+        if partition_map.enforces_catalog_coherence() {
+            participants.insert(partition_map.partition_for_table(&TABLES_TABLE));
+        }
+        participants.insert(owner);
+        return Ok(participants);
     }
-    routed_partition_for_catalog_write(transaction, write, partition_map)
+    if let Some(partition) = routed_partition_for_table(&table_name, partition_map, write_source) {
+        participants.insert(partition);
+    }
+    Ok(participants)
 }
 
 fn routed_partition_for_catalog_write(
@@ -233,54 +243,8 @@ fn routed_partition_for_catalog_write(
     write: &DocumentUpdateWithPrevTs,
     partition_map: &PartitionMap,
 ) -> anyhow::Result<Option<PartitionId>> {
-    let Some(catalog_table) = transaction
-        .table_mapping
-        .tablet_name(write.id.tablet_id)
-        .ok()
-    else {
-        return Ok(None);
-    };
-    if &catalog_table != &*TABLES_TABLE && &catalog_table != &*INDEX_TABLE {
-        return Ok(None);
-    }
-    let Some(document) = write
-        .new_document
-        .as_ref()
-        .or_else(|| write.old_document.as_ref().map(|(document, _)| document))
-    else {
-        return Ok(None);
-    };
-    let user_table = if &catalog_table == &*TABLES_TABLE {
-        catalog_write_user_table(document).with_context(|| {
-            format!(
-                "failed to parse _tables catalog metadata while routing write {:?}",
-                write.id
-            )
-        })?
-    } else {
-        let index: common::document::ParsedDocument<TabletIndexMetadata> =
-            document.parse().with_context(|| {
-                format!(
-                    "failed to parse _index catalog metadata while routing write {:?}",
-                    write.id
-                )
-            })?;
-        let index = index.into_value();
-        let indexed_tablet = *index.name.table();
-        transaction
-            .table_mapping
-            .tablet_name(indexed_tablet)
-            .with_context(|| {
-                format!(
-                    "_index catalog metadata for write {:?} references unknown tablet {:?}",
-                    write.id, indexed_tablet
-                )
-            })?
-    };
-    if user_table.is_system() {
-        return Ok(None);
-    }
-    Ok(Some(partition_map.partition_for_table(&user_table)))
+    Ok(user_catalog_write_target(transaction, write)?
+        .map(|metadata| partition_map.partition_for_table(&metadata.table_name)))
 }
 
 #[cfg(any(test, feature = "testing"))]
@@ -290,11 +254,6 @@ pub fn routed_partition_for_catalog_write_for_test(
     partition_map: &PartitionMap,
 ) -> anyhow::Result<Option<PartitionId>> {
     routed_partition_for_catalog_write(transaction, write, partition_map)
-}
-
-fn catalog_write_user_table(document: &ResolvedDocument) -> anyhow::Result<value::TableName> {
-    let metadata: common::document::ParsedDocument<TableMetadata> = document.parse()?;
-    Ok(metadata.into_value().name)
 }
 
 async fn prepare_participant(

--- a/crates/database/src/two_phase_coordinator.rs
+++ b/crates/database/src/two_phase_coordinator.rs
@@ -29,6 +29,7 @@ use common::{
     runtime::tokio_spawn,
     types::Timestamp,
 };
+use errors::ErrorMetadataAnyhowExt;
 use futures::{
     stream::FuturesUnordered,
     StreamExt,
@@ -834,6 +835,11 @@ fn is_ambiguous_prepare_error(err: &anyhow::Error) -> bool {
 }
 
 fn should_try_next_participant_address(err: &anyhow::Error) -> bool {
+    // An OCC is a deterministic participant response. Trying every peer only
+    // delays the application-level mutation retry and can overload a Raft group.
+    if err.is_occ() {
+        return false;
+    }
     let message = format!("{err:#}").to_ascii_lowercase();
     message.contains("transport error")
         || message.contains("connection error")
@@ -1193,6 +1199,7 @@ mod tests {
         RepeatableTimestamp,
         Timestamp,
     };
+    use errors::ErrorMetadata;
 
     use super::{
         is_ambiguous_prepare_error,
@@ -1269,6 +1276,13 @@ mod tests {
         let err = anyhow::anyhow!(
             "gRPC Prepare failed: status: Internal, message: \"forced prepare failure\""
         );
+        assert!(!is_ambiguous_prepare_error(&err));
+    }
+
+    #[test]
+    fn ambiguous_prepare_error_rejects_structured_occ_from_forwarded_leader() {
+        let err = anyhow::Error::new(ErrorMetadata::system_occ(Some(42), None))
+            .context("Leader Prepare failed");
         assert!(!is_ambiguous_prepare_error(&err));
     }
 

--- a/crates/database/src/two_phase_coordinator.rs
+++ b/crates/database/src/two_phase_coordinator.rs
@@ -34,6 +34,7 @@ use futures::{
     stream::FuturesUnordered,
     StreamExt,
 };
+use value::TableName;
 
 use crate::{
     committer::{
@@ -246,6 +247,19 @@ fn routed_partition_for_catalog_write(
 ) -> anyhow::Result<Option<PartitionId>> {
     Ok(user_catalog_write_target(transaction, write)?
         .map(|metadata| partition_map.partition_for_table(&metadata.table_name)))
+}
+
+fn invalidated_table_names(transaction: &FinalTransaction) -> anyhow::Result<BTreeSet<TableName>> {
+    let mut table_names = BTreeSet::new();
+    for write in transaction.writes.coalesced_writes() {
+        if let Ok(table_name) = transaction.table_mapping.tablet_name(write.id.tablet_id) {
+            table_names.insert(table_name);
+        }
+        if let Some(metadata) = user_catalog_write_target(transaction, write)? {
+            table_names.insert(metadata.table_name);
+        }
+    }
+    Ok(table_names)
 }
 
 #[cfg(any(test, feature = "testing"))]
@@ -931,6 +945,7 @@ pub(crate) async fn coordinate_two_phase_commit_with_mode(
     commit_mode: TwoPhaseCommitMode,
 ) -> anyhow::Result<CommitOutcome> {
     let timer = metrics::two_phase_coordinator_timer();
+    let invalidated_tables = invalidated_table_names(&transaction)?;
     let source_partition = match classify_transaction(&transaction, partition_map, &write_source)? {
         TransactionClassification::SinglePartition => {
             anyhow::bail!("2PC coordinator called for a local single-partition transaction");
@@ -1139,6 +1154,7 @@ pub(crate) async fn coordinate_two_phase_commit_with_mode(
                     ts: prepare_ts,
                     source_partition,
                     read_after_write_partitions: prepared_participants.clone(),
+                    invalidated_tables: invalidated_tables.clone(),
                 });
             },
             TwoPhaseCommitMode::ParallelEarlyAck => {
@@ -1175,6 +1191,7 @@ pub(crate) async fn coordinate_two_phase_commit_with_mode(
                     ts: prepare_ts,
                     source_partition,
                     read_after_write_partitions: prepared_participants.clone(),
+                    invalidated_tables: invalidated_tables.clone(),
                 });
             },
         }

--- a/crates/local_backend/src/lib.rs
+++ b/crates/local_backend/src/lib.rs
@@ -1677,6 +1677,26 @@ pub async fn make_app(
                                             })
                                     })?;
                                 },
+                                RaftStateMachineEntry::TwoPhaseRollback { transaction_id } => {
+                                    tracing::info!(
+                                        "Applying committed Raft 2PC rollback locally: txn={}, \
+                                         leader_now={}",
+                                        transaction_id,
+                                        raft_state_for_entries.is_leader(),
+                                    );
+                                    let committer = committer_for_entries.clone();
+                                    let rt = tokio::runtime::Handle::current();
+                                    rt.block_on(async {
+                                        committer
+                                            .apply_raft_rollback(raft_index, transaction_id)
+                                            .await
+                                            .map_err(|e| {
+                                                anyhow::anyhow!(
+                                                    "Raft 2PC rollback apply failed: {e:#}"
+                                                )
+                                            })
+                                    })?;
+                                },
                                 RaftStateMachineEntry::ClusterGenesis {
                                     manifest,
                                     checkpoint_base64,

--- a/crates/local_backend/src/lib.rs
+++ b/crates/local_backend/src/lib.rs
@@ -126,6 +126,7 @@ pub mod storage;
 pub mod streaming_export;
 pub mod streaming_import;
 pub mod subs;
+pub mod subscription_invalidation_service;
 #[cfg(test)]
 mod test_helpers;
 pub mod two_phase_service;

--- a/crates/local_backend/src/main.rs
+++ b/crates/local_backend/src/main.rs
@@ -29,6 +29,7 @@ use local_backend::{
     owner_read_service::OwnerReadGrpcService,
     proxy::dev_site_proxy,
     router::router,
+    subscription_invalidation_service::SubscriptionInvalidationGrpcService,
     two_phase_service,
     HttpActionRouteMapper,
     MAX_CONCURRENT_REQUESTS,
@@ -157,6 +158,13 @@ async fn run_server_inner(runtime: ProdRuntime, config: LocalConfig) -> anyhow::
             st.placement_metadata_store.clone(),
             cluster_grpc_auth.clone(),
         );
+        let subscription_invalidations = SubscriptionInvalidationGrpcService::new(
+            st.application.database().clone(),
+            st.application.database().committer_client(),
+            st.raft_state.clone(),
+            st.placement_metadata_store.clone(),
+            cluster_grpc_auth.clone(),
+        );
 
         // Add Raft transport server if Raft is enabled.
         let raft_transport = st.raft_mailbox_tx.as_ref().map(|mailbox_tx| {
@@ -172,7 +180,8 @@ async fn run_server_inner(runtime: ProdRuntime, config: LocalConfig) -> anyhow::
             let mut builder = tonic::transport::Server::builder()
                 .add_service(forwarder.into_server())
                 .add_service(two_pc.into_server())
-                .add_service(owner_reads.into_server());
+                .add_service(owner_reads.into_server())
+                .add_service(subscription_invalidations.into_server());
 
             if let Some(raft) = raft_transport {
                 builder = builder.add_service(raft.into_service());

--- a/crates/local_backend/src/owner_read_service.rs
+++ b/crates/local_backend/src/owner_read_service.rs
@@ -220,7 +220,7 @@ impl OwnerReadService for OwnerReadGrpcService {
         })?;
         let outcome = self
             .committer
-            .close_read_timestamp(target_ts)
+            .close_latest_read_timestamp(target_ts)
             .await
             .map_err(|error| {
                 Status::unavailable(format!("Failed to close owner read timestamp: {error:#}"))

--- a/crates/local_backend/src/public_api.rs
+++ b/crates/local_backend/src/public_api.rs
@@ -288,9 +288,23 @@ async fn wait_for_local_mutation_visibility(
     commit_ts: Timestamp,
     source_partition: Option<PartitionId>,
 ) -> anyhow::Result<()> {
+    // A remote partition's committed write is represented by the portable
+    // read-after-write token returned below. Do not delay that acknowledgement
+    // on this node's asynchronous replica materialization; subsequent reads
+    // enforce the owner-partition fence from the token.
+    if !mutation_commit_is_local(st.partition_id, source_partition) {
+        return Ok(());
+    }
     st.database
         .wait_for_read_after_write_fence(source_partition, commit_ts)
         .await
+}
+
+fn mutation_commit_is_local(
+    local_partition: Option<PartitionId>,
+    source_partition: Option<PartitionId>,
+) -> bool {
+    source_partition.is_none() || source_partition == local_partition
 }
 
 async fn maybe_forward_public_mutation(
@@ -1614,6 +1628,19 @@ mod tests {
         assert_eq!(stored["value"]["hello"], "partitioned-local");
 
         Ok(())
+    }
+
+    #[test]
+    fn test_remote_mutation_ack_uses_owner_fence_without_local_visibility_wait() {
+        assert!(!super::mutation_commit_is_local(
+            Some(PartitionId(0)),
+            Some(PartitionId(1)),
+        ));
+        assert!(super::mutation_commit_is_local(
+            Some(PartitionId(1)),
+            Some(PartitionId(1)),
+        ));
+        assert!(super::mutation_commit_is_local(None, None));
     }
 
     #[convex_macro::prod_rt_test]

--- a/crates/local_backend/src/subscription_invalidation_service.rs
+++ b/crates/local_backend/src/subscription_invalidation_service.rs
@@ -1,0 +1,237 @@
+//! Authenticated delivery of remote commit invalidations to the subscription
+//! authority.
+
+use std::{
+    collections::BTreeSet,
+    sync::Arc,
+};
+
+use common::grpc::ClusterGrpcAuth;
+use database::{
+    partition::{
+        PartitionId,
+        PlacementMetadataStore,
+        PlacementVersion,
+    },
+    raft_partition::RaftPartitionState,
+    CommitterClient,
+    Database,
+};
+use pb::replication::{
+    subscription_invalidation_service_server::{
+        SubscriptionInvalidationService,
+        SubscriptionInvalidationServiceServer,
+    },
+    InvalidateTablesRequest,
+};
+use runtime::prod::ProdRuntime;
+use tonic::{
+    Request,
+    Response,
+    Status,
+};
+use value::TableName;
+
+pub struct SubscriptionInvalidationGrpcService {
+    database: Database<ProdRuntime>,
+    committer: CommitterClient,
+    raft_state: Option<RaftPartitionState>,
+    placement_metadata_store: Option<Arc<dyn PlacementMetadataStore>>,
+    cluster_auth: Option<ClusterGrpcAuth>,
+}
+
+fn ensure_subscription_authority(
+    authority_partition: PartitionId,
+    local_partition: PartitionId,
+    raft_state: Option<&RaftPartitionState>,
+) -> Result<(), Status> {
+    if authority_partition != PartitionId::DEFAULT || local_partition != authority_partition {
+        return Err(Status::failed_precondition(format!(
+            "Subscription authority {} reached partition {}",
+            authority_partition, local_partition,
+        )));
+    }
+    let Some(raft_state) = raft_state else {
+        return Ok(());
+    };
+    if !raft_state.is_leader() {
+        return Err(Status::unavailable(format!(
+            "Subscription invalidation reached Raft follower {}; current leader is {}",
+            raft_state.node_id(),
+            raft_state.leader_id(),
+        )));
+    }
+    if !raft_state.has_leader_serving_lease() {
+        return Err(Status::unavailable(format!(
+            "Subscription authority leader {} has no valid serving lease",
+            raft_state.node_id(),
+        )));
+    }
+    Ok(())
+}
+
+impl SubscriptionInvalidationGrpcService {
+    pub fn new(
+        database: Database<ProdRuntime>,
+        committer: CommitterClient,
+        raft_state: Option<RaftPartitionState>,
+        placement_metadata_store: Option<Arc<dyn PlacementMetadataStore>>,
+        cluster_auth: Option<ClusterGrpcAuth>,
+    ) -> Self {
+        Self {
+            database,
+            committer,
+            raft_state,
+            placement_metadata_store,
+            cluster_auth,
+        }
+    }
+
+    pub fn into_server(self) -> SubscriptionInvalidationServiceServer<Self> {
+        SubscriptionInvalidationServiceServer::new(self)
+    }
+
+    fn authenticate<T>(&self, request: &Request<T>) -> Result<(), Status> {
+        if let Some(auth) = &self.cluster_auth {
+            auth.authenticate(request)?;
+        }
+        Ok(())
+    }
+
+    async fn ensure_placement_version(
+        &self,
+        placement_version: PlacementVersion,
+    ) -> Result<(), Status> {
+        if self
+            .committer
+            .ensure_placement_version(placement_version)
+            .is_ok()
+        {
+            return Ok(());
+        }
+        if let Some(store) = self.placement_metadata_store.as_ref()
+            && let Some(metadata) = store.load().await.map_err(|error| {
+                Status::unavailable(format!(
+                    "Failed to refresh placement before subscription invalidation: {error:#}"
+                ))
+            })?
+        {
+            self.committer
+                .refresh_placement_metadata(metadata)
+                .map_err(|error| {
+                    Status::failed_precondition(format!(
+                        "Refreshed placement metadata is invalid: {error:#}"
+                    ))
+                })?;
+        }
+        self.committer
+            .ensure_placement_version(placement_version)
+            .map_err(|error| {
+                Status::failed_precondition(format!(
+                    "Subscription invalidation rejected by placement guard: {error:#}"
+                ))
+            })
+    }
+}
+
+#[tonic::async_trait]
+impl SubscriptionInvalidationService for SubscriptionInvalidationGrpcService {
+    async fn invalidate_tables(
+        &self,
+        request: Request<InvalidateTablesRequest>,
+    ) -> Result<Response<()>, Status> {
+        self.authenticate(&request)?;
+        let request = request.into_inner();
+        let authority_partition = PartitionId(request.authority_partition);
+        let local_partition = self.committer.local_partition().ok_or_else(|| {
+            Status::failed_precondition(
+                "Subscription invalidation service requires a partitioned node",
+            )
+        })?;
+        ensure_subscription_authority(
+            authority_partition,
+            local_partition,
+            self.raft_state.as_ref(),
+        )?;
+
+        let placement_version = PlacementVersion::from(request.placement_version);
+        self.ensure_placement_version(placement_version).await?;
+        ensure_subscription_authority(
+            authority_partition,
+            local_partition,
+            self.raft_state.as_ref(),
+        )?;
+        let commit_ts = request
+            .commit_ts
+            .try_into()
+            .map_err(|error| Status::invalid_argument(format!("Invalid commit ts: {error:#}")))?;
+        let table_names = request
+            .table_names
+            .into_iter()
+            .map(|table_name| {
+                table_name.parse::<TableName>().map_err(|error| {
+                    Status::invalid_argument(format!(
+                        "Invalid subscription table {table_name:?}: {error:#}"
+                    ))
+                })
+            })
+            .collect::<Result<BTreeSet<_>, _>>()?;
+        self.database
+            .invalidate_subscriptions_for_tables(table_names, commit_ts)
+            .map_err(|error| {
+                Status::unavailable(format!(
+                    "Failed to invalidate coordinator subscriptions: {error:#}"
+                ))
+            })?;
+        ensure_subscription_authority(
+            authority_partition,
+            local_partition,
+            self.raft_state.as_ref(),
+        )?;
+        Ok(Response::new(()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use database::{
+        partition::PartitionId,
+        raft_partition::RaftPartitionState,
+    };
+    use tonic::Code;
+
+    use super::ensure_subscription_authority;
+
+    #[test]
+    fn subscription_authority_accepts_only_partition_zero_serving_leader() {
+        let leader = RaftPartitionState::new_for_test(true, 1, PartitionId::DEFAULT, 1);
+        assert!(ensure_subscription_authority(
+            PartitionId::DEFAULT,
+            PartitionId::DEFAULT,
+            Some(&leader),
+        )
+        .is_ok());
+
+        let follower = RaftPartitionState::new_for_test(false, 1, PartitionId::DEFAULT, 2);
+        let follower_error = ensure_subscription_authority(
+            PartitionId::DEFAULT,
+            PartitionId::DEFAULT,
+            Some(&follower),
+        )
+        .unwrap_err();
+        assert_eq!(follower_error.code(), Code::Unavailable);
+
+        leader.expire_leader_serving_lease_for_test();
+        let expired_lease = ensure_subscription_authority(
+            PartitionId::DEFAULT,
+            PartitionId::DEFAULT,
+            Some(&leader),
+        )
+        .unwrap_err();
+        assert_eq!(expired_lease.code(), Code::Unavailable);
+
+        let wrong_partition =
+            ensure_subscription_authority(PartitionId::DEFAULT, PartitionId(1), None).unwrap_err();
+        assert_eq!(wrong_partition.code(), Code::FailedPrecondition);
+    }
+}

--- a/crates/local_backend/src/two_phase_service.rs
+++ b/crates/local_backend/src/two_phase_service.rs
@@ -29,19 +29,22 @@ use database::{
     },
     CommitterClient,
 };
-use pb::replication::{
-    two_phase_commit_service_server::{
-        TwoPhaseCommitService,
-        TwoPhaseCommitServiceServer as TonicTwoPcServer,
+use pb::{
+    error_metadata::ErrorMetadataStatusExt,
+    replication::{
+        two_phase_commit_service_server::{
+            TwoPhaseCommitService,
+            TwoPhaseCommitServiceServer as TonicTwoPcServer,
+        },
+        TwoPcCommitRequest,
+        TwoPcCommitResponse,
+        TwoPcPrepareRequest,
+        TwoPcPrepareResponse,
+        TwoPcRollbackRequest,
+        TwoPcRollbackResponse,
+        TwoPcValidateReadsRequest,
+        TwoPcValidateReadsResponse,
     },
-    TwoPcCommitRequest,
-    TwoPcCommitResponse,
-    TwoPcPrepareRequest,
-    TwoPcPrepareResponse,
-    TwoPcRollbackRequest,
-    TwoPcRollbackResponse,
-    TwoPcValidateReadsRequest,
-    TwoPcValidateReadsResponse,
 };
 use tonic::{
     Request,
@@ -99,7 +102,7 @@ impl TwoPhaseCommitGrpcService {
                         required_prepare_ts: Some(u64::from(retry.required_ts)),
                     }));
                 }
-                Err(Status::internal(format!("{error_context}: {err:#}")))
+                Err(Status::from_anyhow(err.context(error_context.to_owned())))
             },
         }
     }
@@ -118,7 +121,7 @@ impl TwoPhaseCommitGrpcService {
                         required_prepare_ts: Some(u64::from(retry.required_ts)),
                     }));
                 }
-                Err(Status::internal(format!("{error_context}: {err:#}")))
+                Err(Status::from_anyhow(err.context(error_context.to_owned())))
             },
         }
     }
@@ -321,7 +324,7 @@ impl TwoPhaseCommitService for TwoPhaseCommitGrpcService {
             let commit_ts = client
                 .commit_prepared(&txn_id)
                 .await
-                .map_err(|e| Status::internal(format!("Leader CommitPrepared failed: {e:#}")))?;
+                .map_err(|e| Status::from_anyhow(e.context("Leader CommitPrepared failed")))?;
             return Ok(Response::new(TwoPcCommitResponse { commit_ts }));
         }
 
@@ -329,7 +332,7 @@ impl TwoPhaseCommitService for TwoPhaseCommitGrpcService {
             .committer
             .commit_prepared(txn_id)
             .await
-            .map_err(|e| Status::internal(format!("CommitPrepared failed: {e:#}")))?;
+            .map_err(|e| Status::from_anyhow(e.context("CommitPrepared failed")))?;
 
         Ok(Response::new(TwoPcCommitResponse {
             commit_ts: u64::from(ts),
@@ -348,15 +351,53 @@ impl TwoPhaseCommitService for TwoPhaseCommitGrpcService {
             client
                 .rollback_prepared(&txn_id)
                 .await
-                .map_err(|e| Status::internal(format!("Leader RollbackPrepared failed: {e:#}")))?;
+                .map_err(|e| Status::from_anyhow(e.context("Leader RollbackPrepared failed")))?;
             return Ok(Response::new(TwoPcRollbackResponse {}));
         }
 
         self.committer
             .rollback_prepared(txn_id)
             .await
-            .map_err(|e| Status::internal(format!("RollbackPrepared failed: {e:#}")))?;
+            .map_err(|e| Status::from_anyhow(e.context("RollbackPrepared failed")))?;
 
         Ok(Response::new(TwoPcRollbackResponse {}))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use errors::{
+        ErrorMetadata,
+        ErrorMetadataAnyhowExt,
+    };
+
+    use super::*;
+
+    fn system_occ_error() -> anyhow::Error {
+        ErrorMetadata::system_occ(Some(42), Some("catalog coherence test".to_owned())).into()
+    }
+
+    #[test]
+    fn prepare_response_preserves_occ_metadata() {
+        let status =
+            TwoPhaseCommitGrpcService::prepare_response(Err(system_occ_error()), "Prepare failed")
+                .expect_err("OCC prepare must return an error status");
+
+        let err = status.into_anyhow();
+        assert!(err.is_occ());
+        assert!(format!("{err:#}").contains("Prepare failed"));
+    }
+
+    #[test]
+    fn validate_reads_response_preserves_occ_metadata() {
+        let status = TwoPhaseCommitGrpcService::validate_reads_response(
+            Err(system_occ_error()),
+            "ValidateReads failed",
+        )
+        .expect_err("OCC read validation must return an error status");
+
+        let err = status.into_anyhow();
+        assert!(err.is_occ());
+        assert!(format!("{err:#}").contains("ValidateReads failed"));
     }
 }

--- a/crates/pb/protos/replication.proto
+++ b/crates/pb/protos/replication.proto
@@ -192,6 +192,20 @@ message OwnerReadIndexEntry {
   common.ResolvedDocument document = 3;
 }
 
+// Low-latency reactive invalidation control plane. Data remains authoritative
+// at its placement owner; this signal only tells the coordinator's subscription
+// workers that affected queries must rerun against a new cluster-safe snapshot.
+service SubscriptionInvalidationService {
+  rpc InvalidateTables(InvalidateTablesRequest) returns (google.protobuf.Empty);
+}
+
+message InvalidateTablesRequest {
+  uint32 authority_partition = 1;
+  uint64 placement_version = 2;
+  uint64 commit_ts = 3;
+  repeated string table_names = 4;
+}
+
 // Two-Phase Commit service for cross-partition writes (Vitess 2PC pattern).
 // Each partitioned node runs this service. The coordinator sends Prepare
 // to remote partitions, then CommitPrepared or RollbackPrepared.

--- a/self-hosted/docker/docker-compose.yml
+++ b/self-hosted/docker/docker-compose.yml
@@ -130,7 +130,7 @@ services:
       CONVEX_CLOUD_ORIGIN: http://127.0.0.1:3210
       CONVEX_SITE_ORIGIN: http://127.0.0.1:3211
       PARTITION_ID: "0"
-      PARTITION_MAP: messages=0,users=0,projects=1,tasks=1
+      PARTITION_MAP: messages=0,users=0,projects=1,tasks=1,catalog_probe=1
       NUM_PARTITIONS: "2"
       NODE_ADDRESSES: 0=node-p0a:50051|node-p0b:50051|node-p0c:50051,1=node-p1a:50051|node-p1b:50051|node-p1c:50051
       CLUSTER_NODE_ID: partition-0-peer-0
@@ -165,7 +165,7 @@ services:
       CONVEX_CLOUD_ORIGIN: http://127.0.0.1:3220
       CONVEX_SITE_ORIGIN: http://127.0.0.1:3221
       PARTITION_ID: "0"
-      PARTITION_MAP: messages=0,users=0,projects=1,tasks=1
+      PARTITION_MAP: messages=0,users=0,projects=1,tasks=1,catalog_probe=1
       NUM_PARTITIONS: "2"
       NODE_ADDRESSES: 0=node-p0a:50051|node-p0b:50051|node-p0c:50051,1=node-p1a:50051|node-p1b:50051|node-p1c:50051
       CLUSTER_NODE_ID: partition-0-peer-1
@@ -201,7 +201,7 @@ services:
       CONVEX_CLOUD_ORIGIN: http://127.0.0.1:3230
       CONVEX_SITE_ORIGIN: http://127.0.0.1:3231
       PARTITION_ID: "0"
-      PARTITION_MAP: messages=0,users=0,projects=1,tasks=1
+      PARTITION_MAP: messages=0,users=0,projects=1,tasks=1,catalog_probe=1
       NUM_PARTITIONS: "2"
       NODE_ADDRESSES: 0=node-p0a:50051|node-p0b:50051|node-p0c:50051,1=node-p1a:50051|node-p1b:50051|node-p1c:50051
       CLUSTER_NODE_ID: partition-0-peer-2
@@ -239,7 +239,7 @@ services:
       CONVEX_CLOUD_ORIGIN: http://127.0.0.1:3310
       CONVEX_SITE_ORIGIN: http://127.0.0.1:3311
       PARTITION_ID: "1"
-      PARTITION_MAP: messages=0,users=0,projects=1,tasks=1
+      PARTITION_MAP: messages=0,users=0,projects=1,tasks=1,catalog_probe=1
       NUM_PARTITIONS: "2"
       NODE_ADDRESSES: 0=node-p0a:50051|node-p0b:50051|node-p0c:50051,1=node-p1a:50051|node-p1b:50051|node-p1c:50051
       CLUSTER_NODE_ID: partition-1-peer-0
@@ -274,7 +274,7 @@ services:
       CONVEX_CLOUD_ORIGIN: http://127.0.0.1:3320
       CONVEX_SITE_ORIGIN: http://127.0.0.1:3321
       PARTITION_ID: "1"
-      PARTITION_MAP: messages=0,users=0,projects=1,tasks=1
+      PARTITION_MAP: messages=0,users=0,projects=1,tasks=1,catalog_probe=1
       NUM_PARTITIONS: "2"
       NODE_ADDRESSES: 0=node-p0a:50051|node-p0b:50051|node-p0c:50051,1=node-p1a:50051|node-p1b:50051|node-p1c:50051
       CLUSTER_NODE_ID: partition-1-peer-1
@@ -310,7 +310,7 @@ services:
       CONVEX_CLOUD_ORIGIN: http://127.0.0.1:3330
       CONVEX_SITE_ORIGIN: http://127.0.0.1:3331
       PARTITION_ID: "1"
-      PARTITION_MAP: messages=0,users=0,projects=1,tasks=1
+      PARTITION_MAP: messages=0,users=0,projects=1,tasks=1,catalog_probe=1
       NUM_PARTITIONS: "2"
       NODE_ADDRESSES: 0=node-p0a:50051|node-p0b:50051|node-p0c:50051,1=node-p1a:50051|node-p1b:50051|node-p1c:50051
       CLUSTER_NODE_ID: partition-1-peer-2

--- a/self-hosted/docker/test-write-scaling.sh
+++ b/self-hosted/docker/test-write-scaling.sh
@@ -27,6 +27,7 @@
 #   9k. Post-Ack 2PC Exactness After Cleanup-Window Restarts
 #   9l. Parallel 2PC Early-Ack Code-Path Proof
 #   9m. Cluster-Safe Latest Reads With Delayed Participant Delta
+#   0. Fresh Remote Catalog Coherence
 #  10. Rapid-Fire Writes Under Load (Jepsen stress)
 #  11. Write-Then-Immediate-Read Consistency (stale read detection)
 #  12. Double Node Restart (crash recovery stress)
@@ -306,6 +307,24 @@ export const createTask = mutation({
   args: { title: v.string(), assignee: v.string(), project: v.string(), status: v.string() },
   handler: async (ctx, args) => {
     return await ctx.db.insert("tasks", { ...args, createdAt: Date.now() });
+  },
+});
+
+export const createCatalogProbe = mutation({
+  args: { runId: v.string(), token: v.string() },
+  handler: async (ctx, args) => {
+    return await ctx.db.insert("catalog_probe", args);
+  },
+});
+
+export const catalogProbeTokens = query({
+  args: { runId: v.string() },
+  handler: async (ctx, args) => {
+    const rows = await ctx.db.query("catalog_probe").collect();
+    return rows
+      .filter((row: any) => row.runId === args.runId)
+      .map((row: any) => row.token as string)
+      .sort();
   },
 });
 
@@ -590,6 +609,59 @@ subscription = client.onUpdate(
 setTimeout(() => void finish(5, "timeout"), 25000);
 JSEOF
 
+cat > "$DEPLOY_DIR/catalog-coherence-subscription.mjs" << 'JSEOF'
+import { ConvexClient } from "convex/browser";
+import { api } from "./convex/_generated/api.js";
+
+const [url, runId, expectedCountRaw] = process.argv.slice(2);
+const expectedCount = Number(expectedCountRaw);
+const client = new ConvexClient(url, { unsavedChangesWarning: false });
+let subscription;
+let finished = false;
+let sawInitial = false;
+
+const finish = async (code, event, details = {}) => {
+  if (finished) return;
+  finished = true;
+  console.log(JSON.stringify({ event, ...details }));
+  subscription?.unsubscribe();
+  await Promise.race([
+    client.close(),
+    new Promise((resolve) => setTimeout(resolve, 1000)),
+  ]);
+  process.exit(code);
+};
+
+subscription = client.onUpdate(
+  api.messages.catalogProbeTokens,
+  { runId },
+  async (tokens) => {
+    console.log(JSON.stringify({ event: "value", tokens }));
+    if (!sawInitial) {
+      if (tokens.length !== 0) {
+        await finish(2, "unexpected-initial", { tokens });
+        return;
+      }
+      sawInitial = true;
+      console.log(JSON.stringify({ event: "ready" }));
+      return;
+    }
+    if (tokens.length > expectedCount) {
+      await finish(3, "duplicate", { tokens });
+      return;
+    }
+    if (tokens.length === expectedCount) {
+      await finish(0, "complete", { tokens });
+    }
+  },
+  async (error) => {
+    await finish(4, "error", { message: String(error) });
+  },
+);
+
+setTimeout(() => void finish(5, "timeout"), 20000);
+JSEOF
+
 deploy_functions_with_retry() {
     local key="$1"
     local url="$2"
@@ -857,6 +929,234 @@ assert_cross_partition_write_exact_once() {
     fail "$label did not appear exactly once" "messages=$msg_count tasks=$task_count"
     return 1
 }
+
+# ============================================================
+echo ""
+echo -e "${BOLD}Test 0: Fresh Remote Catalog Coherence${NC}"
+# ============================================================
+# catalog_probe is assigned to partition 1 and has never been written. All six
+# public entrypoints race its first implicit creation while partition 0's NATS
+# consumer is paused. A successful response must mean the catalog is already
+# committed through partition 0's Raft group and the row through partition 1's
+# group; neither immediate reads nor subscription reruns may depend on NATS.
+
+CATALOG_RUN="catalog-$(date +%s)-$$"
+CATALOG_EXPECTED="p0a,p0b,p0c,p1a,p1b,p1c"
+CATALOG_SUB_LOG=$(mktemp)
+CATALOG_TMP_DIR=$(mktemp -d)
+CATALOG_COORDINATOR_FOUND=false
+CATALOG_COORDINATOR_CONTAINER=""
+CATALOG_COORDINATOR_URL=""
+CATALOG_COORDINATOR_KEY=""
+
+for entry in \
+    "docker-node-p0a-1|$NODE_P0A_URL|$NODE_P0A_KEY" \
+    "docker-node-p0b-1|$NODE_P0B_URL|$NODE_P0B_KEY" \
+    "docker-node-p0c-1|$NODE_P0C_URL|$NODE_P0C_KEY"; do
+    IFS='|' read -r candidate_container candidate_url candidate_key <<< "$entry"
+    status=$(curl --max-time 2 -s -o /dev/null -w "%{http_code}" \
+        -H "Connection: Upgrade" \
+        -H "Upgrade: websocket" \
+        -H "Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==" \
+        -H "Sec-WebSocket-Version: 13" \
+        "$candidate_url/api/1.34.1/sync" 2>/dev/null || true)
+    if [ "$status" = "101" ]; then
+        CATALOG_COORDINATOR_FOUND=true
+        CATALOG_COORDINATOR_CONTAINER="$candidate_container"
+        CATALOG_COORDINATOR_URL="$candidate_url"
+        CATALOG_COORDINATOR_KEY="$candidate_key"
+        break
+    fi
+done
+
+if $CATALOG_COORDINATOR_FOUND; then
+    CATALOG_NATS_CONSUMER=$(docker exec "$CATALOG_COORDINATOR_CONTAINER" \
+        printenv INSTANCE_NAME 2>/dev/null)
+    (cd "$DEPLOY_DIR" && node catalog-coherence-subscription.mjs \
+        "$CATALOG_COORDINATOR_URL" "$CATALOG_RUN" 6 \
+        > "$CATALOG_SUB_LOG" 2>&1) &
+    CATALOG_SUB_PID=$!
+else
+    CATALOG_SUB_PID=""
+fi
+
+CATALOG_SUB_READY=false
+if $CATALOG_COORDINATOR_FOUND; then
+    for _ in $(seq 1 100); do
+        if grep -q '"event":"ready"' "$CATALOG_SUB_LOG"; then
+            CATALOG_SUB_READY=true
+            break
+        fi
+        if ! kill -0 "$CATALOG_SUB_PID" 2>/dev/null; then
+            break
+        fi
+        sleep 0.1
+    done
+fi
+
+CATALOG_MUTATIONS_OK=true
+CATALOG_MUTATION_DETAILS=""
+if $CATALOG_SUB_READY; then
+    set_jetstream_consumer_pause "$CATALOG_NATS_CONSUMER" 30
+    CATALOG_ENTRYPOINTS=(
+        "p0a|$NODE_P0A_URL|$NODE_P0A_KEY"
+        "p0b|$NODE_P0B_URL|$NODE_P0B_KEY"
+        "p0c|$NODE_P0C_URL|$NODE_P0C_KEY"
+        "p1a|$NODE_P1A_URL|$NODE_P1A_KEY"
+        "p1b|$NODE_P1B_URL|$NODE_P1B_KEY"
+        "p1c|$NODE_P1C_URL|$NODE_P1C_KEY"
+    )
+    CATALOG_PIDS=()
+    for entry in "${CATALOG_ENTRYPOINTS[@]}"; do
+        IFS='|' read -r label url key <<< "$entry"
+        (mutation_response "$url" "$key" "messages:createCatalogProbe" \
+            "{\"runId\":\"$CATALOG_RUN\",\"token\":\"$label\"}" \
+            > "$CATALOG_TMP_DIR/$label.json" 2>&1 || true) &
+        CATALOG_PIDS+=("$!")
+    done
+    for pid in "${CATALOG_PIDS[@]}"; do
+        wait "$pid" || true
+    done
+    for entry in "${CATALOG_ENTRYPOINTS[@]}"; do
+        label="${entry%%|*}"
+        response=$(cat "$CATALOG_TMP_DIR/$label.json")
+        if ! echo "$response" | grep -q '"status":"success"'; then
+            CATALOG_MUTATIONS_OK=false
+            CATALOG_MUTATION_DETAILS="$CATALOG_MUTATION_DETAILS $label=$response"
+        fi
+    done
+else
+    CATALOG_ENTRYPOINTS=()
+    CATALOG_MUTATIONS_OK=false
+    CATALOG_MUTATION_DETAILS="subscription did not reach the empty-table state"
+fi
+
+$CATALOG_MUTATIONS_OK \
+    && pass "All six public entrypoints committed concurrent first writes" \
+    || fail "Fresh remote table creation failed from a public entrypoint" "$CATALOG_MUTATION_DETAILS"
+
+CATALOG_HTTP_OK=true
+CATALOG_HTTP_DETAILS=""
+docker pause docker-nats-1 > /dev/null 2>&1
+for entry in "${CATALOG_ENTRYPOINTS[@]}"; do
+    IFS='|' read -r label url key <<< "$entry"
+    response=$(curl --max-time 10 -s "$url/api/query" \
+        -H "Authorization: Convex $key" \
+        -H "Content-Type: application/json" \
+        -d "{\"path\":\"messages:catalogProbeTokens\",\"args\":{\"runId\":\"$CATALOG_RUN\"}}" \
+        2>/dev/null || true)
+    tokens=$(python3 -c 'import json,sys; print(",".join(json.load(sys.stdin)["value"]))' \
+        <<< "$response" 2>/dev/null || echo parse-error)
+    if [ "$tokens" != "$CATALOG_EXPECTED" ]; then
+        CATALOG_HTTP_OK=false
+        CATALOG_HTTP_DETAILS="$CATALOG_HTTP_DETAILS $label=$tokens response=$response;"
+    fi
+done
+
+CATALOG_SUB_STATUS=124
+if [ -n "$CATALOG_SUB_PID" ]; then
+    for _ in $(seq 1 100); do
+        if ! kill -0 "$CATALOG_SUB_PID" 2>/dev/null; then
+            CATALOG_SUB_STATUS=0
+            wait "$CATALOG_SUB_PID" || CATALOG_SUB_STATUS=$?
+            break
+        fi
+        sleep 0.1
+    done
+fi
+
+docker unpause docker-nats-1 > /dev/null 2>&1 || true
+if $CATALOG_COORDINATOR_FOUND; then
+    set_jetstream_consumer_pause "$CATALOG_NATS_CONSUMER" 0
+fi
+if [ "$CATALOG_SUB_STATUS" -eq 124 ] && [ -n "$CATALOG_SUB_PID" ]; then
+    kill "$CATALOG_SUB_PID" 2>/dev/null || true
+    wait "$CATALOG_SUB_PID" 2>/dev/null || true
+fi
+
+$CATALOG_HTTP_OK \
+    && pass "All six entrypoints immediately resolved catalog and data with NATS unavailable" \
+    || fail "Immediate post-commit read depended on NATS catalog propagation" "$CATALOG_HTTP_DETAILS"
+
+if [ "$CATALOG_SUB_STATUS" -eq 0 ] && \
+    grep -q '"event":"complete"' "$CATALOG_SUB_LOG" && \
+    ! grep -Eq '"event":"(error|duplicate|timeout|unexpected-initial)"' "$CATALOG_SUB_LOG"; then
+    pass "WebSocket subscription crossed first table creation without a catalog gap"
+else
+    fail "WebSocket subscription missed or duplicated the first remote table commit" \
+        "$(tr '\n' ' ' < "$CATALOG_SUB_LOG")"
+fi
+
+CATALOG_FAILOVER_OK=false
+CATALOG_FAILOVER_DETAILS=""
+if $CATALOG_COORDINATOR_FOUND; then
+    docker stop "$CATALOG_COORDINATOR_CONTAINER" > /dev/null 2>&1
+    CATALOG_NEW_COORDINATOR_URL=""
+    CATALOG_NEW_COORDINATOR_KEY=""
+    for _ in $(seq 1 80); do
+        for entry in \
+            "docker-node-p0a-1|$NODE_P0A_URL|$NODE_P0A_KEY" \
+            "docker-node-p0b-1|$NODE_P0B_URL|$NODE_P0B_KEY" \
+            "docker-node-p0c-1|$NODE_P0C_URL|$NODE_P0C_KEY"; do
+            IFS='|' read -r candidate_container candidate_url candidate_key <<< "$entry"
+            [ "$candidate_container" = "$CATALOG_COORDINATOR_CONTAINER" ] && continue
+            status=$(curl --max-time 1 -s -o /dev/null -w "%{http_code}" \
+                -H "Connection: Upgrade" \
+                -H "Upgrade: websocket" \
+                -H "Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==" \
+                -H "Sec-WebSocket-Version: 13" \
+                "$candidate_url/api/1.34.1/sync" 2>/dev/null || true)
+            if [ "$status" = "101" ]; then
+                CATALOG_NEW_COORDINATOR_URL="$candidate_url"
+                CATALOG_NEW_COORDINATOR_KEY="$candidate_key"
+                break 2
+            fi
+        done
+        sleep 0.25
+    done
+
+    if [ -n "$CATALOG_NEW_COORDINATOR_URL" ]; then
+        response=$(query_with_args "$CATALOG_NEW_COORDINATOR_URL" \
+            "$CATALOG_NEW_COORDINATOR_KEY" "messages:catalogProbeTokens" \
+            "{\"runId\":\"$CATALOG_RUN\"}" 2>/dev/null || true)
+        tokens=$(python3 -c 'import json,sys; print(",".join(json.load(sys.stdin)["value"]))' \
+            <<< "$response" 2>/dev/null || echo parse-error)
+        if [ "$tokens" = "$CATALOG_EXPECTED" ]; then
+            CATALOG_FAILOVER_OK=true
+        else
+            CATALOG_FAILOVER_DETAILS="tokens=$tokens response=$response"
+        fi
+    else
+        CATALOG_FAILOVER_DETAILS="no replacement partition-0 leader elected"
+    fi
+
+    docker start "$CATALOG_COORDINATOR_CONTAINER" > /dev/null 2>&1
+    for _ in $(seq 1 60); do
+        curl --max-time 2 -sf "$CATALOG_COORDINATOR_URL/version" > /dev/null 2>&1 && break
+        sleep 0.5
+    done
+    case "$CATALOG_COORDINATOR_CONTAINER" in
+        docker-node-p0a-1)
+            NODE_P0A_KEY=$(docker exec docker-node-p0a-1 ./generate_admin_key.sh 2>&1 | tail -1)
+            NODE_A_KEY="$NODE_P0A_KEY"
+            ;;
+        docker-node-p0b-1)
+            NODE_P0B_KEY=$(docker exec docker-node-p0b-1 ./generate_admin_key.sh 2>&1 | tail -1)
+            ;;
+        docker-node-p0c-1)
+            NODE_P0C_KEY=$(docker exec docker-node-p0c-1 ./generate_admin_key.sh 2>&1 | tail -1)
+            ;;
+    esac
+else
+    CATALOG_FAILOVER_DETAILS="initial partition-0 leader was not found"
+fi
+
+$CATALOG_FAILOVER_OK \
+    && pass "Fresh remote catalog survived partition-0 leader failover" \
+    || fail "Catalog was not Raft-durable across coordinator failover" "$CATALOG_FAILOVER_DETAILS"
+
+rm -f "$CATALOG_SUB_LOG"
+rm -rf "$CATALOG_TMP_DIR"
 
 # --- Baseline: capture existing counts before tests ---
 

--- a/self-hosted/docker/test-write-scaling.sh
+++ b/self-hosted/docker/test-write-scaling.sh
@@ -691,7 +691,7 @@ mutate() {
 }
 
 mutation_response() {
-    curl -s "$1/api/mutation" \
+    curl --max-time 60 -s "$1/api/mutation" \
         -H "Authorization: Convex $2" \
         -H "Content-Type: application/json" \
         -d "{\"path\":\"$3\",\"args\":$4}"


### PR DESCRIPTION
## Summary

- route implicit remote-table catalog writes through the partition-0 authority before owner data commits
- make catalog prepare, rollback, retry, and replay paths Raft-safe and idempotent across leader changes
- notify the subscription authority directly after remote commits so first-table subscriptions do not depend on NATS fanout
- return remote mutation acknowledgements with portable owner-partition fences instead of waiting for local JetStream materialization
- add focused database, service, subscription, replay, and end-to-end cluster coverage

## Root cause

Implicit table creation crossed two independent partition commit paths. Catalog metadata, owner data, Raft replay, and subscription invalidation could therefore race, especially when NATS was delayed or a leader changed. The final response path also waited for the coordinator local replica even after the owner had durably committed, causing a false 503 after success.

## Semantics preserved

A successful first write now means the canonical catalog is Raft-committed by the authority and the row is Raft-committed by its owner. Prepared state remains hidden, concurrent same-name creation stays strict, subscriptions are invalidated without relying on NATS, and read-after-write remains enforced by the returned owner/participant fence token.

## Validation

- cargo test -p database: 609 passed, 0 failed, 2 ignored
- cargo test -p local_backend: 107 passed, 0 failed
- exact local image sha256:354ba375402955c5da8d072e160b832701d26a4f52f2a8b2a1b086e4f4619cc8, OCI revision da554f81a0a6b704f197ac33593e7430ac0802fc
- fresh six-node cluster, --pull never: 156/156 write-scaling checks passed
- same cluster: 24/24 Raft failover checks passed

Fixes #298