### PR TITLE
fix(replication): fail closed on poison deltas

### DIFF
--- a/crates/common/src/persistence.rs
+++ b/crates/common/src/persistence.rs
@@ -195,6 +195,11 @@ pub enum PersistenceGlobalKey {
     /// stream sequences for compact redelivery detection.
     AppliedDataDeltaIds,
 
+    /// Node-local marker for a correctness-critical replication event that
+    /// could not be decoded or applied. A marked node must be re-bootstrapped
+    /// before serving again, so this must not be copied into checkpoints.
+    ReplicationPoisonGap,
+
     /// Latest snapshot of all tables' summaries, cached to speed up startup.
     TableSummary,
 
@@ -251,6 +256,7 @@ impl From<PersistenceGlobalKey> for String {
                 "applied_data_delta_watermarks".to_string()
             },
             PersistenceGlobalKey::AppliedDataDeltaIds => "applied_data_delta_ids".to_string(),
+            PersistenceGlobalKey::ReplicationPoisonGap => "replication_poison_gap".to_string(),
             PersistenceGlobalKey::TableSummary => "table_summary".to_string(),
             PersistenceGlobalKey::TwoPhaseRedoRecords => "two_phase_redo_records".to_string(),
             PersistenceGlobalKey::RaftNatsOutbox => "raft_nats_outbox".to_string(),
@@ -280,6 +286,7 @@ impl FromStr for PersistenceGlobalKey {
             "applied_delta_watermarks" => Ok(Self::AppliedDeltaWatermarks),
             "applied_data_delta_watermarks" => Ok(Self::AppliedDataDeltaWatermarks),
             "applied_data_delta_ids" => Ok(Self::AppliedDataDeltaIds),
+            "replication_poison_gap" => Ok(Self::ReplicationPoisonGap),
             "table_summary" => Ok(Self::TableSummary),
             "two_phase_redo_records" => Ok(Self::TwoPhaseRedoRecords),
             "raft_nats_outbox" => Ok(Self::RaftNatsOutbox),
@@ -308,6 +315,7 @@ impl PersistenceGlobalKey {
                     Self::TwoPhaseRedoRecords
                         | Self::RaftNatsOutbox
                         | Self::ClusterGenesisRaftApplied
+                        | Self::ReplicationPoisonGap
                 )
             })
             .collect()
@@ -1054,5 +1062,13 @@ mod tests {
             let parse_key = s.parse().unwrap();
             assert_eq!(key, parse_key);
         }
+    }
+
+    #[test]
+    fn replication_poison_gap_is_node_local() {
+        assert!(
+            !PersistenceGlobalKey::checkpoint_keys()
+                .contains(&PersistenceGlobalKey::ReplicationPoisonGap)
+        );
     }
 }

--- a/crates/database/src/commit_delta.rs
+++ b/crates/database/src/commit_delta.rs
@@ -122,6 +122,80 @@ impl fmt::Display for RetryableReplicaApplyError {
 
 impl Error for RetryableReplicaApplyError {}
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq, serde::Deserialize, serde::Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ReplicationPoisonKind {
+    RetentionGap,
+    MalformedEnvelope,
+    UnsupportedEnvelopeVersion,
+    InvalidDeltaPayload,
+    DeterministicApplyFailure,
+}
+
+/// Durable evidence that a replica cannot prove it has applied a contiguous
+/// replication prefix. Serving past this point could expose stale reads or
+/// validate writes against incomplete state, so callers must fail the node
+/// closed and rebootstrap its local persistence.
+#[derive(Clone, Debug, Eq, PartialEq, serde::Deserialize, serde::Serialize)]
+pub struct ReplicationPoisonGap {
+    pub kind: ReplicationPoisonKind,
+    pub consumer: Option<String>,
+    pub subject: Option<String>,
+    pub stream_sequence: Option<u64>,
+    pub source_node: Option<String>,
+    pub source_partition: Option<u32>,
+    pub origin_ts: Option<u64>,
+    pub reason: String,
+}
+
+impl ReplicationPoisonGap {
+    pub fn new(
+        kind: ReplicationPoisonKind,
+        consumer: Option<String>,
+        subject: Option<String>,
+        stream_sequence: Option<u64>,
+        source_node: Option<String>,
+        source_partition: Option<PartitionId>,
+        origin_ts: Option<Timestamp>,
+        reason: impl Into<String>,
+    ) -> Self {
+        Self {
+            kind,
+            consumer,
+            subject,
+            stream_sequence,
+            source_node,
+            source_partition: source_partition.map(|partition| partition.0),
+            origin_ts: origin_ts.map(u64::from),
+            reason: reason.into(),
+        }
+    }
+}
+
+impl fmt::Display for ReplicationPoisonGap {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "replication poison gap ({:?}): consumer={:?}, subject={:?}, stream_sequence={:?}, \
+             source_node={:?}, source_partition={:?}, origin_ts={:?}: {}",
+            self.kind,
+            self.consumer,
+            self.subject,
+            self.stream_sequence,
+            self.source_node,
+            self.source_partition,
+            self.origin_ts,
+            self.reason,
+        )
+    }
+}
+
+impl Error for ReplicationPoisonGap {}
+
+pub fn replication_poison_gap(error: &anyhow::Error) -> Option<&ReplicationPoisonGap> {
+    error.downcast_ref::<ReplicationPoisonGap>()
+}
+
 pub struct ReplicationMessage {
     pub delta: CommitDelta,
     transport_id: Option<ReplicationTransportId>,

--- a/crates/database/src/database.rs
+++ b/crates/database/src/database.rs
@@ -1024,6 +1024,17 @@ impl<RT: Runtime> Database<RT> {
 
         // Load data into a DatabaseSnapshot, including indexes.
         let reader = persistence.reader();
+        if let Some(value) = reader
+            .get_persistence_global(PersistenceGlobalKey::ReplicationPoisonGap)
+            .await?
+        {
+            let gap: crate::commit_delta::ReplicationPoisonGap = serde_json::from_value(value)
+                .context("Failed to decode durable replication poison-gap marker")?;
+            return Err(anyhow::Error::new(gap).context(
+                "This node cannot prove a contiguous replication history. Rebootstrap its local \
+                 persistence before serving.",
+            ));
+        }
 
         // Since we hold the lease, update the max repeatable timestamp and get
         // the latest timestamp to perform the load at.

--- a/crates/database/src/nats_distributed_log.rs
+++ b/crates/database/src/nats_distributed_log.rs
@@ -40,6 +40,8 @@ use crate::{
         DistributedLog,
         ReplicationAck,
         ReplicationMessage,
+        ReplicationPoisonGap,
+        ReplicationPoisonKind,
         ReplicationTransportId,
     },
     metrics,
@@ -56,6 +58,45 @@ const STREAM_NAME: &str = "CONVEX_COMMITS";
 const SUBJECT_BASE: &str = "convex.commits";
 const SYSTEM_TABLE_SUBJECT: &str = "convex.commits.system";
 const FRONTIER_HEARTBEAT_SUBJECT: &str = "convex.commits.frontier_heartbeat";
+const DELTA_ENVELOPE_SCHEMA_VERSION: u32 = 1;
+const POISON_REDELIVERY_DELAY: Duration = Duration::from_secs(30);
+
+const fn default_delta_envelope_schema_version() -> u32 {
+    DELTA_ENVELOPE_SCHEMA_VERSION
+}
+
+type EnvelopePoison = (ReplicationPoisonKind, String);
+
+fn deserialize_delta_envelope(payload: &[u8]) -> Result<DeltaEnvelope, EnvelopePoison> {
+    serde_json::from_slice(payload).map_err(|error| {
+        (
+            ReplicationPoisonKind::MalformedEnvelope,
+            format!("failed to deserialize delta envelope: {error}"),
+        )
+    })
+}
+
+fn validate_delta_envelope_version(envelope: &DeltaEnvelope) -> Result<(), EnvelopePoison> {
+    if envelope.schema_version == DELTA_ENVELOPE_SCHEMA_VERSION {
+        return Ok(());
+    }
+    Err((
+        ReplicationPoisonKind::UnsupportedEnvelopeVersion,
+        format!(
+            "unsupported delta envelope schema version {}; expected {}",
+            envelope.schema_version, DELTA_ENVELOPE_SCHEMA_VERSION,
+        ),
+    ))
+}
+
+fn decode_delta_envelope(envelope: DeltaEnvelope) -> Result<CommitDelta, EnvelopePoison> {
+    envelope.to_delta().map_err(|error| {
+        (
+            ReplicationPoisonKind::InvalidDeltaPayload,
+            format!("failed to decode delta payload: {error:#}"),
+        )
+    })
+}
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 struct RetentionGap {
@@ -63,6 +104,17 @@ struct RetentionGap {
     first_retained_sequence: u64,
     ack_floor_stream_sequence: u64,
     delivered_stream_sequence: u64,
+}
+
+async fn reject_poison_message(msg: &JetStreamMessage, gap: ReplicationPoisonGap) -> anyhow::Error {
+    tracing::error!("{gap}");
+    if let Err(ack_err) = msg
+        .ack_with(AckKind::Nak(Some(POISON_REDELIVERY_DELAY)))
+        .await
+    {
+        tracing::warn!("Failed to keep poison NATS message pending for redelivery: {ack_err:?}");
+    }
+    anyhow::Error::new(gap)
 }
 
 /// Configuration for connecting to NATS.
@@ -151,6 +203,7 @@ impl NatsDistributedLog {
                     durable_name: Some(consumer_name.clone()),
                     deliver_policy: jetstream::consumer::DeliverPolicy::All,
                     ack_policy: jetstream::consumer::AckPolicy::Explicit,
+                    max_ack_pending: 1,
                     filter_subjects: filter_subjects.clone().unwrap_or_default(),
                     ..Default::default()
                 },
@@ -177,17 +230,26 @@ impl NatsDistributedLog {
             from_ts,
         ) {
             metrics::log_replication_transport_retention_gap();
-            anyhow::bail!(
-                "NATS replication stream retention gap for consumer '{}': next required stream \
-                 sequence {} is older than first retained sequence {} (ack_floor={}, \
-                 delivered={}, from_ts={}). Rebootstrap from checkpoint before serving.",
-                consumer_name,
-                gap.expected_stream_sequence,
-                gap.first_retained_sequence,
-                gap.ack_floor_stream_sequence,
-                gap.delivered_stream_sequence,
-                from_ts_u64,
-            );
+            return Err(ReplicationPoisonGap::new(
+                ReplicationPoisonKind::RetentionGap,
+                Some(consumer_name.clone()),
+                Some(STREAM_NAME.to_string()),
+                Some(gap.expected_stream_sequence),
+                None,
+                None,
+                None,
+                format!(
+                    "next required stream sequence {} is older than first retained sequence {} \
+                     (ack_floor={}, delivered={}, from_ts={}). Rebootstrap from checkpoint before \
+                     serving",
+                    gap.expected_stream_sequence,
+                    gap.first_retained_sequence,
+                    gap.ack_floor_stream_sequence,
+                    gap.delivered_stream_sequence,
+                    from_ts_u64,
+                ),
+            )
+            .into());
         }
         metrics::log_replication_transport_pending_messages(consumer_info.num_pending);
         metrics::log_replication_transport_stream_sequence(consumer_info.delivered.stream_sequence);
@@ -245,21 +307,42 @@ impl NatsDistributedLog {
                                 None
                             },
                         };
-                        let envelope: DeltaEnvelope = match serde_json::from_slice(&msg.payload) {
+                        let stream_sequence =
+                            transport_id.map(ReplicationTransportId::stream_sequence);
+                        let subject = msg.subject.to_string();
+                        let envelope = match deserialize_delta_envelope(&msg.payload) {
                             Ok(e) => e,
-                            Err(e) => {
-                                tracing::error!("Failed to deserialize delta from NATS: {e}");
-                                if let Err(ack_err) = msg.ack_with(AckKind::Term).await {
-                                    tracing::warn!(
-                                        "Failed to terminate poison NATS message after \
-                                         deserialize error: {ack_err:?}"
-                                    );
-                                }
-                                return Some(Err(anyhow::anyhow!(
-                                    "Failed to deserialize delta: {e}"
-                                )));
+                            Err((kind, reason)) => {
+                                let gap = ReplicationPoisonGap::new(
+                                    kind,
+                                    Some(node_name),
+                                    Some(subject),
+                                    stream_sequence,
+                                    None,
+                                    None,
+                                    None,
+                                    reason,
+                                );
+                                return Some(Err(reject_poison_message(&msg, gap).await));
                             },
                         };
+                        let source_node = (!envelope.source_node.is_empty())
+                            .then(|| envelope.source_node.clone());
+                        let source_partition = envelope.source_partition.map(PartitionId);
+                        let origin_ts = Timestamp::try_from(envelope.ts).ok();
+                        if let Err((kind, reason)) = validate_delta_envelope_version(&envelope) {
+                            let gap = ReplicationPoisonGap::new(
+                                kind,
+                                Some(node_name),
+                                Some(subject),
+                                stream_sequence,
+                                source_node,
+                                source_partition,
+                                origin_ts,
+                                reason,
+                            );
+                            return Some(Err(reject_poison_message(&msg, gap).await));
+                        }
                         if envelope.ts <= from_ts_u64 {
                             if let Err(e) = msg.ack().await {
                                 return Some(Err(anyhow::anyhow!(
@@ -285,17 +368,20 @@ impl NatsDistributedLog {
                             envelope.ts,
                             envelope.source_node,
                         );
-                        let delta = match envelope.to_delta() {
+                        let delta = match decode_delta_envelope(envelope) {
                             Ok(delta) => delta,
-                            Err(e) => {
-                                tracing::error!("Failed to decode NATS delta envelope: {e:#}");
-                                if let Err(ack_err) = msg.ack_with(AckKind::Term).await {
-                                    tracing::warn!(
-                                        "Failed to terminate poison NATS message after delta \
-                                         decode error: {ack_err:?}"
-                                    );
-                                }
-                                return Some(Err(e));
+                            Err((kind, reason)) => {
+                                let gap = ReplicationPoisonGap::new(
+                                    kind,
+                                    Some(node_name),
+                                    Some(subject),
+                                    stream_sequence,
+                                    source_node,
+                                    source_partition,
+                                    origin_ts,
+                                    reason,
+                                );
+                                return Some(Err(reject_poison_message(&msg, gap).await));
                             },
                         };
                         let ack = Box::new(NatsReplicationAck { msg });
@@ -447,8 +533,10 @@ impl ReplicationAck for NatsReplicationAck {
 /// Serializable envelope for transporting CommitDelta over NATS and Raft.
 /// Used by both NatsDistributedLog and the Raft state machine to serialize
 /// deltas for transport between nodes.
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
 pub struct DeltaEnvelope {
+    #[serde(default = "default_delta_envelope_schema_version")]
+    schema_version: u32,
     ts: u64,
     write_source: Option<String>,
     write_bytes: u64,
@@ -493,6 +581,7 @@ impl DeltaEnvelope {
             .collect();
 
         Ok(Self {
+            schema_version: DELTA_ENVELOPE_SCHEMA_VERSION,
             ts: u64::from(delta.ts),
             write_source: delta.write_source.as_str().map(|s| s.to_string()),
             write_bytes: delta.write_bytes,
@@ -505,6 +594,12 @@ impl DeltaEnvelope {
     }
 
     pub fn to_delta(self) -> anyhow::Result<CommitDelta> {
+        anyhow::ensure!(
+            self.schema_version == DELTA_ENVELOPE_SCHEMA_VERSION,
+            "Unsupported delta envelope schema version {}; expected {}",
+            self.schema_version,
+            DELTA_ENVELOPE_SCHEMA_VERSION,
+        );
         let document_updates = self
             .document_updates_proto
             .into_iter()
@@ -665,11 +760,22 @@ impl DistributedLog for NatsDistributedLog {
 mod tests {
     use std::sync::Arc;
 
+    use anyhow::Context;
     use common::types::Timestamp;
 
-    use super::NatsDistributedLog;
+    use super::{
+        decode_delta_envelope,
+        deserialize_delta_envelope,
+        validate_delta_envelope_version,
+        DeltaEnvelope,
+        NatsDistributedLog,
+        DELTA_ENVELOPE_SCHEMA_VERSION,
+    };
     use crate::{
-        commit_delta::CommitDelta,
+        commit_delta::{
+            CommitDelta,
+            ReplicationPoisonKind,
+        },
         partition::PartitionId,
         write_log::WriteSource,
     };
@@ -702,6 +808,86 @@ mod tests {
         let mut no_source = heartbeat.clone();
         no_source.source_partition = None;
         assert!(!NatsDistributedLog::is_frontier_heartbeat_delta(&no_source));
+        Ok(())
+    }
+
+    #[test]
+    fn malformed_envelope_is_classified_as_poison() {
+        let (kind, reason) = deserialize_delta_envelope(br#"{"schema_version":"broken"}"#)
+            .expect_err("invalid JSON types must be rejected");
+
+        assert_eq!(kind, ReplicationPoisonKind::MalformedEnvelope);
+        assert!(reason.contains("failed to deserialize delta envelope"));
+    }
+
+    #[test]
+    fn unknown_envelope_version_is_classified_as_poison() -> anyhow::Result<()> {
+        let delta = CommitDelta {
+            ts: Timestamp::try_from(42u64)?,
+            document_writes: Arc::new(Vec::new()),
+            document_updates: Vec::new(),
+            index_writes: Arc::new(Vec::new()),
+            write_source: WriteSource::unknown(),
+            write_bytes: 0,
+            tablet_id_to_table_name: Default::default(),
+            source_partition: Some(PartitionId(1)),
+        };
+        let mut envelope = DeltaEnvelope::from_delta(&delta, "source", None)?;
+        envelope.schema_version = DELTA_ENVELOPE_SCHEMA_VERSION + 1;
+
+        let (kind, reason) = validate_delta_envelope_version(&envelope)
+            .expect_err("unknown schema versions must be rejected");
+        assert_eq!(kind, ReplicationPoisonKind::UnsupportedEnvelopeVersion);
+        assert!(reason.contains("unsupported delta envelope schema version"));
+        Ok(())
+    }
+
+    #[test]
+    fn retained_unversioned_envelope_is_version_one() -> anyhow::Result<()> {
+        let delta = CommitDelta {
+            ts: Timestamp::try_from(42u64)?,
+            document_writes: Arc::new(Vec::new()),
+            document_updates: Vec::new(),
+            index_writes: Arc::new(Vec::new()),
+            write_source: WriteSource::unknown(),
+            write_bytes: 0,
+            tablet_id_to_table_name: Default::default(),
+            source_partition: Some(PartitionId(1)),
+        };
+        let envelope = DeltaEnvelope::from_delta(&delta, "source", None)?;
+        let mut value = serde_json::to_value(envelope)?;
+        value
+            .as_object_mut()
+            .context("serialized envelope must be an object")?
+            .remove("schema_version");
+        let payload = serde_json::to_vec(&value)?;
+
+        let envelope =
+            deserialize_delta_envelope(&payload).expect("unversioned v1 envelope must decode");
+        validate_delta_envelope_version(&envelope)
+            .expect("unversioned retained envelope must default to v1");
+        Ok(())
+    }
+
+    #[test]
+    fn invalid_document_proto_is_classified_as_poison() -> anyhow::Result<()> {
+        let delta = CommitDelta {
+            ts: Timestamp::try_from(42u64)?,
+            document_writes: Arc::new(Vec::new()),
+            document_updates: Vec::new(),
+            index_writes: Arc::new(Vec::new()),
+            write_source: WriteSource::unknown(),
+            write_bytes: 0,
+            tablet_id_to_table_name: Default::default(),
+            source_partition: Some(PartitionId(1)),
+        };
+        let mut envelope = DeltaEnvelope::from_delta(&delta, "source", None)?;
+        envelope.document_updates_proto.push(vec![0x80]);
+
+        let (kind, reason) =
+            decode_delta_envelope(envelope).expect_err("invalid protobuf must be rejected");
+        assert_eq!(kind, ReplicationPoisonKind::InvalidDeltaPayload);
+        assert!(reason.contains("failed to decode delta payload"));
         Ok(())
     }
 

--- a/crates/database/src/replica.rs
+++ b/crates/database/src/replica.rs
@@ -22,9 +22,12 @@ use futures::{
 
 use crate::{
     commit_delta::{
+        replication_poison_gap,
         CommitDelta,
         DistributedLog,
         ReplicationMessage,
+        ReplicationPoisonGap,
+        ReplicationPoisonKind,
         ReplicationTransportId,
         RetryableReplicaApplyError,
     },
@@ -94,14 +97,8 @@ where
 {
     while let Some(result) = stream.next().await {
         let message = result.context("Error reading from distributed log")?;
-        match apply_message(message).await {
-            Ok((applied_ts, num_updates)) => {
-                after_success(applied_ts, num_updates);
-            },
-            Err(e) => {
-                tracing::error!("Failed to apply replica delta; continuing consumer: {e:#}");
-            },
-        }
+        let (applied_ts, num_updates) = apply_message(message).await?;
+        after_success(applied_ts, num_updates);
     }
 
     anyhow::bail!("ReplicaDeltaConsumer stream ended")
@@ -118,6 +115,7 @@ where
 {
     let (delta, transport_id, ack) = message.into_parts();
     let ts = delta.ts;
+    let source_partition = delta.source_partition;
     let num_updates = delta.document_updates.len();
 
     if let Some(excluded_source_partition) = excluded_source_partition {
@@ -161,10 +159,10 @@ where
                         u64::from(ts),
                     );
                 }
-                anyhow::bail!(
-                    "Retryable failure applying replica delta at ts={}: {e:#}",
+                return Err(e.context(format!(
+                    "Retryable failure applying replica delta at ts={}",
                     u64::from(ts),
-                );
+                )));
             }
             tracing::error!(
                 "Failed to apply replica delta at ts={}: {e:#}",
@@ -176,10 +174,17 @@ where
                     u64::from(ts),
                 );
             }
-            anyhow::bail!(
-                "Failed to apply replica delta at ts={}: {e:#}",
-                u64::from(ts)
-            );
+            Err(ReplicationPoisonGap::new(
+                ReplicationPoisonKind::DeterministicApplyFailure,
+                None,
+                None,
+                transport_id.map(ReplicationTransportId::stream_sequence),
+                None,
+                source_partition,
+                Some(ts),
+                format!("failed to apply replica delta: {e:#}"),
+            )
+            .into())
         },
     }
 }
@@ -222,6 +227,13 @@ impl ReplicaDeltaConsumer {
                     tracing::warn!("ReplicaDeltaConsumer exited cleanly; restarting");
                 },
                 Err(e) => {
+                    if replication_poison_gap(&e).is_some() {
+                        tracing::error!(
+                            "ReplicaDeltaConsumer encountered a fatal replication gap and will \
+                             not restart: {e:#}"
+                        );
+                        return;
+                    }
                     tracing::error!(
                         "ReplicaDeltaConsumer failed; restarting after {:?}: {e:#}",
                         backoff,
@@ -285,9 +297,12 @@ mod tests {
     };
     use crate::{
         commit_delta::{
+            replication_poison_gap,
             CommitDelta,
             ReplicationAck,
             ReplicationMessage,
+            ReplicationPoisonGap,
+            ReplicationPoisonKind,
             RetryableReplicaApplyError,
         },
         partition::PartitionId,
@@ -421,10 +436,9 @@ mod tests {
         .unwrap_err();
 
         let message = format!("{err:#}");
-        assert!(
-            message.contains("Failed to apply replica delta"),
-            "{message}"
-        );
+        let gap = replication_poison_gap(&err).expect("apply failure must become a poison gap");
+        assert_eq!(gap.kind, ReplicationPoisonKind::DeterministicApplyFailure);
+        assert!(message.contains("replication poison gap"), "{message}");
         assert!(message.contains("forced apply failure"), "{message}");
         assert_eq!(counts.ack.load(Ordering::SeqCst), 0);
         assert_eq!(counts.nak.load(Ordering::SeqCst), 1);
@@ -513,7 +527,8 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn consumer_continues_after_retryable_apply_failure() -> anyhow::Result<()> {
+    async fn consumer_stops_before_later_delta_after_retryable_apply_failure() -> anyhow::Result<()>
+    {
         let counts = Arc::new(AckCounts::default());
         let first_ts = Timestamp::try_from(42u64)?;
         let second_ts = Timestamp::try_from(43u64)?;
@@ -522,13 +537,18 @@ mod tests {
         let successes_for_callback = successes.clone();
         let stream = futures::stream::iter(vec![
             Ok(test_message(first_ts, counts.clone())),
-            Ok(test_message(second_ts, counts.clone())),
+            Ok(test_message_from_partition(
+                second_ts,
+                Some(PartitionId(1)),
+                counts.clone(),
+            )),
         ]);
+        let attempts_for_consumer = attempts.clone();
 
         let err = consume_replication_stream_with(
             Box::pin(stream),
             move |message| {
-                let attempts = attempts.clone();
+                let attempts = attempts_for_consumer.clone();
                 async move {
                     apply_replication_message_with(message, None, |delta, _transport_id| {
                         let attempts = attempts.clone();
@@ -552,14 +572,16 @@ mod tests {
         .await
         .expect_err("finite test stream should report stream end");
 
-        assert!(
-            format!("{err:#}").contains("ReplicaDeltaConsumer stream ended"),
-            "unexpected error: {err:#}",
-        );
-        assert_eq!(counts.ack.load(Ordering::SeqCst), 1);
+        assert!(format!("{err:#}").contains("Retryable failure applying replica delta"));
+        assert_eq!(attempts.load(Ordering::SeqCst), 1);
+        assert_eq!(counts.ack.load(Ordering::SeqCst), 0);
         assert_eq!(counts.nak.load(Ordering::SeqCst), 0);
         assert_eq!(counts.delayed_nak.load(Ordering::SeqCst), 1);
-        assert_eq!(successes.load(Ordering::SeqCst), 1);
+        assert_eq!(
+            successes.load(Ordering::SeqCst),
+            0,
+            "later frontier heartbeat must not cross the blocked delta",
+        );
         Ok(())
     }
 
@@ -593,7 +615,8 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn consumer_continues_after_apply_failure() -> anyhow::Result<()> {
+    async fn consumer_fails_closed_before_heartbeat_after_deterministic_apply_failure(
+    ) -> anyhow::Result<()> {
         let counts = Arc::new(AckCounts::default());
         let first_ts = Timestamp::try_from(42u64)?;
         let second_ts = Timestamp::try_from(43u64)?;
@@ -602,13 +625,18 @@ mod tests {
         let successes_for_callback = successes.clone();
         let stream = futures::stream::iter(vec![
             Ok(test_message(first_ts, counts.clone())),
-            Ok(test_message(second_ts, counts.clone())),
+            Ok(test_message_from_partition(
+                second_ts,
+                Some(PartitionId(1)),
+                counts.clone(),
+            )),
         ]);
+        let attempts_for_consumer = attempts.clone();
 
         let err = consume_replication_stream_with(
             Box::pin(stream),
             move |message| {
-                let attempts = attempts.clone();
+                let attempts = attempts_for_consumer.clone();
                 async move {
                     apply_replication_message_with(message, None, |delta, _transport_id| {
                         let attempts = attempts.clone();
@@ -629,14 +657,81 @@ mod tests {
         .await
         .expect_err("finite test stream should report stream end");
 
-        assert!(
-            format!("{err:#}").contains("ReplicaDeltaConsumer stream ended"),
-            "unexpected error: {err:#}",
+        let gap = replication_poison_gap(&err).expect("apply failure must become a poison gap");
+        assert_eq!(gap.kind, ReplicationPoisonKind::DeterministicApplyFailure);
+        assert_eq!(
+            attempts.load(Ordering::SeqCst),
+            1,
+            "consumer must stop before applying the later heartbeat",
         );
-        assert_eq!(counts.ack.load(Ordering::SeqCst), 1);
+        assert_eq!(counts.ack.load(Ordering::SeqCst), 0);
         assert_eq!(counts.nak.load(Ordering::SeqCst), 1);
         assert_eq!(counts.delayed_nak.load(Ordering::SeqCst), 0);
-        assert_eq!(successes.load(Ordering::SeqCst), 1);
+        assert_eq!(
+            successes.load(Ordering::SeqCst),
+            0,
+            "frontier callback must not advance beyond a poisoned delta",
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn transport_poison_stops_before_following_heartbeat() -> anyhow::Result<()> {
+        for kind in [
+            ReplicationPoisonKind::MalformedEnvelope,
+            ReplicationPoisonKind::UnsupportedEnvelopeVersion,
+            ReplicationPoisonKind::InvalidDeltaPayload,
+        ] {
+            let counts = Arc::new(AckCounts::default());
+            let attempts = Arc::new(AtomicUsize::new(0));
+            let successes = Arc::new(AtomicUsize::new(0));
+            let heartbeat_ts = Timestamp::try_from(43u64)?;
+            let gap = ReplicationPoisonGap::new(
+                kind,
+                Some("node-1".to_string()),
+                Some("convex.commits.0".to_string()),
+                Some(42),
+                Some("node-0".to_string()),
+                Some(PartitionId(0)),
+                Some(Timestamp::try_from(42u64)?),
+                "forced transport poison",
+            );
+            let stream = futures::stream::iter(vec![
+                Err(anyhow::Error::new(gap.clone())),
+                Ok(test_message_from_partition(
+                    heartbeat_ts,
+                    Some(PartitionId(0)),
+                    counts.clone(),
+                )),
+            ]);
+            let attempts_for_consumer = attempts.clone();
+            let successes_for_callback = successes.clone();
+
+            let error = consume_replication_stream_with(
+                Box::pin(stream),
+                move |_message| {
+                    let attempts = attempts_for_consumer.clone();
+                    async move {
+                        attempts.fetch_add(1, Ordering::SeqCst);
+                        Ok((heartbeat_ts, 0))
+                    }
+                },
+                move |_ts, _num_updates| {
+                    successes_for_callback.fetch_add(1, Ordering::SeqCst);
+                },
+            )
+            .await
+            .expect_err("transport poison must terminate the consumer");
+
+            assert_eq!(replication_poison_gap(&error), Some(&gap));
+            assert_eq!(attempts.load(Ordering::SeqCst), 0);
+            assert_eq!(successes.load(Ordering::SeqCst), 0);
+            assert_eq!(
+                counts.ack.load(Ordering::SeqCst),
+                0,
+                "heartbeat after {kind:?} must remain unacknowledged",
+            );
+        }
         Ok(())
     }
 }

--- a/crates/database/src/tests/replication_tests.rs
+++ b/crates/database/src/tests/replication_tests.rs
@@ -3,6 +3,10 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use common::{
     assert_obj,
+    persistence::{
+        Persistence,
+        PersistenceGlobalKey,
+    },
     runtime::{
         new_unlimited_rate_limiter,
         testing::TestRuntime,
@@ -23,6 +27,8 @@ use crate::{
         CommitDelta,
         DistributedLog,
         ReplicationMessage,
+        ReplicationPoisonGap,
+        ReplicationPoisonKind,
     },
     Database,
     TestFacingModel,
@@ -32,11 +38,18 @@ async fn load_test_primary(
     rt: &TestRuntime,
     distributed_log: Arc<dyn DistributedLog>,
 ) -> anyhow::Result<Database<TestRuntime>> {
-    let tp = Arc::new(TestPersistence::new());
+    load_test_primary_with_persistence(rt, Arc::new(TestPersistence::new()), distributed_log).await
+}
+
+async fn load_test_primary_with_persistence(
+    rt: &TestRuntime,
+    persistence: Arc<dyn Persistence>,
+    distributed_log: Arc<dyn DistributedLog>,
+) -> anyhow::Result<Database<TestRuntime>> {
     let searcher: Arc<dyn search::Searcher> = Arc::new(SearcherStub {});
     let (deleted_tablet_sender, _) = tokio::sync::mpsc::channel(100);
     let primary = Database::load(
-        tp,
+        persistence,
         rt.clone(),
         searcher,
         ShutdownSignal::no_op(),
@@ -59,6 +72,49 @@ async fn load_test_primary(
     let handle = primary.start_search_and_vector_bootstrap();
     handle.join().await?;
     Ok(primary)
+}
+
+#[convex_macro::test_runtime]
+async fn test_database_rejects_persisted_replication_poison_gap(
+    rt: TestRuntime,
+) -> anyhow::Result<()> {
+    let persistence = Arc::new(TestPersistence::new());
+    let gap = ReplicationPoisonGap::new(
+        ReplicationPoisonKind::MalformedEnvelope,
+        Some("node-1".to_string()),
+        Some("convex.commits.0".to_string()),
+        Some(42),
+        Some("node-0".to_string()),
+        Some(crate::partition::PartitionId(0)),
+        Some(Timestamp::try_from(100u64)?),
+        "invalid JSON",
+    );
+    persistence
+        .write_persistence_global(
+            PersistenceGlobalKey::ReplicationPoisonGap,
+            serde_json::to_value(&gap)?,
+        )
+        .await?;
+
+    let error = match load_test_primary_with_persistence(
+        &rt,
+        persistence,
+        Arc::new(InMemoryDistributedLog::new()),
+    )
+    .await
+    {
+        Ok(_) => anyhow::bail!("database must not start with a poison-gap marker"),
+        Err(error) => error,
+    };
+    let recovered_gap = error
+        .downcast_ref::<ReplicationPoisonGap>()
+        .expect("startup error must retain the poison-gap type");
+    assert_eq!(recovered_gap, &gap);
+    assert!(
+        format!("{error:#}").contains("Rebootstrap its local persistence before serving"),
+        "{error:#}",
+    );
+    Ok(())
 }
 
 struct FailingPublishDistributedLog;

--- a/crates/local_backend/src/lib.rs
+++ b/crates/local_backend/src/lib.rs
@@ -579,6 +579,38 @@ async fn record_raft_applied_genesis(
     .await
 }
 
+async fn fail_closed_on_replication_poison(
+    persistence: &Arc<dyn Persistence>,
+    preempt_tx: &ShutdownSignal,
+    error: anyhow::Error,
+) -> Option<anyhow::Error> {
+    let Some(gap) = database::commit_delta::replication_poison_gap(&error).cloned() else {
+        return Some(error);
+    };
+    let marker_result = async {
+        let marker = serde_json::to_value(&gap)?;
+        persistence
+            .write_persistence_global(
+                common::persistence::PersistenceGlobalKey::ReplicationPoisonGap,
+                marker,
+            )
+            .await
+    }
+    .await;
+    let fatal_error = match marker_result {
+        Ok(()) => error.context(
+            "Persisted a replication poison-gap marker and failed this node closed. Rebootstrap \
+             its local persistence before serving.",
+        ),
+        Err(marker_error) => error.context(format!(
+            "Failed this node closed after a replication poison gap, but could not persist the \
+             poison marker: {marker_error:#}"
+        )),
+    };
+    preempt_tx.signal(fatal_error);
+    None
+}
+
 async fn prepare_cluster_genesis(
     runtime: &ProdRuntime,
     database: &Database<ProdRuntime>,
@@ -1425,6 +1457,8 @@ pub async fn make_app(
                 config.partition_id.map(database::partition::PartitionId);
             let consumer_runtime = runtime.clone();
             let consumer_genesis_ready = cluster_genesis_ready.clone();
+            let consumer_persistence = persistence.clone();
+            let consumer_preempt_tx = preempt_tx.clone();
             runtime.spawn_background("replica_delta_consumer_setup", async move {
                 while !consumer_genesis_ready.load(Ordering::SeqCst) {
                     consumer_runtime.wait(Duration::from_millis(100)).await;
@@ -1473,6 +1507,15 @@ pub async fn make_app(
                             )
                             .await;
                             if let Err(e) = result {
+                                let Some(e) = fail_closed_on_replication_poison(
+                                    &consumer_persistence,
+                                    &consumer_preempt_tx,
+                                    e,
+                                )
+                                .await
+                                else {
+                                    return;
+                                };
                                 tracing::error!(
                                     "ReplicaDeltaConsumer stream failed; restarting after {:?}: \
                                      {e:#}",
@@ -1486,6 +1529,15 @@ pub async fn make_app(
                             }
                         },
                         Err(e) => {
+                            let Some(e) = fail_closed_on_replication_poison(
+                                &consumer_persistence,
+                                &consumer_preempt_tx,
+                                e,
+                            )
+                            .await
+                            else {
+                                return;
+                            };
                             tracing::error!(
                                 "Failed to subscribe to NATS; retrying after {:?}: {e:#}",
                                 backoff,
@@ -1851,10 +1903,13 @@ mod tests {
         sync::Arc,
     };
 
+    use anyhow::Context;
     use common::{
         assert_obj,
         persistence::{
             NoopRetentionValidator,
+            Persistence,
+            PersistenceGlobalKey,
             PersistenceReader,
             TimestampRange,
         },
@@ -1896,6 +1951,49 @@ mod tests {
             local_snapshot_ts,
         );
 
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn replication_poison_is_persisted_before_fatal_shutdown() -> anyhow::Result<()> {
+        let persistence: Arc<dyn Persistence> = Arc::new(TestPersistence::new());
+        let gap = database::commit_delta::ReplicationPoisonGap::new(
+            database::commit_delta::ReplicationPoisonKind::InvalidDeltaPayload,
+            Some("node-1".to_string()),
+            Some("convex.commits.0".to_string()),
+            Some(42),
+            Some("node-0".to_string()),
+            Some(database::partition::PartitionId(0)),
+            Some(Timestamp::try_from(100u64)?),
+            "invalid protobuf",
+        );
+        let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel();
+        let shutdown = ShutdownSignal::new(shutdown_tx);
+
+        let retry_error = super::fail_closed_on_replication_poison(
+            &persistence,
+            &shutdown,
+            anyhow::Error::new(gap.clone()),
+        )
+        .await;
+        assert!(
+            retry_error.is_none(),
+            "poison gaps must not return to the retry loop"
+        );
+
+        let fatal_error = shutdown_rx.await?;
+        assert_eq!(
+            fatal_error.downcast_ref::<database::commit_delta::ReplicationPoisonGap>(),
+            Some(&gap),
+        );
+        let persisted = persistence
+            .reader()
+            .get_persistence_global(PersistenceGlobalKey::ReplicationPoisonGap)
+            .await?
+            .context("poison marker must be persisted before shutdown")?;
+        let persisted_gap: database::commit_delta::ReplicationPoisonGap =
+            serde_json::from_value(persisted)?;
+        assert_eq!(persisted_gap, gap);
         Ok(())
     }
 


### PR DESCRIPTION
## Summary

- version and classify correctness-critical replication envelopes
- keep malformed, unsupported, invalid-payload, and deterministic-apply failures pending instead of terminating and consuming past them
- stop the consumer at the first gap, persist a node-local poison marker, and trigger fatal backend shutdown
- reject startup while the durable marker exists so recovery requires local persistence rebootstrap
- keep retryable transport/apply failures on the supervised reconnect path

## Why

The previous TERM-and-continue behavior could permanently discard one delta and then consume a later heartbeat. That allowed the replication frontier to advance across missing state, so the node could claim freshness and serve incorrect reads. A correctness-critical stream must never cross an unprocessed entry.

## Correctness contract

- poison entries remain pending with delayed NAK delivery
- each durable consumer has `max_ack_pending = 1`
- no later delta or heartbeat is consumed after a poison gap
- the persisted marker is node-local and excluded from checkpoints
- legacy envelopes with no version remain version 1; unknown future versions fail closed

## Validation

- `cargo test -p common --lib`: 331 passed, 1 ignored
- `cargo test -p database --lib`: 615 passed, 2 ignored
- `cargo test -p local_backend --lib`: 108 passed
- exact local image: `sha256:1e61882ff147705a5b4b3a2bafee42dde17ce88aa7e9b9847783c886501b95e3`
- embedded revision: `7518d945c3274a0c833b0d44da2875764d3209bf`
- fresh six-node Docker write-scaling suite: 156/156 passed
- Docker Raft failover suite: 24/24 passed
- full harness: ALL SUITES PASSED

Fixes #279