### PR TITLE
fix: harden authority routing and commit acknowledgements

### DIFF
--- a/crates/database/src/committer.rs
+++ b/crates/database/src/committer.rs
@@ -1810,9 +1810,12 @@ impl<RT: Runtime> Committer<RT> {
                             let use_raft_nats_outbox =
                                 Self::should_record_raft_nats_outbox_delta(&published_commit.delta);
                             if use_raft_nats_outbox {
-                                if let Err(err) = Self::record_and_replay_raft_nats_outbox_delta(
+                                // Raft has accepted this write. Durably enqueue cross-partition
+                                // delivery before acknowledging it, but do not make client success
+                                // depend on NATS availability. The ordered replay loop publishes the
+                                // outbox after transport recovery.
+                                if let Err(err) = Self::record_raft_nats_outbox_delta(
                                     self.persistence.clone(),
-                                    self.distributed_log.clone(),
                                     &published_commit.delta,
                                     "local",
                                 )
@@ -1959,9 +1962,11 @@ impl<RT: Runtime> Committer<RT> {
                             let use_raft_nats_outbox =
                                 Self::should_record_raft_nats_outbox_delta(&published_commit.delta);
                             if use_raft_nats_outbox {
-                                if let Err(err) = Self::record_and_replay_raft_nats_outbox_delta(
+                                // The 2PC decision is final once the participant commits. Keep NATS
+                                // publication outside that acknowledgement boundary while retaining
+                                // the delta durably for ordered replay.
+                                if let Err(err) = Self::record_raft_nats_outbox_delta(
                                     self.persistence.clone(),
-                                    self.distributed_log.clone(),
                                     &published_commit.delta,
                                     "2pc_participant",
                                 )
@@ -4204,23 +4209,6 @@ impl<RT: Runtime> Committer<RT> {
             replayed += 1;
         }
         Ok(replayed)
-    }
-
-    async fn record_and_replay_raft_nats_outbox_delta(
-        persistence: Arc<dyn Persistence>,
-        distributed_log: Arc<dyn DistributedLog>,
-        delta: &CommitDelta,
-        path: &'static str,
-    ) -> anyhow::Result<()> {
-        Self::record_raft_nats_outbox_delta(persistence.clone(), delta, path).await?;
-        if let Err(err) = Self::replay_raft_nats_outbox_once(persistence, distributed_log).await {
-            tracing::error!(
-                "Failed to publish committed write at ts={} to replication log through ordered \
-                 Raft->NATS outbox; leaving outbox entries for replay: {err:#}",
-                u64::from(delta.ts),
-            );
-        }
-        Ok(())
     }
 
     fn should_record_raft_nats_outbox_delta(delta: &CommitDelta) -> bool {
@@ -8942,6 +8930,44 @@ mod tests {
                 .await?
                 .len(),
             1
+        );
+
+        log.allow_publishes();
+        let replayed = Committer::<TestRuntime>::replay_raft_nats_outbox_once(
+            persistence.clone(),
+            log.clone(),
+        )
+        .await?;
+        assert_eq!(replayed, 1);
+        assert_eq!(log.published(), vec![ts]);
+        assert!(
+            Committer::<TestRuntime>::load_raft_nats_outbox_records(persistence)
+                .await?
+                .is_empty()
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn raft_nats_outbox_record_does_not_publish_synchronously() -> anyhow::Result<()> {
+        let persistence: Arc<dyn Persistence> = Arc::new(TestPersistence::new());
+        let log = Arc::new(RecordingDistributedLog::failing());
+        let ts = Timestamp::must(13);
+
+        Committer::<TestRuntime>::record_raft_nats_outbox_delta(
+            persistence.clone(),
+            &test_outbox_delta(ts),
+            "test",
+        )
+        .await?;
+
+        assert_eq!(log.published(), Vec::<Timestamp>::new());
+        assert_eq!(
+            Committer::<TestRuntime>::load_raft_nats_outbox_records(persistence.clone())
+                .await?
+                .len(),
+            1,
+            "the accepted write must be durable without waiting for NATS",
         );
 
         log.allow_publishes();

--- a/crates/database/src/committer.rs
+++ b/crates/database/src/committer.rs
@@ -1348,6 +1348,8 @@ pub struct Committer<RT: Runtime> {
     // None means single-node mode (local clock, existing behavior).
     timestamp_oracle: Option<Arc<dyn crate::timestamp_oracle::TimestampOracle>>,
     maintenance_tso_refill_in_flight: Arc<AtomicBool>,
+    pending_tso_committed_floor: Arc<Mutex<Timestamp>>,
+    tso_committed_floor_flush_in_flight: Arc<AtomicBool>,
 
     // 2PC prepared transactions awaiting CommitPrepared or RollbackPrepared.
     // Keyed by TwoPhaseTransactionId, storing the prepared intent and metadata
@@ -1533,6 +1535,8 @@ impl<RT: Runtime> Committer<RT> {
             placement_state,
             timestamp_oracle,
             maintenance_tso_refill_in_flight: Arc::new(AtomicBool::new(false)),
+            pending_tso_committed_floor: Arc::new(Mutex::new(Timestamp::MIN)),
+            tso_committed_floor_flush_in_flight: Arc::new(AtomicBool::new(false)),
             prepared_transactions: std::collections::HashMap::new(),
             prepared_commit_waiters: std::collections::HashMap::new(),
             prepared_rollback_waiters: std::collections::HashMap::new(),
@@ -4473,29 +4477,7 @@ impl<RT: Runtime> Committer<RT> {
             latest_snapshot_ts,
         );
 
-        if let Some(ref tso) = self.timestamp_oracle {
-            let tso = tso.clone();
-            let tso_advance_timer =
-                metrics::commit_hot_path_stage_timer(path, "tso_advance_committed");
-            let advance_result = block_in_place(|| {
-                let rt = tokio::runtime::Handle::current();
-                if rt.runtime_flavor() == tokio::runtime::RuntimeFlavor::CurrentThread {
-                    futures::executor::block_on(tso.advance_committed_ts(commit_ts))
-                } else {
-                    rt.block_on(tso.advance_committed_ts(commit_ts))
-                }
-            });
-            if advance_result.is_ok() {
-                tso_advance_timer.finish();
-            }
-            if let Err(err) = advance_result {
-                tracing::warn!(
-                    "Failed to advance global max_committed to {} before publishing commit: \
-                     {err:#}",
-                    u64::from(commit_ts),
-                );
-            }
-        }
+        self.queue_tso_committed_floor_flush(commit_ts);
 
         // Write transaction state at the commit ts to the document store.
         let hot_path_apply_timer = metrics::commit_hot_path_stage_timer(path, "apply_visible");
@@ -7296,6 +7278,71 @@ impl<RT: Runtime> Committer<RT> {
                 );
             }
             refill_in_flight.store(false, Ordering::Release);
+        });
+    }
+
+    fn queue_tso_committed_floor_flush(&self, commit_ts: Timestamp) {
+        let Some(tso) = self.timestamp_oracle.clone() else {
+            return;
+        };
+
+        // Timestamp uniqueness was established when this commit's batch range
+        // was reserved. Keep the local allocation floor current immediately,
+        // but do not make a quorum-committed write wait on NATS KV.
+        tso.observe_committed_ts(commit_ts);
+        {
+            let mut pending_floor = self.pending_tso_committed_floor.lock();
+            if commit_ts > *pending_floor {
+                *pending_floor = commit_ts;
+            }
+        }
+
+        if self
+            .tso_committed_floor_flush_in_flight
+            .swap(true, Ordering::AcqRel)
+        {
+            return;
+        }
+
+        let pending_floor = self.pending_tso_committed_floor.clone();
+        let flush_in_flight = self.tso_committed_floor_flush_in_flight.clone();
+        let runtime = self.runtime.clone();
+        tokio_spawn("flush_tso_committed_floor", async move {
+            let mut backoff = Backoff::new(
+                INITIAL_PERSISTENCE_WRITES_BACKOFF,
+                MAX_PERSISTENCE_WRITES_BACKOFF,
+            );
+            loop {
+                let target = *pending_floor.lock();
+                match tso.advance_committed_ts(target).await {
+                    Ok(()) => {
+                        backoff.reset();
+                    },
+                    Err(mut error) => {
+                        let delay = backoff.fail(&mut runtime.rng());
+                        report_error(&mut error).await;
+                        tracing::warn!(
+                            target = u64::from(target),
+                            retry_delay_seconds = delay.as_secs_f64(),
+                            "Failed to publish the TSO committed floor; retrying in background",
+                        );
+                        runtime.wait(delay).await;
+                        continue;
+                    },
+                }
+
+                if *pending_floor.lock() > target {
+                    continue;
+                }
+
+                // Clear the marker, then close the race with a commit that may
+                // have raised the pending floor while the marker was still set.
+                flush_in_flight.store(false, Ordering::Release);
+                if *pending_floor.lock() > target && !flush_in_flight.swap(true, Ordering::AcqRel) {
+                    continue;
+                }
+                break;
+            }
         });
     }
 }

--- a/crates/database/src/committer.rs
+++ b/crates/database/src/committer.rs
@@ -6868,6 +6868,22 @@ impl<RT: Runtime> Committer<RT> {
             .expect("validated commit should stage a pending snapshot");
         let commit_ts = pending_write.must_commit_ts();
         self.enqueue_snapshot(commit_id, commit_ts, queued_snapshot);
+        if result.is_closed() {
+            return Some(
+                async move {
+                    Ok(PersistenceWrite::RejectedBeforePersistence {
+                        pending_write,
+                        commit_timer,
+                        result,
+                        commit_id,
+                        err: anyhow::anyhow!(
+                            "Commit request was cancelled before Raft proposal at ts={commit_ts}"
+                        ),
+                    })
+                }
+                .boxed(),
+            );
+        }
         let virtual_system_mapping = self.virtual_system_mapping.clone();
 
         Self::track_commit(

--- a/crates/database/src/database.rs
+++ b/crates/database/src/database.rs
@@ -3244,6 +3244,10 @@ impl<RT: Runtime> Database<RT> {
     pub fn runtime(&self) -> &RT {
         &self.runtime
     }
+
+    pub fn table_number_allocator(&self) -> Arc<dyn TableNumberAllocator> {
+        self.table_number_allocator.clone()
+    }
 }
 
 /// Transaction statistics reported for a retried transaction

--- a/crates/database/src/tests/write_scaling_tests.rs
+++ b/crates/database/src/tests/write_scaling_tests.rs
@@ -102,7 +102,10 @@ use search::searcher::SearcherStub;
 use storage::LocalDirStorage;
 use tokio::{
     net::TcpListener,
-    sync::oneshot,
+    sync::{
+        oneshot,
+        Notify,
+    },
     task::JoinHandle,
 };
 use tokio_stream::wrappers::TcpListenerStream;
@@ -1479,6 +1482,63 @@ impl TimestampOracle for HangingTimestampOracle {
 
     async fn advance_committed_ts(&self, _ts: Timestamp) -> anyhow::Result<()> {
         std::future::pending().await
+    }
+}
+
+struct BlockingAdvanceTimestampOracle {
+    state: Mutex<RecordingTimestampOracleState>,
+    advance_targets: Mutex<Vec<Timestamp>>,
+    advance_started: Notify,
+    release_advance: Notify,
+    advance_finished: Notify,
+}
+
+impl BlockingAdvanceTimestampOracle {
+    fn new() -> Self {
+        Self {
+            state: Mutex::new(RecordingTimestampOracleState {
+                last_assigned: Timestamp::MIN,
+                max_committed: Timestamp::MIN,
+                requested_floors: Vec::new(),
+            }),
+            advance_targets: Mutex::new(Vec::new()),
+            advance_started: Notify::new(),
+            release_advance: Notify::new(),
+            advance_finished: Notify::new(),
+        }
+    }
+}
+
+#[async_trait]
+impl TimestampOracle for BlockingAdvanceTimestampOracle {
+    async fn next_ts_at_or_after(&self, min_ts: Timestamp) -> anyhow::Result<Timestamp> {
+        let mut state = self.state.lock();
+        let next = std::cmp::max(
+            min_ts,
+            std::cmp::max(state.last_assigned.succ()?, state.max_committed.succ()?),
+        );
+        state.last_assigned = next;
+        Ok(next)
+    }
+
+    async fn max_committed_ts(&self) -> anyhow::Result<Timestamp> {
+        Ok(self.state.lock().max_committed)
+    }
+
+    fn observe_committed_ts(&self, ts: Timestamp) {
+        let mut state = self.state.lock();
+        if ts > state.max_committed {
+            state.max_committed = ts;
+        }
+    }
+
+    async fn advance_committed_ts(&self, ts: Timestamp) -> anyhow::Result<()> {
+        self.observe_committed_ts(ts);
+        self.advance_targets.lock().push(ts);
+        self.advance_started.notify_one();
+        self.release_advance.notified().await;
+        self.advance_finished.notify_one();
+        Ok(())
     }
 }
 
@@ -10279,6 +10339,74 @@ fn test_tso_request_includes_local_replica_floor() -> anyhow::Result<()> {
              and letting the committer bump it outside the reserved range",
         );
 
+        Ok(())
+    })
+}
+
+#[test]
+fn test_committed_write_does_not_wait_for_tso_floor_publication() -> anyhow::Result<()> {
+    let td = TestDriver::new_with_io();
+    let rt = td.rt();
+    td.run_until(async move {
+        let log = Arc::new(InMemoryDistributedLog::new());
+        let tso = Arc::new(BlockingAdvanceTimestampOracle::new());
+        let node = create_node_with_options(
+            &rt,
+            log,
+            Some(partitioned_map(PartitionId(0))),
+            None,
+            Some(tso.clone()),
+        )
+        .await?;
+
+        let first_commit_ts = tokio::time::timeout(
+            Duration::from_secs(1),
+            insert_doc(
+                &node,
+                "messages",
+                assert_obj!("text" => "committed-while-floor-blocked"),
+            ),
+        )
+        .await
+        .context("commit waited for cluster-wide TSO floor publication")??;
+
+        tokio::time::timeout(Duration::from_secs(1), tso.advance_started.notified())
+            .await
+            .context("background TSO floor publication did not start")?;
+        let second_commit_ts = tokio::time::timeout(
+            Duration::from_secs(1),
+            insert_doc(
+                &node,
+                "messages",
+                assert_obj!("text" => "second-commit-while-floor-blocked"),
+            ),
+        )
+        .await
+        .context("newer commit waited for an in-flight TSO floor publication")??;
+        let messages = run_query(
+            node,
+            TableNamespace::root_component(),
+            Query::full_table_scan("messages".parse()?, Order::Asc),
+        )
+        .await?;
+        assert_eq!(messages.len(), 2);
+
+        tso.release_advance.notify_one();
+        tokio::time::timeout(Duration::from_secs(1), tso.advance_finished.notified())
+            .await
+            .context("first background TSO floor publication did not finish")?;
+        tokio::time::timeout(Duration::from_secs(1), tso.advance_started.notified())
+            .await
+            .context("coalesced TSO floor publication did not start")?;
+        assert_eq!(
+            *tso.advance_targets.lock(),
+            vec![first_commit_ts, second_commit_ts],
+            "the single background publisher must advance directly to the newest pending floor",
+        );
+        tso.release_advance.notify_one();
+        tokio::time::timeout(Duration::from_secs(1), tso.advance_finished.notified())
+            .await
+            .context("coalesced TSO floor publication did not finish")?;
         Ok(())
     })
 }

--- a/crates/database/src/timestamp_oracle.rs
+++ b/crates/database/src/timestamp_oracle.rs
@@ -78,6 +78,14 @@ pub trait TimestampOracle: Send + Sync + 'static {
     /// Used for read-after-write consistency.
     async fn max_committed_ts(&self) -> anyhow::Result<Timestamp>;
 
+    /// Record a committed timestamp in node-local state without network I/O.
+    ///
+    /// The commit path calls this before publishing the new snapshot so future
+    /// local allocations immediately respect the floor. Durable publication of
+    /// the cluster-wide floor is asynchronous and handled by
+    /// `advance_committed_ts`.
+    fn observe_committed_ts(&self, _ts: Timestamp) {}
+
     /// Advance the max committed timestamp. Called after a successful commit.
     async fn advance_committed_ts(&self, ts: Timestamp) -> anyhow::Result<()>;
 
@@ -144,11 +152,15 @@ impl<RT: Runtime> TimestampOracle for LocalTimestampOracle<RT> {
         Ok(self.state.lock().max_committed)
     }
 
-    async fn advance_committed_ts(&self, ts: Timestamp) -> anyhow::Result<()> {
+    fn observe_committed_ts(&self, ts: Timestamp) {
         let mut state = self.state.lock();
         if ts > state.max_committed {
             state.max_committed = ts;
         }
+    }
+
+    async fn advance_committed_ts(&self, ts: Timestamp) -> anyhow::Result<()> {
+        self.observe_committed_ts(ts);
         Ok(())
     }
 }
@@ -461,18 +473,19 @@ impl TimestampOracle for BatchTimestampOracle {
         result
     }
 
+    fn observe_committed_ts(&self, ts: Timestamp) {
+        let mut state = self.state.lock();
+        if ts > state.max_committed {
+            state.max_committed = ts;
+        }
+    }
+
     async fn advance_committed_ts(&self, ts: Timestamp) -> anyhow::Result<()> {
         let timer = metrics::tso_operation_timer("advance_committed");
         let result = async {
             let ts_u64 = u64::from(ts);
 
-            // Update local state.
-            {
-                let mut state = self.state.lock();
-                if ts > state.max_committed {
-                    state.max_committed = ts;
-                }
-            }
+            self.observe_committed_ts(ts);
 
             let value = ts_u64.to_be_bytes().to_vec();
             for attempt in 0..10 {
@@ -587,11 +600,15 @@ pub mod testing {
             Ok(self.state.lock().max_committed)
         }
 
-        async fn advance_committed_ts(&self, ts: Timestamp) -> anyhow::Result<()> {
+        fn observe_committed_ts(&self, ts: Timestamp) {
             let mut state = self.state.lock();
             if ts > state.max_committed {
                 state.max_committed = ts;
             }
+        }
+
+        async fn advance_committed_ts(&self, ts: Timestamp) -> anyhow::Result<()> {
+            self.observe_committed_ts(ts);
             Ok(())
         }
     }

--- a/crates/function_runner/src/in_memory_indexes.rs
+++ b/crates/function_runner/src/in_memory_indexes.rs
@@ -46,6 +46,7 @@ use database::{
     DatabaseSnapshot,
     SchemaRegistry,
     TableCountSnapshot,
+    TableNumberAllocator,
     TableRegistry,
     Transaction,
     TransactionIdGenerator,
@@ -105,6 +106,7 @@ fn make_transaction<RT: Runtime>(
     retention_validator: Arc<dyn RetentionValidator>,
     virtual_system_mapping: VirtualSystemMapping,
     usage_tracker: FunctionUsageTracker,
+    table_number_allocator: Arc<dyn TableNumberAllocator>,
 ) -> anyhow::Result<Transaction<RT>> {
     let id_generator = TransactionIdGenerator::new(&rt)?;
     // The transaction timestamp might be few minutes behind if the backend
@@ -112,7 +114,7 @@ fn make_transaction<RT: Runtime>(
     let creation_time = CreationTime::try_from(cmp::max(*ts, rt.generate_timestamp()?))?;
     let transaction_index =
         TransactionIndex::new(index_registry, database_index_snapshot, text_index_snapshot);
-    Ok(Transaction::new(
+    Ok(Transaction::new_with_table_number_allocator(
         identity,
         id_generator,
         creation_time,
@@ -125,6 +127,7 @@ fn make_transaction<RT: Runtime>(
         usage_tracker,
         retention_validator,
         virtual_system_mapping,
+        table_number_allocator,
     ))
 }
 
@@ -600,6 +603,7 @@ impl<RT: Runtime> InMemoryIndexCache<RT> {
         usage_tracker: FunctionUsageTracker,
         retention_validator: Arc<dyn RetentionValidator>,
         index_reader_override: Option<Arc<dyn IndexReader>>,
+        table_number_allocator: Arc<dyn TableNumberAllocator>,
     ) -> anyhow::Result<Transaction<RT>> {
         let _timer = begin_tx_timer();
         for (index_id, last_modified) in &in_memory_index_last_modified {
@@ -650,6 +654,7 @@ impl<RT: Runtime> InMemoryIndexCache<RT> {
             retention_validator,
             virtual_system_mapping().clone(),
             usage_tracker,
+            table_number_allocator,
         )?;
         tx.merge_writes(existing_writes.updates)?;
         Ok(tx)

--- a/crates/function_runner/src/in_process_function_runner.rs
+++ b/crates/function_runner/src/in_process_function_runner.rs
@@ -122,7 +122,9 @@ impl<RT: Runtime> InProcessFunctionRunner<RT> {
     ) -> anyhow::Result<Self> {
         // InProcessFunrun is single tenant and thus can use the full capacity.
         let max_percent_per_client = 100;
-        let server = FunctionRunnerCore::new(rt, storage, max_percent_per_client)?;
+        let table_number_allocator = database.table_number_allocator();
+        let server =
+            FunctionRunnerCore::new(rt, storage, max_percent_per_client, table_number_allocator)?;
         Ok(Self {
             server,
             persistence_reader,

--- a/crates/function_runner/src/server.rs
+++ b/crates/function_runner/src/server.rs
@@ -47,6 +47,7 @@ use database::{
     BootstrapMetadata,
     FollowerRetentionManager,
     TableCountSnapshot,
+    TableNumberAllocator,
     Transaction,
     TransactionTextSnapshot,
 };
@@ -194,6 +195,7 @@ pub struct FunctionRunnerCore<RT: Runtime, S: StorageForDeployment<RT>> {
     module_cache: ModuleCache<RT>,
     code_cache: CodeCache,
     isolate_client: IsolateClient<RT>,
+    table_number_allocator: Arc<dyn TableNumberAllocator>,
 }
 
 impl<RT: Runtime, S: StorageForDeployment<RT>> Clone for FunctionRunnerCore<RT, S> {
@@ -205,6 +207,7 @@ impl<RT: Runtime, S: StorageForDeployment<RT>> Clone for FunctionRunnerCore<RT, 
             module_cache: self.module_cache.clone(),
             code_cache: self.code_cache.clone(),
             isolate_client: self.isolate_client.clone(),
+            table_number_allocator: self.table_number_allocator.clone(),
         }
     }
 }
@@ -230,8 +233,19 @@ pub async fn validate_run_function_result(
 }
 
 impl<RT: Runtime, S: StorageForDeployment<RT>> FunctionRunnerCore<RT, S> {
-    pub fn new(rt: RT, storage: S, max_percent_per_client: usize) -> anyhow::Result<Self> {
-        Self::_new(rt, storage, max_percent_per_client, MAX_ISOLATE_WORKERS)
+    pub fn new(
+        rt: RT,
+        storage: S,
+        max_percent_per_client: usize,
+        table_number_allocator: Arc<dyn TableNumberAllocator>,
+    ) -> anyhow::Result<Self> {
+        Self::_new(
+            rt,
+            storage,
+            max_percent_per_client,
+            MAX_ISOLATE_WORKERS,
+            table_number_allocator,
+        )
     }
 
     fn _new(
@@ -239,6 +253,7 @@ impl<RT: Runtime, S: StorageForDeployment<RT>> FunctionRunnerCore<RT, S> {
         storage: S,
         max_percent_per_client: usize,
         max_isolate_workers: usize,
+        table_number_allocator: Arc<dyn TableNumberAllocator>,
     ) -> anyhow::Result<Self> {
         let isolate_client = IsolateClient::new(
             rt.clone(),
@@ -257,6 +272,7 @@ impl<RT: Runtime, S: StorageForDeployment<RT>> FunctionRunnerCore<RT, S> {
             module_cache,
             code_cache,
             isolate_client,
+            table_number_allocator,
         })
     }
 
@@ -349,6 +365,7 @@ impl<RT: Runtime, S: StorageForDeployment<RT>> FunctionRunnerCore<RT, S> {
                 usage_tracker.clone(),
                 retention_validator,
                 index_reader_override,
+                self.table_number_allocator.clone(),
             )
             .await?;
         let storage = self

--- a/crates/local_backend/src/authority_routing.rs
+++ b/crates/local_backend/src/authority_routing.rs
@@ -182,7 +182,16 @@ impl AuthorityResolver {
                     self.policy.total_timeout,
                     failures.join("; "),
                 );
-                let attempt_timeout = remaining.min(self.policy.per_attempt_timeout);
+                // Read-only attempts can use short probes and move on. Once a
+                // side-effecting request may be dispatched, give it the full
+                // remaining deadline because timing it out is ambiguous and we
+                // intentionally will not replay it.
+                let attempt_timeout = match timeout_disposition {
+                    AttemptTimeoutDisposition::Retry => {
+                        remaining.min(self.policy.per_attempt_timeout)
+                    },
+                    AttemptTimeoutDisposition::Fail => remaining,
+                };
                 let outcome = tokio::time::timeout(
                     attempt_timeout,
                     attempt(AuthorityAttempt {
@@ -680,6 +689,39 @@ mod tests {
 
         assert!(started.elapsed() < Duration::from_millis(500));
         assert!(format!("{error:#}").contains("timed out"));
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn side_effect_attempt_receives_remaining_total_deadline() -> anyhow::Result<()> {
+        let policy = test_policy();
+        let resolver = AuthorityResolver::new(
+            SharedNodeAddresses::new(Some(database::two_phase::NodeAddresses::from_config(
+                "0=leader:50051",
+            ))),
+            None,
+            None,
+            None,
+            None,
+        )
+        .with_policy(policy);
+
+        let result = resolver
+            .route(
+                PartitionId::DEFAULT,
+                AuthorityEndpointKind::Grpc,
+                AttemptTimeoutDisposition::Fail,
+                move |attempt| async move {
+                    assert!(
+                        attempt.timeout > policy.per_attempt_timeout,
+                        "a dispatched side effect must not inherit the short candidate timeout"
+                    );
+                    Ok("served")
+                },
+            )
+            .await?;
+
+        assert_eq!(result.value, "served");
         Ok(())
     }
 

--- a/crates/local_backend/src/authority_routing.rs
+++ b/crates/local_backend/src/authority_routing.rs
@@ -1,0 +1,703 @@
+use std::{
+    collections::{
+        BTreeMap,
+        BTreeSet,
+    },
+    future::Future,
+    sync::Arc,
+    time::Duration,
+};
+
+use anyhow::Context;
+use database::{
+    membership::MembershipStore,
+    partition::PartitionId,
+    raft_partition::RaftPartitionState,
+};
+use tokio::time::Instant;
+use tonic::{
+    metadata::{
+        MetadataMap,
+        MetadataValue,
+    },
+    Code,
+    Status,
+};
+
+use crate::SharedNodeAddresses;
+
+const AUTHORITY_REDIRECT_METADATA: &str = "x-convex-authority-redirect";
+const AUTHORITY_LEADER_GRPC_URL_METADATA: &str = "x-convex-authority-grpc-url";
+const INTERNAL_BACKEND_HTTP_PORT: u16 = 3210;
+
+#[derive(Clone, Copy, Debug)]
+pub(crate) enum AuthorityEndpointKind {
+    Grpc,
+    Http,
+}
+
+#[derive(Clone, Copy, Debug)]
+pub(crate) enum AttemptTimeoutDisposition {
+    Retry,
+    Fail,
+}
+
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct AuthorityRoutingPolicy {
+    total_timeout: Duration,
+    per_attempt_timeout: Duration,
+    initial_backoff: Duration,
+    max_backoff: Duration,
+}
+
+impl Default for AuthorityRoutingPolicy {
+    fn default() -> Self {
+        Self {
+            total_timeout: Duration::from_secs(5),
+            per_attempt_timeout: Duration::from_secs(1),
+            initial_backoff: Duration::from_millis(25),
+            max_backoff: Duration::from_millis(250),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub(crate) struct AuthorityAttempt {
+    pub endpoint: String,
+    pub timeout: Duration,
+}
+
+#[derive(Debug)]
+pub(crate) enum AuthorityAttemptError {
+    Retry {
+        error: anyhow::Error,
+        leader_hint: Option<String>,
+    },
+    Fail(anyhow::Error),
+}
+
+impl AuthorityAttemptError {
+    pub fn retry(error: impl Into<anyhow::Error>) -> Self {
+        Self::Retry {
+            error: error.into(),
+            leader_hint: None,
+        }
+    }
+
+    pub fn retry_with_leader(error: impl Into<anyhow::Error>, leader_hint: Option<String>) -> Self {
+        Self::Retry {
+            error: error.into(),
+            leader_hint,
+        }
+    }
+
+    pub fn fail(error: impl Into<anyhow::Error>) -> Self {
+        Self::Fail(error.into())
+    }
+}
+
+#[derive(Debug)]
+pub(crate) struct ResolvedAuthority<T> {
+    pub value: T,
+    deadline: Instant,
+}
+
+impl<T> ResolvedAuthority<T> {
+    pub fn remaining(&self) -> anyhow::Result<Duration> {
+        let remaining = self.deadline.saturating_duration_since(Instant::now());
+        anyhow::ensure!(
+            !remaining.is_zero(),
+            "Authority routing deadline elapsed before request dispatch"
+        );
+        Ok(remaining)
+    }
+}
+
+#[derive(Clone)]
+pub(crate) struct AuthorityResolver {
+    node_addresses: SharedNodeAddresses,
+    membership_store: Option<Arc<dyn MembershipStore>>,
+    raft_state: Option<RaftPartitionState>,
+    raft_peer_grpc_urls: Option<BTreeMap<u64, String>>,
+    raft_peer_http_origins: Option<BTreeMap<u64, String>>,
+    policy: AuthorityRoutingPolicy,
+}
+
+impl AuthorityResolver {
+    pub fn new(
+        node_addresses: SharedNodeAddresses,
+        membership_store: Option<Arc<dyn MembershipStore>>,
+        raft_state: Option<RaftPartitionState>,
+        raft_peer_grpc_urls: Option<BTreeMap<u64, String>>,
+        raft_peer_http_origins: Option<BTreeMap<u64, String>>,
+    ) -> Self {
+        Self {
+            node_addresses,
+            membership_store,
+            raft_state,
+            raft_peer_grpc_urls,
+            raft_peer_http_origins,
+            policy: AuthorityRoutingPolicy::default(),
+        }
+    }
+
+    #[cfg(test)]
+    pub fn with_policy(mut self, policy: AuthorityRoutingPolicy) -> Self {
+        self.policy = policy;
+        self
+    }
+
+    pub async fn route<T, F, Fut>(
+        &self,
+        partition: PartitionId,
+        endpoint_kind: AuthorityEndpointKind,
+        timeout_disposition: AttemptTimeoutDisposition,
+        mut attempt: F,
+    ) -> anyhow::Result<ResolvedAuthority<T>>
+    where
+        F: FnMut(AuthorityAttempt) -> Fut,
+        Fut: Future<Output = Result<T, AuthorityAttemptError>>,
+    {
+        let deadline = Instant::now() + self.policy.total_timeout;
+        let mut backoff = self.policy.initial_backoff;
+        let mut preferred_leader = None;
+        let mut failures = Vec::new();
+
+        loop {
+            let candidates =
+                self.candidates(partition, endpoint_kind, preferred_leader.as_deref())?;
+            let mut received_leader_hint = false;
+            let mut attempted = BTreeSet::new();
+            if candidates.is_empty() {
+                failures.push("membership has no live authority candidates".to_string());
+            }
+
+            for endpoint in candidates {
+                attempted.insert(endpoint.clone());
+                let remaining = deadline.saturating_duration_since(Instant::now());
+                anyhow::ensure!(
+                    !remaining.is_zero(),
+                    "Authority routing to partition {} timed out after {:?}: {}",
+                    partition,
+                    self.policy.total_timeout,
+                    failures.join("; "),
+                );
+                let attempt_timeout = remaining.min(self.policy.per_attempt_timeout);
+                let outcome = tokio::time::timeout(
+                    attempt_timeout,
+                    attempt(AuthorityAttempt {
+                        endpoint: endpoint.clone(),
+                        timeout: attempt_timeout,
+                    }),
+                )
+                .await;
+                match outcome {
+                    Ok(Ok(value)) => return Ok(ResolvedAuthority { value, deadline }),
+                    Ok(Err(AuthorityAttemptError::Fail(error))) => return Err(error),
+                    Ok(Err(AuthorityAttemptError::Retry { error, leader_hint })) => {
+                        failures.push(format!("{endpoint}: {error:#}"));
+                        if let Some(leader_hint) = leader_hint
+                            && !attempted.contains(&leader_hint)
+                        {
+                            preferred_leader = Some(leader_hint);
+                            received_leader_hint = true;
+                        }
+                    },
+                    Err(_) if matches!(timeout_disposition, AttemptTimeoutDisposition::Fail) => {
+                        anyhow::bail!(
+                            "Authority request to {endpoint} timed out after {attempt_timeout:?}; \
+                             the request may have reached the authority and will not be replayed"
+                        );
+                    },
+                    Err(_) => {
+                        failures.push(format!(
+                            "{endpoint}: attempt timed out after {attempt_timeout:?}"
+                        ));
+                    },
+                }
+                if let Err(error) = self.refresh_membership().await {
+                    failures.push(format!("membership refresh failed: {error:#}"));
+                }
+                if received_leader_hint {
+                    break;
+                }
+            }
+
+            if received_leader_hint {
+                continue;
+            }
+
+            let remaining = deadline.saturating_duration_since(Instant::now());
+            anyhow::ensure!(
+                !remaining.is_zero(),
+                "Authority routing to partition {} timed out after {:?}: {}",
+                partition,
+                self.policy.total_timeout,
+                failures.join("; "),
+            );
+            tokio::time::sleep(backoff.min(remaining)).await;
+            backoff = (backoff * 2).min(self.policy.max_backoff);
+        }
+    }
+
+    fn candidates(
+        &self,
+        partition: PartitionId,
+        endpoint_kind: AuthorityEndpointKind,
+        preferred_leader: Option<&str>,
+    ) -> anyhow::Result<Vec<String>> {
+        let mut candidates = Vec::new();
+        if let Some(preferred_leader) = preferred_leader {
+            candidates.push(preferred_leader.to_string());
+        }
+        if let Some(raft_state) = self
+            .raft_state
+            .as_ref()
+            .filter(|state| state.partition_id() == partition)
+        {
+            let leader_id = raft_state.leader_id();
+            if leader_id != 0 {
+                let leader = match endpoint_kind {
+                    AuthorityEndpointKind::Grpc => self
+                        .raft_peer_grpc_urls
+                        .as_ref()
+                        .and_then(|urls| urls.get(&leader_id)),
+                    AuthorityEndpointKind::Http => self
+                        .raft_peer_http_origins
+                        .as_ref()
+                        .and_then(|origins| origins.get(&leader_id)),
+                };
+                if let Some(leader) = leader {
+                    candidates.push(leader.clone());
+                }
+            }
+        }
+        let advertised_http_origins = self.node_addresses.http_origins_for(partition);
+        if matches!(endpoint_kind, AuthorityEndpointKind::Http)
+            && !advertised_http_origins.is_empty()
+        {
+            candidates.extend(advertised_http_origins);
+        } else if let Some(addresses) = self
+            .node_addresses
+            .get()
+            .and_then(|addresses| addresses.addresses_for(partition).map(<[_]>::to_vec))
+        {
+            for address in addresses {
+                candidates.push(match endpoint_kind {
+                    AuthorityEndpointKind::Grpc => address,
+                    AuthorityEndpointKind::Http => http_origin_from_peer_addr(&address)?,
+                });
+            }
+        }
+
+        let mut seen = BTreeSet::new();
+        candidates.retain(|candidate| seen.insert(candidate.clone()));
+        Ok(candidates)
+    }
+
+    async fn refresh_membership(&self) -> anyhow::Result<()> {
+        let Some(store) = self.membership_store.as_ref() else {
+            return Ok(());
+        };
+        let snapshot = store
+            .load()
+            .await
+            .context("Failed to reload cluster membership while routing")?;
+        if let Some(snapshot) = snapshot {
+            self.node_addresses.refresh_from_membership(&snapshot);
+        }
+        Ok(())
+    }
+}
+
+pub(crate) fn http_origin_from_peer_addr(addr: &str) -> anyhow::Result<String> {
+    let normalized = if addr.contains("://") {
+        addr.to_string()
+    } else {
+        format!("http://{addr}")
+    };
+    let mut url = url::Url::parse(&normalized)?;
+    url.set_path("");
+    url.set_query(None);
+    url.set_fragment(None);
+    url.set_port(Some(INTERNAL_BACKEND_HTTP_PORT))
+        .map_err(|_| anyhow::anyhow!("Failed to map peer address {addr} to backend HTTP port"))?;
+    Ok(url.to_string().trim_end_matches('/').to_string())
+}
+
+pub(crate) fn authority_redirect_status(
+    reason: impl Into<String>,
+    raft_state: Option<&RaftPartitionState>,
+    raft_peer_grpc_urls: Option<&BTreeMap<u64, String>>,
+) -> Status {
+    let mut metadata = MetadataMap::new();
+    metadata.insert(
+        AUTHORITY_REDIRECT_METADATA,
+        MetadataValue::from_static("true"),
+    );
+    if let Some(leader_url) = raft_state
+        .map(RaftPartitionState::leader_id)
+        .filter(|leader_id| *leader_id != 0)
+        .and_then(|leader_id| raft_peer_grpc_urls.and_then(|urls| urls.get(&leader_id)))
+        .and_then(|url| MetadataValue::try_from(url.as_str()).ok())
+    {
+        metadata.insert(AUTHORITY_LEADER_GRPC_URL_METADATA, leader_url);
+    }
+    Status::with_metadata(Code::FailedPrecondition, reason, metadata)
+}
+
+pub(crate) fn is_authority_redirect(error: &anyhow::Error) -> bool {
+    authority_status(error)
+        .is_some_and(|status| status.metadata().get(AUTHORITY_REDIRECT_METADATA).is_some())
+}
+
+pub(crate) fn authority_leader_hint(error: &anyhow::Error) -> Option<String> {
+    authority_status(error)
+        .and_then(|status| status.metadata().get(AUTHORITY_LEADER_GRPC_URL_METADATA))
+        .and_then(|value| value.to_str().ok())
+        .map(ToOwned::to_owned)
+}
+
+fn authority_status(error: &anyhow::Error) -> Option<&Status> {
+    error
+        .chain()
+        .find_map(|source| source.downcast_ref::<Status>())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Mutex;
+
+    use database::membership::{
+        ClusterNodeId,
+        MembershipSnapshot,
+        MembershipVersion,
+        NodeMembership,
+    };
+
+    use super::*;
+
+    struct StaticMembershipStore {
+        snapshot: MembershipSnapshot,
+    }
+
+    #[async_trait::async_trait]
+    impl MembershipStore for StaticMembershipStore {
+        async fn load(&self) -> anyhow::Result<Option<MembershipSnapshot>> {
+            Ok(Some(self.snapshot.clone()))
+        }
+
+        async fn ensure_initialized(
+            &self,
+            _bootstrap_snapshot: MembershipSnapshot,
+        ) -> anyhow::Result<MembershipSnapshot> {
+            Ok(self.snapshot.clone())
+        }
+
+        async fn register_node(&self, _node: NodeMembership) -> anyhow::Result<MembershipSnapshot> {
+            Ok(self.snapshot.clone())
+        }
+    }
+
+    fn test_policy() -> AuthorityRoutingPolicy {
+        AuthorityRoutingPolicy {
+            total_timeout: Duration::from_millis(100),
+            per_attempt_timeout: Duration::from_millis(20),
+            initial_backoff: Duration::from_millis(1),
+            max_backoff: Duration::from_millis(5),
+        }
+    }
+
+    fn snapshot(address: &str) -> anyhow::Result<MembershipSnapshot> {
+        Ok(MembershipSnapshot::new(
+            MembershipVersion::new(1),
+            vec![NodeMembership::new(
+                ClusterNodeId::new("p0-node")?,
+                PartitionId::DEFAULT,
+                address,
+            )?],
+        ))
+    }
+
+    fn snapshot_with_http(
+        grpc_address: &str,
+        http_origin: &str,
+    ) -> anyhow::Result<MembershipSnapshot> {
+        let mut node = NodeMembership::new(
+            ClusterNodeId::new("p0-node")?,
+            PartitionId::DEFAULT,
+            grpc_address,
+        )?;
+        node.http_origin = Some(http_origin.to_string());
+        Ok(MembershipSnapshot::new(
+            MembershipVersion::new(1),
+            vec![node],
+        ))
+    }
+
+    #[tokio::test]
+    async fn retries_live_candidates_when_first_endpoint_is_dead() -> anyhow::Result<()> {
+        let resolver = AuthorityResolver::new(
+            SharedNodeAddresses::new(Some(database::two_phase::NodeAddresses::from_config(
+                "0=dead:50051|live:50051",
+            ))),
+            None,
+            None,
+            None,
+            None,
+        )
+        .with_policy(test_policy());
+        let attempts = Arc::new(Mutex::new(Vec::new()));
+        let observed = attempts.clone();
+
+        let result = resolver
+            .route(
+                PartitionId::DEFAULT,
+                AuthorityEndpointKind::Grpc,
+                AttemptTimeoutDisposition::Retry,
+                move |attempt| {
+                    observed.lock().unwrap().push(attempt.endpoint.clone());
+                    async move {
+                        if attempt.endpoint == "live:50051" {
+                            Ok("served")
+                        } else {
+                            Err(AuthorityAttemptError::retry(anyhow::anyhow!(
+                                "connection refused"
+                            )))
+                        }
+                    }
+                },
+            )
+            .await?;
+
+        assert_eq!(result.value, "served");
+        assert_eq!(*attempts.lock().unwrap(), vec!["dead:50051", "live:50051"]);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn stale_leader_redirect_targets_current_leader_immediately() -> anyhow::Result<()> {
+        let raft_state = RaftPartitionState::new_for_test(false, 1, PartitionId::DEFAULT, 3);
+        let resolver = AuthorityResolver::new(
+            SharedNodeAddresses::new(Some(database::two_phase::NodeAddresses::from_config(
+                "0=follower:50051",
+            ))),
+            None,
+            Some(raft_state),
+            Some(BTreeMap::from([(1, "stale-leader:50051".to_string())])),
+            None,
+        )
+        .with_policy(test_policy());
+        let attempts = Arc::new(Mutex::new(Vec::new()));
+        let observed = attempts.clone();
+
+        let result = resolver
+            .route(
+                PartitionId::DEFAULT,
+                AuthorityEndpointKind::Grpc,
+                AttemptTimeoutDisposition::Retry,
+                move |attempt| {
+                    observed.lock().unwrap().push(attempt.endpoint.clone());
+                    async move {
+                        match attempt.endpoint.as_str() {
+                            "stale-leader:50051" => Err(AuthorityAttemptError::retry_with_leader(
+                                anyhow::anyhow!("not leader"),
+                                Some("current-leader:50051".to_string()),
+                            )),
+                            "current-leader:50051" => Ok("served"),
+                            endpoint => Err(AuthorityAttemptError::retry(anyhow::anyhow!(
+                                "unexpected endpoint {endpoint}"
+                            ))),
+                        }
+                    }
+                },
+            )
+            .await?;
+
+        assert_eq!(result.value, "served");
+        assert_eq!(
+            *attempts.lock().unwrap(),
+            vec!["stale-leader:50051", "current-leader:50051"]
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn stale_redirect_does_not_starve_untried_live_candidate() -> anyhow::Result<()> {
+        let raft_state = RaftPartitionState::new_for_test(false, 1, PartitionId::DEFAULT, 3);
+        let resolver = AuthorityResolver::new(
+            SharedNodeAddresses::new(Some(database::two_phase::NodeAddresses::from_config(
+                "0=follower:50051|live-leader:50051",
+            ))),
+            None,
+            Some(raft_state),
+            Some(BTreeMap::from([(1, "dead-leader:50051".to_string())])),
+            None,
+        )
+        .with_policy(test_policy());
+        let attempts = Arc::new(Mutex::new(Vec::new()));
+        let observed = attempts.clone();
+
+        let result = resolver
+            .route(
+                PartitionId::DEFAULT,
+                AuthorityEndpointKind::Grpc,
+                AttemptTimeoutDisposition::Retry,
+                move |attempt| {
+                    observed.lock().unwrap().push(attempt.endpoint.clone());
+                    async move {
+                        match attempt.endpoint.as_str() {
+                            "dead-leader:50051" => {
+                                Err(AuthorityAttemptError::retry(anyhow::anyhow!("offline")))
+                            },
+                            "follower:50051" => Err(AuthorityAttemptError::retry_with_leader(
+                                anyhow::anyhow!("stale not-leader response"),
+                                Some("dead-leader:50051".to_string()),
+                            )),
+                            "live-leader:50051" => Ok("served"),
+                            endpoint => Err(AuthorityAttemptError::retry(anyhow::anyhow!(
+                                "unexpected endpoint {endpoint}"
+                            ))),
+                        }
+                    }
+                },
+            )
+            .await?;
+
+        assert_eq!(result.value, "served");
+        assert_eq!(
+            *attempts.lock().unwrap(),
+            vec!["dead-leader:50051", "follower:50051", "live-leader:50051"]
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn refreshes_membership_after_endpoint_replacement() -> anyhow::Result<()> {
+        let shared = SharedNodeAddresses::new(Some(
+            database::two_phase::NodeAddresses::from_config("0=old:50051"),
+        ));
+        let resolver = AuthorityResolver::new(
+            shared,
+            Some(Arc::new(StaticMembershipStore {
+                snapshot: snapshot("replacement:50051")?,
+            })),
+            None,
+            None,
+            None,
+        )
+        .with_policy(test_policy());
+        let attempts = Arc::new(Mutex::new(Vec::new()));
+        let observed = attempts.clone();
+
+        let result = resolver
+            .route(
+                PartitionId::DEFAULT,
+                AuthorityEndpointKind::Grpc,
+                AttemptTimeoutDisposition::Retry,
+                move |attempt| {
+                    observed.lock().unwrap().push(attempt.endpoint.clone());
+                    async move {
+                        if attempt.endpoint == "replacement:50051" {
+                            Ok("served")
+                        } else {
+                            Err(AuthorityAttemptError::retry(anyhow::anyhow!(
+                                "old endpoint unavailable"
+                            )))
+                        }
+                    }
+                },
+            )
+            .await?;
+
+        assert_eq!(result.value, "served");
+        assert_eq!(
+            *attempts.lock().unwrap(),
+            vec!["old:50051", "replacement:50051"]
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn uses_advertised_http_origin_after_membership_refresh() -> anyhow::Result<()> {
+        let shared = SharedNodeAddresses::new(Some(
+            database::two_phase::NodeAddresses::from_config("0=old:50051"),
+        ));
+        shared.refresh_from_membership(&snapshot_with_http(
+            "replacement:55000",
+            "http://replacement:38080/",
+        )?);
+        let resolver =
+            AuthorityResolver::new(shared, None, None, None, None).with_policy(test_policy());
+
+        let result = resolver
+            .route(
+                PartitionId::DEFAULT,
+                AuthorityEndpointKind::Http,
+                AttemptTimeoutDisposition::Retry,
+                |attempt| async move {
+                    if attempt.endpoint == "http://replacement:38080" {
+                        Ok("served")
+                    } else {
+                        Err(AuthorityAttemptError::retry(anyhow::anyhow!(
+                            "unexpected endpoint {}",
+                            attempt.endpoint
+                        )))
+                    }
+                },
+            )
+            .await?;
+
+        assert_eq!(result.value, "served");
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn all_unavailable_candidates_fail_within_total_deadline() -> anyhow::Result<()> {
+        let resolver = AuthorityResolver::new(
+            SharedNodeAddresses::new(Some(database::two_phase::NodeAddresses::from_config(
+                "0=dead-a:50051|dead-b:50051",
+            ))),
+            None,
+            None,
+            None,
+            None,
+        )
+        .with_policy(test_policy());
+        let started = Instant::now();
+
+        let error = resolver
+            .route(
+                PartitionId::DEFAULT,
+                AuthorityEndpointKind::Grpc,
+                AttemptTimeoutDisposition::Retry,
+                |_attempt| async {
+                    Err::<(), _>(AuthorityAttemptError::retry(anyhow::anyhow!("unavailable")))
+                },
+            )
+            .await
+            .expect_err("all unavailable candidates must fail");
+
+        assert!(started.elapsed() < Duration::from_millis(500));
+        assert!(format!("{error:#}").contains("timed out"));
+        Ok(())
+    }
+
+    #[test]
+    fn redirect_status_preserves_current_leader_endpoint() -> anyhow::Result<()> {
+        let raft_state = RaftPartitionState::new_for_test(false, 2, PartitionId::DEFAULT, 1);
+        let status = authority_redirect_status(
+            "not leader",
+            Some(&raft_state),
+            Some(&BTreeMap::from([(2, "leader:50051".to_string())])),
+        );
+        let error = anyhow::Error::new(status);
+
+        assert!(is_authority_redirect(&error));
+        assert_eq!(
+            authority_leader_hint(&error).as_deref(),
+            Some("leader:50051")
+        );
+        Ok(())
+    }
+}

--- a/crates/local_backend/src/authority_routing.rs
+++ b/crates/local_backend/src/authority_routing.rs
@@ -224,9 +224,6 @@ impl AuthorityResolver {
                         ));
                     },
                 }
-                if let Err(error) = self.refresh_membership().await {
-                    failures.push(format!("membership refresh failed: {error:#}"));
-                }
                 if received_leader_hint {
                     break;
                 }
@@ -244,6 +241,18 @@ impl AuthorityResolver {
                 self.policy.total_timeout,
                 failures.join("; "),
             );
+            let refresh_timeout = remaining.min(self.policy.per_attempt_timeout);
+            match tokio::time::timeout(refresh_timeout, self.refresh_membership()).await {
+                Ok(Ok(())) => {},
+                Ok(Err(error)) => {
+                    failures.push(format!("membership refresh failed: {error:#}"));
+                },
+                Err(_) => {
+                    failures.push(format!(
+                        "membership refresh timed out after {refresh_timeout:?}"
+                    ));
+                },
+            }
             tokio::time::sleep(backoff.min(remaining)).await;
             backoff = (backoff * 2).min(self.policy.max_backoff);
         }
@@ -390,6 +399,8 @@ mod tests {
         snapshot: MembershipSnapshot,
     }
 
+    struct BlockingMembershipStore;
+
     #[async_trait::async_trait]
     impl MembershipStore for StaticMembershipStore {
         async fn load(&self) -> anyhow::Result<Option<MembershipSnapshot>> {
@@ -405,6 +416,24 @@ mod tests {
 
         async fn register_node(&self, _node: NodeMembership) -> anyhow::Result<MembershipSnapshot> {
             Ok(self.snapshot.clone())
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl MembershipStore for BlockingMembershipStore {
+        async fn load(&self) -> anyhow::Result<Option<MembershipSnapshot>> {
+            std::future::pending().await
+        }
+
+        async fn ensure_initialized(
+            &self,
+            _bootstrap_snapshot: MembershipSnapshot,
+        ) -> anyhow::Result<MembershipSnapshot> {
+            std::future::pending().await
+        }
+
+        async fn register_node(&self, _node: NodeMembership) -> anyhow::Result<MembershipSnapshot> {
+            std::future::pending().await
         }
     }
 
@@ -528,6 +557,98 @@ mod tests {
             *attempts.lock().unwrap(),
             vec!["stale-leader:50051", "current-leader:50051"]
         );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn leader_redirect_does_not_wait_for_membership_refresh() -> anyhow::Result<()> {
+        let resolver = AuthorityResolver::new(
+            SharedNodeAddresses::new(Some(database::two_phase::NodeAddresses::from_config(
+                "0=follower:50051",
+            ))),
+            Some(Arc::new(BlockingMembershipStore)),
+            None,
+            None,
+            None,
+        )
+        .with_policy(test_policy());
+        let attempts = Arc::new(Mutex::new(Vec::new()));
+        let observed = attempts.clone();
+
+        let result = tokio::time::timeout(
+            Duration::from_millis(50),
+            resolver.route(
+                PartitionId::DEFAULT,
+                AuthorityEndpointKind::Grpc,
+                AttemptTimeoutDisposition::Retry,
+                move |attempt| {
+                    observed.lock().unwrap().push(attempt.endpoint.clone());
+                    async move {
+                        match attempt.endpoint.as_str() {
+                            "follower:50051" => Err(AuthorityAttemptError::retry_with_leader(
+                                anyhow::anyhow!("not leader"),
+                                Some("current-leader:50051".to_string()),
+                            )),
+                            "current-leader:50051" => Ok("served"),
+                            endpoint => Err(AuthorityAttemptError::retry(anyhow::anyhow!(
+                                "unexpected endpoint {endpoint}"
+                            ))),
+                        }
+                    }
+                },
+            ),
+        )
+        .await
+        .context("leader redirect waited for unavailable membership storage")??;
+
+        assert_eq!(result.value, "served");
+        assert_eq!(
+            *attempts.lock().unwrap(),
+            vec!["follower:50051", "current-leader:50051"]
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn tries_cached_candidates_before_membership_refresh() -> anyhow::Result<()> {
+        let resolver = AuthorityResolver::new(
+            SharedNodeAddresses::new(Some(database::two_phase::NodeAddresses::from_config(
+                "0=dead:50051|live:50051",
+            ))),
+            Some(Arc::new(BlockingMembershipStore)),
+            None,
+            None,
+            None,
+        )
+        .with_policy(test_policy());
+        let attempts = Arc::new(Mutex::new(Vec::new()));
+        let observed = attempts.clone();
+
+        let result = tokio::time::timeout(
+            Duration::from_millis(50),
+            resolver.route(
+                PartitionId::DEFAULT,
+                AuthorityEndpointKind::Grpc,
+                AttemptTimeoutDisposition::Retry,
+                move |attempt| {
+                    observed.lock().unwrap().push(attempt.endpoint.clone());
+                    async move {
+                        if attempt.endpoint == "live:50051" {
+                            Ok("served")
+                        } else {
+                            Err(AuthorityAttemptError::retry(anyhow::anyhow!(
+                                "connection refused"
+                            )))
+                        }
+                    }
+                },
+            ),
+        )
+        .await
+        .context("cached live candidate was blocked by membership refresh")??;
+
+        assert_eq!(result.value, "served");
+        assert_eq!(*attempts.lock().unwrap(), vec!["dead:50051", "live:50051"]);
         Ok(())
     }
 
@@ -686,6 +807,40 @@ mod tests {
             )
             .await
             .expect_err("all unavailable candidates must fail");
+
+        assert!(started.elapsed() < Duration::from_millis(500));
+        assert!(format!("{error:#}").contains("timed out"));
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn membership_refresh_cannot_outlive_total_deadline() -> anyhow::Result<()> {
+        let resolver = AuthorityResolver::new(
+            SharedNodeAddresses::new(Some(database::two_phase::NodeAddresses::from_config(
+                "0=dead:50051",
+            ))),
+            Some(Arc::new(BlockingMembershipStore)),
+            None,
+            None,
+            None,
+        )
+        .with_policy(test_policy());
+        let started = Instant::now();
+
+        let error = tokio::time::timeout(
+            Duration::from_millis(500),
+            resolver.route(
+                PartitionId::DEFAULT,
+                AuthorityEndpointKind::Grpc,
+                AttemptTimeoutDisposition::Retry,
+                |_attempt| async {
+                    Err::<(), _>(AuthorityAttemptError::retry(anyhow::anyhow!("unavailable")))
+                },
+            ),
+        )
+        .await
+        .context("membership refresh outlived the routing deadline")?
+        .expect_err("unavailable authority must fail");
 
         assert!(started.elapsed() < Duration::from_millis(500));
         assert!(format!("{error:#}").contains("timed out"));

--- a/crates/local_backend/src/authority_routing.rs
+++ b/crates/local_backend/src/authority_routing.rs
@@ -39,6 +39,7 @@ pub(crate) enum AuthorityEndpointKind {
 #[derive(Clone, Copy, Debug)]
 pub(crate) enum AttemptTimeoutDisposition {
     Retry,
+    RetryableRead,
     Fail,
 }
 
@@ -182,15 +183,19 @@ impl AuthorityResolver {
                     self.policy.total_timeout,
                     failures.join("; "),
                 );
-                // Read-only attempts can use short probes and move on. Once a
-                // side-effecting request may be dispatched, give it the full
-                // remaining deadline because timing it out is ambiguous and we
-                // intentionally will not replay it.
+                // Lightweight probes can use short attempts and move on. Real
+                // reads and side-effecting requests need the remaining
+                // end-to-end deadline once dispatched: queries can legitimately
+                // spend longer than the candidate-probe timeout establishing a
+                // cluster-safe snapshot, while replaying an ambiguously timed
+                // out mutation would be unsafe.
                 let attempt_timeout = match timeout_disposition {
                     AttemptTimeoutDisposition::Retry => {
                         remaining.min(self.policy.per_attempt_timeout)
                     },
-                    AttemptTimeoutDisposition::Fail => remaining,
+                    AttemptTimeoutDisposition::RetryableRead | AttemptTimeoutDisposition::Fail => {
+                        remaining
+                    },
                 };
                 let outcome = tokio::time::timeout(
                     attempt_timeout,
@@ -871,6 +876,40 @@ mod tests {
                         attempt.timeout > policy.per_attempt_timeout,
                         "a dispatched side effect must not inherit the short candidate timeout"
                     );
+                    Ok("served")
+                },
+            )
+            .await?;
+
+        assert_eq!(result.value, "served");
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn dispatched_read_can_outlive_candidate_probe_timeout() -> anyhow::Result<()> {
+        let policy = test_policy();
+        let resolver = AuthorityResolver::new(
+            SharedNodeAddresses::new(Some(database::two_phase::NodeAddresses::from_config(
+                "0=leader:50051",
+            ))),
+            None,
+            None,
+            None,
+            None,
+        )
+        .with_policy(policy);
+
+        let result = resolver
+            .route(
+                PartitionId::DEFAULT,
+                AuthorityEndpointKind::Grpc,
+                AttemptTimeoutDisposition::RetryableRead,
+                move |attempt| async move {
+                    assert!(
+                        attempt.timeout > policy.per_attempt_timeout,
+                        "a dispatched read must receive the remaining request deadline"
+                    );
+                    tokio::time::sleep(policy.per_attempt_timeout * 2).await;
                     Ok("served")
                 },
             )

--- a/crates/local_backend/src/deploy_config.rs
+++ b/crates/local_backend/src/deploy_config.rs
@@ -3,7 +3,6 @@ use std::{
     time::Duration,
 };
 
-use anyhow::Context;
 use application::deploy_config::{
     EvaluatePushResponse,
     FinishPushDiff,
@@ -75,7 +74,6 @@ use serde::{
     Serialize,
 };
 use serde_json::Value as JsonValue;
-use url::Url;
 use value::{
     base64,
     DocumentObject,
@@ -87,6 +85,13 @@ use crate::{
     admin::{
         must_be_admin_from_key,
         must_be_admin_from_key_with_write_access,
+    },
+    authority_routing::{
+        http_origin_from_peer_addr as resolve_http_origin_from_peer_addr,
+        AttemptTimeoutDisposition,
+        AuthorityAttemptError,
+        AuthorityEndpointKind,
+        AuthorityResolver,
     },
     DeployRouterState,
 };
@@ -155,9 +160,13 @@ pub async fn get_config_hashes(
     }))
 }
 
-const INTERNAL_BACKEND_HTTP_PORT: u16 = 3210;
-
-async fn raft_leader_origin(st: &DeployRouterState) -> anyhow::Result<Option<String>> {
+fn deploy_target_partition(st: &DeployRouterState) -> anyhow::Result<Option<PartitionId>> {
+    let Some(local_partition) = st.partition_id else {
+        return Ok(None);
+    };
+    if local_partition != PartitionId::DEFAULT {
+        return Ok(Some(PartitionId::DEFAULT));
+    }
     let Some(raft_state) = st.raft_state.as_ref() else {
         return Ok(None);
     };
@@ -172,59 +181,11 @@ async fn raft_leader_origin(st: &DeployRouterState) -> anyhow::Result<Option<Str
         !raft_state.is_leader(),
         "Raft leader is still applying its current-term barrier and cannot serve deploy metadata"
     );
-    let peer_http_origins = st.raft_peer_http_origins.as_ref().context(
-        "RAFT_PEERS is required to forward deploy metadata operations to the Raft leader",
-    )?;
-    for _ in 0..50 {
-        let leader_id = raft_state.leader_id();
-        if leader_id != 0 {
-            let leader_origin = peer_http_origins.get(&leader_id).with_context(|| {
-                format!("Missing RAFT_PEERS entry for Raft leader node {leader_id}")
-            })?;
-            return Ok(Some(leader_origin.clone()));
-        }
-        tokio::time::sleep(Duration::from_millis(100)).await;
-    }
-    Ok(None)
-}
-
-async fn deploy_target_origin(st: &DeployRouterState) -> anyhow::Result<Option<String>> {
-    if let Some(origin) = metadata_owner_origin(st)? {
-        return Ok(Some(origin));
-    }
-    raft_leader_origin(st).await
-}
-
-fn metadata_owner_origin(st: &DeployRouterState) -> anyhow::Result<Option<String>> {
-    let Some(local_partition) = st.partition_id else {
-        return Ok(None);
-    };
-    if local_partition == PartitionId::DEFAULT {
-        return Ok(None);
-    }
-    let node_addresses = st
-        .node_addresses
-        .get()
-        .context("Membership is required to forward deploy metadata operations to the owner")?;
-    let owner_addr = node_addresses
-        .address_for(PartitionId::DEFAULT)
-        .context("Missing live membership entry for deploy metadata owner partition-0")?;
-    Ok(Some(http_origin_from_peer_addr(owner_addr)?))
+    Ok(Some(PartitionId::DEFAULT))
 }
 
 pub(crate) fn http_origin_from_peer_addr(addr: &str) -> anyhow::Result<String> {
-    let normalized = if addr.contains("://") {
-        addr.to_string()
-    } else {
-        format!("http://{addr}")
-    };
-    let mut url = Url::parse(&normalized)?;
-    url.set_path("");
-    url.set_query(None);
-    url.set_fragment(None);
-    url.set_port(Some(INTERNAL_BACKEND_HTTP_PORT))
-        .map_err(|_| anyhow::anyhow!("Failed to map peer address {addr} to backend HTTP port"))?;
-    Ok(url.to_string().trim_end_matches('/').to_string())
+    resolve_http_origin_from_peer_addr(addr)
 }
 
 trait AdminKeyCarrier {
@@ -232,9 +193,17 @@ trait AdminKeyCarrier {
     fn set_admin_key(&mut self, admin_key: String);
 }
 
-async fn metadata_owner_instance_name(owner_origin: &str) -> anyhow::Result<String> {
+async fn metadata_owner_instance_name(
+    owner_origin: &str,
+    timeout: Duration,
+) -> anyhow::Result<String> {
     let url = format!("{owner_origin}/instance_name");
-    let response = reqwest::Client::new().get(&url).send().await?;
+    let response = reqwest::Client::builder()
+        .timeout(timeout)
+        .build()?
+        .get(&url)
+        .send()
+        .await?;
     let status = response.status();
     let body = response.text().await?;
     anyhow::ensure!(
@@ -287,7 +256,7 @@ where
     Req: Serialize + AdminKeyCarrier,
     Resp: DeserializeOwned,
 {
-    let Some(target_origin) = deploy_target_origin(st).await? else {
+    let Some(target_partition) = deploy_target_partition(st)? else {
         return Ok(None);
     };
     let identity = if needs_write_access {
@@ -305,11 +274,32 @@ where
         )
         .await?
     };
-    let target_instance_name = metadata_owner_instance_name(&target_origin).await?;
+    let resolver = AuthorityResolver::new(
+        st.node_addresses.clone(),
+        st.membership_store.clone(),
+        st.raft_state.clone(),
+        None,
+        st.raft_peer_http_origins.clone(),
+    );
+    let resolved = resolver
+        .route(
+            target_partition,
+            AuthorityEndpointKind::Http,
+            AttemptTimeoutDisposition::Retry,
+            |attempt| async move {
+                metadata_owner_instance_name(&attempt.endpoint, attempt.timeout)
+                    .await
+                    .map(|instance_name| (attempt.endpoint, instance_name))
+                    .map_err(AuthorityAttemptError::retry)
+            },
+        )
+        .await?;
+    let remaining = resolved.remaining()?;
+    let (target_origin, target_instance_name) = resolved.value;
     let target_admin_key = issue_owner_admin_key(st, &target_instance_name, &identity)?;
     req.set_admin_key(target_admin_key);
     Ok(Some(
-        forward_deploy_request(&target_origin, path, req).await?,
+        forward_deploy_request(&target_origin, path, req, remaining).await?,
     ))
 }
 
@@ -317,13 +307,20 @@ async fn forward_deploy_request<Req, Resp>(
     owner_origin: &str,
     path: &str,
     req: &Req,
+    timeout: Duration,
 ) -> anyhow::Result<Resp>
 where
     Req: Serialize + ?Sized,
     Resp: DeserializeOwned,
 {
     let url = format!("{owner_origin}{path}");
-    let response = reqwest::Client::new().post(&url).json(req).send().await?;
+    let response = reqwest::Client::builder()
+        .timeout(timeout)
+        .build()?
+        .post(&url)
+        .json(req)
+        .send()
+        .await?;
     let status = response.status();
     let body = response.text().await?;
     anyhow::ensure!(

--- a/crates/local_backend/src/lib.rs
+++ b/crates/local_backend/src/lib.rs
@@ -96,6 +96,7 @@ pub mod admin;
 mod app_metrics;
 mod args_structs;
 pub mod authentication;
+mod authority_routing;
 pub mod beacon;
 pub mod canonical_urls;
 pub mod config;
@@ -135,22 +136,61 @@ pub const MAX_CONCURRENT_REQUESTS: usize = 128;
 const MEMBERSHIP_HEARTBEAT_INTERVAL: Duration = Duration::from_secs(2);
 const MEMBERSHIP_LEASE_TTL: Duration = Duration::from_secs(15);
 
+#[derive(Default)]
+struct SharedNodeAddressState {
+    grpc_addresses: Option<database::two_phase::NodeAddresses>,
+    http_origins: BTreeMap<database::partition::PartitionId, Vec<String>>,
+}
+
 #[derive(Clone, Default)]
-pub struct SharedNodeAddresses(Arc<RwLock<Option<database::two_phase::NodeAddresses>>>);
+pub struct SharedNodeAddresses(Arc<RwLock<SharedNodeAddressState>>);
 
 impl SharedNodeAddresses {
     pub fn new(addresses: Option<database::two_phase::NodeAddresses>) -> Self {
-        Self(Arc::new(RwLock::new(addresses)))
+        Self(Arc::new(RwLock::new(SharedNodeAddressState {
+            grpc_addresses: addresses,
+            http_origins: BTreeMap::new(),
+        })))
     }
 
     pub fn get(&self) -> Option<database::two_phase::NodeAddresses> {
-        self.0.read().clone()
+        self.0.read().grpc_addresses.clone()
+    }
+
+    pub fn http_origins_for(&self, partition: database::partition::PartitionId) -> Vec<String> {
+        self.0
+            .read()
+            .http_origins
+            .get(&partition)
+            .cloned()
+            .unwrap_or_default()
     }
 
     pub fn refresh_from_membership(&self, snapshot: &database::membership::MembershipSnapshot) {
-        let addresses =
-            snapshot.to_live_node_addresses(database::membership::current_unix_timestamp_millis());
-        *self.0.write() = (!addresses.partitions().is_empty()).then_some(addresses);
+        let now_ms = database::membership::current_unix_timestamp_millis();
+        let addresses = snapshot.to_live_node_addresses(now_ms);
+        let mut http_origins: BTreeMap<_, Vec<_>> = BTreeMap::new();
+        for node in snapshot
+            .nodes()
+            .values()
+            .filter(|node| node.is_live_at(now_ms))
+        {
+            if let Some(http_origin) = node
+                .http_origin
+                .as_ref()
+                .map(|origin| origin.trim())
+                .filter(|origin| !origin.is_empty())
+            {
+                http_origins
+                    .entry(node.partition)
+                    .or_default()
+                    .push(http_origin.trim_end_matches('/').to_string());
+            }
+        }
+        *self.0.write() = SharedNodeAddressState {
+            grpc_addresses: (!addresses.partitions().is_empty()).then_some(addresses),
+            http_origins,
+        };
     }
 }
 
@@ -192,6 +232,7 @@ impl BackendAppState {
             self.node_addresses.clone(),
             self.raft_state.clone(),
             self.raft_peer_grpc_urls.clone(),
+            self.membership_store.clone(),
             self.cluster_grpc_auth.clone(),
         ))
     }
@@ -340,6 +381,7 @@ pub struct RouterState {
     pub cluster_grpc_auth: Option<common::grpc::ClusterGrpcAuth>,
     pub mutation_forwarder_pool: mutation_forwarder::MutationForwarderGrpcClientPool,
     pub replica_mutation_forwarder: Option<Arc<mutation_forwarder::MutationForwarderGrpcClient>>,
+    pub membership_store: Option<Arc<dyn database::membership::MembershipStore>>,
 }
 
 #[derive(Clone)]
@@ -352,6 +394,7 @@ pub struct DeployRouterState {
     pub node_addresses: SharedNodeAddresses,
     pub raft_state: Option<database::raft_partition::RaftPartitionState>,
     pub raft_peer_http_origins: Option<BTreeMap<u64, String>>,
+    pub membership_store: Option<Arc<dyn database::membership::MembershipStore>>,
 }
 
 impl From<&BackendAppState> for DeployRouterState {
@@ -365,6 +408,7 @@ impl From<&BackendAppState> for DeployRouterState {
             node_addresses: st.node_addresses.clone(),
             raft_state: st.raft_state.clone(),
             raft_peer_http_origins: st.raft_peer_http_origins.clone(),
+            membership_store: st.membership_store.clone(),
         }
     }
 }

--- a/crates/local_backend/src/main.rs
+++ b/crates/local_backend/src/main.rs
@@ -142,8 +142,13 @@ async fn run_server_inner(runtime: ProdRuntime, config: LocalConfig) -> anyhow::
         let grpc_addr = format!("0.0.0.0:{}", config.grpc_port).parse()?;
         let api = st.cluster_aware_api();
         let cluster_grpc_auth = st.cluster_grpc_auth.clone();
-        let forwarder =
-            MutationForwarderService::new(api, st.instance_name.clone(), cluster_grpc_auth.clone());
+        let forwarder = MutationForwarderService::new_with_raft(
+            api,
+            st.instance_name.clone(),
+            cluster_grpc_auth.clone(),
+            st.raft_state.clone(),
+            st.raft_peer_grpc_urls.clone(),
+        );
         let two_pc = two_phase_service::TwoPhaseCommitGrpcService::new(
             st.application.database().committer_client(),
             st.raft_state.clone(),

--- a/crates/local_backend/src/mutation_forwarder.rs
+++ b/crates/local_backend/src/mutation_forwarder.rs
@@ -10,6 +10,7 @@
 use std::{
     collections::BTreeMap,
     sync::Arc,
+    time::Duration,
 };
 
 use anyhow::Context;
@@ -30,6 +31,7 @@ use common::{
 };
 use database::{
     partition::PartitionId,
+    raft_partition::RaftPartitionState,
     Token,
 };
 use keybroker::Identity;
@@ -54,18 +56,28 @@ use serde_json::Value as JsonValue;
 use sync_types::types::SerializedArgs;
 use tokio::sync::Mutex;
 use tonic::{
-    transport::Channel,
+    transport::{
+        Channel,
+        Endpoint,
+    },
     Request,
     Response,
     Status,
 };
 use value::JsonPackedValue;
 
+use crate::authority_routing::authority_redirect_status;
+
+const FORWARDER_CONNECT_TIMEOUT: Duration = Duration::from_millis(500);
+const FORWARDER_DEFAULT_TIMEOUT: Duration = Duration::from_secs(5);
+
 /// gRPC server for mutation forwarding. Runs on the Primary.
 pub struct MutationForwarderService {
     api: Arc<dyn ApplicationApi>,
     instance_name: String,
     cluster_auth: Option<ClusterGrpcAuth>,
+    raft_state: Option<RaftPartitionState>,
+    raft_peer_grpc_urls: Option<BTreeMap<u64, String>>,
 }
 
 impl MutationForwarderService {
@@ -78,6 +90,24 @@ impl MutationForwarderService {
             api,
             instance_name,
             cluster_auth,
+            raft_state: None,
+            raft_peer_grpc_urls: None,
+        }
+    }
+
+    pub fn new_with_raft(
+        api: Arc<dyn ApplicationApi>,
+        instance_name: String,
+        cluster_auth: Option<ClusterGrpcAuth>,
+        raft_state: Option<RaftPartitionState>,
+        raft_peer_grpc_urls: Option<BTreeMap<u64, String>>,
+    ) -> Self {
+        Self {
+            api,
+            instance_name,
+            cluster_auth,
+            raft_state,
+            raft_peer_grpc_urls,
         }
     }
 
@@ -91,6 +121,29 @@ impl MutationForwarderService {
         }
         Ok(())
     }
+
+    fn ensure_authority(&self, require_serving_lease: bool) -> Result<(), Status> {
+        let Some(raft_state) = self.raft_state.as_ref() else {
+            return Ok(());
+        };
+        if raft_state.is_cluster_genesis_ready()
+            && raft_state.is_leader_ready()
+            && (!require_serving_lease || raft_state.has_leader_serving_lease())
+        {
+            return Ok(());
+        }
+        Err(authority_redirect_status(
+            format!(
+                "Node {} is not ready to serve as the authority for partition {}; current leader \
+                 is {}",
+                raft_state.node_id(),
+                raft_state.partition_id(),
+                raft_state.leader_id(),
+            ),
+            Some(raft_state),
+            self.raft_peer_grpc_urls.as_ref(),
+        ))
+    }
 }
 
 #[tonic::async_trait]
@@ -100,6 +153,7 @@ impl MutationForwarder for MutationForwarderService {
         request: Request<ForwardMutationRequest>,
     ) -> Result<Response<ForwardMutationResponse>, Status> {
         self.authenticate(&request)?;
+        self.ensure_authority(false)?;
         let req = request.into_inner();
 
         let identity = req
@@ -190,6 +244,7 @@ impl MutationForwarder for MutationForwarderService {
         request: Request<ForwardQueryRequest>,
     ) -> Result<Response<ForwardQueryResponse>, Status> {
         self.authenticate(&request)?;
+        self.ensure_authority(true)?;
         let req = request.into_inner();
 
         let identity = req
@@ -370,9 +425,12 @@ impl MutationForwarderGrpcClient {
         cluster_auth: Option<ClusterGrpcAuth>,
     ) -> anyhow::Result<Self> {
         let normalized_url = normalize_grpc_url(primary_url);
-        let client = TonicMutationForwarderClient::connect(normalized_url.clone())
+        let channel = Endpoint::from_shared(normalized_url.clone())?
+            .connect_timeout(FORWARDER_CONNECT_TIMEOUT)
+            .connect()
             .await
             .with_context(|| format!("Failed to connect to Primary at {normalized_url}"))?;
+        let client = TonicMutationForwarderClient::new(channel);
         tracing::info!("Connected to Primary mutation forwarder at {normalized_url}");
         Ok(Self {
             client,
@@ -387,6 +445,12 @@ impl MutationForwarderGrpcClient {
         }
     }
 
+    fn request_with_timeout<T>(&self, message: T, timeout: Duration) -> Request<T> {
+        let mut request = self.request(message);
+        request.set_timeout(timeout);
+        request
+    }
+
     /// Forward a mutation to the Primary and return the result.
     pub async fn forward(
         &self,
@@ -394,6 +458,18 @@ impl MutationForwarderGrpcClient {
         args: &str,
         identity: Identity,
         caller: &str,
+    ) -> anyhow::Result<ForwardMutationResponse> {
+        self.forward_with_timeout(path, args, identity, caller, FORWARDER_DEFAULT_TIMEOUT)
+            .await
+    }
+
+    pub async fn forward_with_timeout(
+        &self,
+        path: &str,
+        args: &str,
+        identity: Identity,
+        caller: &str,
+        timeout: Duration,
     ) -> anyhow::Result<ForwardMutationResponse> {
         let identity_proto: pb::convex_identity::UncheckedIdentity = identity.into();
         let request = ForwardMutationRequest {
@@ -407,7 +483,7 @@ impl MutationForwarderGrpcClient {
         let response = self
             .client
             .clone()
-            .forward_mutation(self.request(request))
+            .forward_mutation(self.request_with_timeout(request, timeout))
             .await
             .context("gRPC mutation forwarding failed")?;
         Ok(response.into_inner())
@@ -422,6 +498,31 @@ impl MutationForwarderGrpcClient {
         ts: Option<u64>,
         read_after_write: Option<Vec<ReadAfterWriteFence>>,
         journal: Option<String>,
+    ) -> anyhow::Result<RedactedQueryReturn> {
+        self.forward_query_with_timeout(
+            path,
+            args,
+            identity,
+            caller,
+            ts,
+            read_after_write,
+            journal,
+            FORWARDER_DEFAULT_TIMEOUT,
+        )
+        .await
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub async fn forward_query_with_timeout(
+        &self,
+        path: &str,
+        args: &str,
+        identity: Identity,
+        caller: FunctionCaller,
+        ts: Option<u64>,
+        read_after_write: Option<Vec<ReadAfterWriteFence>>,
+        journal: Option<String>,
+        timeout: Duration,
     ) -> anyhow::Result<RedactedQueryReturn> {
         let identity_proto: pb::convex_identity::UncheckedIdentity = identity.into();
         let read_after_write_fences = read_after_write.clone().unwrap_or_default();
@@ -447,7 +548,7 @@ impl MutationForwarderGrpcClient {
         let response = self
             .client
             .clone()
-            .forward_query(self.request(request))
+            .forward_query(self.request_with_timeout(request, timeout))
             .await
             .context("gRPC query forwarding failed")?;
         let response = response.into_inner();

--- a/crates/local_backend/src/public_api.rs
+++ b/crates/local_backend/src/public_api.rs
@@ -1,4 +1,7 @@
-use std::sync::Arc;
+use std::{
+    sync::Arc,
+    time::Instant,
+};
 
 use anyhow::Context;
 use application::{
@@ -60,6 +63,14 @@ use value::{
 use crate::{
     args_structs::UdfPostRequestWithComponent,
     authentication::ExtractAuthenticationToken,
+    authority_routing::{
+        authority_leader_hint,
+        is_authority_redirect,
+        AttemptTimeoutDisposition,
+        AuthorityAttemptError,
+        AuthorityEndpointKind,
+        AuthorityResolver,
+    },
     mutation_forwarder::MutationForwarderGrpcClient,
     parse::{
         parse_export_path,
@@ -317,7 +328,7 @@ async fn maybe_forward_public_mutation(
 ) -> Result<Option<Result<UdfResponse, HttpResponseError>>, HttpResponseError> {
     enum ForwardingMode {
         Replica(Arc<MutationForwarderGrpcClient>),
-        RaftFollower(Arc<MutationForwarderGrpcClient>),
+        RaftFollower(PartitionId),
     }
 
     let forwarding_mode = if st.replica_mode {
@@ -346,40 +357,7 @@ async fn maybe_forward_public_mutation(
                 ),
             ));
         } else {
-            let leader_id = raft_state.leader_id();
-            if leader_id == 0 {
-                tracing::warn!(
-                    "Skipping follower mutation forwarding because partition has no elected Raft \
-                     leader yet"
-                );
-                return Ok(None);
-            }
-            let Some(leader_grpc_url) = st
-                .raft_peer_grpc_urls
-                .as_ref()
-                .and_then(|urls| urls.get(&leader_id))
-                .cloned()
-            else {
-                tracing::warn!(
-                    "Skipping follower mutation forwarding because RAFT_PEERS is missing leader \
-                     node {leader_id}"
-                );
-                return Ok(None);
-            };
-            let client_result = st.mutation_forwarder_pool.client(&leader_grpc_url).await;
-            match client_result {
-                Ok(client) => Some(ForwardingMode::RaftFollower(client)),
-                Err(e) => {
-                    tracing::warn!(
-                        "Skipping follower mutation forwarding because leader {} at {} is not \
-                         reachable yet: {:#}",
-                        leader_id,
-                        leader_grpc_url,
-                        e
-                    );
-                    return Ok(None);
-                },
-            }
+            Some(ForwardingMode::RaftFollower(raft_state.partition_id()))
         }
     } else {
         None
@@ -388,36 +366,103 @@ async fn maybe_forward_public_mutation(
     let Some(forwarding_mode) = forwarding_mode else {
         return Ok(None);
     };
-    let forwarder = match &forwarding_mode {
-        ForwardingMode::Replica(client) | ForwardingMode::RaftFollower(client) => client,
-    };
 
     let value_format = format.map(|f| f.parse()).transpose()?;
-    let forwarded = match forwarder
-        .forward(
-            path,
-            serialized_args.get(),
-            identity,
-            &client_version.to_string(),
-        )
-        .await
-    {
-        Ok(forwarded) => forwarded,
-        Err(e) => match forwarding_mode {
-            ForwardingMode::Replica(_) => {
-                return Ok(Some(Err(anyhow::anyhow!(
-                    ErrorMetadata::service_unavailable()
+    let forwarded = match &forwarding_mode {
+        ForwardingMode::Replica(forwarder) => {
+            match forwarder
+                .forward(
+                    path,
+                    serialized_args.get(),
+                    identity,
+                    &client_version.to_string(),
                 )
-                .context(format!("Failed to forward mutation to primary: {e:#}"))
-                .into())));
-            },
-            ForwardingMode::RaftFollower(_) => {
-                tracing::warn!(
-                    "Skipping follower mutation forwarding because the leader RPC failed: {:#}",
-                    e
-                );
-                return Ok(None);
-            },
+                .await
+            {
+                Ok(forwarded) => forwarded,
+                Err(e) => {
+                    return Ok(Some(Err(anyhow::anyhow!(
+                        ErrorMetadata::service_unavailable()
+                    )
+                    .context(format!("Failed to forward mutation to primary: {e:#}"))
+                    .into())));
+                },
+            }
+        },
+        ForwardingMode::RaftFollower(partition) => {
+            let resolver = AuthorityResolver::new(
+                st.node_addresses.clone(),
+                st.membership_store.clone(),
+                st.raft_state.clone(),
+                st.raft_peer_grpc_urls.clone(),
+                None,
+            );
+            let pool = st.mutation_forwarder_pool.clone();
+            let path = path.to_owned();
+            let args = serialized_args.get().to_owned();
+            let caller = client_version.to_string();
+            let resolved = resolver
+                .route(
+                    *partition,
+                    AuthorityEndpointKind::Grpc,
+                    AttemptTimeoutDisposition::Fail,
+                    move |attempt| {
+                        let pool = pool.clone();
+                        let path = path.clone();
+                        let args = args.clone();
+                        let identity = identity.clone();
+                        let caller = caller.clone();
+                        async move {
+                            let started = Instant::now();
+                            let client = pool.client(&attempt.endpoint).await.map_err(|error| {
+                                AuthorityAttemptError::retry(error.context(format!(
+                                    "Failed to connect to mutation authority at {}",
+                                    attempt.endpoint
+                                )))
+                            })?;
+                            let Some(request_timeout) =
+                                attempt.timeout.checked_sub(started.elapsed())
+                            else {
+                                return Err(AuthorityAttemptError::retry(anyhow::anyhow!(
+                                    "Mutation authority connection consumed the attempt deadline"
+                                )));
+                            };
+                            client
+                                .forward_with_timeout(
+                                    &path,
+                                    &args,
+                                    identity,
+                                    &caller,
+                                    request_timeout,
+                                )
+                                .await
+                                .map_err(|error| {
+                                    if is_authority_redirect(&error) {
+                                        let leader_hint = authority_leader_hint(&error);
+                                        AuthorityAttemptError::retry_with_leader(error, leader_hint)
+                                    } else {
+                                        AuthorityAttemptError::fail(error.context(
+                                            "Mutation forwarding failed after dispatch; refusing \
+                                             to replay an ambiguous side effect",
+                                        ))
+                                    }
+                                })
+                        }
+                    },
+                )
+                .await;
+            match resolved {
+                Ok(resolved) => resolved.value,
+                Err(e) => {
+                    return Ok(Some(Err(anyhow::anyhow!(
+                        ErrorMetadata::service_unavailable()
+                    )
+                    .context(format!(
+                        "Failed to route mutation to the current Raft leader: {e:#}"
+                    ))
+                    .into())));
+                },
+            }
         },
     };
 
@@ -1073,7 +1118,13 @@ where
 mod tests {
     use std::{
         collections::BTreeMap,
-        sync::Arc,
+        sync::{
+            atomic::{
+                AtomicUsize,
+                Ordering,
+            },
+            Arc,
+        },
         time::Duration,
     };
 
@@ -1121,6 +1172,10 @@ mod tests {
     use http_body_util::BodyExt;
     use keybroker::Identity;
     use metrics::SERVER_VERSION_STR;
+    use pb::replication::mutation_forwarder_server::{
+        MutationForwarder as TonicMutationForwarder,
+        MutationForwarderServer as TonicMutationForwarderServer,
+    };
     use runtime::prod::ProdRuntime;
     use serde_json::{
         json,
@@ -1143,6 +1198,30 @@ mod tests {
         SharedNodeAddresses,
         MAX_CONCURRENT_REQUESTS,
     };
+
+    struct CountingMutationForwarder {
+        inner: MutationForwarderService,
+        mutation_calls: Arc<AtomicUsize>,
+    }
+
+    #[tonic::async_trait]
+    impl TonicMutationForwarder for CountingMutationForwarder {
+        async fn forward_mutation(
+            &self,
+            request: tonic::Request<pb::replication::ForwardMutationRequest>,
+        ) -> Result<tonic::Response<pb::replication::ForwardMutationResponse>, tonic::Status>
+        {
+            self.mutation_calls.fetch_add(1, Ordering::SeqCst);
+            TonicMutationForwarder::forward_mutation(&self.inner, request).await
+        }
+
+        async fn forward_query(
+            &self,
+            request: tonic::Request<pb::replication::ForwardQueryRequest>,
+        ) -> Result<tonic::Response<pb::replication::ForwardQueryResponse>, tonic::Status> {
+            TonicMutationForwarder::forward_query(&self.inner, request).await
+        }
+    }
 
     async fn expect_success_from_app<T: serde::de::DeserializeOwned>(
         app: &ConvexHttpService,
@@ -1509,6 +1588,83 @@ mod tests {
     }
 
     #[convex_macro::prod_rt_test]
+    async fn test_http_mutation_retries_dead_leader_before_dispatch(
+        rt: ProdRuntime,
+    ) -> anyhow::Result<()> {
+        let backend = setup_backend_for_test(rt.clone()).await?;
+        backend.st.application.load_udf_tests_modules().await?;
+
+        let dead_listener = tokio::net::TcpListener::bind("127.0.0.1:0").await?;
+        let dead_grpc_addr = dead_listener.local_addr()?;
+        drop(dead_listener);
+        let live_listener = tokio::net::TcpListener::bind("127.0.0.1:0").await?;
+        let live_grpc_addr = live_listener.local_addr()?;
+        let mutation_calls = Arc::new(AtomicUsize::new(0));
+        let forwarder = CountingMutationForwarder {
+            inner: MutationForwarderService::new(
+                Arc::new(backend.st.application.clone()),
+                backend.st.instance_name.clone(),
+                backend.st.cluster_grpc_auth.clone(),
+            ),
+            mutation_calls: mutation_calls.clone(),
+        };
+        let (shutdown_tx, shutdown_rx) = oneshot::channel();
+        let _server_handle = rt.spawn("test_dead_leader_mutation_retry", async move {
+            let _ = tonic::transport::Server::builder()
+                .add_service(TonicMutationForwarderServer::new(forwarder))
+                .serve_with_incoming_shutdown(TcpListenerStream::new(live_listener), async move {
+                    let _ = shutdown_rx.await;
+                })
+                .await;
+        });
+
+        let dead_grpc_addr = dead_grpc_addr.to_string();
+        let live_grpc_addr = live_grpc_addr.to_string();
+        let mut follower_state = backend.st.clone();
+        follower_state.partition_id = Some(PartitionId::DEFAULT);
+        follower_state.raft_state = Some(RaftPartitionState::new_for_test(
+            false,
+            3,
+            PartitionId::DEFAULT,
+            1,
+        ));
+        follower_state.raft_peer_grpc_urls = Some(BTreeMap::from([(3, dead_grpc_addr.clone())]));
+        follower_state.node_addresses = SharedNodeAddresses::new(Some(NodeAddresses::from_config(
+            &format!("0={dead_grpc_addr}|{live_grpc_addr}"),
+        )));
+        follower_state.membership_store = None;
+        let follower_app = ConvexHttpService::new(
+            router(follower_state),
+            "backend_dead_leader_mutation_retry_test",
+            SERVER_VERSION_STR.to_string(),
+            MAX_CONCURRENT_REQUESTS,
+            Duration::from_secs(125),
+            NoopRouteMapper,
+        );
+
+        let response: JsonValue = expect_success_from_app(
+            &follower_app,
+            post_request(
+                "/api/mutation",
+                json!({
+                    "path": "values:insertObject",
+                    "args": { "obj": { "hello": "retried before dispatch" } },
+                }),
+            )?,
+        )
+        .await?;
+        assert_eq!(response["status"], "success");
+        assert_eq!(
+            mutation_calls.load(Ordering::SeqCst),
+            1,
+            "the mutation must execute exactly once on the live authority",
+        );
+
+        let _ = shutdown_tx.send(());
+        Ok(())
+    }
+
+    #[convex_macro::prod_rt_test]
     async fn test_internal_grpc_services_reject_missing_cluster_auth(
         rt: ProdRuntime,
     ) -> anyhow::Result<()> {
@@ -1714,7 +1870,7 @@ mod tests {
     }
 
     #[convex_macro::prod_rt_test]
-    async fn test_selective_query_forwarding_api_routes_partitioned_queries(
+    async fn test_selective_query_forwarding_retries_when_first_authority_is_dead(
         rt: ProdRuntime,
     ) -> anyhow::Result<()> {
         let primary = setup_backend_for_test(rt.clone()).await?;
@@ -1738,6 +1894,9 @@ mod tests {
 
         let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await?;
         let grpc_addr = listener.local_addr()?;
+        let dead_listener = tokio::net::TcpListener::bind("127.0.0.1:0").await?;
+        let dead_grpc_addr = dead_listener.local_addr()?;
+        drop(dead_listener);
         let forwarder = MutationForwarderService::new(
             Arc::new(primary.st.application.clone()),
             primary.st.instance_name.clone(),
@@ -1758,7 +1917,10 @@ mod tests {
             selective.st.application.database().clone(),
             false,
             Some(PartitionId(1)),
-            SharedNodeAddresses::new(Some(NodeAddresses::from_config(&format!("0={grpc_addr}")))),
+            SharedNodeAddresses::new(Some(NodeAddresses::from_config(&format!(
+                "0={dead_grpc_addr}|{grpc_addr}"
+            )))),
+            None,
             None,
             None,
             None,
@@ -1784,6 +1946,111 @@ mod tests {
         assert_eq!(value["hello"], "selective forwarded query");
 
         let _ = shutdown_tx.send(());
+        Ok(())
+    }
+
+    #[convex_macro::prod_rt_test]
+    async fn test_selective_query_forwarding_follows_remote_leader_redirect(
+        rt: ProdRuntime,
+    ) -> anyhow::Result<()> {
+        let primary = setup_backend_for_test(rt.clone()).await?;
+        let selective = setup_backend_for_test(rt.clone()).await?;
+        primary.st.application.load_udf_tests_modules().await?;
+        selective.st.application.load_udf_tests_modules().await?;
+
+        let inserted: JsonValue = primary
+            .expect_success(post_request(
+                "/api/mutation",
+                json!({
+                    "path": "values:insertObject",
+                    "args": { "obj": { "hello": "leader redirect" } },
+                }),
+            )?)
+            .await?;
+        let inserted_id = inserted["value"]
+            .as_str()
+            .context("insertObject should return a document id string")?
+            .to_string();
+
+        let leader_listener = tokio::net::TcpListener::bind("127.0.0.1:0").await?;
+        let leader_grpc_addr = leader_listener.local_addr()?;
+        let leader_forwarder = MutationForwarderService::new(
+            Arc::new(primary.st.application.clone()),
+            primary.st.instance_name.clone(),
+            None,
+        );
+        let (leader_shutdown_tx, leader_shutdown_rx) = oneshot::channel();
+        let _leader_handle = rt.spawn("test_redirected_query_leader", async move {
+            let _ = tonic::transport::Server::builder()
+                .add_service(leader_forwarder.into_server())
+                .serve_with_incoming_shutdown(TcpListenerStream::new(leader_listener), async move {
+                    let _ = leader_shutdown_rx.await;
+                })
+                .await;
+        });
+
+        let follower_listener = tokio::net::TcpListener::bind("127.0.0.1:0").await?;
+        let follower_grpc_addr = follower_listener.local_addr()?;
+        let follower_forwarder = MutationForwarderService::new_with_raft(
+            Arc::new(selective.st.application.clone()),
+            selective.st.instance_name.clone(),
+            None,
+            Some(RaftPartitionState::new_for_test(
+                false,
+                3,
+                PartitionId::DEFAULT,
+                1,
+            )),
+            Some(BTreeMap::from([(3, format!("http://{leader_grpc_addr}"))])),
+        );
+        let (follower_shutdown_tx, follower_shutdown_rx) = oneshot::channel();
+        let _follower_handle = rt.spawn("test_redirected_query_follower", async move {
+            let _ = tonic::transport::Server::builder()
+                .add_service(follower_forwarder.into_server())
+                .serve_with_incoming_shutdown(
+                    TcpListenerStream::new(follower_listener),
+                    async move {
+                        let _ = follower_shutdown_rx.await;
+                    },
+                )
+                .await;
+        });
+
+        let api: Arc<dyn ApplicationApi> = Arc::new(SelectiveQueryForwardingApi::new(
+            Arc::new(selective.st.application.clone()),
+            selective.st.application.database().clone(),
+            false,
+            Some(PartitionId(1)),
+            SharedNodeAddresses::new(Some(NodeAddresses::from_config(&format!(
+                "0={follower_grpc_addr}"
+            )))),
+            None,
+            None,
+            None,
+            None,
+        ));
+        let query_result = api
+            .execute_public_query(
+                &ResolvedHostname {
+                    instance_name: selective.st.instance_name.clone(),
+                    destination: RequestDestination::ConvexCloud,
+                },
+                common::RequestId::new(),
+                Identity::system(),
+                "values:getObject".parse()?,
+                SerializedArgs::from_args(vec![json!({ "id": inserted_id })])?,
+                FunctionCaller::HttpApi(ClientVersion::unknown()),
+                ExecuteQueryTimestamp::Latest,
+                None,
+                None,
+            )
+            .await?;
+
+        let value: JsonValue = serde_json::from_str(query_result.result?.as_str())?;
+        assert_eq!(value["hello"], "leader redirect");
+
+        let _ = follower_shutdown_tx.send(());
+        let _ = leader_shutdown_tx.send(());
         Ok(())
     }
 
@@ -1843,6 +2110,7 @@ mod tests {
             )),
             Some(raft_peer_grpc_urls),
             None,
+            None,
         ));
         let query_result = api
             .execute_public_query(
@@ -1879,6 +2147,7 @@ mod tests {
             false,
             Some(PartitionId(1)),
             SharedNodeAddresses::default(),
+            None,
             None,
             None,
             None,
@@ -1968,6 +2237,7 @@ mod tests {
             None,
             None,
             None,
+            None,
         ));
 
         let err = api
@@ -2008,6 +2278,7 @@ mod tests {
             false,
             Some(PartitionId(1)),
             SharedNodeAddresses::default(),
+            None,
             None,
             None,
             None,
@@ -2082,6 +2353,7 @@ mod tests {
             true,
             None,
             SharedNodeAddresses::default(),
+            None,
             None,
             None,
             None,

--- a/crates/local_backend/src/query_forwarding_api.rs
+++ b/crates/local_backend/src/query_forwarding_api.rs
@@ -2,10 +2,12 @@ use std::{
     collections::BTreeMap,
     ops::Bound,
     sync::Arc,
-    time::Duration,
+    time::{
+        Duration,
+        Instant,
+    },
 };
 
-use anyhow::Context;
 use application::api::SubscriptionClient;
 use async_trait::async_trait;
 use axum::body::Bytes;
@@ -25,6 +27,7 @@ use common::{
     RequestId,
 };
 use database::{
+    membership::MembershipStore,
     partition::PartitionId,
     raft_partition::RaftPartitionState,
     Database,
@@ -57,6 +60,13 @@ use value::{
 };
 
 use crate::{
+    authority_routing::{
+        authority_leader_hint,
+        AttemptTimeoutDisposition,
+        AuthorityAttemptError,
+        AuthorityEndpointKind,
+        AuthorityResolver,
+    },
     mutation_forwarder::MutationForwarderGrpcClientPool,
     SharedNodeAddresses,
 };
@@ -70,9 +80,8 @@ pub struct SelectiveQueryForwardingApi {
     database: Database<ProdRuntime>,
     replica_mode: bool,
     partition_id: Option<PartitionId>,
-    node_addresses: SharedNodeAddresses,
     raft_state: Option<RaftPartitionState>,
-    raft_peer_grpc_urls: Option<BTreeMap<u64, String>>,
+    authority_resolver: AuthorityResolver,
     mutation_forwarder_pool: MutationForwarderGrpcClientPool,
 }
 
@@ -85,77 +94,44 @@ impl SelectiveQueryForwardingApi {
         node_addresses: SharedNodeAddresses,
         raft_state: Option<RaftPartitionState>,
         raft_peer_grpc_urls: Option<BTreeMap<u64, String>>,
+        membership_store: Option<Arc<dyn MembershipStore>>,
         cluster_grpc_auth: Option<ClusterGrpcAuth>,
     ) -> Self {
+        let authority_resolver = AuthorityResolver::new(
+            node_addresses,
+            membership_store,
+            raft_state.clone(),
+            raft_peer_grpc_urls,
+            None,
+        );
         Self {
             inner,
             database,
             replica_mode,
             partition_id,
-            node_addresses,
             raft_state,
-            raft_peer_grpc_urls,
+            authority_resolver,
             mutation_forwarder_pool: MutationForwarderGrpcClientPool::new(cluster_grpc_auth),
         }
     }
 
-    async fn public_query_target_grpc_url(&self) -> anyhow::Result<Option<String>> {
+    fn should_forward_public_query(&self) -> anyhow::Result<bool> {
         let Some(partition_id) = self.partition_id else {
-            return Ok(None);
+            return Ok(false);
         };
 
         if partition_id != SELECTIVE_QUERY_AUTHORITY_PARTITION {
-            return Ok(Some(self.authority_grpc_url()?));
+            return Ok(true);
         }
 
         let Some(raft_state) = self.raft_state.as_ref() else {
-            return Ok(None);
+            return Ok(false);
         };
         anyhow::ensure!(
             raft_state.is_cluster_genesis_ready(),
             "Canonical cluster genesis is not ready"
         );
-        if raft_state.is_leader() {
-            anyhow::ensure!(
-                raft_state.is_leader_ready(),
-                "Coordinator partition is elected leader but has not applied its current-term \
-                 barrier"
-            );
-            if raft_state.has_leader_serving_lease() {
-                return Ok(None);
-            }
-            anyhow::bail!(
-                "Coordinator partition is leader but does not have a fresh Raft serving lease"
-            );
-        }
-        let peer_grpc_urls = self.raft_peer_grpc_urls.as_ref().context(
-            "Follower public query forwarding requires RAFT_PEERS gRPC URLs to find the current \
-             leader",
-        )?;
-        for _ in 0..50 {
-            let leader_id = raft_state.leader_id();
-            if leader_id != 0 {
-                let leader_grpc_url = peer_grpc_urls.get(&leader_id).with_context(|| {
-                    format!("Missing RAFT_PEERS entry for Raft leader node {leader_id}")
-                })?;
-                return Ok(Some(leader_grpc_url.clone()));
-            }
-            tokio::time::sleep(Duration::from_millis(100)).await;
-        }
-        Ok(None)
-    }
-
-    fn authority_grpc_url(&self) -> anyhow::Result<String> {
-        let addresses = self.node_addresses.get().context(
-            "Selective public query forwarding requires membership to find the authoritative \
-             query node",
-        )?;
-        addresses
-            .address_for(SELECTIVE_QUERY_AUTHORITY_PARTITION)
-            .map(ToOwned::to_owned)
-            .context(
-                "Selective public query forwarding requires a live partition-0 membership entry",
-            )
+        Ok(!raft_state.can_serve_as_leader())
     }
 
     fn note_recent_interest(&self, token: &database::Token) {
@@ -255,30 +231,69 @@ impl application::api::ApplicationApi for SelectiveQueryForwardingApi {
         read_after_write: Option<Vec<application::api::ReadAfterWriteFence>>,
         journal: Option<SerializedQueryJournal>,
     ) -> anyhow::Result<application::RedactedQueryReturn> {
-        let result = if let Some(target_grpc_url) = self.public_query_target_grpc_url().await? {
-            let client = self
-                .mutation_forwarder_pool
-                .client(&target_grpc_url)
-                .await
-                .with_context(|| {
-                    format!("Failed to connect to selective query authority at {target_grpc_url}")
-                })
-                .map_err(|e| anyhow::anyhow!(ErrorMetadata::service_unavailable()).context(e))?;
-            client
-                .forward_query(
-                    &String::from(path.clone()),
-                    args.get(),
-                    identity,
-                    caller,
-                    match ts {
-                        application::api::ExecuteQueryTimestamp::Latest => None,
-                        application::api::ExecuteQueryTimestamp::At(ts) => Some(u64::from(ts)),
+        let result = if self.should_forward_public_query()? {
+            let path = String::from(path.clone());
+            let args = args.get().to_owned();
+            let ts = match ts {
+                application::api::ExecuteQueryTimestamp::Latest => None,
+                application::api::ExecuteQueryTimestamp::At(ts) => Some(u64::from(ts)),
+            };
+            let journal = journal.flatten();
+            let pool = self.mutation_forwarder_pool.clone();
+            self.authority_resolver
+                .route(
+                    SELECTIVE_QUERY_AUTHORITY_PARTITION,
+                    AuthorityEndpointKind::Grpc,
+                    AttemptTimeoutDisposition::Retry,
+                    move |attempt| {
+                        let pool = pool.clone();
+                        let path = path.clone();
+                        let args = args.clone();
+                        let identity = identity.clone();
+                        let caller = caller.clone();
+                        let read_after_write = read_after_write.clone();
+                        let journal = journal.clone();
+                        async move {
+                            let started = Instant::now();
+                            let client = pool.client(&attempt.endpoint).await.map_err(|error| {
+                                AuthorityAttemptError::retry(error.context(format!(
+                                    "Failed to connect to query authority at {}",
+                                    attempt.endpoint
+                                )))
+                            })?;
+                            let Some(request_timeout) =
+                                attempt.timeout.checked_sub(started.elapsed())
+                            else {
+                                return Err(AuthorityAttemptError::retry(anyhow::anyhow!(
+                                    "Query authority connection consumed the attempt deadline"
+                                )));
+                            };
+                            client
+                                .forward_query_with_timeout(
+                                    &path,
+                                    &args,
+                                    identity,
+                                    caller,
+                                    ts,
+                                    read_after_write,
+                                    journal,
+                                    request_timeout,
+                                )
+                                .await
+                                .map_err(|error| {
+                                    let leader_hint = authority_leader_hint(&error);
+                                    AuthorityAttemptError::retry_with_leader(error, leader_hint)
+                                })
+                        }
                     },
-                    read_after_write,
-                    journal.flatten(),
                 )
                 .await
-                .map_err(|e| anyhow::anyhow!(ErrorMetadata::service_unavailable()).context(e))?
+                .map(|resolved| resolved.value)
+                .map_err(|e| {
+                    anyhow::anyhow!(ErrorMetadata::service_unavailable()).context(format!(
+                        "Failed to route query to the current authority: {e:#}"
+                    ))
+                })?
         } else {
             self.inner
                 .execute_public_query(

--- a/crates/local_backend/src/query_forwarding_api.rs
+++ b/crates/local_backend/src/query_forwarding_api.rs
@@ -244,7 +244,7 @@ impl application::api::ApplicationApi for SelectiveQueryForwardingApi {
                 .route(
                     SELECTIVE_QUERY_AUTHORITY_PARTITION,
                     AuthorityEndpointKind::Grpc,
-                    AttemptTimeoutDisposition::Retry,
+                    AttemptTimeoutDisposition::RetryableRead,
                     move |attempt| {
                         let pool = pool.clone();
                         let path = path.clone();

--- a/crates/local_backend/src/router.rs
+++ b/crates/local_backend/src/router.rs
@@ -558,6 +558,7 @@ pub fn router(st: BackendAppState) -> Router {
         cluster_grpc_auth: st.cluster_grpc_auth.clone(),
         mutation_forwarder_pool: st.mutation_forwarder_pool.clone(),
         replica_mutation_forwarder: st.replica_mutation_forwarder.clone(),
+        membership_store: st.membership_store.clone(),
     };
 
     let sync_routes = Router::new()


### PR DESCRIPTION
## Summary

- route queries, mutations, and deploy traffic through one live authority resolver that prefers current Raft leadership, refreshes membership, follows explicit redirects, and retries safe candidates within one request deadline
- preserve side-effect safety by retrying mutations only before dispatch or after an explicit redirect, while allowing dispatched reads to use the full remaining deadline
- make committed Raft/NATS outbox work acknowledge durable state without synchronously waiting for NATS delivery or the global TSO floor
- propagate the cluster-wide table-number allocator into in-process UDF transactions so concurrent implicit table creation cannot reuse numbers across partitions
- abort cancelled local writes before Raft proposal and preserve dispatched mutation deadlines

## Root cause

Authority forwarding selected stale single endpoints and used a one-second candidate probe as the execution deadline for real reads. Separately, a quorum-committed mutation synchronously updated the NATS-backed TSO committed floor before returning, so a NATS outage produced a false 503 even though the write was already durable and later visible exactly once. UDF transactions also fell back to a local table-number allocator, bypassing the cluster-wide CAS allocator.

## Correctness

The commit timestamp remains globally unique when its TSO batch is reserved. After quorum commit, the local committed floor is updated immediately; one coalescing background publisher retries the highest pending cluster floor without blocking client acknowledgment or spawning competing CAS writers. Ambiguous post-dispatch mutation failures are never replayed.

## Validation

- `local_backend` unit tests: 122/122
- focused TSO batch and leadership-fence tests: 8/8
- focused local-floor and nonblocking-maintenance tests: 3/3
- new blocked-TSO-floor regression, including coalescing two commits: passed
- exact backend image `sha256:39bf702d546764997a59da63867182279ce166b8a8e7d66a5eabcf5f41049790`
- embedded revision `3afcce47f971a6dd54f8fe27b00b1b91e3d9fe49`
- default write-scaling harness: 156/156
- Raft failover harness: 24/24
- parallel 2PC early-ack harness: 160/160

Closes #280
Closes #303